### PR TITLE
Fix melos command not found in CI

### DIFF
--- a/.github/actions/setup-application-runtime/action.yaml
+++ b/.github/actions/setup-application-runtime/action.yaml
@@ -27,6 +27,7 @@ runs:
       run: |
         MELOS_VERSION=$(cat pubspec.lock | yq ".packages.melos.version" -r)
         dart pub global activate melos $MELOS_VERSION
+        echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
 
     - name: Resolve dependencies
       shell: bash


### PR DESCRIPTION
Add Dart's global pub cache bin directory to the PATH in CI to resolve "melos: command not found" errors.

The `dart pub global activate melos` command was run, but the directory containing the `melos` executable (`~/.pub-cache/bin`) was not added to the system's PATH, causing subsequent steps to fail when trying to invoke `melos`.

---
[Slack Thread](https://yumemi.slack.com/archives/D093S22KP9S/p1760106624733349?thread_ts=1760106624.733349&cid=D093S22KP9S)

<a href="https://cursor.com/background-agent?bcId=bc-bdcf709a-6ce4-447e-9387-cb474c3fcefa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bdcf709a-6ce4-447e-9387-cb474c3fcefa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

