### PR TITLE
Auto sync notification settings

### DIFF
--- a/app/lib/feature/settings/features/notification_remote_settings/data/notification_remote_settings_notifier.dart
+++ b/app/lib/feature/settings/features/notification_remote_settings/data/notification_remote_settings_notifier.dart
@@ -15,6 +15,14 @@ class NotificationRemoteSettingsNotifier
   Future<NotificationRemoteSettingsState> build() async {
     final savedState =
         ref.watch(notificationRemoteSettingsSavedStateNotifierProvider.future);
+    ref.listen<NotificationRemoteSettingsState>(
+      notificationRemoteSettingsNotifierProvider,
+      (previous, next) {
+        if (previous != next) {
+          save();
+        }
+      },
+    );
     return savedState;
   }
 

--- a/app/lib/feature/settings/features/notification_remote_settings/ui/notification_remote_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_remote_settings/ui/notification_remote_settings_page.dart
@@ -91,20 +91,6 @@ class NotificationRemoteSettingsPage extends HookConsumerWidget {
           title: const Text('通知条件設定'),
         ),
         body: const _Body(),
-        floatingActionButton: hasChanged
-            ? FloatingActionButton.extended(
-                heroTag: 'save',
-                onPressed: () async {
-                  final notifier = ref.read(
-                    notificationRemoteSettingsNotifierProvider.notifier,
-                  );
-                  await _save(context, notifier);
-                  ref.invalidate(notificationRemoteSettingsNotifierProvider);
-                },
-                label: const Text('保存する'),
-                icon: const Icon(Icons.save),
-              )
-            : null,
       ),
     );
   }

--- a/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_earthquake_page.dart
+++ b/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_earthquake_page.dart
@@ -24,18 +24,25 @@ class NotificationRemoteSettingsEarthquakePage extends ConsumerWidget {
         child: CircularProgressIndicator.adaptive(),
       );
     }
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('地震情報の通知条件設定'),
+    return WillPopScope(
+      onWillPop: () async {
+        final notifier = ref.read(notificationRemoteSettingsNotifierProvider.notifier);
+        await notifier.save();
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('地震情報の通知条件設定'),
+        ),
+        body: _Body(
+          state: state,
+        ),
+        floatingActionButton: (state.global != JmaForecastIntensity.zero)
+            ? _AddRegionFloatingActionButton(
+                regions: state.regions,
+              )
+            : null,
       ),
-      body: _Body(
-        state: state,
-      ),
-      floatingActionButton: (state.global != JmaForecastIntensity.zero)
-          ? _AddRegionFloatingActionButton(
-              regions: state.regions,
-            )
-          : null,
     );
   }
 }

--- a/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_earthquake_page.dart
+++ b/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_earthquake_page.dart
@@ -26,7 +26,8 @@ class NotificationRemoteSettingsEarthquakePage extends ConsumerWidget {
     }
     return WillPopScope(
       onWillPop: () async {
-        final notifier = ref.read(notificationRemoteSettingsNotifierProvider.notifier);
+        final notifier =
+            ref.read(notificationRemoteSettingsNotifierProvider.notifier);
         await notifier.save();
         return true;
       },

--- a/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_eew_page.dart
+++ b/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_eew_page.dart
@@ -22,18 +22,25 @@ class NotificationRemoteSettingsEewPage extends ConsumerWidget {
         child: CircularProgressIndicator.adaptive(),
       );
     }
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('緊急地震速報の通知条件設定'),
+    return WillPopScope(
+      onWillPop: () async {
+        final notifier = ref.read(notificationRemoteSettingsNotifierProvider.notifier);
+        await notifier.save();
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('緊急地震速報の通知条件設定'),
+        ),
+        body: _Body(
+          state: state,
+        ),
+        floatingActionButton: (state.global != JmaForecastIntensity.zero)
+            ? _AddRegionFloatingActionButton(
+                regions: state.regions,
+              )
+            : null,
       ),
-      body: _Body(
-        state: state,
-      ),
-      floatingActionButton: (state.global != JmaForecastIntensity.zero)
-          ? _AddRegionFloatingActionButton(
-              regions: state.regions,
-            )
-          : null,
     );
   }
 }

--- a/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_eew_page.dart
+++ b/app/lib/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_eew_page.dart
@@ -24,7 +24,8 @@ class NotificationRemoteSettingsEewPage extends ConsumerWidget {
     }
     return WillPopScope(
       onWillPop: () async {
-        final notifier = ref.read(notificationRemoteSettingsNotifierProvider.notifier);
+        final notifier =
+            ref.read(notificationRemoteSettingsNotifierProvider.notifier);
         await notifier.save();
         return true;
       },


### PR DESCRIPTION
Fixes #788

Implement automatic synchronization of notification settings after changes.

* **Automatic Synchronization**:
  - Add a `ref.listen` method in `app/lib/feature/settings/features/notification_remote_settings/data/notification_remote_settings_notifier.dart` to listen for changes in the notification settings and automatically invoke the `save` method.
* **UI Changes**:
  - Remove the `FloatingActionButton` used to manually save notification settings in `app/lib/feature/settings/features/notification_remote_settings/ui/notification_remote_settings_page.dart`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YumNumm/EQMonitor/issues/788?shareId=91e17891-1deb-4bad-b3e3-5dc7bbb00a21).