### PR TITLE
[FIX] 震度データベースのJSON typesを変更

### DIFF
--- a/packages/eqapi_types/lib/model/components/accuracy.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/accuracy.freezed.dart
@@ -25,8 +25,12 @@ mixin _$EewAccuracy {
   String get magnitudeCalculation => throw _privateConstructorUsedError;
   String get numberOfMagnitudeCalculation => throw _privateConstructorUsedError;
 
+  /// Serializes this EewAccuracy to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EewAccuracyCopyWith<EewAccuracy> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -54,6 +58,8 @@ class _$EewAccuracyCopyWithImpl<$Res, $Val extends EewAccuracy>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -106,6 +112,8 @@ class __$$EewAccuracyImplCopyWithImpl<$Res>
       _$EewAccuracyImpl _value, $Res Function(_$EewAccuracyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -185,7 +193,7 @@ class _$EewAccuracyImpl implements _EewAccuracy {
                     numberOfMagnitudeCalculation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -194,7 +202,9 @@ class _$EewAccuracyImpl implements _EewAccuracy {
       magnitudeCalculation,
       numberOfMagnitudeCalculation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EewAccuracyImplCopyWith<_$EewAccuracyImpl> get copyWith =>
@@ -226,8 +236,11 @@ abstract class _EewAccuracy implements EewAccuracy {
   String get magnitudeCalculation;
   @override
   String get numberOfMagnitudeCalculation;
+
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EewAccuracyImplCopyWith<_$EewAccuracyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/comments.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/comments.freezed.dart
@@ -25,8 +25,12 @@ mixin _$Comments {
   @JsonValue('var')
   VarComments? get varComments => throw _privateConstructorUsedError;
 
+  /// Serializes this Comments to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Comments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CommentsCopyWith<Comments> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -55,6 +59,8 @@ class _$CommentsCopyWithImpl<$Res, $Val extends Comments>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Comments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -78,6 +84,8 @@ class _$CommentsCopyWithImpl<$Res, $Val extends Comments>
     ) as $Val);
   }
 
+  /// Create a copy of Comments
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ForecastCommentsCopyWith<$Res>? get forecast {
@@ -90,6 +98,8 @@ class _$CommentsCopyWithImpl<$Res, $Val extends Comments>
     });
   }
 
+  /// Create a copy of Comments
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $VarCommentsCopyWith<$Res>? get varComments {
@@ -130,6 +140,8 @@ class __$$CommentsImplCopyWithImpl<$Res>
       _$CommentsImpl _value, $Res Function(_$CommentsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Comments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -191,11 +203,13 @@ class _$CommentsImpl implements _Comments {
                 other.varComments == varComments));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, free, forecast, varComments);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Comments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CommentsImplCopyWith<_$CommentsImpl> get copyWith =>
@@ -226,8 +240,11 @@ abstract class _Comments implements Comments {
   @override
   @JsonValue('var')
   VarComments? get varComments;
+
+  /// Create a copy of Comments
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CommentsImplCopyWith<_$CommentsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -241,8 +258,12 @@ mixin _$CommentsOmitVar {
   String? get free => throw _privateConstructorUsedError;
   ForecastComments? get forecast => throw _privateConstructorUsedError;
 
+  /// Serializes this CommentsOmitVar to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of CommentsOmitVar
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CommentsOmitVarCopyWith<CommentsOmitVar> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -268,6 +289,8 @@ class _$CommentsOmitVarCopyWithImpl<$Res, $Val extends CommentsOmitVar>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CommentsOmitVar
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -286,6 +309,8 @@ class _$CommentsOmitVarCopyWithImpl<$Res, $Val extends CommentsOmitVar>
     ) as $Val);
   }
 
