### PR TITLE
Implement tsunami information display screen

### DIFF
--- a/app/lib/core/provider/tsunami_provider.dart
+++ b/app/lib/core/provider/tsunami_provider.dart
@@ -1,0 +1,35 @@
+import 'dart:developer';
+
+import 'package:eqapi_types/eqapi_types.dart';
+import 'package:eqmonitor/core/api/eq_api.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'tsunami_provider.g.dart';
+
+/// 津波情報のサマリーを取得するプロバイダー
+@Riverpod(keepAlive: true)
+class TsunamiSummary extends _$TsunamiSummary {
+  @override
+  FutureOr<TsunamiSummaryResponse> build() async {
+    return _fetch();
+  }
+
+  Future<TsunamiSummaryResponse> _fetch() async {
+    try {
+      log('津波情報を取得中...');
+      final eqApi = ref.read(eqApiProvider);
+      final response = await eqApi.v1.getTsunamiSummary();
+      log('津波情報取得成功: ${response.data.data.length} items');
+      return response.data;
+    } catch (e, stackTrace) {
+      log('津波情報取得失敗: $e', stackTrace: stackTrace);
+      rethrow;
+    }
+  }
+
+  /// 津波情報を強制的に再取得する
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _fetch());
+  }
+}

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -32,6 +32,7 @@ import 'package:eqmonitor/feature/settings/features/notification_remote_settings
 import 'package:eqmonitor/feature/settings/features/notification_remote_settings/ui/pages/notification_remote_settings_eew_page.dart';
 import 'package:eqmonitor/feature/settings/settings_screen.dart';
 import 'package:eqmonitor/feature/setup/screen/setup_screen.dart';
+import 'package:eqmonitor/feature/tsunami_history/page/tsunami_history_page.dart';
 import 'package:eqmonitor/page/home_page.dart';
 import 'package:eqmonitor/page/talker/talker_page.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -115,6 +116,15 @@ class InformationHistoryDetailsRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       InformationHistoryDetailsPage(data: $extra);
