### PR TITLE
fix: correct malformed applicationName variable in AndroidManifest.xml

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     </queries>
 
     <application
-        android:name="${applicationName"
+        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">
 


### PR DESCRIPTION
Fix missing closing brace in android:name attribute that was causing Android build failure.

Fixes #916

Generated with [Claude Code](https://claude.ai/code)