+  /// Create a copy of CommentsOmitVar
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ForecastCommentsCopyWith<$Res>? get forecast {
@@ -321,6 +346,8 @@ class __$$CommentsOmitVarImplCopyWithImpl<$Res>
       _$CommentsOmitVarImpl _value, $Res Function(_$CommentsOmitVarImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CommentsOmitVar
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -369,11 +396,13 @@ class _$CommentsOmitVarImpl implements _CommentsOmitVar {
                 other.forecast == forecast));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, free, forecast);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CommentsOmitVar
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CommentsOmitVarImplCopyWith<_$CommentsOmitVarImpl> get copyWith =>
@@ -400,8 +429,11 @@ abstract class _CommentsOmitVar implements CommentsOmitVar {
   String? get free;
   @override
   ForecastComments? get forecast;
+
+  /// Create a copy of CommentsOmitVar
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CommentsOmitVarImplCopyWith<_$CommentsOmitVarImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -415,8 +447,12 @@ mixin _$ForecastComments {
   String get text => throw _privateConstructorUsedError;
   List<String> get codes => throw _privateConstructorUsedError;
 
+  /// Serializes this ForecastComments to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ForecastComments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ForecastCommentsCopyWith<ForecastComments> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -440,6 +476,8 @@ class _$ForecastCommentsCopyWithImpl<$Res, $Val extends ForecastComments>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ForecastComments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -478,6 +516,8 @@ class __$$ForecastCommentsImplCopyWithImpl<$Res>
       $Res Function(_$ForecastCommentsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ForecastComments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -532,12 +572,14 @@ class _$ForecastCommentsImpl implements _ForecastComments {
             const DeepCollectionEquality().equals(other._codes, _codes));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, text, const DeepCollectionEquality().hash(_codes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ForecastComments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ForecastCommentsImplCopyWith<_$ForecastCommentsImpl> get copyWith =>
@@ -564,8 +606,11 @@ abstract class _ForecastComments implements ForecastComments {
   String get text;
   @override
   List<String> get codes;
+
+  /// Create a copy of ForecastComments
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ForecastCommentsImplCopyWith<_$ForecastCommentsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -579,8 +624,12 @@ mixin _$VarComments {
   String get text => throw _privateConstructorUsedError;
   List<String> get codes => throw _privateConstructorUsedError;
 
+  /// Serializes this VarComments to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of VarComments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $VarCommentsCopyWith<VarComments> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -604,6 +653,8 @@ class _$VarCommentsCopyWithImpl<$Res, $Val extends VarComments>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of VarComments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -642,6 +693,8 @@ class __$$VarCommentsImplCopyWithImpl<$Res>
       _$VarCommentsImpl _value, $Res Function(_$VarCommentsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of VarComments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -696,12 +749,14 @@ class _$VarCommentsImpl implements _VarComments {
             const DeepCollectionEquality().equals(other._codes, _codes));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, text, const DeepCollectionEquality().hash(_codes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of VarComments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$VarCommentsImplCopyWith<_$VarCommentsImpl> get copyWith =>
@@ -727,8 +782,11 @@ abstract class _VarComments implements VarComments {
   String get text;
   @override
   List<String> get codes;
+
+  /// Create a copy of VarComments
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$VarCommentsImplCopyWith<_$VarCommentsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -741,8 +799,12 @@ CommentsOnlyFree _$CommentsOnlyFreeFromJson(Map<String, dynamic> json) {
 mixin _$CommentsOnlyFree {
   String get free => throw _privateConstructorUsedError;
 
+  /// Serializes this CommentsOnlyFree to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of CommentsOnlyFree
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CommentsOnlyFreeCopyWith<CommentsOnlyFree> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -766,6 +828,8 @@ class _$CommentsOnlyFreeCopyWithImpl<$Res, $Val extends CommentsOnlyFree>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CommentsOnlyFree
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -799,6 +863,8 @@ class __$$CommentsOnlyFreeImplCopyWithImpl<$Res>
       $Res Function(_$CommentsOnlyFreeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CommentsOnlyFree
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -838,11 +904,13 @@ class _$CommentsOnlyFreeImpl implements _CommentsOnlyFree {
             (identical(other.free, free) || other.free == free));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, free);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CommentsOnlyFree
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CommentsOnlyFreeImplCopyWith<_$CommentsOnlyFreeImpl> get copyWith =>
@@ -866,8 +934,11 @@ abstract class _CommentsOnlyFree implements CommentsOnlyFree {
 
   @override
   String get free;
+
+  /// Create a copy of CommentsOnlyFree
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CommentsOnlyFreeImplCopyWith<_$CommentsOnlyFreeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/earthquake-explanation/naming.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/earthquake-explanation/naming.freezed.dart
@@ -23,8 +23,12 @@ mixin _$Naming {
   String get text => throw _privateConstructorUsedError;
   String? get en => throw _privateConstructorUsedError;
 
+  /// Serializes this Naming to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Naming
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NamingCopyWith<Naming> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -46,6 +50,8 @@ class _$NamingCopyWithImpl<$Res, $Val extends Naming>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Naming
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -83,6 +89,8 @@ class __$$NamingImplCopyWithImpl<$Res>
       _$NamingImpl _value, $Res Function(_$NamingImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Naming
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -129,11 +137,13 @@ class _$NamingImpl implements _Naming {
             (identical(other.en, en) || other.en == en));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, text, en);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Naming
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NamingImplCopyWith<_$NamingImpl> get copyWith =>
@@ -157,8 +167,11 @@ abstract class _Naming implements Naming {
   String get text;
   @override
   String? get en;
+
+  /// Create a copy of Naming
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NamingImplCopyWith<_$NamingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/earthquake-nankai/earthquake_info.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/earthquake-nankai/earthquake_info.freezed.dart
@@ -24,8 +24,12 @@ mixin _$EarthquakeNankaiInfo {
   String? get appendix => throw _privateConstructorUsedError;
   EarthquakeNankaiKind? get kind => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeNankaiInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeNankaiInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeNankaiInfoCopyWith<EarthquakeNankaiInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -52,6 +56,8 @@ class _$EarthquakeNankaiInfoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeNankaiInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -75,6 +81,8 @@ class _$EarthquakeNankaiInfoCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of EarthquakeNankaiInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeNankaiKindCopyWith<$Res>? get kind {
@@ -110,6 +118,8 @@ class __$$EarthquakeNankaiInfoImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeNankaiInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeNankaiInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -166,11 +176,13 @@ class _$EarthquakeNankaiInfoImpl implements _EarthquakeNankaiInfo {
             (identical(other.kind, kind) || other.kind == kind));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, text, appendix, kind);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeNankaiInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeNankaiInfoImplCopyWith<_$EarthquakeNankaiInfoImpl>
@@ -201,8 +213,11 @@ abstract class _EarthquakeNankaiInfo implements EarthquakeNankaiInfo {
   String? get appendix;
   @override
   EarthquakeNankaiKind? get kind;
+
+  /// Create a copy of EarthquakeNankaiInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeNankaiInfoImplCopyWith<_$EarthquakeNankaiInfoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -216,8 +231,12 @@ mixin _$EarthquakeNankaiKind {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeNankaiKind to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeNankaiKind
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeNankaiKindCopyWith<EarthquakeNankaiKind> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -242,6 +261,8 @@ class _$EarthquakeNankaiKindCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeNankaiKind
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -280,6 +301,8 @@ class __$$EarthquakeNankaiKindImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeNankaiKindImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeNankaiKind
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -326,11 +349,13 @@ class _$EarthquakeNankaiKindImpl implements _EarthquakeNankaiKind {
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeNankaiKind
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeNankaiKindImplCopyWith<_$EarthquakeNankaiKindImpl>
@@ -358,8 +383,11 @@ abstract class _EarthquakeNankaiKind implements EarthquakeNankaiKind {
   String get code;
   @override
   String get name;
+
+  /// Create a copy of EarthquakeNankaiKind
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeNankaiKindImplCopyWith<_$EarthquakeNankaiKindImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/earthquake.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/earthquake.freezed.dart
@@ -25,8 +25,12 @@ mixin _$Earthquake {
   EarthquakeHypocenter get hypocenter => throw _privateConstructorUsedError;
   EarthquakeMagnitude get magnitude => throw _privateConstructorUsedError;
 
+  /// Serializes this Earthquake to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeCopyWith<Earthquake> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -57,6 +61,8 @@ class _$EarthquakeCopyWithImpl<$Res, $Val extends Earthquake>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -85,6 +91,8 @@ class _$EarthquakeCopyWithImpl<$Res, $Val extends Earthquake>
     ) as $Val);
   }
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeHypocenterCopyWith<$Res> get hypocenter {
@@ -93,6 +101,8 @@ class _$EarthquakeCopyWithImpl<$Res, $Val extends Earthquake>
     });
   }
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeMagnitudeCopyWith<$Res> get magnitude {
@@ -130,6 +140,8 @@ class __$$EarthquakeImplCopyWithImpl<$Res>
       _$EarthquakeImpl _value, $Res Function(_$EarthquakeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -201,12 +213,14 @@ class _$EarthquakeImpl implements _Earthquake {
                 other.magnitude == magnitude));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, originTime, arrivalTime, hypocenter, magnitude);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeImplCopyWith<_$EarthquakeImpl> get copyWith =>
@@ -238,8 +252,11 @@ abstract class _Earthquake implements Earthquake {
   EarthquakeHypocenter get hypocenter;
   @override
   EarthquakeMagnitude get magnitude;
+
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeImplCopyWith<_$EarthquakeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -261,8 +278,12 @@ mixin _$EarthquakeHypocenter {
       throw _privateConstructorUsedError;
   LatLng? get coordinate => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeHypocenter to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeHypocenterCopyWith<EarthquakeHypocenter> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -294,6 +315,8 @@ class _$EarthquakeHypocenterCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -327,6 +350,8 @@ class _$EarthquakeHypocenterCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeHypocenterDetailedCopyWith<$Res>? get detailed {
@@ -368,6 +393,8 @@ class __$$EarthquakeHypocenterImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeHypocenterImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -450,12 +477,14 @@ class _$EarthquakeHypocenterImpl implements _EarthquakeHypocenter {
                 other.coordinate == coordinate));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, name, code, depth, detailed, coordinate);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeHypocenterImplCopyWith<_$EarthquakeHypocenterImpl>
@@ -486,18 +515,21 @@ abstract class _EarthquakeHypocenter implements EarthquakeHypocenter {
   String get name;
   @override
   String get code;
-  @override
 
   /// 0: ごく浅い
   /// 700: 700km以上
   /// null: 不明
+  @override
   int? get depth;
   @override
   EarthquakeHypocenterDetailed? get detailed;
   @override
   LatLng? get coordinate;
+
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeHypocenterImplCopyWith<_$EarthquakeHypocenterImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -512,8 +544,12 @@ mixin _$EarthquakeHypocenterDetailed {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeHypocenterDetailed to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeHypocenterDetailedCopyWith<EarthquakeHypocenterDetailed>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -540,6 +576,8 @@ class _$EarthquakeHypocenterDetailedCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -581,6 +619,8 @@ class __$$EarthquakeHypocenterDetailedImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeHypocenterDetailedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -631,11 +671,13 @@ class _$EarthquakeHypocenterDetailedImpl
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeHypocenterDetailedImplCopyWith<
@@ -664,8 +706,11 @@ abstract class _EarthquakeHypocenterDetailed
   String get code;
   @override
   String get name;
+
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeHypocenterDetailedImplCopyWith<
           _$EarthquakeHypocenterDetailedImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -680,8 +725,12 @@ mixin _$EarthquakeMagnitude {
   double? get value => throw _privateConstructorUsedError;
   String? get condition => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeMagnitude to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeMagnitudeCopyWith<EarthquakeMagnitude> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -705,6 +754,8 @@ class _$EarthquakeMagnitudeCopyWithImpl<$Res, $Val extends EarthquakeMagnitude>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -743,6 +794,8 @@ class __$$EarthquakeMagnitudeImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeMagnitudeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -792,11 +845,13 @@ class _$EarthquakeMagnitudeImpl implements _EarthquakeMagnitude {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, value, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeMagnitudeImplCopyWith<_$EarthquakeMagnitudeImpl> get copyWith =>
@@ -823,8 +878,11 @@ abstract class _EarthquakeMagnitude implements EarthquakeMagnitude {
   double? get value;
   @override
   String? get condition;
+
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeMagnitudeImplCopyWith<_$EarthquakeMagnitudeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/eew_hypocenter.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/eew_hypocenter.freezed.dart
@@ -24,8 +24,12 @@ mixin _$EewHypocenter {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
+  /// Serializes this EewHypocenter to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EewHypocenter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EewHypocenterCopyWith<EewHypocenter> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -49,6 +53,8 @@ class _$EewHypocenterCopyWithImpl<$Res, $Val extends EewHypocenter>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EewHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -92,6 +98,8 @@ class __$$EewHypocenterImplCopyWithImpl<$Res>
       _$EewHypocenterImpl _value, $Res Function(_$EewHypocenterImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EewHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -149,11 +157,13 @@ class _$EewHypocenterImpl implements _EewHypocenter {
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, coordinate, code, name);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EewHypocenter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EewHypocenterImplCopyWith<_$EewHypocenterImpl> get copyWith =>
@@ -182,8 +192,11 @@ abstract class _EewHypocenter implements EewHypocenter {
   String get code;
   @override
   String get name;
+
+  /// Create a copy of EewHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EewHypocenterImplCopyWith<_$EewHypocenterImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/eew_intensity.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/eew_intensity.freezed.dart
@@ -23,8 +23,12 @@ mixin _$ForecastMaxInt {
   JmaForecastIntensity get from => throw _privateConstructorUsedError;
   JmaForecastIntensityOver get to => throw _privateConstructorUsedError;
 
+  /// Serializes this ForecastMaxInt to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ForecastMaxInt
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ForecastMaxIntCopyWith<ForecastMaxInt> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -48,6 +52,8 @@ class _$ForecastMaxIntCopyWithImpl<$Res, $Val extends ForecastMaxInt>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ForecastMaxInt
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -86,6 +92,8 @@ class __$$ForecastMaxIntImplCopyWithImpl<$Res>
       _$ForecastMaxIntImpl _value, $Res Function(_$ForecastMaxIntImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ForecastMaxInt
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -133,11 +141,13 @@ class _$ForecastMaxIntImpl implements _ForecastMaxInt {
             (identical(other.to, to) || other.to == to));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, from, to);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ForecastMaxInt
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ForecastMaxIntImplCopyWith<_$ForecastMaxIntImpl> get copyWith =>
@@ -164,8 +174,11 @@ abstract class _ForecastMaxInt implements ForecastMaxInt {
   JmaForecastIntensity get from;
   @override
   JmaForecastIntensityOver get to;
+
+  /// Create a copy of ForecastMaxInt
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ForecastMaxIntImplCopyWith<_$ForecastMaxIntImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -179,8 +192,12 @@ mixin _$ForecastMaxLgInt {
   JmaForecastLgIntensity get from => throw _privateConstructorUsedError;
   JmaForecastLgIntensityOver get to => throw _privateConstructorUsedError;
 
+  /// Serializes this ForecastMaxLgInt to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ForecastMaxLgInt
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ForecastMaxLgIntCopyWith<ForecastMaxLgInt> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -204,6 +221,8 @@ class _$ForecastMaxLgIntCopyWithImpl<$Res, $Val extends ForecastMaxLgInt>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ForecastMaxLgInt
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -242,6 +261,8 @@ class __$$ForecastMaxLgIntImplCopyWithImpl<$Res>
       $Res Function(_$ForecastMaxLgIntImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ForecastMaxLgInt
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -289,11 +310,13 @@ class _$ForecastMaxLgIntImpl implements _ForecastMaxLgInt {
             (identical(other.to, to) || other.to == to));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, from, to);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ForecastMaxLgInt
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ForecastMaxLgIntImplCopyWith<_$ForecastMaxLgIntImpl> get copyWith =>
@@ -320,8 +343,11 @@ abstract class _ForecastMaxLgInt implements ForecastMaxLgInt {
   JmaForecastLgIntensity get from;
   @override
   JmaForecastLgIntensityOver get to;
+
+  /// Create a copy of ForecastMaxLgInt
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ForecastMaxLgIntImplCopyWith<_$ForecastMaxLgIntImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/eew_region.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/eew_region.freezed.dart
@@ -31,8 +31,12 @@ mixin _$EewRegion {
   /// PLUM法の場合は最初にその階級震度を予測した時刻
   DateTime? get arrivalTime => throw _privateConstructorUsedError;
 
+  /// Serializes this EewRegion to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EewRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EewRegionCopyWith<EewRegion> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -65,6 +69,8 @@ class _$EewRegionCopyWithImpl<$Res, $Val extends EewRegion>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EewRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -108,6 +114,8 @@ class _$EewRegionCopyWithImpl<$Res, $Val extends EewRegion>
     ) as $Val);
   }
 
+  /// Create a copy of EewRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ForecastMaxIntCopyWith<$Res> get forecastMaxInt {
@@ -116,6 +124,8 @@ class _$EewRegionCopyWithImpl<$Res, $Val extends EewRegion>
     });
   }
 
+  /// Create a copy of EewRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ForecastMaxLgIntCopyWith<$Res>? get forecastMaxLgInt {
@@ -160,6 +170,8 @@ class __$$EewRegionImplCopyWithImpl<$Res>
       _$EewRegionImpl _value, $Res Function(_$EewRegionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EewRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -261,12 +273,14 @@ class _$EewRegionImpl implements _EewRegion {
                 other.arrivalTime == arrivalTime));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name, isPlum, isWarning,
       forecastMaxInt, forecastMaxLgInt, arrivalTime);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EewRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EewRegionImplCopyWith<_$EewRegionImpl> get copyWith =>
@@ -305,13 +319,16 @@ abstract class _EewRegion implements EewRegion {
   ForecastMaxInt get forecastMaxInt;
   @override
   ForecastMaxLgInt? get forecastMaxLgInt;
-  @override
 
   /// undefinedの場合は null
   /// PLUM法の場合は最初にその階級震度を予測した時刻
-  DateTime? get arrivalTime;
   @override
-  @JsonKey(ignore: true)
+  DateTime? get arrivalTime;
+
+  /// Create a copy of EewRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EewRegionImplCopyWith<_$EewRegionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/intensity.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/intensity.freezed.dart
@@ -28,8 +28,12 @@ mixin _$Intensity {
   List<RegionIntensity>? get cities => throw _privateConstructorUsedError;
   List<RegionIntensity>? get stations => throw _privateConstructorUsedError;
 
+  /// Serializes this Intensity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Intensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $IntensityCopyWith<Intensity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -59,6 +63,8 @@ class _$IntensityCopyWithImpl<$Res, $Val extends Intensity>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Intensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -129,6 +135,8 @@ class __$$IntensityImplCopyWithImpl<$Res>
       _$IntensityImpl _value, $Res Function(_$IntensityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Intensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -259,7 +267,7 @@ class _$IntensityImpl implements _Intensity {
             const DeepCollectionEquality().equals(other._stations, _stations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -271,7 +279,9 @@ class _$IntensityImpl implements _Intensity {
       const DeepCollectionEquality().hash(_cities),
       const DeepCollectionEquality().hash(_stations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Intensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$IntensityImplCopyWith<_$IntensityImpl> get copyWith =>
@@ -312,8 +322,11 @@ abstract class _Intensity implements Intensity {
   List<RegionIntensity>? get cities;
   @override
   List<RegionIntensity>? get stations;
+
+  /// Create a copy of Intensity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$IntensityImplCopyWith<_$IntensityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/region_intensity.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/region_intensity.freezed.dart
@@ -25,8 +25,12 @@ mixin _$RegionIntensity {
   JmaIntensity? get maxInt => throw _privateConstructorUsedError;
   JmaLgIntensity? get maxLgInt => throw _privateConstructorUsedError;
 
+  /// Serializes this RegionIntensity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RegionIntensityCopyWith<RegionIntensity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -54,6 +58,8 @@ class _$RegionIntensityCopyWithImpl<$Res, $Val extends RegionIntensity>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -106,6 +112,8 @@ class __$$RegionIntensityImplCopyWithImpl<$Res>
       _$RegionIntensityImpl _value, $Res Function(_$RegionIntensityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -174,11 +182,13 @@ class _$RegionIntensityImpl implements _RegionIntensity {
                 other.maxLgInt == maxLgInt));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name, maxInt, maxLgInt);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RegionIntensityImplCopyWith<_$RegionIntensityImpl> get copyWith =>
@@ -211,8 +221,11 @@ abstract class _RegionIntensity implements RegionIntensity {
   JmaIntensity? get maxInt;
   @override
   JmaLgIntensity? get maxLgInt;
+
+  /// Create a copy of RegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RegionIntensityImplCopyWith<_$RegionIntensityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/tsunami-information/comments.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/tsunami-information/comments.freezed.dart
@@ -24,8 +24,12 @@ mixin _$TsunamiComments {
   TsunamiForecastCommentWarning? get warning =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiComments to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiComments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiCommentsCopyWith<TsunamiComments> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -51,6 +55,8 @@ class _$TsunamiCommentsCopyWithImpl<$Res, $Val extends TsunamiComments>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiComments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -69,6 +75,8 @@ class _$TsunamiCommentsCopyWithImpl<$Res, $Val extends TsunamiComments>
     ) as $Val);
   }
 
+  /// Create a copy of TsunamiComments
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TsunamiForecastCommentWarningCopyWith<$Res>? get warning {
@@ -105,6 +113,8 @@ class __$$TsunamiCommentsImplCopyWithImpl<$Res>
       _$TsunamiCommentsImpl _value, $Res Function(_$TsunamiCommentsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiComments
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -151,11 +161,13 @@ class _$TsunamiCommentsImpl implements _TsunamiComments {
             (identical(other.warning, warning) || other.warning == warning));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, free, warning);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiComments
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiCommentsImplCopyWith<_$TsunamiCommentsImpl> get copyWith =>
@@ -183,8 +195,11 @@ abstract class _TsunamiComments implements TsunamiComments {
   String? get free;
   @override
   TsunamiForecastCommentWarning? get warning;
+
+  /// Create a copy of TsunamiComments
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiCommentsImplCopyWith<_$TsunamiCommentsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -199,8 +214,12 @@ mixin _$TsunamiForecastCommentWarning {
   String get text => throw _privateConstructorUsedError;
   List<String> get codes => throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecastCommentWarning to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecastCommentWarning
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastCommentWarningCopyWith<TsunamiForecastCommentWarning>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -227,6 +246,8 @@ class _$TsunamiForecastCommentWarningCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecastCommentWarning
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -268,6 +289,8 @@ class __$$TsunamiForecastCommentWarningImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiForecastCommentWarningImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecastCommentWarning
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -323,12 +346,14 @@ class _$TsunamiForecastCommentWarningImpl
             const DeepCollectionEquality().equals(other._codes, _codes));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, text, const DeepCollectionEquality().hash(_codes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecastCommentWarning
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastCommentWarningImplCopyWith<
@@ -357,8 +382,11 @@ abstract class _TsunamiForecastCommentWarning
   String get text;
   @override
   List<String> get codes;
+
+  /// Create a copy of TsunamiForecastCommentWarning
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastCommentWarningImplCopyWith<
           _$TsunamiForecastCommentWarningImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/eqapi_types/lib/model/components/tsunami-information/tsunami_estimation.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/tsunami-information/tsunami_estimation.freezed.dart
@@ -32,8 +32,12 @@ mixin _$TsunamiEstimation {
       throw _privateConstructorUsedError;
   bool? get isObserving => throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiEstimation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiEstimationCopyWith<TsunamiEstimation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -66,6 +70,8 @@ class _$TsunamiEstimationCopyWithImpl<$Res, $Val extends TsunamiEstimation>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -148,6 +154,8 @@ class __$$TsunamiEstimationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiEstimationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -266,7 +274,7 @@ class _$TsunamiEstimationImpl implements _TsunamiEstimation {
                 other.isObserving == isObserving));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -280,7 +288,9 @@ class _$TsunamiEstimationImpl implements _TsunamiEstimation {
       maxHeightCondition,
       isObserving);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiEstimationImplCopyWith<_$TsunamiEstimationImpl> get copyWith =>
@@ -329,8 +339,11 @@ abstract class _TsunamiEstimation implements TsunamiEstimation {
   TsunamiEstimationMaxHeightCondition? get maxHeightCondition;
   @override
   bool? get isObserving;
+
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiEstimationImplCopyWith<_$TsunamiEstimationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/tsunami-information/tsunami_forecast.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/tsunami-information/tsunami_forecast.freezed.dart
@@ -32,8 +32,12 @@ mixin _$TsunamiForecast {
   List<TsunamiForecastStation>? get stations =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecast to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastCopyWith<TsunamiForecast> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -67,6 +71,8 @@ class _$TsunamiForecastCopyWithImpl<$Res, $Val extends TsunamiForecast>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -110,6 +116,8 @@ class _$TsunamiForecastCopyWithImpl<$Res, $Val extends TsunamiForecast>
     ) as $Val);
   }
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TsunamiForecastFirstHeightCopyWith<$Res>? get firstHeight {
@@ -123,6 +131,8 @@ class _$TsunamiForecastCopyWithImpl<$Res, $Val extends TsunamiForecast>
     });
   }
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TsunamiForecastMaxHeightCopyWith<$Res>? get maxHeight {
@@ -167,6 +177,8 @@ class __$$TsunamiForecastImplCopyWithImpl<$Res>
       _$TsunamiForecastImpl _value, $Res Function(_$TsunamiForecastImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -273,12 +285,14 @@ class _$TsunamiForecastImpl implements _TsunamiForecast {
             const DeepCollectionEquality().equals(other._stations, _stations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name, kind, lastKind,
       firstHeight, maxHeight, const DeepCollectionEquality().hash(_stations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastImplCopyWith<_$TsunamiForecastImpl> get copyWith =>
@@ -311,9 +325,9 @@ abstract class _TsunamiForecast implements TsunamiForecast {
   String get code;
   @override
   String get name;
-  @override
 
   /// 種別コードを用いる
+  @override
   String get kind;
   @override
   String get lastKind;
@@ -323,8 +337,11 @@ abstract class _TsunamiForecast implements TsunamiForecast {
   TsunamiForecastMaxHeight? get maxHeight;
   @override
   List<TsunamiForecastStation>? get stations;
+
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastImplCopyWith<_$TsunamiForecastImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -339,8 +356,12 @@ mixin _$TsunamiForecastFirstHeight {
   DateTime? get arrivalTime => throw _privateConstructorUsedError;
   TsunamiForecastCondition? get condition => throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecastFirstHeight to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastFirstHeightCopyWith<TsunamiForecastFirstHeight>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -366,6 +387,8 @@ class _$TsunamiForecastFirstHeightCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -407,6 +430,8 @@ class __$$TsunamiForecastFirstHeightImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiForecastFirstHeightImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -457,11 +482,13 @@ class _$TsunamiForecastFirstHeightImpl implements _TsunamiForecastFirstHeight {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, arrivalTime, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastFirstHeightImplCopyWith<_$TsunamiForecastFirstHeightImpl>
@@ -490,8 +517,11 @@ abstract class _TsunamiForecastFirstHeight
   DateTime? get arrivalTime;
   @override
   TsunamiForecastCondition? get condition;
+
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastFirstHeightImplCopyWith<_$TsunamiForecastFirstHeightImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -508,8 +538,12 @@ mixin _$TsunamiForecastMaxHeight {
   TsunamiForecastMaxHeightCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecastMaxHeight to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastMaxHeightCopyWith<TsunamiForecastMaxHeight> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -537,6 +571,8 @@ class _$TsunamiForecastMaxHeightCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -586,6 +622,8 @@ class __$$TsunamiForecastMaxHeightImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiForecastMaxHeightImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -642,11 +680,13 @@ class _$TsunamiForecastMaxHeightImpl implements _TsunamiForecastMaxHeight {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, value, isOver, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastMaxHeightImplCopyWith<_$TsunamiForecastMaxHeightImpl>
@@ -677,8 +717,11 @@ abstract class _TsunamiForecastMaxHeight implements TsunamiForecastMaxHeight {
   bool? get isOver;
   @override
   TsunamiForecastMaxHeightCondition? get condition;
+
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastMaxHeightImplCopyWith<_$TsunamiForecastMaxHeightImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -697,8 +740,12 @@ mixin _$TsunamiForecastStation {
   TsunamiForecastStationCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecastStation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastStationCopyWith<TsunamiForecastStation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -728,6 +775,8 @@ class _$TsunamiForecastStationCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -789,6 +838,8 @@ class __$$TsunamiForecastStationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiForecastStationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -867,12 +918,14 @@ class _$TsunamiForecastStationImpl implements _TsunamiForecastStation {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, highTideTime, firstHeightTime, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastStationImplCopyWith<_$TsunamiForecastStationImpl>
@@ -909,8 +962,11 @@ abstract class _TsunamiForecastStation implements TsunamiForecastStation {
   DateTime? get firstHeightTime;
   @override
   TsunamiForecastStationCondition? get condition;
+
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastStationImplCopyWith<_$TsunamiForecastStationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/tsunami-information/tsunami_observations.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/tsunami-information/tsunami_observations.freezed.dart
@@ -25,8 +25,12 @@ mixin _$TsunamiObservation {
   List<TsunamiObservationStation> get stations =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiObservation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiObservationCopyWith<TsunamiObservation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -51,6 +55,8 @@ class _$TsunamiObservationCopyWithImpl<$Res, $Val extends TsunamiObservation>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -95,6 +101,8 @@ class __$$TsunamiObservationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiObservationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -158,12 +166,14 @@ class _$TsunamiObservationImpl implements _TsunamiObservation {
             const DeepCollectionEquality().equals(other._stations, _stations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, const DeepCollectionEquality().hash(_stations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiObservationImplCopyWith<_$TsunamiObservationImpl> get copyWith =>
@@ -194,8 +204,11 @@ abstract class _TsunamiObservation implements TsunamiObservation {
   String? get name;
   @override
   List<TsunamiObservationStation> get stations;
+
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiObservationImplCopyWith<_$TsunamiObservationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -225,8 +238,12 @@ mixin _$TsunamiObservationStation {
   TsunamiObservationStationCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiObservationStation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiObservationStationCopyWith<TsunamiObservationStation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -260,6 +277,8 @@ class _$TsunamiObservationStationCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -345,6 +364,8 @@ class __$$TsunamiObservationStationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiObservationStationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -469,7 +490,7 @@ class _$TsunamiObservationStationImpl implements _TsunamiObservationStation {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -483,7 +504,9 @@ class _$TsunamiObservationStationImpl implements _TsunamiObservationStation {
       maxHeightIsRising,
       condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiObservationStationImplCopyWith<_$TsunamiObservationStationImpl>
@@ -518,9 +541,9 @@ abstract class _TsunamiObservationStation implements TsunamiObservationStation {
   String get code;
   @override
   String get name;
-  @override
 
   /// nullの時は`識別不能`
+  @override
   DateTime? get firstHeightArrivalTime;
   @override
   TsunamiObservationFirstHeightInitial? get firstHeightInitial;
@@ -528,18 +551,21 @@ abstract class _TsunamiObservationStation implements TsunamiObservationStation {
   DateTime? get maxHeightTime;
   @override
   double? get maxHeightValue;
-  @override
 
   /// `maxHeightValue`「以上」かどうか
-  bool? get maxHeightIsOver;
   @override
+  bool? get maxHeightIsOver;
 
   ///  上昇中かどうか
+  @override
   bool? get maxHeightIsRising;
   @override
   TsunamiObservationStationCondition? get condition;
+
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiObservationStationImplCopyWith<_$TsunamiObservationStationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/tsunami-information/vtse41.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/tsunami-information/vtse41.freezed.dart
@@ -23,8 +23,12 @@ PublicBodyVtse41Tsunami _$PublicBodyVtse41TsunamiFromJson(
 mixin _$PublicBodyVtse41Tsunami {
   List<TsunamiForecast> get forecasts => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVtse41Tsunami to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVtse41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVtse41TsunamiCopyWith<PublicBodyVtse41Tsunami> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -49,6 +53,8 @@ class _$PublicBodyVtse41TsunamiCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVtse41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -85,6 +91,8 @@ class __$$PublicBodyVtse41TsunamiImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVtse41TsunamiImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVtse41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -131,12 +139,14 @@ class _$PublicBodyVtse41TsunamiImpl implements _PublicBodyVtse41Tsunami {
                 .equals(other._forecasts, _forecasts));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_forecasts));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVtse41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVtse41TsunamiImplCopyWith<_$PublicBodyVtse41TsunamiImpl>
@@ -161,8 +171,11 @@ abstract class _PublicBodyVtse41Tsunami implements PublicBodyVtse41Tsunami {
 
   @override
   List<TsunamiForecast> get forecasts;
+
+  /// Create a copy of PublicBodyVtse41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVtse41TsunamiImplCopyWith<_$PublicBodyVtse41TsunamiImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/tsunami-information/vtse51.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/tsunami-information/vtse51.freezed.dart
@@ -25,8 +25,12 @@ mixin _$PublicBodyVtse51Tsunami {
   List<TsunamiObservation>? get observations =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVtse51Tsunami to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVtse51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVtse51TsunamiCopyWith<PublicBodyVtse51Tsunami> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -53,6 +57,8 @@ class _$PublicBodyVtse51TsunamiCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVtse51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -96,6 +102,8 @@ class __$$PublicBodyVtse51TsunamiImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVtse51TsunamiImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVtse51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -161,14 +169,16 @@ class _$PublicBodyVtse51TsunamiImpl implements _PublicBodyVtse51Tsunami {
                 .equals(other._observations, _observations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_forecasts),
       const DeepCollectionEquality().hash(_observations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVtse51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVtse51TsunamiImplCopyWith<_$PublicBodyVtse51TsunamiImpl>
@@ -196,8 +206,11 @@ abstract class _PublicBodyVtse51Tsunami implements PublicBodyVtse51Tsunami {
   List<TsunamiForecast> get forecasts;
   @override
   List<TsunamiObservation>? get observations;
+
+  /// Create a copy of PublicBodyVtse51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVtse51TsunamiImplCopyWith<_$PublicBodyVtse51TsunamiImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/components/tsunami-information/vtse52.freezed.dart
+++ b/packages/eqapi_types/lib/model/components/tsunami-information/vtse52.freezed.dart
@@ -25,8 +25,12 @@ mixin _$PublicBodyVtse52Tsunami {
       throw _privateConstructorUsedError;
   List<TsunamiEstimation> get estimations => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVtse52Tsunami to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVtse52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVtse52TsunamiCopyWith<PublicBodyVtse52Tsunami> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -53,6 +57,8 @@ class _$PublicBodyVtse52TsunamiCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVtse52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -96,6 +102,8 @@ class __$$PublicBodyVtse52TsunamiImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVtse52TsunamiImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVtse52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -161,14 +169,16 @@ class _$PublicBodyVtse52TsunamiImpl implements _PublicBodyVtse52Tsunami {
                 .equals(other._estimations, _estimations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_observations),
       const DeepCollectionEquality().hash(_estimations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVtse52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVtse52TsunamiImplCopyWith<_$PublicBodyVtse52TsunamiImpl>
@@ -196,8 +206,11 @@ abstract class _PublicBodyVtse52Tsunami implements PublicBodyVtse52Tsunami {
   List<TsunamiObservation>? get observations;
   @override
   List<TsunamiEstimation> get estimations;
+
+  /// Create a copy of PublicBodyVtse52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVtse52TsunamiImplCopyWith<_$PublicBodyVtse52TsunamiImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/app_information.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/app_information.freezed.dart
@@ -23,8 +23,12 @@ mixin _$AppInformation {
   PlatformAppInformation get ios => throw _privateConstructorUsedError;
   PlatformAppInformation get android => throw _privateConstructorUsedError;
 
+  /// Serializes this AppInformation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AppInformationCopyWith<AppInformation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -51,6 +55,8 @@ class _$AppInformationCopyWithImpl<$Res, $Val extends AppInformation>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -69,6 +75,8 @@ class _$AppInformationCopyWithImpl<$Res, $Val extends AppInformation>
     ) as $Val);
   }
 
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $PlatformAppInformationCopyWith<$Res> get ios {
@@ -77,6 +85,8 @@ class _$AppInformationCopyWithImpl<$Res, $Val extends AppInformation>
     });
   }
 
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $PlatformAppInformationCopyWith<$Res> get android {
@@ -110,6 +120,8 @@ class __$$AppInformationImplCopyWithImpl<$Res>
       _$AppInformationImpl _value, $Res Function(_$AppInformationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -156,11 +168,13 @@ class _$AppInformationImpl implements _AppInformation {
             (identical(other.android, android) || other.android == android));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, ios, android);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AppInformationImplCopyWith<_$AppInformationImpl> get copyWith =>
@@ -187,8 +201,11 @@ abstract class _AppInformation implements AppInformation {
   PlatformAppInformation get ios;
   @override
   PlatformAppInformation get android;
+
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AppInformationImplCopyWith<_$AppInformationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -204,8 +221,12 @@ mixin _$PlatformAppInformation {
   AppVersion? get minimum => throw _privateConstructorUsedError;
   String? get downloadUrl => throw _privateConstructorUsedError;
 
+  /// Serializes this PlatformAppInformation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PlatformAppInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PlatformAppInformationCopyWith<PlatformAppInformation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -233,6 +254,8 @@ class _$PlatformAppInformationCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PlatformAppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -256,6 +279,8 @@ class _$PlatformAppInformationCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of PlatformAppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $AppVersionCopyWith<$Res>? get latest {
@@ -268,6 +293,8 @@ class _$PlatformAppInformationCopyWithImpl<$Res,
     });
   }
 
+  /// Create a copy of PlatformAppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $AppVersionCopyWith<$Res>? get minimum {
@@ -308,6 +335,8 @@ class __$$PlatformAppInformationImplCopyWithImpl<$Res>
       $Res Function(_$PlatformAppInformationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PlatformAppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -364,11 +393,13 @@ class _$PlatformAppInformationImpl implements _PlatformAppInformation {
                 other.downloadUrl == downloadUrl));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, latest, minimum, downloadUrl);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PlatformAppInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PlatformAppInformationImplCopyWith<_$PlatformAppInformationImpl>
@@ -398,8 +429,11 @@ abstract class _PlatformAppInformation implements PlatformAppInformation {
   AppVersion? get minimum;
   @override
   String? get downloadUrl;
+
+  /// Create a copy of PlatformAppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PlatformAppInformationImplCopyWith<_$PlatformAppInformationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -413,8 +447,12 @@ mixin _$AppVersion {
   String get version => throw _privateConstructorUsedError;
   String? get message => throw _privateConstructorUsedError;
 
+  /// Serializes this AppVersion to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AppVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AppVersionCopyWith<AppVersion> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -438,6 +476,8 @@ class _$AppVersionCopyWithImpl<$Res, $Val extends AppVersion>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AppVersion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -476,6 +516,8 @@ class __$$AppVersionImplCopyWithImpl<$Res>
       _$AppVersionImpl _value, $Res Function(_$AppVersionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AppVersion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -522,11 +564,13 @@ class _$AppVersionImpl implements _AppVersion {
             (identical(other.message, message) || other.message == message));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, version, message);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AppVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AppVersionImplCopyWith<_$AppVersionImpl> get copyWith =>
@@ -552,8 +596,11 @@ abstract class _AppVersion implements AppVersion {
   String get version;
   @override
   String? get message;
+
+  /// Create a copy of AppVersion
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AppVersionImplCopyWith<_$AppVersionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/auth/fcm_token_request.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/auth/fcm_token_request.freezed.dart
@@ -22,8 +22,12 @@ FcmTokenRequest _$FcmTokenRequestFromJson(Map<String, dynamic> json) {
 mixin _$FcmTokenRequest {
   String get fcmToken => throw _privateConstructorUsedError;
 
+  /// Serializes this FcmTokenRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of FcmTokenRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $FcmTokenRequestCopyWith<FcmTokenRequest> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -47,6 +51,8 @@ class _$FcmTokenRequestCopyWithImpl<$Res, $Val extends FcmTokenRequest>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of FcmTokenRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -80,6 +86,8 @@ class __$$FcmTokenRequestImplCopyWithImpl<$Res>
       _$FcmTokenRequestImpl _value, $Res Function(_$FcmTokenRequestImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of FcmTokenRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -119,11 +127,13 @@ class _$FcmTokenRequestImpl implements _FcmTokenRequest {
                 other.fcmToken == fcmToken));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, fcmToken);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of FcmTokenRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$FcmTokenRequestImplCopyWith<_$FcmTokenRequestImpl> get copyWith =>
@@ -147,8 +157,11 @@ abstract class _FcmTokenRequest implements FcmTokenRequest {
 
   @override
   String get fcmToken;
+
+  /// Create a copy of FcmTokenRequest
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$FcmTokenRequestImplCopyWith<_$FcmTokenRequestImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/auth/fcm_token_response.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/auth/fcm_token_response.freezed.dart
@@ -24,8 +24,12 @@ mixin _$FcmTokenUpdateResponse {
   String? get token => throw _privateConstructorUsedError;
   String? get fcmVerify => throw _privateConstructorUsedError;
 
+  /// Serializes this FcmTokenUpdateResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of FcmTokenUpdateResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $FcmTokenUpdateResponseCopyWith<FcmTokenUpdateResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -50,6 +54,8 @@ class _$FcmTokenUpdateResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of FcmTokenUpdateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -91,6 +97,8 @@ class __$$FcmTokenUpdateResponseImplCopyWithImpl<$Res>
       $Res Function(_$FcmTokenUpdateResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of FcmTokenUpdateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -139,11 +147,13 @@ class _$FcmTokenUpdateResponseImpl implements _FcmTokenUpdateResponse {
                 other.fcmVerify == fcmVerify));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, token, fcmVerify);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of FcmTokenUpdateResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$FcmTokenUpdateResponseImplCopyWith<_$FcmTokenUpdateResponseImpl>
@@ -170,8 +180,11 @@ abstract class _FcmTokenUpdateResponse implements FcmTokenUpdateResponse {
   String? get token;
   @override
   String? get fcmVerify;
+
+  /// Create a copy of FcmTokenUpdateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$FcmTokenUpdateResponseImplCopyWith<_$FcmTokenUpdateResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/auth/notification_settings_request.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/auth/notification_settings_request.freezed.dart
@@ -25,8 +25,12 @@ mixin _$NotificationSettingsRequest {
   List<NotificationSettingsRegion>? get regions =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this NotificationSettingsRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationSettingsRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NotificationSettingsRequestCopyWith<NotificationSettingsRequest>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -57,6 +61,8 @@ class _$NotificationSettingsRequestCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NotificationSettingsRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -75,6 +81,8 @@ class _$NotificationSettingsRequestCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of NotificationSettingsRequest
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $NotificationSettingsGlobalCopyWith<$Res>? get global {
@@ -115,6 +123,8 @@ class __$$NotificationSettingsRequestImplCopyWithImpl<$Res>
       $Res Function(_$NotificationSettingsRequestImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationSettingsRequest
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -172,12 +182,14 @@ class _$NotificationSettingsRequestImpl
             const DeepCollectionEquality().equals(other._regions, _regions));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, global, const DeepCollectionEquality().hash(_regions));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationSettingsRequest
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NotificationSettingsRequestImplCopyWith<_$NotificationSettingsRequestImpl>
@@ -206,8 +218,11 @@ abstract class _NotificationSettingsRequest
   NotificationSettingsGlobal? get global;
   @override
   List<NotificationSettingsRegion>? get regions;
+
+  /// Create a copy of NotificationSettingsRequest
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NotificationSettingsRequestImplCopyWith<_$NotificationSettingsRequestImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -222,8 +237,12 @@ mixin _$NotificationSettingsGlobal {
   JmaForecastIntensity get minJmaIntensity =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this NotificationSettingsGlobal to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationSettingsGlobal
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NotificationSettingsGlobalCopyWith<NotificationSettingsGlobal>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -249,6 +268,8 @@ class _$NotificationSettingsGlobalCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NotificationSettingsGlobal
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -285,6 +306,8 @@ class __$$NotificationSettingsGlobalImplCopyWithImpl<$Res>
       $Res Function(_$NotificationSettingsGlobalImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationSettingsGlobal
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -325,11 +348,13 @@ class _$NotificationSettingsGlobalImpl implements _NotificationSettingsGlobal {
                 other.minJmaIntensity == minJmaIntensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, minJmaIntensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationSettingsGlobal
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NotificationSettingsGlobalImplCopyWith<_$NotificationSettingsGlobalImpl>
@@ -355,8 +380,11 @@ abstract class _NotificationSettingsGlobal
 
   @override
   JmaForecastIntensity get minJmaIntensity;
+
+  /// Create a copy of NotificationSettingsGlobal
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NotificationSettingsGlobalImplCopyWith<_$NotificationSettingsGlobalImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -371,8 +399,12 @@ mixin _$NotificationSettingsRegion {
   int get code => throw _privateConstructorUsedError;
   JmaForecastIntensity get minIntensity => throw _privateConstructorUsedError;
 
+  /// Serializes this NotificationSettingsRegion to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationSettingsRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NotificationSettingsRegionCopyWith<NotificationSettingsRegion>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -398,6 +430,8 @@ class _$NotificationSettingsRegionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NotificationSettingsRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -439,6 +473,8 @@ class __$$NotificationSettingsRegionImplCopyWithImpl<$Res>
       $Res Function(_$NotificationSettingsRegionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationSettingsRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -488,11 +524,13 @@ class _$NotificationSettingsRegionImpl implements _NotificationSettingsRegion {
                 other.minIntensity == minIntensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, minIntensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationSettingsRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NotificationSettingsRegionImplCopyWith<_$NotificationSettingsRegionImpl>
@@ -521,8 +559,11 @@ abstract class _NotificationSettingsRegion
   int get code;
   @override
   JmaForecastIntensity get minIntensity;
+
+  /// Create a copy of NotificationSettingsRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NotificationSettingsRegionImplCopyWith<_$NotificationSettingsRegionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/auth/notification_settings_response.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/auth/notification_settings_response.freezed.dart
@@ -25,8 +25,12 @@ mixin _$NotificationSettingsResponse {
       throw _privateConstructorUsedError;
   List<DevicesEewSettings> get eew => throw _privateConstructorUsedError;
 
+  /// Serializes this NotificationSettingsResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NotificationSettingsResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NotificationSettingsResponseCopyWith<NotificationSettingsResponse>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -55,6 +59,8 @@ class _$NotificationSettingsResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NotificationSettingsResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -98,6 +104,8 @@ class __$$NotificationSettingsResponseImplCopyWithImpl<$Res>
       $Res Function(_$NotificationSettingsResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NotificationSettingsResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -162,14 +170,16 @@ class _$NotificationSettingsResponseImpl
             const DeepCollectionEquality().equals(other._eew, _eew));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_earthquake),
       const DeepCollectionEquality().hash(_eew));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NotificationSettingsResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NotificationSettingsResponseImplCopyWith<
@@ -199,8 +209,11 @@ abstract class _NotificationSettingsResponse
   List<DevicesEarthquakeSettings> get earthquake;
   @override
   List<DevicesEewSettings> get eew;
+
+  /// Create a copy of NotificationSettingsResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NotificationSettingsResponseImplCopyWith<
           _$NotificationSettingsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/eqapi_types/lib/model/v1/devices_earthquake_settings.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/devices_earthquake_settings.freezed.dart
@@ -28,8 +28,12 @@ mixin _$DevicesEarthquakeSettings {
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
 
+  /// Serializes this DevicesEarthquakeSettings to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of DevicesEarthquakeSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DevicesEarthquakeSettingsCopyWith<DevicesEarthquakeSettings> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -59,6 +63,8 @@ class _$DevicesEarthquakeSettingsCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of DevicesEarthquakeSettings
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -120,6 +126,8 @@ class __$$DevicesEarthquakeSettingsImplCopyWithImpl<$Res>
       $Res Function(_$DevicesEarthquakeSettingsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of DevicesEarthquakeSettings
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -199,12 +207,14 @@ class _$DevicesEarthquakeSettingsImpl implements _DevicesEarthquakeSettings {
                 other.updatedAt == updatedAt));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, id, minJmaIntensity, regionId, createdAt, updatedAt);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of DevicesEarthquakeSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DevicesEarthquakeSettingsImplCopyWith<_$DevicesEarthquakeSettingsImpl>
@@ -240,8 +250,11 @@ abstract class _DevicesEarthquakeSettings implements DevicesEarthquakeSettings {
   DateTime get createdAt;
   @override
   DateTime get updatedAt;
+
+  /// Create a copy of DevicesEarthquakeSettings
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DevicesEarthquakeSettingsImplCopyWith<_$DevicesEarthquakeSettingsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/devices_eew_settings.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/devices_eew_settings.freezed.dart
@@ -27,8 +27,12 @@ mixin _$DevicesEewSettings {
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
 
+  /// Serializes this DevicesEewSettings to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of DevicesEewSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DevicesEewSettingsCopyWith<DevicesEewSettings> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -57,6 +61,8 @@ class _$DevicesEewSettingsCopyWithImpl<$Res, $Val extends DevicesEewSettings>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of DevicesEewSettings
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -115,6 +121,8 @@ class __$$DevicesEewSettingsImplCopyWithImpl<$Res>
       $Res Function(_$DevicesEewSettingsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of DevicesEewSettings
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -194,12 +202,14 @@ class _$DevicesEewSettingsImpl implements _DevicesEewSettings {
                 other.updatedAt == updatedAt));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, id, minJmaIntensity, regionId, createdAt, updatedAt);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of DevicesEewSettings
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DevicesEewSettingsImplCopyWith<_$DevicesEewSettingsImpl> get copyWith =>
@@ -235,8 +245,11 @@ abstract class _DevicesEewSettings implements DevicesEewSettings {
   DateTime get createdAt;
   @override
   DateTime get updatedAt;
+
+  /// Create a copy of DevicesEewSettings
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DevicesEewSettingsImplCopyWith<_$DevicesEewSettingsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/earthquake.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/earthquake.freezed.dart
@@ -51,8 +51,12 @@ mixin _$EarthquakeV1 {
   String get status => throw _privateConstructorUsedError;
   String? get text => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeV1 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeV1CopyWith<EarthquakeV1> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -99,6 +103,8 @@ class _$EarthquakeV1CopyWithImpl<$Res, $Val extends EarthquakeV1>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -265,6 +271,8 @@ class __$$EarthquakeV1ImplCopyWithImpl<$Res>
       _$EarthquakeV1Impl _value, $Res Function(_$EarthquakeV1Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -600,7 +608,7 @@ class _$EarthquakeV1Impl implements _EarthquakeV1 {
             (identical(other.text, text) || other.text == text));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hashAll([
         runtimeType,
@@ -629,7 +637,9 @@ class _$EarthquakeV1Impl implements _EarthquakeV1 {
         text
       ]);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeV1ImplCopyWith<_$EarthquakeV1Impl> get copyWith =>
@@ -718,8 +728,11 @@ abstract class _EarthquakeV1 implements EarthquakeV1 {
   String get status;
   @override
   String? get text;
+
+  /// Create a copy of EarthquakeV1
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeV1ImplCopyWith<_$EarthquakeV1Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -747,8 +760,12 @@ mixin _$EarthquakeV1Base {
   String get status => throw _privateConstructorUsedError;
   String? get text => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeV1Base to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeV1Base
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeV1BaseCopyWith<EarthquakeV1Base> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -788,6 +805,8 @@ class _$EarthquakeV1BaseCopyWithImpl<$Res, $Val extends EarthquakeV1Base>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeV1Base
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -912,6 +931,8 @@ class __$$EarthquakeV1BaseImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeV1BaseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeV1Base
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1108,7 +1129,7 @@ class _$EarthquakeV1BaseImpl implements _EarthquakeV1Base {
             (identical(other.text, text) || other.text == text));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1129,7 +1150,9 @@ class _$EarthquakeV1BaseImpl implements _EarthquakeV1Base {
       status,
       text);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeV1Base
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeV1BaseImplCopyWith<_$EarthquakeV1BaseImpl> get copyWith =>
@@ -1198,8 +1221,11 @@ abstract class _EarthquakeV1Base implements EarthquakeV1Base {
   String get status;
   @override
   String? get text;
+
+  /// Create a copy of EarthquakeV1Base
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeV1BaseImplCopyWith<_$EarthquakeV1BaseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1216,8 +1242,12 @@ mixin _$ObservedRegionIntensity {
   @JsonKey(name: 'maxInt')
   JmaIntensity? get intensity => throw _privateConstructorUsedError;
 
+  /// Serializes this ObservedRegionIntensity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ObservedRegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ObservedRegionIntensityCopyWith<ObservedRegionIntensity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1245,6 +1275,8 @@ class _$ObservedRegionIntensityCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ObservedRegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1294,6 +1326,8 @@ class __$$ObservedRegionIntensityImplCopyWithImpl<$Res>
       $Res Function(_$ObservedRegionIntensityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ObservedRegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1353,11 +1387,13 @@ class _$ObservedRegionIntensityImpl implements _ObservedRegionIntensity {
                 other.intensity == intensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name, intensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ObservedRegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ObservedRegionIntensityImplCopyWith<_$ObservedRegionIntensityImpl>
@@ -1389,8 +1425,11 @@ abstract class _ObservedRegionIntensity implements ObservedRegionIntensity {
   @override
   @JsonKey(name: 'maxInt')
   JmaIntensity? get intensity;
+
+  /// Create a copy of ObservedRegionIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ObservedRegionIntensityImplCopyWith<_$ObservedRegionIntensityImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1409,8 +1448,12 @@ mixin _$ObservedRegionLpgmIntensity {
   @JsonKey(name: 'maxLgInt')
   JmaLgIntensity? get lpgmIntensity => throw _privateConstructorUsedError;
 
+  /// Serializes this ObservedRegionLpgmIntensity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ObservedRegionLpgmIntensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ObservedRegionLpgmIntensityCopyWith<ObservedRegionLpgmIntensity>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1441,6 +1484,8 @@ class _$ObservedRegionLpgmIntensityCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ObservedRegionLpgmIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1496,6 +1541,8 @@ class __$$ObservedRegionLpgmIntensityImplCopyWithImpl<$Res>
       $Res Function(_$ObservedRegionLpgmIntensityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ObservedRegionLpgmIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1568,12 +1615,14 @@ class _$ObservedRegionLpgmIntensityImpl
                 other.lpgmIntensity == lpgmIntensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, code, name, intensity, lpgmIntensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ObservedRegionLpgmIntensity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ObservedRegionLpgmIntensityImplCopyWith<_$ObservedRegionLpgmIntensityImpl>
@@ -1611,8 +1660,11 @@ abstract class _ObservedRegionLpgmIntensity
   @override
   @JsonKey(name: 'maxLgInt')
   JmaLgIntensity? get lpgmIntensity;
+
+  /// Create a copy of ObservedRegionLpgmIntensity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ObservedRegionLpgmIntensityImplCopyWith<_$ObservedRegionLpgmIntensityImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/earthquake_early.dart
+++ b/packages/eqapi_types/lib/model/v1/earthquake_early.dart
@@ -70,7 +70,7 @@ class EarthquakeEarlyRegion with _$EarthquakeEarlyRegion {
 class EarthquakeEarlyCity with _$EarthquakeEarlyCity {
   const factory EarthquakeEarlyCity({
     required String name,
-    required String code,
+    required String? code,
     required JmaForecastIntensity maxIntensity,
     required List<EarthquakeEarlyObservationPoint> observationPoints,
   }) = _EarthquakeEarlyCity;

--- a/packages/eqapi_types/lib/model/v1/earthquake_early.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/earthquake_early.freezed.dart
@@ -32,8 +32,12 @@ mixin _$EarthquakeEarly {
   OriginTimePrecision get originTimePrecision =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarly to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarly
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyCopyWith<EarthquakeEarly> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -67,6 +71,8 @@ class _$EarthquakeEarlyCopyWithImpl<$Res, $Val extends EarthquakeEarly>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarly
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -155,6 +161,8 @@ class __$$EarthquakeEarlyImplCopyWithImpl<$Res>
       _$EarthquakeEarlyImpl _value, $Res Function(_$EarthquakeEarlyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarly
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -282,7 +290,7 @@ class _$EarthquakeEarlyImpl implements _EarthquakeEarly {
                 other.originTimePrecision == originTimePrecision));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -297,7 +305,9 @@ class _$EarthquakeEarlyImpl implements _EarthquakeEarly {
       originTime,
       originTimePrecision);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarly
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyImplCopyWith<_$EarthquakeEarlyImpl> get copyWith =>
@@ -349,8 +359,11 @@ abstract class _EarthquakeEarly implements EarthquakeEarly {
   DateTime get originTime;
   @override
   OriginTimePrecision get originTimePrecision;
+
+  /// Create a copy of EarthquakeEarly
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyImplCopyWith<_$EarthquakeEarlyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -375,8 +388,12 @@ mixin _$EarthquakeEarlyEvent {
   List<EarthquakeEarlyRegion> get regions => throw _privateConstructorUsedError;
   List<EarthquakeEarlyCity> get cities => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyEvent to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyEventCopyWith<EarthquakeEarlyEvent> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -413,6 +430,8 @@ class _$EarthquakeEarlyEventCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -513,6 +532,8 @@ class __$$EarthquakeEarlyEventImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyEventImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -669,7 +690,7 @@ class _$EarthquakeEarlyEventImpl implements _EarthquakeEarlyEvent {
             const DeepCollectionEquality().equals(other._cities, _cities));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -686,7 +707,9 @@ class _$EarthquakeEarlyEventImpl implements _EarthquakeEarlyEvent {
       const DeepCollectionEquality().hash(_regions),
       const DeepCollectionEquality().hash(_cities));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyEventImplCopyWith<_$EarthquakeEarlyEventImpl>
@@ -745,8 +768,11 @@ abstract class _EarthquakeEarlyEvent implements EarthquakeEarlyEvent {
   List<EarthquakeEarlyRegion> get regions;
   @override
   List<EarthquakeEarlyCity> get cities;
+
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyEventImplCopyWith<_$EarthquakeEarlyEventImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -762,8 +788,12 @@ mixin _$EarthquakeEarlyRegion {
   String get code => throw _privateConstructorUsedError;
   JmaForecastIntensity get maxIntensity => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyRegion to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyRegionCopyWith<EarthquakeEarlyRegion> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -788,6 +818,8 @@ class _$EarthquakeEarlyRegionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -833,6 +865,8 @@ class __$$EarthquakeEarlyRegionImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyRegionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -889,11 +923,13 @@ class _$EarthquakeEarlyRegionImpl implements _EarthquakeEarlyRegion {
                 other.maxIntensity == maxIntensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, code, maxIntensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyRegionImplCopyWith<_$EarthquakeEarlyRegionImpl>
@@ -924,8 +960,11 @@ abstract class _EarthquakeEarlyRegion implements EarthquakeEarlyRegion {
   String get code;
   @override
   JmaForecastIntensity get maxIntensity;
+
+  /// Create a copy of EarthquakeEarlyRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyRegionImplCopyWith<_$EarthquakeEarlyRegionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -937,13 +976,17 @@ EarthquakeEarlyCity _$EarthquakeEarlyCityFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$EarthquakeEarlyCity {
   String get name => throw _privateConstructorUsedError;
-  String get code => throw _privateConstructorUsedError;
+  String? get code => throw _privateConstructorUsedError;
   JmaForecastIntensity get maxIntensity => throw _privateConstructorUsedError;
   List<EarthquakeEarlyObservationPoint> get observationPoints =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyCity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyCity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyCityCopyWith<EarthquakeEarlyCity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -956,7 +999,7 @@ abstract class $EarthquakeEarlyCityCopyWith<$Res> {
   @useResult
   $Res call(
       {String name,
-      String code,
+      String? code,
       JmaForecastIntensity maxIntensity,
       List<EarthquakeEarlyObservationPoint> observationPoints});
 }
@@ -971,11 +1014,13 @@ class _$EarthquakeEarlyCityCopyWithImpl<$Res, $Val extends EarthquakeEarlyCity>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyCity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? name = null,
-    Object? code = null,
+    Object? code = freezed,
     Object? maxIntensity = null,
     Object? observationPoints = null,
   }) {
@@ -984,10 +1029,10 @@ class _$EarthquakeEarlyCityCopyWithImpl<$Res, $Val extends EarthquakeEarlyCity>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      code: null == code
+      code: freezed == code
           ? _value.code
           : code // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       maxIntensity: null == maxIntensity
           ? _value.maxIntensity
           : maxIntensity // ignore: cast_nullable_to_non_nullable
@@ -1010,7 +1055,7 @@ abstract class _$$EarthquakeEarlyCityImplCopyWith<$Res>
   @useResult
   $Res call(
       {String name,
-      String code,
+      String? code,
       JmaForecastIntensity maxIntensity,
       List<EarthquakeEarlyObservationPoint> observationPoints});
 }
@@ -1023,11 +1068,13 @@ class __$$EarthquakeEarlyCityImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyCityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyCity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? name = null,
-    Object? code = null,
+    Object? code = freezed,
     Object? maxIntensity = null,
     Object? observationPoints = null,
   }) {
@@ -1036,10 +1083,10 @@ class __$$EarthquakeEarlyCityImplCopyWithImpl<$Res>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      code: null == code
+      code: freezed == code
           ? _value.code
           : code // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       maxIntensity: null == maxIntensity
           ? _value.maxIntensity
           : maxIntensity // ignore: cast_nullable_to_non_nullable
@@ -1068,7 +1115,7 @@ class _$EarthquakeEarlyCityImpl implements _EarthquakeEarlyCity {
   @override
   final String name;
   @override
-  final String code;
+  final String? code;
   @override
   final JmaForecastIntensity maxIntensity;
   final List<EarthquakeEarlyObservationPoint> _observationPoints;
@@ -1098,12 +1145,14 @@ class _$EarthquakeEarlyCityImpl implements _EarthquakeEarlyCity {
                 .equals(other._observationPoints, _observationPoints));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, code, maxIntensity,
       const DeepCollectionEquality().hash(_observationPoints));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyCity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyCityImplCopyWith<_$EarthquakeEarlyCityImpl> get copyWith =>
@@ -1121,7 +1170,7 @@ class _$EarthquakeEarlyCityImpl implements _EarthquakeEarlyCity {
 abstract class _EarthquakeEarlyCity implements EarthquakeEarlyCity {
   const factory _EarthquakeEarlyCity(
       {required final String name,
-      required final String code,
+      required final String? code,
       required final JmaForecastIntensity maxIntensity,
       required final List<EarthquakeEarlyObservationPoint>
           observationPoints}) = _$EarthquakeEarlyCityImpl;
@@ -1132,13 +1181,16 @@ abstract class _EarthquakeEarlyCity implements EarthquakeEarlyCity {
   @override
   String get name;
   @override
-  String get code;
+  String? get code;
   @override
   JmaForecastIntensity get maxIntensity;
   @override
   List<EarthquakeEarlyObservationPoint> get observationPoints;
+
+  /// Create a copy of EarthquakeEarlyCity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyCityImplCopyWith<_$EarthquakeEarlyCityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1155,8 +1207,12 @@ mixin _$EarthquakeEarlyObservationPoint {
   double get lon => throw _privateConstructorUsedError;
   JmaForecastIntensity get intensity => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyObservationPoint to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyObservationPointCopyWith<EarthquakeEarlyObservationPoint>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1184,6 +1240,8 @@ class _$EarthquakeEarlyObservationPointCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1236,6 +1294,8 @@ class __$$EarthquakeEarlyObservationPointImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyObservationPointImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1305,11 +1365,13 @@ class _$EarthquakeEarlyObservationPointImpl
                 other.intensity == intensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, lat, lon, intensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyObservationPointImplCopyWith<
@@ -1345,8 +1407,11 @@ abstract class _EarthquakeEarlyObservationPoint
   double get lon;
   @override
   JmaForecastIntensity get intensity;
+
+  /// Create a copy of EarthquakeEarlyObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyObservationPointImplCopyWith<
           _$EarthquakeEarlyObservationPointImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/eqapi_types/lib/model/v1/earthquake_early.g.dart
+++ b/packages/eqapi_types/lib/model/v1/earthquake_early.g.dart
@@ -177,7 +177,7 @@ _$EarthquakeEarlyCityImpl _$$EarthquakeEarlyCityImplFromJson(
       ($checkedConvert) {
         final val = _$EarthquakeEarlyCityImpl(
           name: $checkedConvert('name', (v) => v as String),
-          code: $checkedConvert('code', (v) => v as String),
+          code: $checkedConvert('code', (v) => v as String?),
           maxIntensity: $checkedConvert('max_intensity',
               (v) => $enumDecode(_$JmaForecastIntensityEnumMap, v)),
           observationPoints: $checkedConvert(

--- a/packages/eqapi_types/lib/model/v1/earthquake_early_event.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/earthquake_early_event.freezed.dart
@@ -35,8 +35,12 @@ mixin _$EarthquakeEarlyEvent {
   List<EarthquakeEarlyEventObservationCity> get cities =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyEvent to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyEventCopyWith<EarthquakeEarlyEvent> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -72,6 +76,8 @@ class _$EarthquakeEarlyEventCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -166,6 +172,8 @@ class __$$EarthquakeEarlyEventImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyEventImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -314,7 +322,7 @@ class _$EarthquakeEarlyEventImpl implements _EarthquakeEarlyEvent {
             const DeepCollectionEquality().equals(other._cities, _cities));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -330,7 +338,9 @@ class _$EarthquakeEarlyEventImpl implements _EarthquakeEarlyEvent {
       const DeepCollectionEquality().hash(_regions),
       const DeepCollectionEquality().hash(_cities));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyEventImplCopyWith<_$EarthquakeEarlyEventImpl>
@@ -386,8 +396,11 @@ abstract class _EarthquakeEarlyEvent implements EarthquakeEarlyEvent {
   List<EarthquakeEarlyEventRegion> get regions;
   @override
   List<EarthquakeEarlyEventObservationCity> get cities;
+
+  /// Create a copy of EarthquakeEarlyEvent
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyEventImplCopyWith<_$EarthquakeEarlyEventImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -403,8 +416,12 @@ mixin _$EarthquakeEarlyEventRegion {
   String? get code => throw _privateConstructorUsedError;
   JmaIntensity? get maxIntensity => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyEventRegion to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyEventRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyEventRegionCopyWith<EarthquakeEarlyEventRegion>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -430,6 +447,8 @@ class _$EarthquakeEarlyEventRegionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyEventRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -476,6 +495,8 @@ class __$$EarthquakeEarlyEventRegionImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyEventRegionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyEventRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -533,11 +554,13 @@ class _$EarthquakeEarlyEventRegionImpl implements _EarthquakeEarlyEventRegion {
                 other.maxIntensity == maxIntensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, code, maxIntensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyEventRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyEventRegionImplCopyWith<_$EarthquakeEarlyEventRegionImpl>
@@ -569,8 +592,11 @@ abstract class _EarthquakeEarlyEventRegion
   String? get code;
   @override
   JmaIntensity? get maxIntensity;
+
+  /// Create a copy of EarthquakeEarlyEventRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyEventRegionImplCopyWith<_$EarthquakeEarlyEventRegionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -588,8 +614,12 @@ mixin _$EarthquakeEarlyEventObservationCity {
   List<EarthquakeEarlyEventObservationPoint> get observationPoints =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyEventObservationCity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyEventObservationCity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyEventObservationCityCopyWith<
           EarthquakeEarlyEventObservationCity>
       get copyWith => throw _privateConstructorUsedError;
@@ -621,6 +651,8 @@ class _$EarthquakeEarlyEventObservationCityCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyEventObservationCity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -676,6 +708,8 @@ class __$$EarthquakeEarlyEventObservationCityImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyEventObservationCityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyEventObservationCity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -754,12 +788,14 @@ class _$EarthquakeEarlyEventObservationCityImpl
                 .equals(other._observationPoints, _observationPoints));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, code, maxIntensity,
       const DeepCollectionEquality().hash(_observationPoints));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyEventObservationCity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyEventObservationCityImplCopyWith<
@@ -796,8 +832,11 @@ abstract class _EarthquakeEarlyEventObservationCity
   JmaIntensity? get maxIntensity;
   @override
   List<EarthquakeEarlyEventObservationPoint> get observationPoints;
+
+  /// Create a copy of EarthquakeEarlyEventObservationCity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyEventObservationCityImplCopyWith<
           _$EarthquakeEarlyEventObservationCityImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -815,8 +854,12 @@ mixin _$EarthquakeEarlyEventObservationPoint {
   String get name => throw _privateConstructorUsedError;
   JmaIntensity get intensity => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeEarlyEventObservationPoint to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeEarlyEventObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeEarlyEventObservationPointCopyWith<
           EarthquakeEarlyEventObservationPoint>
       get copyWith => throw _privateConstructorUsedError;
@@ -844,6 +887,8 @@ class _$EarthquakeEarlyEventObservationPointCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeEarlyEventObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -895,6 +940,8 @@ class __$$EarthquakeEarlyEventObservationPointImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeEarlyEventObservationPointImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeEarlyEventObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -964,11 +1011,13 @@ class _$EarthquakeEarlyEventObservationPointImpl
                 other.intensity == intensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, lat, lon, name, intensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeEarlyEventObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeEarlyEventObservationPointImplCopyWith<
@@ -1005,8 +1054,11 @@ abstract class _EarthquakeEarlyEventObservationPoint
   String get name;
   @override
   JmaIntensity get intensity;
+
+  /// Create a copy of EarthquakeEarlyEventObservationPoint
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeEarlyEventObservationPointImplCopyWith<
           _$EarthquakeEarlyEventObservationPointImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/eqapi_types/lib/model/v1/eew.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/eew.freezed.dart
@@ -51,8 +51,12 @@ mixin _$EewV1 {
   bool? get isPlum => throw _privateConstructorUsedError;
   EewAccuracy? get accuracy => throw _privateConstructorUsedError;
 
+  /// Serializes this EewV1 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EewV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EewV1CopyWith<EewV1> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -102,6 +106,8 @@ class _$EewV1CopyWithImpl<$Res, $Val extends EewV1>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EewV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -240,6 +246,8 @@ class _$EewV1CopyWithImpl<$Res, $Val extends EewV1>
     ) as $Val);
   }
 
+  /// Create a copy of EewV1
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EewAccuracyCopyWith<$Res>? get accuracy {
@@ -300,6 +308,8 @@ class __$$EewV1ImplCopyWithImpl<$Res>
       _$EewV1Impl _value, $Res Function(_$EewV1Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EewV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -597,7 +607,7 @@ class _$EewV1Impl implements _EewV1 {
                 other.accuracy == accuracy));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hashAll([
         runtimeType,
@@ -629,7 +639,9 @@ class _$EewV1Impl implements _EewV1 {
         accuracy
       ]);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EewV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EewV1ImplCopyWith<_$EewV1Impl> get copyWith =>
@@ -726,8 +738,11 @@ abstract class _EewV1 implements EewV1 {
   bool? get isPlum;
   @override
   EewAccuracy? get accuracy;
+
+  /// Create a copy of EewV1
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EewV1ImplCopyWith<_$EewV1Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -754,8 +769,12 @@ mixin _$EstimatedIntensityRegion {
   @JsonKey(name: 'arrivalTime')
   DateTime? get arrivalTime => throw _privateConstructorUsedError;
 
+  /// Serializes this EstimatedIntensityRegion to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EstimatedIntensityRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EstimatedIntensityRegionCopyWith<EstimatedIntensityRegion> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -790,6 +809,8 @@ class _$EstimatedIntensityRegionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EstimatedIntensityRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -833,6 +854,8 @@ class _$EstimatedIntensityRegionCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of EstimatedIntensityRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ForecastMaxIntCopyWith<$Res> get forecastMaxInt {
@@ -841,6 +864,8 @@ class _$EstimatedIntensityRegionCopyWithImpl<$Res,
     });
   }
 
+  /// Create a copy of EstimatedIntensityRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ForecastMaxLgIntCopyWith<$Res>? get forecastMaxLgInt {
@@ -888,6 +913,8 @@ class __$$EstimatedIntensityRegionImplCopyWithImpl<$Res>
       $Res Function(_$EstimatedIntensityRegionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EstimatedIntensityRegion
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -992,12 +1019,14 @@ class _$EstimatedIntensityRegionImpl implements _EstimatedIntensityRegion {
                 other.arrivalTime == arrivalTime));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name, isPlum, isWarning,
       forecastMaxInt, forecastMaxLgInt, arrivalTime);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EstimatedIntensityRegion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EstimatedIntensityRegionImplCopyWith<_$EstimatedIntensityRegionImpl>
@@ -1044,13 +1073,16 @@ abstract class _EstimatedIntensityRegion implements EstimatedIntensityRegion {
   @override
   @JsonKey(name: 'forecastMaxLgInt')
   ForecastMaxLgInt? get forecastMaxLgInt;
-  @override
 
   /// nullの場合 `既に主要動到達と推測`
+  @override
   @JsonKey(name: 'arrivalTime')
   DateTime? get arrivalTime;
+
+  /// Create a copy of EstimatedIntensityRegion
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EstimatedIntensityRegionImplCopyWith<_$EstimatedIntensityRegionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1072,8 +1104,12 @@ mixin _$EewAccuracy {
   @JsonKey(fromJson: int.parse, toJson: intToString)
   int get numberOfMagnitudeCalculation => throw _privateConstructorUsedError;
 
+  /// Serializes this EewAccuracy to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EewAccuracyCopyWith<EewAccuracy> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1104,6 +1140,8 @@ class _$EewAccuracyCopyWithImpl<$Res, $Val extends EewAccuracy>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1159,6 +1197,8 @@ class __$$EewAccuracyImplCopyWithImpl<$Res>
       _$EewAccuracyImpl _value, $Res Function(_$EewAccuracyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1250,7 +1290,7 @@ class _$EewAccuracyImpl implements _EewAccuracy {
                     numberOfMagnitudeCalculation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1259,7 +1299,9 @@ class _$EewAccuracyImpl implements _EewAccuracy {
       magnitudeCalculation,
       numberOfMagnitudeCalculation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EewAccuracyImplCopyWith<_$EewAccuracyImpl> get copyWith =>
@@ -1287,10 +1329,9 @@ abstract class _EewAccuracy implements EewAccuracy {
   factory _EewAccuracy.fromJson(Map<String, dynamic> json) =
       _$EewAccuracyImpl.fromJson;
 
-  @override
-
   /// ['0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8',
   /// '0' | '1' | '2' | '3' | '4' | '9']
+  @override
   @JsonKey(fromJson: stringListToIntList, toJson: intListToStringList)
   List<int> get epicenters;
   @override
@@ -1302,8 +1343,11 @@ abstract class _EewAccuracy implements EewAccuracy {
   @override
   @JsonKey(fromJson: int.parse, toJson: intToString)
   int get numberOfMagnitudeCalculation;
+
+  /// Create a copy of EewAccuracy
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EewAccuracyImplCopyWith<_$EewAccuracyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/information.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/information.freezed.dart
@@ -35,8 +35,12 @@ mixin _$InformationV1 {
   String get title => throw _privateConstructorUsedError;
   String get type => throw _privateConstructorUsedError;
 
+  /// Serializes this InformationV1 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InformationV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $InformationV1CopyWith<InformationV1> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -73,6 +77,8 @@ class _$InformationV1CopyWithImpl<$Res, $Val extends InformationV1>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of InformationV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -149,6 +155,8 @@ class __$$InformationV1ImplCopyWithImpl<$Res>
       _$InformationV1Impl _value, $Res Function(_$InformationV1Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InformationV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -263,7 +271,7 @@ class _$InformationV1Impl implements _InformationV1 {
             (identical(other.type, type) || other.type == type));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -275,7 +283,9 @@ class _$InformationV1Impl implements _InformationV1 {
       title,
       type);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InformationV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InformationV1ImplCopyWith<_$InformationV1Impl> get copyWith =>
@@ -329,8 +339,11 @@ abstract class _InformationV1 implements InformationV1 {
   String get title;
   @override
   String get type;
+
+  /// Create a copy of InformationV1
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InformationV1ImplCopyWith<_$InformationV1Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/intensity_sub_division.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/intensity_sub_division.freezed.dart
@@ -26,8 +26,12 @@ mixin _$IntensitySubDivision {
   JmaIntensity get maxIntensity => throw _privateConstructorUsedError;
   JmaLgIntensity? get maxLpgmIntensity => throw _privateConstructorUsedError;
 
+  /// Serializes this IntensitySubDivision to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of IntensitySubDivision
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $IntensitySubDivisionCopyWith<IntensitySubDivision> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -57,6 +61,8 @@ class _$IntensitySubDivisionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of IntensitySubDivision
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -115,6 +121,8 @@ class __$$IntensitySubDivisionImplCopyWithImpl<$Res>
       $Res Function(_$IntensitySubDivisionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of IntensitySubDivision
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -193,12 +201,14 @@ class _$IntensitySubDivisionImpl implements _IntensitySubDivision {
                 other.maxLpgmIntensity == maxLpgmIntensity));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, id, eventId, areaCode, maxIntensity, maxLpgmIntensity);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of IntensitySubDivision
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$IntensitySubDivisionImplCopyWith<_$IntensitySubDivisionImpl>
@@ -236,8 +246,11 @@ abstract class _IntensitySubDivision implements IntensitySubDivision {
   JmaIntensity get maxIntensity;
   @override
   JmaLgIntensity? get maxLpgmIntensity;
+
+  /// Create a copy of IntensitySubDivision
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$IntensitySubDivisionImplCopyWith<_$IntensitySubDivisionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/response/region.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/response/region.freezed.dart
@@ -27,8 +27,12 @@ mixin _$RegionItem {
   JmaLgIntensity? get maxLpgmIntensity => throw _privateConstructorUsedError;
   EarthquakeV1Base get earthquake => throw _privateConstructorUsedError;
 
+  /// Serializes this RegionItem to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RegionItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RegionItemCopyWith<RegionItem> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -60,6 +64,8 @@ class _$RegionItemCopyWithImpl<$Res, $Val extends RegionItem>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RegionItem
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -98,6 +104,8 @@ class _$RegionItemCopyWithImpl<$Res, $Val extends RegionItem>
     ) as $Val);
   }
 
+  /// Create a copy of RegionItem
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeV1BaseCopyWith<$Res> get earthquake {
@@ -135,6 +143,8 @@ class __$$RegionItemImplCopyWithImpl<$Res>
       _$RegionItemImpl _value, $Res Function(_$RegionItemImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RegionItem
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -223,12 +233,14 @@ class _$RegionItemImpl implements _RegionItem {
                 other.earthquake == earthquake));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, id, eventId, areaCode,
       maxIntensity, maxLpgmIntensity, earthquake);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RegionItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RegionItemImplCopyWith<_$RegionItemImpl> get copyWith =>
@@ -266,8 +278,11 @@ abstract class _RegionItem implements RegionItem {
   JmaLgIntensity? get maxLpgmIntensity;
   @override
   EarthquakeV1Base get earthquake;
+
+  /// Create a copy of RegionItem
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RegionItemImplCopyWith<_$RegionItemImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/telegram.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/telegram.freezed.dart
@@ -33,8 +33,12 @@ mixin _$TelegramV1 {
   String? get headline => throw _privateConstructorUsedError;
   Map<String, dynamic> get body => throw _privateConstructorUsedError;
 
+  /// Serializes this TelegramV1 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TelegramV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TelegramV1CopyWith<TelegramV1> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -70,6 +74,8 @@ class _$TelegramV1CopyWithImpl<$Res, $Val extends TelegramV1>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TelegramV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -170,6 +176,8 @@ class __$$TelegramV1ImplCopyWithImpl<$Res>
       _$TelegramV1Impl _value, $Res Function(_$TelegramV1Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TelegramV1
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -321,7 +329,7 @@ class _$TelegramV1Impl implements _TelegramV1 {
             const DeepCollectionEquality().equals(other._body, _body));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -338,7 +346,9 @@ class _$TelegramV1Impl implements _TelegramV1 {
       headline,
       const DeepCollectionEquality().hash(_body));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TelegramV1
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TelegramV1ImplCopyWith<_$TelegramV1Impl> get copyWith =>
@@ -394,8 +404,11 @@ abstract class _TelegramV1 implements TelegramV1 {
   String? get headline;
   @override
   Map<String, dynamic> get body;
+
+  /// Create a copy of TelegramV1
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TelegramV1ImplCopyWith<_$TelegramV1Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/tsunami.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/tsunami.freezed.dart
@@ -31,8 +31,12 @@ mixin _$TsunamiV1Base {
   String get type => throw _privateConstructorUsedError;
   DateTime? get validAt => throw _privateConstructorUsedError;
 
+  /// Serializes this _TsunamiV1Base to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of _TsunamiV1Base
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$TsunamiV1BaseCopyWith<_TsunamiV1Base> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -66,6 +70,8 @@ class __$TsunamiV1BaseCopyWithImpl<$Res, $Val extends _TsunamiV1Base>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of _TsunamiV1Base
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -154,6 +160,8 @@ class __$$_TsunamiV1BaseImplCopyWithImpl<$Res>
       _$_TsunamiV1BaseImpl _value, $Res Function(_$_TsunamiV1BaseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of _TsunamiV1Base
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -278,12 +286,14 @@ class _$_TsunamiV1BaseImpl implements __TsunamiV1Base {
             (identical(other.validAt, validAt) || other.validAt == validAt));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, eventId, headline, id, infoType,
       pressAt, reportAt, serialNo, status, type, validAt);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of _TsunamiV1Base
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$_TsunamiV1BaseImplCopyWith<_$_TsunamiV1BaseImpl> get copyWith =>
@@ -334,8 +344,11 @@ abstract class __TsunamiV1Base implements _TsunamiV1Base {
   String get type;
   @override
   DateTime? get validAt;
+
+  /// Create a copy of _TsunamiV1Base
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$_TsunamiV1BaseImplCopyWith<_$_TsunamiV1BaseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -349,8 +362,12 @@ mixin _$Comment {
   String? get free => throw _privateConstructorUsedError;
   CommentWarning? get warning => throw _privateConstructorUsedError;
 
+  /// Serializes this Comment to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Comment
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CommentCopyWith<Comment> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -374,6 +391,8 @@ class _$CommentCopyWithImpl<$Res, $Val extends Comment>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Comment
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -392,6 +411,8 @@ class _$CommentCopyWithImpl<$Res, $Val extends Comment>
     ) as $Val);
   }
 
+  /// Create a copy of Comment
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $CommentWarningCopyWith<$Res>? get warning {
@@ -426,6 +447,8 @@ class __$$CommentImplCopyWithImpl<$Res>
       _$CommentImpl _value, $Res Function(_$CommentImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Comment
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -472,11 +495,13 @@ class _$CommentImpl implements _Comment {
             (identical(other.warning, warning) || other.warning == warning));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, free, warning);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Comment
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
@@ -501,8 +526,11 @@ abstract class _Comment implements Comment {
   String? get free;
   @override
   CommentWarning? get warning;
+
+  /// Create a copy of Comment
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -516,8 +544,12 @@ mixin _$CommentWarning {
   String get text => throw _privateConstructorUsedError;
   List<String> get codes => throw _privateConstructorUsedError;
 
+  /// Serializes this CommentWarning to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of CommentWarning
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CommentWarningCopyWith<CommentWarning> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -541,6 +573,8 @@ class _$CommentWarningCopyWithImpl<$Res, $Val extends CommentWarning>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CommentWarning
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -579,6 +613,8 @@ class __$$CommentWarningImplCopyWithImpl<$Res>
       _$CommentWarningImpl _value, $Res Function(_$CommentWarningImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CommentWarning
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -632,12 +668,14 @@ class _$CommentWarningImpl implements _CommentWarning {
             const DeepCollectionEquality().equals(other._codes, _codes));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, text, const DeepCollectionEquality().hash(_codes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CommentWarning
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CommentWarningImplCopyWith<_$CommentWarningImpl> get copyWith =>
@@ -664,8 +702,11 @@ abstract class _CommentWarning implements CommentWarning {
   String get text;
   @override
   List<String> get codes;
+
+  /// Create a copy of CommentWarning
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CommentWarningImplCopyWith<_$CommentWarningImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -678,8 +719,12 @@ CancelBody _$CancelBodyFromJson(Map<String, dynamic> json) {
 mixin _$CancelBody {
   String get text => throw _privateConstructorUsedError;
 
+  /// Serializes this CancelBody to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of CancelBody
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CancelBodyCopyWith<CancelBody> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -703,6 +748,8 @@ class _$CancelBodyCopyWithImpl<$Res, $Val extends CancelBody>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CancelBody
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -736,6 +783,8 @@ class __$$CancelBodyImplCopyWithImpl<$Res>
       _$CancelBodyImpl _value, $Res Function(_$CancelBodyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CancelBody
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -774,11 +823,13 @@ class _$CancelBodyImpl implements _CancelBody {
             (identical(other.text, text) || other.text == text));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, text);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CancelBody
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CancelBodyImplCopyWith<_$CancelBodyImpl> get copyWith =>
@@ -800,8 +851,11 @@ abstract class _CancelBody implements CancelBody {
 
   @override
   String get text;
+
+  /// Create a copy of CancelBody
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CancelBodyImplCopyWith<_$CancelBodyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -815,8 +869,12 @@ PublicBodyVTSE41Tsunami _$PublicBodyVTSE41TsunamiFromJson(
 mixin _$PublicBodyVTSE41Tsunami {
   List<TsunamiForecast> get forecasts => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVTSE41Tsunami to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVTSE41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVTSE41TsunamiCopyWith<PublicBodyVTSE41Tsunami> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -841,6 +899,8 @@ class _$PublicBodyVTSE41TsunamiCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVTSE41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -877,6 +937,8 @@ class __$$PublicBodyVTSE41TsunamiImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVTSE41TsunamiImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVTSE41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -923,12 +985,14 @@ class _$PublicBodyVTSE41TsunamiImpl implements _PublicBodyVTSE41Tsunami {
                 .equals(other._forecasts, _forecasts));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_forecasts));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVTSE41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVTSE41TsunamiImplCopyWith<_$PublicBodyVTSE41TsunamiImpl>
@@ -953,8 +1017,11 @@ abstract class _PublicBodyVTSE41Tsunami implements PublicBodyVTSE41Tsunami {
 
   @override
   List<TsunamiForecast> get forecasts;
+
+  /// Create a copy of PublicBodyVTSE41Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVTSE41TsunamiImplCopyWith<_$PublicBodyVTSE41TsunamiImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -970,8 +1037,12 @@ mixin _$PublicBodyVTSE51Tsunami {
   List<TsunamiObservation>? get observations =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVTSE51Tsunami to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVTSE51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVTSE51TsunamiCopyWith<PublicBodyVTSE51Tsunami> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -998,6 +1069,8 @@ class _$PublicBodyVTSE51TsunamiCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVTSE51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1041,6 +1114,8 @@ class __$$PublicBodyVTSE51TsunamiImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVTSE51TsunamiImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVTSE51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1106,14 +1181,16 @@ class _$PublicBodyVTSE51TsunamiImpl implements _PublicBodyVTSE51Tsunami {
                 .equals(other._observations, _observations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_forecasts),
       const DeepCollectionEquality().hash(_observations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVTSE51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVTSE51TsunamiImplCopyWith<_$PublicBodyVTSE51TsunamiImpl>
@@ -1141,8 +1218,11 @@ abstract class _PublicBodyVTSE51Tsunami implements PublicBodyVTSE51Tsunami {
   List<TsunamiForecast> get forecasts;
   @override
   List<TsunamiObservation>? get observations;
+
+  /// Create a copy of PublicBodyVTSE51Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVTSE51TsunamiImplCopyWith<_$PublicBodyVTSE51TsunamiImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1158,8 +1238,12 @@ mixin _$PublicBodyVTSE52Tsunami {
       throw _privateConstructorUsedError;
   List<TsunamiEstimation> get estimations => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVTSE52Tsunami to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVTSE52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVTSE52TsunamiCopyWith<PublicBodyVTSE52Tsunami> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1186,6 +1270,8 @@ class _$PublicBodyVTSE52TsunamiCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVTSE52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1229,6 +1315,8 @@ class __$$PublicBodyVTSE52TsunamiImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVTSE52TsunamiImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVTSE52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1294,14 +1382,16 @@ class _$PublicBodyVTSE52TsunamiImpl implements _PublicBodyVTSE52Tsunami {
                 .equals(other._estimations, _estimations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_observations),
       const DeepCollectionEquality().hash(_estimations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVTSE52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVTSE52TsunamiImplCopyWith<_$PublicBodyVTSE52TsunamiImpl>
@@ -1329,8 +1419,11 @@ abstract class _PublicBodyVTSE52Tsunami implements PublicBodyVTSE52Tsunami {
   List<TsunamiObservation>? get observations;
   @override
   List<TsunamiEstimation> get estimations;
+
+  /// Create a copy of PublicBodyVTSE52Tsunami
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVTSE52TsunamiImplCopyWith<_$PublicBodyVTSE52TsunamiImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1351,8 +1444,12 @@ mixin _$TsunamiForecast {
   List<TsunamiForecastStation>? get stations =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecast to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastCopyWith<TsunamiForecast> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1386,6 +1483,8 @@ class _$TsunamiForecastCopyWithImpl<$Res, $Val extends TsunamiForecast>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1429,6 +1528,8 @@ class _$TsunamiForecastCopyWithImpl<$Res, $Val extends TsunamiForecast>
     ) as $Val);
   }
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TsunamiForecastFirstHeightCopyWith<$Res>? get firstHeight {
@@ -1442,6 +1543,8 @@ class _$TsunamiForecastCopyWithImpl<$Res, $Val extends TsunamiForecast>
     });
   }
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TsunamiForecastMaxHeightCopyWith<$Res>? get maxHeight {
@@ -1486,6 +1589,8 @@ class __$$TsunamiForecastImplCopyWithImpl<$Res>
       _$TsunamiForecastImpl _value, $Res Function(_$TsunamiForecastImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1591,12 +1696,14 @@ class _$TsunamiForecastImpl implements _TsunamiForecast {
             const DeepCollectionEquality().equals(other._stations, _stations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name, kind, lastKind,
       firstHeight, maxHeight, const DeepCollectionEquality().hash(_stations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastImplCopyWith<_$TsunamiForecastImpl> get copyWith =>
@@ -1639,8 +1746,11 @@ abstract class _TsunamiForecast implements TsunamiForecast {
   TsunamiForecastMaxHeight? get maxHeight;
   @override
   List<TsunamiForecastStation>? get stations;
+
+  /// Create a copy of TsunamiForecast
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastImplCopyWith<_$TsunamiForecastImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1656,8 +1766,12 @@ mixin _$TsunamiForecastFirstHeight {
   TsunamiForecastFirstHeightCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecastFirstHeight to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastFirstHeightCopyWith<TsunamiForecastFirstHeight>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1684,6 +1798,8 @@ class _$TsunamiForecastFirstHeightCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1726,6 +1842,8 @@ class __$$TsunamiForecastFirstHeightImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiForecastFirstHeightImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1777,11 +1895,13 @@ class _$TsunamiForecastFirstHeightImpl implements _TsunamiForecastFirstHeight {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, arrivalTime, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastFirstHeightImplCopyWith<_$TsunamiForecastFirstHeightImpl>
@@ -1810,8 +1930,11 @@ abstract class _TsunamiForecastFirstHeight
   DateTime? get arrivalTime;
   @override
   TsunamiForecastFirstHeightCondition? get condition;
+
+  /// Create a copy of TsunamiForecastFirstHeight
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastFirstHeightImplCopyWith<_$TsunamiForecastFirstHeightImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1831,8 +1954,12 @@ mixin _$TsunamiForecastMaxHeight {
   TsunamiMaxHeightCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecastMaxHeight to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastMaxHeightCopyWith<TsunamiForecastMaxHeight> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1858,6 +1985,8 @@ class _$TsunamiForecastMaxHeightCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1905,6 +2034,8 @@ class __$$TsunamiForecastMaxHeightImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiForecastMaxHeightImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1965,11 +2096,13 @@ class _$TsunamiForecastMaxHeightImpl implements _TsunamiForecastMaxHeight {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, value, isOver, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastMaxHeightImplCopyWith<_$TsunamiForecastMaxHeightImpl>
@@ -1994,18 +2127,20 @@ abstract class _TsunamiForecastMaxHeight implements TsunamiForecastMaxHeight {
   factory _TsunamiForecastMaxHeight.fromJson(Map<String, dynamic> json) =
       _$TsunamiForecastMaxHeightImpl.fromJson;
 
-  @override
-
   /// 定量表現
+  @override
   double? get value;
   @override
   bool? get isOver;
-  @override
 
   /// 定性表現
-  TsunamiMaxHeightCondition? get condition;
   @override
-  @JsonKey(ignore: true)
+  TsunamiMaxHeightCondition? get condition;
+
+  /// Create a copy of TsunamiForecastMaxHeight
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastMaxHeightImplCopyWith<_$TsunamiForecastMaxHeightImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -2024,8 +2159,12 @@ mixin _$TsunamiForecastStation {
   TsunamiForecastFirstHeightCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiForecastStation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiForecastStationCopyWith<TsunamiForecastStation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2055,6 +2194,8 @@ class _$TsunamiForecastStationCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2116,6 +2257,8 @@ class __$$TsunamiForecastStationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiForecastStationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2195,12 +2338,14 @@ class _$TsunamiForecastStationImpl implements _TsunamiForecastStation {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, highTideTime, firstHeightTime, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiForecastStationImplCopyWith<_$TsunamiForecastStationImpl>
@@ -2237,8 +2382,11 @@ abstract class _TsunamiForecastStation implements TsunamiForecastStation {
   DateTime? get firstHeightTime;
   @override
   TsunamiForecastFirstHeightCondition? get condition;
+
+  /// Create a copy of TsunamiForecastStation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiForecastStationImplCopyWith<_$TsunamiForecastStationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -2254,8 +2402,12 @@ mixin _$TsunamiObservation {
   List<TsunamiObservationStation> get stations =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiObservation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiObservationCopyWith<TsunamiObservation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2280,6 +2432,8 @@ class _$TsunamiObservationCopyWithImpl<$Res, $Val extends TsunamiObservation>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2324,6 +2478,8 @@ class __$$TsunamiObservationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiObservationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2388,12 +2544,14 @@ class _$TsunamiObservationImpl implements _TsunamiObservation {
             const DeepCollectionEquality().equals(other._stations, _stations));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, const DeepCollectionEquality().hash(_stations));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiObservationImplCopyWith<_$TsunamiObservationImpl> get copyWith =>
@@ -2424,8 +2582,11 @@ abstract class _TsunamiObservation implements TsunamiObservation {
   String? get name;
   @override
   List<TsunamiObservationStation> get stations;
+
+  /// Create a copy of TsunamiObservation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiObservationImplCopyWith<_$TsunamiObservationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2453,8 +2614,12 @@ mixin _$TsunamiObservationStation {
   TsunamiObservationStationCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiObservationStation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiObservationStationCopyWith<TsunamiObservationStation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2488,6 +2653,8 @@ class _$TsunamiObservationStationCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2573,6 +2740,8 @@ class __$$TsunamiObservationStationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiObservationStationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2696,7 +2865,7 @@ class _$TsunamiObservationStationImpl implements _TsunamiObservationStation {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -2710,7 +2879,9 @@ class _$TsunamiObservationStationImpl implements _TsunamiObservationStation {
       maxHeightIsRising,
       condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiObservationStationImplCopyWith<_$TsunamiObservationStationImpl>
@@ -2746,9 +2917,9 @@ abstract class _TsunamiObservationStation implements TsunamiObservationStation {
   String get code;
   @override
   String get name;
-  @override
 
   /// null: `識別不能`
+  @override
   DateTime? get firstHeightArrivalTime;
   @override
   TsunamiObservationStationFirstHeightIntial? get firstHeightInitial;
@@ -2758,14 +2929,17 @@ abstract class _TsunamiObservationStation implements TsunamiObservationStation {
   double? get maxHeightValue;
   @override
   bool? get maxHeightIsOver;
-  @override
 
   /// 上昇中かどうか
+  @override
   bool? get maxHeightIsRising;
   @override
   TsunamiObservationStationCondition? get condition;
+
+  /// Create a copy of TsunamiObservationStation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiObservationStationImplCopyWith<_$TsunamiObservationStationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -2789,8 +2963,12 @@ mixin _$TsunamiEstimation {
 // *津波観測中*
   bool? get isObserving => throw _privateConstructorUsedError;
 
+  /// Serializes this TsunamiEstimation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TsunamiEstimationCopyWith<TsunamiEstimation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2823,6 +3001,8 @@ class _$TsunamiEstimationCopyWithImpl<$Res, $Val extends TsunamiEstimation>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2905,6 +3085,8 @@ class __$$TsunamiEstimationImplCopyWithImpl<$Res>
       $Res Function(_$TsunamiEstimationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3026,7 +3208,7 @@ class _$TsunamiEstimationImpl implements _TsunamiEstimation {
                 other.isObserving == isObserving));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -3040,7 +3222,9 @@ class _$TsunamiEstimationImpl implements _TsunamiEstimation {
       maxHeightCondition,
       isObserving);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TsunamiEstimationImplCopyWith<_$TsunamiEstimationImpl> get copyWith =>
@@ -3086,12 +3270,16 @@ abstract class _TsunamiEstimation implements TsunamiEstimation {
   @override
   bool? get maxHeightIsOver;
   @override
-  TsunamiMaxHeightCondition? get maxHeightCondition;
-  @override // 津波警報以上でまだ津波の観測値が小さい場合に出現する
+  TsunamiMaxHeightCondition?
+      get maxHeightCondition; // 津波警報以上でまだ津波の観測値が小さい場合に出現する
 // *津波観測中*
-  bool? get isObserving;
   @override
-  @JsonKey(ignore: true)
+  bool? get isObserving;
+
+  /// Create a copy of TsunamiEstimation
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TsunamiEstimationImplCopyWith<_$TsunamiEstimationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3107,8 +3295,12 @@ mixin _$PublicBodyVTSE41 {
   String? get text => throw _privateConstructorUsedError;
   Comment? get comment => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVTSE41 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVTSE41
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVTSE41CopyWith<PublicBodyVTSE41> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3139,6 +3331,8 @@ class _$PublicBodyVTSE41CopyWithImpl<$Res, $Val extends PublicBodyVTSE41>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVTSE41
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3167,6 +3361,8 @@ class _$PublicBodyVTSE41CopyWithImpl<$Res, $Val extends PublicBodyVTSE41>
     ) as $Val);
   }
 
+  /// Create a copy of PublicBodyVTSE41
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $PublicBodyVTSE41TsunamiCopyWith<$Res> get tsunami {
@@ -3175,6 +3371,8 @@ class _$PublicBodyVTSE41CopyWithImpl<$Res, $Val extends PublicBodyVTSE41>
     });
   }
 
+  /// Create a copy of PublicBodyVTSE41
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $CommentCopyWith<$Res>? get comment {
@@ -3216,6 +3414,8 @@ class __$$PublicBodyVTSE41ImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVTSE41Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVTSE41
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3290,12 +3490,14 @@ class _$PublicBodyVTSE41Impl implements _PublicBodyVTSE41 {
             (identical(other.comment, comment) || other.comment == comment));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, tsunami,
       const DeepCollectionEquality().hash(_earthquakes), text, comment);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVTSE41
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVTSE41ImplCopyWith<_$PublicBodyVTSE41Impl> get copyWith =>
@@ -3328,8 +3530,11 @@ abstract class _PublicBodyVTSE41 implements PublicBodyVTSE41 {
   String? get text;
   @override
   Comment? get comment;
+
+  /// Create a copy of PublicBodyVTSE41
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVTSE41ImplCopyWith<_$PublicBodyVTSE41Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3345,8 +3550,12 @@ mixin _$PublicBodyVTSE51 {
   String? get text => throw _privateConstructorUsedError;
   Comment? get comment => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVTSE51 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVTSE51
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVTSE51CopyWith<PublicBodyVTSE51> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3377,6 +3586,8 @@ class _$PublicBodyVTSE51CopyWithImpl<$Res, $Val extends PublicBodyVTSE51>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVTSE51
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3405,6 +3616,8 @@ class _$PublicBodyVTSE51CopyWithImpl<$Res, $Val extends PublicBodyVTSE51>
     ) as $Val);
   }
 
+  /// Create a copy of PublicBodyVTSE51
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $PublicBodyVTSE51TsunamiCopyWith<$Res> get tsunami {
@@ -3413,6 +3626,8 @@ class _$PublicBodyVTSE51CopyWithImpl<$Res, $Val extends PublicBodyVTSE51>
     });
   }
 
+  /// Create a copy of PublicBodyVTSE51
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $CommentCopyWith<$Res>? get comment {
@@ -3454,6 +3669,8 @@ class __$$PublicBodyVTSE51ImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVTSE51Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVTSE51
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3528,12 +3745,14 @@ class _$PublicBodyVTSE51Impl implements _PublicBodyVTSE51 {
             (identical(other.comment, comment) || other.comment == comment));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, tsunami,
       const DeepCollectionEquality().hash(_earthquakes), text, comment);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVTSE51
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVTSE51ImplCopyWith<_$PublicBodyVTSE51Impl> get copyWith =>
@@ -3566,8 +3785,11 @@ abstract class _PublicBodyVTSE51 implements PublicBodyVTSE51 {
   String? get text;
   @override
   Comment? get comment;
+
+  /// Create a copy of PublicBodyVTSE51
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVTSE51ImplCopyWith<_$PublicBodyVTSE51Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3583,8 +3805,12 @@ mixin _$PublicBodyVTSE52 {
   String? get text => throw _privateConstructorUsedError;
   Comment? get comment => throw _privateConstructorUsedError;
 
+  /// Serializes this PublicBodyVTSE52 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PublicBodyVTSE52
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PublicBodyVTSE52CopyWith<PublicBodyVTSE52> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3615,6 +3841,8 @@ class _$PublicBodyVTSE52CopyWithImpl<$Res, $Val extends PublicBodyVTSE52>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PublicBodyVTSE52
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3643,6 +3871,8 @@ class _$PublicBodyVTSE52CopyWithImpl<$Res, $Val extends PublicBodyVTSE52>
     ) as $Val);
   }
 
+  /// Create a copy of PublicBodyVTSE52
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $PublicBodyVTSE52TsunamiCopyWith<$Res> get tsunami {
@@ -3651,6 +3881,8 @@ class _$PublicBodyVTSE52CopyWithImpl<$Res, $Val extends PublicBodyVTSE52>
     });
   }
 
+  /// Create a copy of PublicBodyVTSE52
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $CommentCopyWith<$Res>? get comment {
@@ -3692,6 +3924,8 @@ class __$$PublicBodyVTSE52ImplCopyWithImpl<$Res>
       $Res Function(_$PublicBodyVTSE52Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PublicBodyVTSE52
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3766,12 +4000,14 @@ class _$PublicBodyVTSE52Impl implements _PublicBodyVTSE52 {
             (identical(other.comment, comment) || other.comment == comment));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, tsunami,
       const DeepCollectionEquality().hash(_earthquakes), text, comment);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PublicBodyVTSE52
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PublicBodyVTSE52ImplCopyWith<_$PublicBodyVTSE52Impl> get copyWith =>
@@ -3804,8 +4040,11 @@ abstract class _PublicBodyVTSE52 implements PublicBodyVTSE52 {
   String? get text;
   @override
   Comment? get comment;
+
+  /// Create a copy of PublicBodyVTSE52
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PublicBodyVTSE52ImplCopyWith<_$PublicBodyVTSE52Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3821,8 +4060,12 @@ mixin _$Earthquake {
   EarthquakeHypocenter get hypocenter => throw _privateConstructorUsedError;
   EarthquakeMagnitude get magnitude => throw _privateConstructorUsedError;
 
+  /// Serializes this Earthquake to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeCopyWith<Earthquake> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3853,6 +4096,8 @@ class _$EarthquakeCopyWithImpl<$Res, $Val extends Earthquake>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3881,6 +4126,8 @@ class _$EarthquakeCopyWithImpl<$Res, $Val extends Earthquake>
     ) as $Val);
   }
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeHypocenterCopyWith<$Res> get hypocenter {
@@ -3889,6 +4136,8 @@ class _$EarthquakeCopyWithImpl<$Res, $Val extends Earthquake>
     });
   }
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeMagnitudeCopyWith<$Res> get magnitude {
@@ -3926,6 +4175,8 @@ class __$$EarthquakeImplCopyWithImpl<$Res>
       _$EarthquakeImpl _value, $Res Function(_$EarthquakeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3996,12 +4247,14 @@ class _$EarthquakeImpl implements _Earthquake {
                 other.magnitude == magnitude));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, originTime, arrivalTime, hypocenter, magnitude);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeImplCopyWith<_$EarthquakeImpl> get copyWith =>
@@ -4033,8 +4286,11 @@ abstract class _Earthquake implements Earthquake {
   EarthquakeHypocenter get hypocenter;
   @override
   EarthquakeMagnitude get magnitude;
+
+  /// Create a copy of Earthquake
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeImplCopyWith<_$EarthquakeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4053,8 +4309,12 @@ mixin _$EarthquakeHypocenter {
   EarthquakeHypocenterCoordinate? get coordinate =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeHypocenter to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeHypocenterCopyWith<EarthquakeHypocenter> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4087,6 +4347,8 @@ class _$EarthquakeHypocenterCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4120,6 +4382,8 @@ class _$EarthquakeHypocenterCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeHypocenterDetailedCopyWith<$Res>? get detailed {
@@ -4133,6 +4397,8 @@ class _$EarthquakeHypocenterCopyWithImpl<$Res,
     });
   }
 
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $EarthquakeHypocenterCoordinateCopyWith<$Res>? get coordinate {
@@ -4176,6 +4442,8 @@ class __$$EarthquakeHypocenterImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeHypocenterImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4253,12 +4521,14 @@ class _$EarthquakeHypocenterImpl implements _EarthquakeHypocenter {
                 other.coordinate == coordinate));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, name, code, depth, detailed, coordinate);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeHypocenterImplCopyWith<_$EarthquakeHypocenterImpl>
@@ -4296,8 +4566,11 @@ abstract class _EarthquakeHypocenter implements EarthquakeHypocenter {
   EarthquakeHypocenterDetailed? get detailed;
   @override
   EarthquakeHypocenterCoordinate? get coordinate;
+
+  /// Create a copy of EarthquakeHypocenter
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeHypocenterImplCopyWith<_$EarthquakeHypocenterImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -4312,8 +4585,12 @@ mixin _$EarthquakeHypocenterDetailed {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeHypocenterDetailed to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeHypocenterDetailedCopyWith<EarthquakeHypocenterDetailed>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -4340,6 +4617,8 @@ class _$EarthquakeHypocenterDetailedCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4381,6 +4660,8 @@ class __$$EarthquakeHypocenterDetailedImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeHypocenterDetailedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4430,11 +4711,13 @@ class _$EarthquakeHypocenterDetailedImpl
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeHypocenterDetailedImplCopyWith<
@@ -4463,8 +4746,11 @@ abstract class _EarthquakeHypocenterDetailed
   String get code;
   @override
   String get name;
+
+  /// Create a copy of EarthquakeHypocenterDetailed
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeHypocenterDetailedImplCopyWith<
           _$EarthquakeHypocenterDetailedImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -4480,8 +4766,12 @@ mixin _$EarthquakeHypocenterCoordinate {
   double get lat => throw _privateConstructorUsedError;
   double get lon => throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeHypocenterCoordinate to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeHypocenterCoordinate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeHypocenterCoordinateCopyWith<EarthquakeHypocenterCoordinate>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -4508,6 +4798,8 @@ class _$EarthquakeHypocenterCoordinateCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeHypocenterCoordinate
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4549,6 +4841,8 @@ class __$$EarthquakeHypocenterCoordinateImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeHypocenterCoordinateImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeHypocenterCoordinate
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4598,11 +4892,13 @@ class _$EarthquakeHypocenterCoordinateImpl
             (identical(other.lon, lon) || other.lon == lon));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, lat, lon);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeHypocenterCoordinate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeHypocenterCoordinateImplCopyWith<
@@ -4631,8 +4927,11 @@ abstract class _EarthquakeHypocenterCoordinate
   double get lat;
   @override
   double get lon;
+
+  /// Create a copy of EarthquakeHypocenterCoordinate
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeHypocenterCoordinateImplCopyWith<
           _$EarthquakeHypocenterCoordinateImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -4648,8 +4947,12 @@ mixin _$EarthquakeMagnitude {
   EarthquakeMagnitudeCondition? get condition =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this EarthquakeMagnitude to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $EarthquakeMagnitudeCopyWith<EarthquakeMagnitude> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4673,6 +4976,8 @@ class _$EarthquakeMagnitudeCopyWithImpl<$Res, $Val extends EarthquakeMagnitude>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4711,6 +5016,8 @@ class __$$EarthquakeMagnitudeImplCopyWithImpl<$Res>
       $Res Function(_$EarthquakeMagnitudeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4759,11 +5066,13 @@ class _$EarthquakeMagnitudeImpl implements _EarthquakeMagnitude {
                 other.condition == condition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, value, condition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$EarthquakeMagnitudeImplCopyWith<_$EarthquakeMagnitudeImpl> get copyWith =>
@@ -4791,8 +5100,11 @@ abstract class _EarthquakeMagnitude implements EarthquakeMagnitude {
   double? get value;
   @override
   EarthquakeMagnitudeCondition? get condition;
+
+  /// Create a copy of EarthquakeMagnitude
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$EarthquakeMagnitudeImplCopyWith<_$EarthquakeMagnitudeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v1/websocket/realtime_postgres_changes_payload.freezed.dart
+++ b/packages/eqapi_types/lib/model/v1/websocket/realtime_postgres_changes_payload.freezed.dart
@@ -29,9 +29,13 @@ mixin _$RealtimePostgresInsertPayload<T extends V1Database> {
   @JsonKey(name: 'new')
   T get newData => throw _privateConstructorUsedError;
 
+  /// Serializes this RealtimePostgresInsertPayload to a JSON map.
   Map<String, dynamic> toJson(Object? Function(T) toJsonT) =>
       throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RealtimePostgresInsertPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RealtimePostgresInsertPayloadCopyWith<T, RealtimePostgresInsertPayload<T>>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -64,6 +68,8 @@ class _$RealtimePostgresInsertPayloadCopyWithImpl<T extends V1Database, $Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RealtimePostgresInsertPayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -127,6 +133,8 @@ class __$$RealtimePostgresInsertPayloadImplCopyWithImpl<T extends V1Database,
       $Res Function(_$RealtimePostgresInsertPayloadImpl<T>) _then)
       : super(_value, _then);
 
+  /// Create a copy of RealtimePostgresInsertPayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -215,7 +223,7 @@ class _$RealtimePostgresInsertPayloadImpl<T extends V1Database>
             const DeepCollectionEquality().equals(other.newData, newData));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -225,7 +233,9 @@ class _$RealtimePostgresInsertPayloadImpl<T extends V1Database>
       const DeepCollectionEquality().hash(_errors),
       const DeepCollectionEquality().hash(newData));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RealtimePostgresInsertPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RealtimePostgresInsertPayloadImplCopyWith<T,
@@ -264,8 +274,11 @@ abstract class _RealtimePostgresInsertPayload<T extends V1Database>
   @override
   @JsonKey(name: 'new')
   T get newData;
+
+  /// Create a copy of RealtimePostgresInsertPayload
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RealtimePostgresInsertPayloadImplCopyWith<T,
           _$RealtimePostgresInsertPayloadImpl<T>>
       get copyWith => throw _privateConstructorUsedError;
@@ -289,9 +302,13 @@ mixin _$RealtimePostgresUpdatePayload<T extends V1Database> {
   /// Partical<T> | null
   Map<String, dynamic>? get old => throw _privateConstructorUsedError;
 
+  /// Serializes this RealtimePostgresUpdatePayload to a JSON map.
   Map<String, dynamic> toJson(Object? Function(T) toJsonT) =>
       throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RealtimePostgresUpdatePayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RealtimePostgresUpdatePayloadCopyWith<T, RealtimePostgresUpdatePayload<T>>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -325,6 +342,8 @@ class _$RealtimePostgresUpdatePayloadCopyWithImpl<T extends V1Database, $Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RealtimePostgresUpdatePayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -394,6 +413,8 @@ class __$$RealtimePostgresUpdatePayloadImplCopyWithImpl<T extends V1Database,
       $Res Function(_$RealtimePostgresUpdatePayloadImpl<T>) _then)
       : super(_value, _then);
 
+  /// Create a copy of RealtimePostgresUpdatePayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -503,7 +524,7 @@ class _$RealtimePostgresUpdatePayloadImpl<T extends V1Database>
             const DeepCollectionEquality().equals(other._old, _old));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -514,7 +535,9 @@ class _$RealtimePostgresUpdatePayloadImpl<T extends V1Database>
       const DeepCollectionEquality().hash(newData),
       const DeepCollectionEquality().hash(_old));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RealtimePostgresUpdatePayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RealtimePostgresUpdatePayloadImplCopyWith<T,
@@ -554,12 +577,15 @@ abstract class _RealtimePostgresUpdatePayload<T extends V1Database>
   @override
   @JsonKey(name: 'new')
   T get newData;
-  @override
 
   /// Partical<T> | null
-  Map<String, dynamic>? get old;
   @override
-  @JsonKey(ignore: true)
+  Map<String, dynamic>? get old;
+
+  /// Create a copy of RealtimePostgresUpdatePayload
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RealtimePostgresUpdatePayloadImplCopyWith<T,
           _$RealtimePostgresUpdatePayloadImpl<T>>
       get copyWith => throw _privateConstructorUsedError;
@@ -581,9 +607,13 @@ mixin _$RealtimePostgresDeletePayload<T extends V1Database> {
   /// Partical<T> | null
   Map<String, dynamic>? get old => throw _privateConstructorUsedError;
 
+  /// Serializes this RealtimePostgresDeletePayload to a JSON map.
   Map<String, dynamic> toJson(Object? Function(T) toJsonT) =>
       throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RealtimePostgresDeletePayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RealtimePostgresDeletePayloadCopyWith<T, RealtimePostgresDeletePayload<T>>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -616,6 +646,8 @@ class _$RealtimePostgresDeletePayloadCopyWithImpl<T extends V1Database, $Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RealtimePostgresDeletePayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -679,6 +711,8 @@ class __$$RealtimePostgresDeletePayloadImplCopyWithImpl<T extends V1Database,
       $Res Function(_$RealtimePostgresDeletePayloadImpl<T>) _then)
       : super(_value, _then);
 
+  /// Create a copy of RealtimePostgresDeletePayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -777,7 +811,7 @@ class _$RealtimePostgresDeletePayloadImpl<T extends V1Database>
             const DeepCollectionEquality().equals(other._old, _old));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -787,7 +821,9 @@ class _$RealtimePostgresDeletePayloadImpl<T extends V1Database>
       const DeepCollectionEquality().hash(_errors),
       const DeepCollectionEquality().hash(_old));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RealtimePostgresDeletePayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RealtimePostgresDeletePayloadImplCopyWith<T,
@@ -823,12 +859,15 @@ abstract class _RealtimePostgresDeletePayload<T extends V1Database>
   DateTime get commitTimestamp;
   @override
   List<String>? get errors;
-  @override
 
   /// Partical<T> | null
-  Map<String, dynamic>? get old;
   @override
-  @JsonKey(ignore: true)
+  Map<String, dynamic>? get old;
+
+  /// Create a copy of RealtimePostgresDeletePayload
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RealtimePostgresDeletePayloadImplCopyWith<T,
           _$RealtimePostgresDeletePayloadImpl<T>>
       get copyWith => throw _privateConstructorUsedError;

--- a/packages/eqapi_types/lib/model/v3/app_information.freezed.dart
+++ b/packages/eqapi_types/lib/model/v3/app_information.freezed.dart
@@ -28,8 +28,12 @@ mixin _$AppInformation {
   String? get androidDownloadUrl => throw _privateConstructorUsedError;
   String? get forceUpdateMessage => throw _privateConstructorUsedError;
 
+  /// Serializes this AppInformation to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AppInformationCopyWith<AppInformation> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -60,6 +64,8 @@ class _$AppInformationCopyWithImpl<$Res, $Val extends AppInformation>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -130,6 +136,8 @@ class __$$AppInformationImplCopyWithImpl<$Res>
       _$AppInformationImpl _value, $Res Function(_$AppInformationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -230,7 +238,7 @@ class _$AppInformationImpl implements _AppInformation {
                 other.forceUpdateMessage == forceUpdateMessage));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -242,7 +250,9 @@ class _$AppInformationImpl implements _AppInformation {
       androidDownloadUrl,
       forceUpdateMessage);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AppInformationImplCopyWith<_$AppInformationImpl> get copyWith =>
@@ -284,8 +294,11 @@ abstract class _AppInformation implements AppInformation {
   String? get androidDownloadUrl;
   @override
   String? get forceUpdateMessage;
+
+  /// Create a copy of AppInformation
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AppInformationImplCopyWith<_$AppInformationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/eqapi_types/lib/model/v3/information_v3.freezed.dart
+++ b/packages/eqapi_types/lib/model/v3/information_v3.freezed.dart
@@ -22,8 +22,12 @@ InformationV3Result _$InformationV3ResultFromJson(Map<String, dynamic> json) {
 mixin _$InformationV3Result {
   List<InformationV3> get items => throw _privateConstructorUsedError;
 
+  /// Serializes this InformationV3Result to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InformationV3Result
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $InformationV3ResultCopyWith<InformationV3Result> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -47,6 +51,8 @@ class _$InformationV3ResultCopyWithImpl<$Res, $Val extends InformationV3Result>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of InformationV3Result
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -80,6 +86,8 @@ class __$$InformationV3ResultImplCopyWithImpl<$Res>
       $Res Function(_$InformationV3ResultImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InformationV3Result
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -124,12 +132,14 @@ class _$InformationV3ResultImpl implements _InformationV3Result {
             const DeepCollectionEquality().equals(other._items, _items));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_items));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InformationV3Result
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InformationV3ResultImplCopyWith<_$InformationV3ResultImpl> get copyWith =>
@@ -153,8 +163,11 @@ abstract class _InformationV3Result implements InformationV3Result {
 
   @override
   List<InformationV3> get items;
+
+  /// Create a copy of InformationV3Result
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InformationV3ResultImplCopyWith<_$InformationV3ResultImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -176,8 +189,12 @@ mixin _$InformationV3 {
   Level get level => throw _privateConstructorUsedError;
   int? get eventId => throw _privateConstructorUsedError;
 
+  /// Serializes this InformationV3 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InformationV3
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $InformationV3CopyWith<InformationV3> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -208,6 +225,8 @@ class _$InformationV3CopyWithImpl<$Res, $Val extends InformationV3>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of InformationV3
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -278,6 +297,8 @@ class __$$InformationV3ImplCopyWithImpl<$Res>
       _$InformationV3Impl _value, $Res Function(_$InformationV3Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InformationV3
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -375,12 +396,14 @@ class _$InformationV3Impl implements _InformationV3 {
             (identical(other.eventId, eventId) || other.eventId == eventId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, id, title, body, author, createdAt, level, eventId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InformationV3
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InformationV3ImplCopyWith<_$InformationV3Impl> get copyWith =>
@@ -424,8 +447,11 @@ abstract class _InformationV3 implements InformationV3 {
   Level get level;
   @override
   int? get eventId;
+
+  /// Create a copy of InformationV3
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InformationV3ImplCopyWith<_$InformationV3Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
## 概要
- city要素は下記schemaなので、修正
```ts
export const EqmonitorEarthquakeIntensityObservationCitySchema = v.object({
  name: v.string(),
  code: v.nullable(StringNumber),
  max_intensity: intensity,
  observation_points: v.array(EqmonitorEarthquakeIntensityObservationSchema),
});
```