### PR TITLE
Fix ios build errors and pod issues

### DIFF
--- a/app/ios/Widget/MapEarthquakeWidget.swift
+++ b/app/ios/Widget/MapEarthquakeWidget.swift
@@ -20,7 +20,6 @@ struct MapEarthquakeWidget: Widget {
             if #available(iOS 17.0, *) {
                 MapEarthquakeWidgetView(entry: entry)
                     .containerBackground(.background, for: .widget)
-                    .contentMarginsDisabled()
             } else {
                 MapEarthquakeWidgetView(entry: entry)
                     .containerBackground(.background, for: .widget)

--- a/app/ios/Widget/Widget.swift
+++ b/app/ios/Widget/Widget.swift
@@ -104,49 +104,34 @@ struct EarthquakeTimelineProvider: AppIntentTimelineProvider {
     private func mockEarthquakes() -> [EarthquakeItem] {
         [
             EarthquakeItem(
-                id: mock1,
+                id: "mock1",
                 magnitude: 6.4,
                 magnitudeCondition: nil,
                 maxIntensity: "5-",
                 hypocenterName: "XXX県沖",
                 depth: 10,
                 originTime: Date().addingTimeInterval(-1200),
-                headline: nil,
-                latitude: 35.0,
-                longitude: 139.0
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
+                headline: nil
             ),
             EarthquakeItem(
-                id: mock2,
+                id: "mock2",
                 magnitude: nil,
                 magnitudeCondition: "不明",
                 maxIntensity: "4",
                 hypocenterName: "YY地方西部",
                 depth: nil,
                 originTime: Date().addingTimeInterval(-14400),
-                headline: nil,
-                latitude: 35.5,
-                longitude: 139.5
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
+                headline: nil
             ),
             EarthquakeItem(
-                id: mock3,
+                id: "mock3",
                 magnitude: 8.0,
                 magnitudeCondition: nil,
                 maxIntensity: "5-",
                 hypocenterName: "ZZZZ",
                 depth: 700,
                 originTime: Date().addingTimeInterval(-86400),
-                headline: nil,
-                latitude: 36.0,
-                longitude: 140.0
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
+                headline: nil
             )
         ]
     }
@@ -183,7 +168,7 @@ struct EarthquakeWidget: Widget {
         configuration: EarthquakeWidgetIntent(regionType: .nationwide),
         earthquakes: [
             EarthquakeItem(
-                id: preview1,
+                id: "preview1",
                 magnitude: 6.4,
                 magnitudeCondition: nil,
                 maxIntensity: "5-",
@@ -191,12 +176,9 @@ struct EarthquakeWidget: Widget {
                 depth: 10,
                 originTime: Date().addingTimeInterval(-1200),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             ),
             EarthquakeItem(
-                id: preview2,
+                id: "preview2",
                 magnitude: nil,
                 magnitudeCondition: "不明",
                 maxIntensity: "4",
@@ -204,12 +186,9 @@ struct EarthquakeWidget: Widget {
                 depth: nil,
                 originTime: Date().addingTimeInterval(-14400),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             ),
             EarthquakeItem(
-                id: preview3,
+                id: "preview3",
                 magnitude: 8.0,
                 magnitudeCondition: nil,
                 maxIntensity: "5-",
@@ -217,9 +196,6 @@ struct EarthquakeWidget: Widget {
                 depth: 700,
                 originTime: Date().addingTimeInterval(-86400),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             )
         ],
         error: nil
@@ -234,7 +210,7 @@ struct EarthquakeWidget: Widget {
         configuration: EarthquakeWidgetIntent(regionType: .nationwide),
         earthquakes: [
             EarthquakeItem(
-                id: preview1,
+                id: "preview1",
                 magnitude: 6.4,
                 magnitudeCondition: nil,
                 maxIntensity: "5-",
@@ -242,12 +218,9 @@ struct EarthquakeWidget: Widget {
                 depth: 10,
                 originTime: Date().addingTimeInterval(-1200),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             ),
             EarthquakeItem(
-                id: preview2,
+                id: "preview2",
                 magnitude: nil,
                 magnitudeCondition: "不明",
                 maxIntensity: "4",
@@ -255,12 +228,9 @@ struct EarthquakeWidget: Widget {
                 depth: nil,
                 originTime: Date().addingTimeInterval(-14400),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             ),
             EarthquakeItem(
-                id: preview3,
+                id: "preview3",
                 magnitude: 8.0,
                 magnitudeCondition: nil,
                 maxIntensity: "5+",
@@ -268,9 +238,6 @@ struct EarthquakeWidget: Widget {
                 depth: 700,
                 originTime: Date().addingTimeInterval(-86400),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             )
         ],
         error: nil
@@ -288,7 +255,7 @@ struct EarthquakeWidget: Widget {
         ),
         earthquakes: [
             EarthquakeItem(
-                id: preview1,
+                id: "preview1",
                 magnitude: 6.4,
                 magnitudeCondition: nil,
                 maxIntensity: "5-",
@@ -296,12 +263,9 @@ struct EarthquakeWidget: Widget {
                 depth: 10,
                 originTime: Date().addingTimeInterval(-1200),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             ),
             EarthquakeItem(
-                id: preview2,
+                id: "preview2",
                 magnitude: 5.2,
                 magnitudeCondition: nil,
                 maxIntensity: "4",
@@ -309,12 +273,9 @@ struct EarthquakeWidget: Widget {
                 depth: 20,
                 originTime: Date().addingTimeInterval(-14400),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             ),
             EarthquakeItem(
-                id: preview3,
+                id: "preview3",
                 magnitude: 4.8,
                 magnitudeCondition: nil,
                 maxIntensity: "3",
@@ -322,9 +283,6 @@ struct EarthquakeWidget: Widget {
                 depth: 30,
                 originTime: Date().addingTimeInterval(-28800),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             )
         ],
         error: nil
@@ -350,7 +308,7 @@ struct EarthquakeWidget: Widget {
         configuration: EarthquakeWidgetIntent(regionType: .nationwide),
         earthquakes: [
             EarthquakeItem(
-                id: preview1,
+                id: "preview1",
                 magnitude: 7.2,
                 magnitudeCondition: nil,
                 maxIntensity: "6+",
@@ -358,12 +316,9 @@ struct EarthquakeWidget: Widget {
                 depth: 15,
                 originTime: Date().addingTimeInterval(-600),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             ),
             EarthquakeItem(
-                id: preview2,
+                id: "preview2",
                 magnitude: 5.8,
                 magnitudeCondition: nil,
                 maxIntensity: "5+",
@@ -371,9 +326,6 @@ struct EarthquakeWidget: Widget {
                 depth: 12,
                 originTime: Date().addingTimeInterval(-3600),
                 headline: nil
-            ,
-                latitude: 35.6762,
-                longitude: 139.6503
             )
         ],
         error: nil


### PR DESCRIPTION
Fix Swift compiler errors in Widget extensions to enable successful iOS app builds.

The errors included `Cannot find 'previewX' in scope` and `Extra arguments in call` due to `id` values being treated as undeclared variables and duplicate `latitude`/`longitude` parameters in `EarthquakeItem` initializers. Additionally, the `.contentMarginsDisabled()` modifier was removed as it does not exist.

---
<a href="https://cursor.com/background-agent?bcId=bc-43f0b811-be20-4f4a-9376-2d430c6fc350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43f0b811-be20-4f4a-9376-2d430c6fc350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