+}
+
+@TypedGoRoute<TsunamiHistoryRoute>(path: '/tsunami-history')
+class TsunamiHistoryRoute extends GoRouteData {
+  const TsunamiHistoryRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const TsunamiHistoryPage();
 }
 
 @TypedGoRoute<HomeRoute>(

--- a/app/lib/feature/tsunami_history/page/tsunami_history_page.dart
+++ b/app/lib/feature/tsunami_history/page/tsunami_history_page.dart
@@ -1,0 +1,291 @@
+import 'package:eqapi_types/eqapi_types.dart';
+import 'package:eqmonitor/core/component/container/background_container.dart';
+import 'package:eqmonitor/core/provider/tsunami_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class TsunamiHistoryPage extends HookConsumerWidget {
+  const TsunamiHistoryPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tsunamiAsync = ref.watch(tsunamiSummaryProvider);
+    
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('津波情報'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => ref.read(tsunamiSummaryProvider.notifier).refresh(),
+          ),
+        ],
+      ),
+      body: BackgroundContainer(
+        child: tsunamiAsync.when(
+          data: (data) => _TsunamiList(data: data),
+          loading: () => const Center(
+            child: CircularProgressIndicator(),
+          ),
+          error: (error, stackTrace) => Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.error, size: 64, color: Colors.red),
+                const SizedBox(height: 16),
+                Text('エラーが発生しました'),
+                const SizedBox(height: 8),
+                Text(error.toString()),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () => ref.read(tsunamiSummaryProvider.notifier).refresh(),
+                  child: const Text('再試行'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TsunamiList extends StatelessWidget {
+  const _TsunamiList({required this.data});
+
+  final TsunamiSummaryResponse data;
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.data.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.tsunami, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text('津波情報がありません'),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: data.data.length,
+      itemBuilder: (context, index) {
+        final group = data.data[index];
+        return _TsunamiGroupCard(group: group);
+      },
+    );
+  }
+}
+
+class _TsunamiGroupCard extends StatelessWidget {
+  const _TsunamiGroupCard({required this.group});
+
+  final TsunamiGroupedByEvent group;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
+    // 最新の津波データを取得
+    final latestData = _getLatestTsunamiData();
+    if (latestData == null) return const SizedBox.shrink();
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ヘッダー部分
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: _getTsunamiTypeColor(latestData.type),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    _getTsunamiTypeShort(latestData.type),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    latestData.headline ?? 'ヘッドラインなし',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            
+            // 情報詳細
+            _buildInfoRow('イベントID', group.eventId),
+            _buildInfoRow('発表時刻', _formatDateTime(latestData.pressAt)),
+            _buildInfoRow('報告時刻', _formatDateTime(latestData.reportAt)),
+            _buildInfoRow('情報種別', latestData.infoType),
+            _buildInfoRow('状態', latestData.status),
+            
+            // 津波データの種類
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                if (group.vtse41 != null) _buildTypeChip('警報・注意報', Colors.red),
+                if (group.vtse51 != null) _buildTypeChip('津波情報', Colors.orange),
+                if (group.vtse52 != null) _buildTypeChip('沖合観測', Colors.blue),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontSize: 12,
+                color: Colors.grey,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTypeChip(String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 10,
+          color: color,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+
+  // 最新の津波データを取得（優先度: vtse41 > vtse51 > vtse52）
+  ({
+    int id,
+    int eventId,
+    int? serialNo,
+    String type,
+    String status,
+    String? headline,
+    String infoType,
+    DateTime pressAt,
+    DateTime reportAt,
+    DateTime? validAt,
+  })? _getLatestTsunamiData() {
+    if (group.vtse41 != null) {
+      final data = group.vtse41!;
+      return (
+        id: data.id,
+        eventId: data.eventId,
+        serialNo: data.serialNo,
+        type: data.type,
+        status: data.status,
+        headline: data.headline,
+        infoType: data.infoType,
+        pressAt: data.pressAt,
+        reportAt: data.reportAt,
+        validAt: data.validAt,
+      );
+    }
+    if (group.vtse51 != null) {
+      final data = group.vtse51!;
+      return (
+        id: data.id,
+        eventId: data.eventId,
+        serialNo: data.serialNo,
+        type: data.type,
+        status: data.status,
+        headline: data.headline,
+        infoType: data.infoType,
+        pressAt: data.pressAt,
+        reportAt: data.reportAt,
+        validAt: data.validAt,
+      );
+    }
+    if (group.vtse52 != null) {
+      final data = group.vtse52!;
+      return (
+        id: data.id,
+        eventId: data.eventId,
+        serialNo: data.serialNo,
+        type: data.type,
+        status: data.status,
+        headline: data.headline,
+        infoType: data.infoType,
+        pressAt: data.pressAt,
+        reportAt: data.reportAt,
+        validAt: data.validAt,
+      );
+    }
+    return null;
+  }
+
+  String _getTsunamiTypeShort(String type) {
+    return switch (type) {
+      '津波警報・注意報・予報a' => '警報・注意報',
+      '津波情報a' => '津波情報',
+      '沖合の津波観測に関する情報' => '沖合観測',
+      _ => type,
+    };
+  }
+
+  Color _getTsunamiTypeColor(String type) {
+    return switch (type) {
+      '津波警報・注意報・予報a' => Colors.red,
+      '津波情報a' => Colors.orange,
+      '沖合の津波観測に関する情報' => Colors.blue,
+      _ => Colors.grey,
+    };
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    return '${dateTime.month.toString().padLeft(2, '0')}/'
+        '${dateTime.day.toString().padLeft(2, '0')} '
+        '${dateTime.hour.toString().padLeft(2, '0')}:'
+        '${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -68,6 +68,11 @@ class _SheetBody extends ConsumerWidget {
             const _ShakeDetectionList(),
             const HomeEarthquakeHistorySheet(),
             ListTile(
+              title: const Text('津波情報'),
+              leading: const Icon(Icons.tsunami),
+              onTap: () async => const TsunamiHistoryRoute().push<void>(context),
+            ),
+            ListTile(
               title: const Text('設定'),
               leading: const Icon(Icons.settings),
               onTap: () async => const SettingsRoute().push<void>(context),

--- a/packages/eqapi_client/lib/src/children/v1.dart
+++ b/packages/eqapi_client/lib/src/children/v1.dart
@@ -105,6 +105,9 @@ abstract class V1 {
 
   @GET('/v1/shake-detection/latest')
   Future<List<ShakeDetectionEvent>> getLatestShakeDetectionEvents();
+
+  @GET('/v2/tsunami')
+  Future<HttpResponse<TsunamiSummaryResponse>> getTsunamiSummary();
 }
 
 enum EarthquakeEarlySortType {

--- a/packages/eqapi_types/lib/src/model/v1/tsunami.dart
+++ b/packages/eqapi_types/lib/src/model/v1/tsunami.dart
@@ -471,3 +471,124 @@ enum EarthquakeMagnitudeCondition {
   const EarthquakeMagnitudeCondition(this.value);
   final String value;
 }
+
+// ------------------ New Tsunami API Response Types ------------------ //
+
+/// 津波データ（VTSE41タイプ）
+@freezed
+abstract class TsunamiDataVTSE41 with _$TsunamiDataVTSE41 {
+  const factory TsunamiDataVTSE41({
+    required int id,
+    required int eventId,
+    required int? serialNo,
+    @Default('津波警報・注意報・予報a') String type,
+    required TsunamiBody body,
+    required String status,
+    required String? headline,
+    required String infoType,
+    required DateTime pressAt,
+    required DateTime reportAt,
+    required DateTime? validAt,
+  }) = _TsunamiDataVTSE41;
+
+  factory TsunamiDataVTSE41.fromJson(Map<String, dynamic> json) =>
+      _$TsunamiDataVTSE41FromJson(json);
+}
+
+/// 津波データ（VTSE51タイプ）
+@freezed
+abstract class TsunamiDataVTSE51 with _$TsunamiDataVTSE51 {
+  const factory TsunamiDataVTSE51({
+    required int id,
+    required int eventId,
+    required int? serialNo,
+    @Default('津波情報a') String type,
+    required TsunamiBody body,
+    required String status,
+    required String? headline,
+    required String infoType,
+    required DateTime pressAt,
+    required DateTime reportAt,
+    required DateTime? validAt,
+  }) = _TsunamiDataVTSE51;
+
+  factory TsunamiDataVTSE51.fromJson(Map<String, dynamic> json) =>
+      _$TsunamiDataVTSE51FromJson(json);
+}
+
+/// 津波データ（VTSE52タイプ）
+@freezed
+abstract class TsunamiDataVTSE52 with _$TsunamiDataVTSE52 {
+  const factory TsunamiDataVTSE52({
+    required int id,
+    required int eventId,
+    required int? serialNo,
+    @Default('沖合の津波観測に関する情報') String type,
+    required TsunamiBody body,
+    required String status,
+    required String? headline,
+    required String infoType,
+    required DateTime pressAt,
+    required DateTime reportAt,
+    required DateTime? validAt,
+  }) = _TsunamiDataVTSE52;
+
+  factory TsunamiDataVTSE52.fromJson(Map<String, dynamic> json) =>
+      _$TsunamiDataVTSE52FromJson(json);
+}
+
+/// 津波データ（全タイプのUnion）
+@freezed
+abstract class TsunamiData with _$TsunamiData {
+  const factory TsunamiData.vtse41(TsunamiDataVTSE41 data) = _TsunamiDataVTSE41;
+  const factory TsunamiData.vtse51(TsunamiDataVTSE51 data) = _TsunamiDataVTSE51;
+  const factory TsunamiData.vtse52(TsunamiDataVTSE52 data) = _TsunamiDataVTSE52;
+
+  factory TsunamiData.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      '津波警報・注意報・予報a' => TsunamiData.vtse41(TsunamiDataVTSE41.fromJson(json)),
+      '津波情報a' => TsunamiData.vtse51(TsunamiDataVTSE51.fromJson(json)),
+      '沖合の津波観測に関する情報' => TsunamiData.vtse52(TsunamiDataVTSE52.fromJson(json)),
+      _ => throw ArgumentError('Unknown tsunami type: $type'),
+    };
+  }
+}
+
+/// eventIdごとにグループ化された津波情報
+@freezed
+abstract class TsunamiGroupedByEvent with _$TsunamiGroupedByEvent {
+  const factory TsunamiGroupedByEvent({
+    @JsonKey(name: 'event_id') required String eventId,
+    required TsunamiDataVTSE41? vtse41,
+    required TsunamiDataVTSE51? vtse51,
+    required TsunamiDataVTSE52? vtse52,
+  }) = _TsunamiGroupedByEvent;
+
+  factory TsunamiGroupedByEvent.fromJson(Map<String, dynamic> json) =>
+      _$TsunamiGroupedByEventFromJson(json);
+}
+
+/// 津波情報一覧レスポンス（eventIdでグループ化）
+@freezed
+abstract class TsunamiSummaryResponse with _$TsunamiSummaryResponse {
+  const factory TsunamiSummaryResponse({
+    required List<TsunamiGroupedByEvent> data,
+  }) = _TsunamiSummaryResponse;
+
+  factory TsunamiSummaryResponse.fromJson(Map<String, dynamic> json) =>
+      _$TsunamiSummaryResponseFromJson(json);
+}
+
+/// 特定eventIdの津波情報詳細レスポンス
+@freezed
+abstract class TsunamiDetailResponse with _$TsunamiDetailResponse {
+  const factory TsunamiDetailResponse({
+    @JsonKey(name: 'event_id') required int eventId,
+    required List<TsunamiData> data,
+    required int count,
+  }) = _TsunamiDetailResponse;
+
+  factory TsunamiDetailResponse.fromJson(Map<String, dynamic> json) =>
+      _$TsunamiDetailResponseFromJson(json);
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement a tsunami information display screen, including API client and data models, to show tsunami summaries in a compact list format.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---
<a href="https://cursor.com/background-agent?bcId=bc-5adee13e-4323-4c65-8a6b-6093fedca6a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5adee13e-4323-4c65-8a6b-6093fedca6a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>