### PR TITLE
fix: prevent MapLibre source duplication crash in earthquake history details

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/layers/earthquake_hypocenter_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/components/layers/earthquake_hypocenter_layer.dart
@@ -40,6 +40,8 @@ class EarthquakeHypocenterLayer extends HookConsumerWidget implements MapLayer {
             if (!isInitialized.value) {
               await mapUtility.addHypocenterImages(controller);
 
+              // Remove source if it already exists to prevent duplicates
+              await controller.removeSource(_sourceId);
               await controller.addGeoJsonSource(
                 _sourceId,
                 _createGeoJson(latLng: latLng, hypocenterType: hypocenterType),
@@ -71,18 +73,24 @@ class EarthquakeHypocenterLayer extends HookConsumerWidget implements MapLayer {
     }, [controller]);
 
     useEffect(() {
+      if (!isInitialized.value) {
+        return;
+      }
       unawaited(
         controller.synchronized(() async {
-          await controller.addGeoJsonSource(
+          await controller.setGeoJsonSource(
             _sourceId,
             _createGeoJson(latLng: latLng, hypocenterType: hypocenterType),
           );
         }),
       );
       return null;
-    }, [latLng, controller]);
+    }, [latLng, controller, isInitialized.value]);
 
     useEffect(() {
+      if (!isInitialized.value) {
+        return;
+      }
       unawaited(
         controller.synchronized(() async {
           await controller.setLayerProperties(
@@ -92,7 +100,7 @@ class EarthquakeHypocenterLayer extends HookConsumerWidget implements MapLayer {
         }),
       );
       return null;
-    }, [isVisible, controller]);
+    }, [isVisible, controller, isInitialized.value]);
 
     return const SizedBox.shrink();
   }


### PR DESCRIPTION
Fixes #971

### Changes
- Add removeSource() call before addGeoJsonSource() during initialization
- Use setGeoJsonSource() instead of addGeoJsonSource() for coordinate updates
- Add initialization checks to prevent operations before layer setup

The crash was caused by trying to add a GeoJSON source with the same ID multiple times. This fix follows the pattern used in other map layers in the codebase.

Generated with [Claude Code](https://claude.ai/code)