### PR TITLE
Refactor: Preferences層のDataSource化とAsyncNotifier移行 (Step 0)

### DIFF
--- a/app/lib/core/component/intenisty/intensity_value_icon.dart
+++ b/app/lib/core/component/intenisty/intensity_value_icon.dart
@@ -24,7 +24,9 @@ class IntensityValueIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final intensityColorModel = ref.watch(intensityColorProvider);
+    final intensityColorModel =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final colorScheme = intensityColorModel.fromJmaIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
 

--- a/app/lib/core/component/intenisty/jma_forecast_intensity_icon.dart
+++ b/app/lib/core/component/intenisty/jma_forecast_intensity_icon.dart
@@ -25,7 +25,9 @@ class JmaForecastIntensityWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final intensityColorModel =
-        (colorModel ?? ref.watch(intensityColorProvider))!;
+        colorModel ??
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final colorScheme = intensityColorModel.fromJmaIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
     final intensityMainText = intensity.mainText;
@@ -117,7 +119,9 @@ class JmaForecastIntensityIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final intensityColorModel = ref.watch(intensityColorProvider);
+    final intensityColorModel =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final colorScheme = intensityColorModel.fromJmaIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
     final intensityMainText = intensity.mainText;

--- a/app/lib/core/component/intenisty/jma_forecast_lg_intensity_icon.dart
+++ b/app/lib/core/component/intenisty/jma_forecast_lg_intensity_icon.dart
@@ -25,7 +25,9 @@ class JmaForecastLgIntensityWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final intensityColorModel =
-        (colorModel ?? ref.watch(intensityColorProvider))!;
+        colorModel ??
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final colorScheme = intensityColorModel.fromJmaLpgmIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
     final intensityMainText = intensity.label;

--- a/app/lib/core/component/intenisty/jma_intensity_icon.dart
+++ b/app/lib/core/component/intenisty/jma_intensity_icon.dart
@@ -24,7 +24,9 @@ class JmaIntensityIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final intensityColorModel = ref.watch(intensityColorProvider);
+    final intensityColorModel =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final colorScheme = intensityColorModel.fromJmaIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
     final intensityMainText = intensity.mainText;

--- a/app/lib/core/component/intenisty/jma_lg_intensity_icon.dart
+++ b/app/lib/core/component/intenisty/jma_lg_intensity_icon.dart
@@ -22,7 +22,9 @@ class JmaLgIntensityIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final intensityColorModel = ref.watch(intensityColorProvider);
+    final intensityColorModel =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final colorScheme = intensityColorModel.fromJmaLpgmIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
 

--- a/app/lib/core/component/intenisty/lpgm_intensity_icon.dart
+++ b/app/lib/core/component/intenisty/lpgm_intensity_icon.dart
@@ -22,7 +22,9 @@ class LpgmIntensityIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final intensityColorModel = ref.watch(intensityColorProvider);
+    final intensityColorModel =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final colorScheme = intensityColorModel.fromJmaLpgmIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
 

--- a/app/lib/core/data/preferences/preferences.dart
+++ b/app/lib/core/data/preferences/preferences.dart
@@ -1,0 +1,5 @@
+export 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
+export 'package:eqmonitor/core/data/preferences/secure/secure_preferences_data_source.dart';
+export 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
+export 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+export 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';

--- a/app/lib/core/data/preferences/preferences_data_source.dart
+++ b/app/lib/core/data/preferences/preferences_data_source.dart
@@ -1,0 +1,17 @@
+abstract class PreferencesDataSource<T> {
+  Future<void> setString({required T key, required String value});
+  Future<String?> getString({required T key});
+
+  Future<void> setInt({required T key, required int value});
+  Future<int?> getInt({required T key});
+
+  Future<void> setDouble({required T key, required double value});
+  Future<double?> getDouble({required T key});
+
+  Future<void> setBool({required T key, required bool value});
+  Future<bool?> getBool({required T key});
+
+  Future<void> remove({required T key});
+
+  Future<void> clear();
+}

--- a/app/lib/core/data/preferences/secure/secure_preferences_data_source.dart
+++ b/app/lib/core/data/preferences/secure/secure_preferences_data_source.dart
@@ -1,0 +1,71 @@
+import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'secure_preferences_data_source.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<SecurePreferencesDataSource> securePreferencesDataSource(Ref ref) async {
+  final storage = await ref.watch(secureStorageProvider.future);
+  return SecurePreferencesDataSource(secureStorage: storage);
+}
+
+class SecurePreferencesDataSource
+    implements PreferencesDataSource<SecureStorageKey> {
+  SecurePreferencesDataSource({required FlutterSecureStorage secureStorage})
+      : _secureStorage = secureStorage;
+
+  final FlutterSecureStorage _secureStorage;
+
+  @override
+  Future<void> setString({
+    required SecureStorageKey key,
+    required String value,
+  }) => _secureStorage.write(key: key.key, value: value);
+
+  @override
+  Future<String?> getString({required SecureStorageKey key}) =>
+      _secureStorage.read(key: key.key);
+
+  @override
+  Future<void> setInt({
+    required SecureStorageKey key,
+    required int value,
+  }) => _secureStorage.write(key: key.key, value: value.toString());
+
+  @override
+  Future<int?> getInt({required SecureStorageKey key}) => _secureStorage
+      .read(key: key.key)
+      .then((value) => value != null ? int.parse(value) : null);
+
+  @override
+  Future<void> setDouble({
+    required SecureStorageKey key,
+    required double value,
+  }) => _secureStorage.write(key: key.key, value: value.toString());
+
+  @override
+  Future<double?> getDouble({required SecureStorageKey key}) => _secureStorage
+      .read(key: key.key)
+      .then((value) => value != null ? double.parse(value) : null);
+
+  @override
+  Future<void> setBool({
+    required SecureStorageKey key,
+    required bool value,
+  }) => _secureStorage.write(key: key.key, value: value.toString());
+
+  @override
+  Future<bool?> getBool({required SecureStorageKey key}) => _secureStorage
+      .read(key: key.key)
+      .then((value) => value != null ? bool.parse(value) : null);
+
+  @override
+  Future<void> remove({required SecureStorageKey key}) =>
+      _secureStorage.delete(key: key.key);
+
+  @override
+  Future<void> clear() => _secureStorage.deleteAll();
+}

--- a/app/lib/core/data/preferences/secure/secure_preferences_data_source.g.dart
+++ b/app/lib/core/data/preferences/secure/secure_preferences_data_source.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'secure_preferences_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(securePreferencesDataSource)
+final securePreferencesDataSourceProvider =
+    SecurePreferencesDataSourceProvider._();
+
+final class SecurePreferencesDataSourceProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<SecurePreferencesDataSource>,
+          SecurePreferencesDataSource,
+          FutureOr<SecurePreferencesDataSource>
+        >
+    with
+        $FutureModifier<SecurePreferencesDataSource>,
+        $FutureProvider<SecurePreferencesDataSource> {
+  SecurePreferencesDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'securePreferencesDataSourceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$securePreferencesDataSourceHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<SecurePreferencesDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<SecurePreferencesDataSource> create(Ref ref) {
+    return securePreferencesDataSource(ref);
+  }
+}
+
+String _$securePreferencesDataSourceHash() =>
+    r'e58bcb0be7f3ea5a373aaa97f529ce0282293852';

--- a/app/lib/core/data/preferences/secure/secure_storage.dart
+++ b/app/lib/core/data/preferences/secure/secure_storage.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'secure_storage.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<FlutterSecureStorage> secureStorage(Ref ref) async {
+  const storage = FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock_this_device,
+      groupId: 'group.net.yumnumm.eqmonitor',
+    ),
+  );
+
+  final sharedDs = ref.read(sharedPreferencesDataSourceProvider);
+  const secureStorageInitializedKey =
+      SharedPreferencesKey.secureStorageInitialized;
+  final hasInitialized =
+      await sharedDs.getBool(key: secureStorageInitializedKey);
+
+  if (hasInitialized == null) {
+    await storage.deleteAll();
+    await sharedDs.setBool(key: secureStorageInitializedKey, value: true);
+  }
+  return storage;
+}

--- a/app/lib/core/data/preferences/secure/secure_storage.g.dart
+++ b/app/lib/core/data/preferences/secure/secure_storage.g.dart
@@ -1,0 +1,53 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'secure_storage.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(secureStorage)
+final secureStorageProvider = SecureStorageProvider._();
+
+final class SecureStorageProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<FlutterSecureStorage>,
+          FlutterSecureStorage,
+          FutureOr<FlutterSecureStorage>
+        >
+    with
+        $FutureModifier<FlutterSecureStorage>,
+        $FutureProvider<FlutterSecureStorage> {
+  SecureStorageProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'secureStorageProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$secureStorageHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<FlutterSecureStorage> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<FlutterSecureStorage> create(Ref ref) {
+    return secureStorage(ref);
+  }
+}
+
+String _$secureStorageHash() => r'9df46ddbe92d560b42b10f09cc6f8e50053cfd90';

--- a/app/lib/core/data/preferences/secure/secure_storage_key.dart
+++ b/app/lib/core/data/preferences/secure/secure_storage_key.dart
@@ -1,0 +1,8 @@
+enum SecureStorageKey {
+  sessionToken('SESSION_TOKEN'),
+  userId('user_id'),
+  ;
+
+  const SecureStorageKey(this.key);
+  final String key;
+}

--- a/app/lib/core/data/preferences/shared/shared_preferences.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences.dart
@@ -1,0 +1,8 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'shared_preferences.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<SharedPreferences> sharedPreferences(Ref ref) =>
+    SharedPreferences.getInstance();

--- a/app/lib/core/data/preferences/shared/shared_preferences.g.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences.g.dart
@@ -1,0 +1,53 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'shared_preferences.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(sharedPreferences)
+final sharedPreferencesProvider = SharedPreferencesProvider._();
+
+final class SharedPreferencesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<SharedPreferences>,
+          SharedPreferences,
+          FutureOr<SharedPreferences>
+        >
+    with
+        $FutureModifier<SharedPreferences>,
+        $FutureProvider<SharedPreferences> {
+  SharedPreferencesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sharedPreferencesProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sharedPreferencesHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<SharedPreferences> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<SharedPreferences> create(Ref ref) {
+    return sharedPreferences(ref);
+  }
+}
+
+String _$sharedPreferencesHash() => r'ad13470fe866595ad0f58a3e26f11048d94ef22e';

--- a/app/lib/core/data/preferences/shared/shared_preferences_data_source.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_data_source.dart
@@ -1,0 +1,69 @@
+import 'package:eqmonitor/core/data/preferences/preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'shared_preferences_data_source.g.dart';
+
+@Riverpod(keepAlive: true)
+SharedPreferencesDataSource sharedPreferencesDataSource(Ref ref) {
+  final prefs = ref.watch(sharedPreferencesProvider).requireValue;
+  return SharedPreferencesDataSource(sharedPreferences: prefs);
+}
+
+class SharedPreferencesDataSource
+    implements PreferencesDataSource<SharedPreferencesKey> {
+  SharedPreferencesDataSource({
+    required SharedPreferences sharedPreferences,
+  }) : _sharedPreferences = sharedPreferences;
+
+  final SharedPreferences _sharedPreferences;
+
+  @override
+  Future<void> setString({
+    required SharedPreferencesKey key,
+    required String value,
+  }) => _sharedPreferences.setString(key.key, value);
+
+  @override
+  Future<String?> getString({required SharedPreferencesKey key}) =>
+      Future.value(_sharedPreferences.getString(key.key));
+
+  @override
+  Future<void> setInt({
+    required SharedPreferencesKey key,
+    required int value,
+  }) => _sharedPreferences.setInt(key.key, value);
+
+  @override
+  Future<int?> getInt({required SharedPreferencesKey key}) =>
+      Future.value(_sharedPreferences.getInt(key.key));
+
+  @override
+  Future<void> setDouble({
+    required SharedPreferencesKey key,
+    required double value,
+  }) => _sharedPreferences.setDouble(key.key, value);
+
+  @override
+  Future<double?> getDouble({required SharedPreferencesKey key}) =>
+      Future.value(_sharedPreferences.getDouble(key.key));
+
+  @override
+  Future<void> setBool({
+    required SharedPreferencesKey key,
+    required bool value,
+  }) => _sharedPreferences.setBool(key.key, value);
+
+  @override
+  Future<bool?> getBool({required SharedPreferencesKey key}) =>
+      Future.value(_sharedPreferences.getBool(key.key));
+
+  @override
+  Future<void> remove({required SharedPreferencesKey key}) =>
+      _sharedPreferences.remove(key.key);
+
+  @override
+  Future<void> clear() => _sharedPreferences.clear();
+}

--- a/app/lib/core/data/preferences/shared/shared_preferences_data_source.g.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_data_source.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'shared_preferences_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(sharedPreferencesDataSource)
+final sharedPreferencesDataSourceProvider =
+    SharedPreferencesDataSourceProvider._();
+
+final class SharedPreferencesDataSourceProvider
+    extends
+        $FunctionalProvider<
+          SharedPreferencesDataSource,
+          SharedPreferencesDataSource,
+          SharedPreferencesDataSource
+        >
+    with $Provider<SharedPreferencesDataSource> {
+  SharedPreferencesDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sharedPreferencesDataSourceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sharedPreferencesDataSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<SharedPreferencesDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SharedPreferencesDataSource create(Ref ref) {
+    return sharedPreferencesDataSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SharedPreferencesDataSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SharedPreferencesDataSource>(value),
+    );
+  }
+}
+
+String _$sharedPreferencesDataSourceHash() =>
+    r'0b2e0e0aeb939b045382730cae64c4cf5febab89';

--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -1,0 +1,17 @@
+enum SharedPreferencesKey {
+  secureStorageInitialized('SECURE_STORAGE_INITIALIZED'),
+  ntpConfig('ntp_config'),
+  earthquakeHistoryConfig('earthquake_history_config'),
+  telegramUrl('telegram_url'),
+  debug('debug'),
+  kmoniSettings('_kmoni_settings'),
+  themeMode('theme_mode'),
+  mapConfiguration('map_configuration'),
+  intensityColor('intensity_color'),
+  locationTrackingMode('location_tracking_mode'),
+  homeConfiguration('home_configuration'),
+  ;
+
+  const SharedPreferencesKey(this.key);
+  final String key;
+}

--- a/app/lib/core/provider/config/theme/intensity_color/intensity_color_provider.dart
+++ b/app/lib/core/provider/config/theme/intensity_color/intensity_color_provider.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'intensity_color_provider.g.dart';
@@ -9,34 +10,30 @@ part 'intensity_color_provider.g.dart';
 @Riverpod(keepAlive: true)
 class IntensityColor extends _$IntensityColor {
   @override
-  IntensityColorModel build() {
-    final result = load();
-    if (result != null) {
-      return result;
-    }
-    return IntensityColorModel.eqmonitor();
-  }
+  Future<IntensityColorModel> build() async => load();
 
-  static const _key = 'intensity_color';
-
-  Future<void> update(IntensityColorModel model) async {
-    state = model;
-    await ref
-        .read(sharedPreferencesProvider)
-        .setString(_key, jsonEncode(model.toJson()));
-  }
-
-  IntensityColorModel? load() {
-    final value = ref.read(sharedPreferencesProvider).getString(_key);
+  Future<IntensityColorModel> load() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final value =
+        await ds.getString(key: SharedPreferencesKey.intensityColor);
     if (value == null) {
-      return null;
+      return IntensityColorModel.eqmonitor();
     }
     try {
       return IntensityColorModel.fromJson(
         jsonDecode(value) as Map<String, dynamic>,
       );
     } on Exception catch (_) {
-      return null;
+      return IntensityColorModel.eqmonitor();
     }
+  }
+
+  Future<void> setModel(IntensityColorModel model) async {
+    state = AsyncValue.data(model);
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setString(
+      key: SharedPreferencesKey.intensityColor,
+      value: jsonEncode(model.toJson()),
+    );
   }
 }

--- a/app/lib/core/provider/config/theme/intensity_color/intensity_color_provider.dart
+++ b/app/lib/core/provider/config/theme/intensity_color/intensity_color_provider.dart
@@ -14,8 +14,7 @@ class IntensityColor extends _$IntensityColor {
 
   Future<IntensityColorModel> load() async {
     final ds = ref.read(sharedPreferencesDataSourceProvider);
-    final value =
-        await ds.getString(key: SharedPreferencesKey.intensityColor);
+    final value = await ds.getString(key: SharedPreferencesKey.intensityColor);
     if (value == null) {
       return IntensityColorModel.eqmonitor();
     }

--- a/app/lib/core/provider/config/theme/intensity_color/intensity_color_provider.g.dart
+++ b/app/lib/core/provider/config/theme/intensity_color/intensity_color_provider.g.dart
@@ -15,7 +15,7 @@ part of 'intensity_color_provider.dart';
 final intensityColorProvider = IntensityColorProvider._();
 
 final class IntensityColorProvider
-    extends $NotifierProvider<IntensityColor, IntensityColorModel> {
+    extends $AsyncNotifierProvider<IntensityColor, IntensityColorModel> {
   IntensityColorProvider._()
     : super(
         from: null,
@@ -33,29 +33,22 @@ final class IntensityColorProvider
   @$internal
   @override
   IntensityColor create() => IntensityColor();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(IntensityColorModel value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<IntensityColorModel>(value),
-    );
-  }
 }
 
-String _$intensityColorHash() => r'9c5f1148d0001d84e37f1a0bb14d65cdaee14795';
+String _$intensityColorHash() => r'dd69cb67db6e7c90548cd6135372abce766b7d7f';
 
-abstract class _$IntensityColor extends $Notifier<IntensityColorModel> {
-  IntensityColorModel build();
+abstract class _$IntensityColor extends $AsyncNotifier<IntensityColorModel> {
+  FutureOr<IntensityColorModel> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<IntensityColorModel, IntensityColorModel>;
+    final ref =
+        this.ref as $Ref<AsyncValue<IntensityColorModel>, IntensityColorModel>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<IntensityColorModel, IntensityColorModel>,
-              IntensityColorModel,
+              AnyNotifier<AsyncValue<IntensityColorModel>, IntensityColorModel>,
+              AsyncValue<IntensityColorModel>,
               Object?,
               Object?
             >;

--- a/app/lib/core/provider/ntp/ntp_config_provider.dart
+++ b/app/lib/core/provider/ntp/ntp_config_provider.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:eqmonitor/core/provider/ntp/ntp_config_model.dart';
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'ntp_config_provider.g.dart';
@@ -9,13 +10,11 @@ part 'ntp_config_provider.g.dart';
 @Riverpod(keepAlive: true)
 class NtpConfig extends _$NtpConfig {
   @override
-  NtpConfigModel build() => _load();
+  Future<NtpConfigModel> build() async => _load();
 
-  static const _prefsKey = 'ntp_config';
-
-  NtpConfigModel _load() {
-    final prefs = ref.read(sharedPreferencesProvider);
-    final json = prefs.getString(_prefsKey);
+  Future<NtpConfigModel> _load() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final json = await ds.getString(key: SharedPreferencesKey.ntpConfig);
     if (json == null) {
       return const NtpConfigModel();
     }
@@ -28,22 +27,28 @@ class NtpConfig extends _$NtpConfig {
   }
 
   Future<void> changeLookUpAddress(String url) async {
-    state = state.copyWith(lookUpAddress: url);
-    await _save(state);
+    final current = state.valueOrNull ?? const NtpConfigModel();
+    state = AsyncValue.data(current.copyWith(lookUpAddress: url));
+    await _save(state.valueOrNull!);
   }
 
   Future<void> changeTimeout(Duration timeout) async {
-    state = state.copyWith(timeout: timeout);
-    await _save(state);
+    final current = state.valueOrNull ?? const NtpConfigModel();
+    state = AsyncValue.data(current.copyWith(timeout: timeout));
+    await _save(state.valueOrNull!);
   }
 
   Future<void> changeInterval(Duration interval) async {
-    state = state.copyWith(interval: interval);
-    await _save(state);
+    final current = state.valueOrNull ?? const NtpConfigModel();
+    state = AsyncValue.data(current.copyWith(interval: interval));
+    await _save(state.valueOrNull!);
   }
 
   Future<void> _save(NtpConfigModel config) async {
-    final prefs = ref.read(sharedPreferencesProvider);
-    await prefs.setString(_prefsKey, jsonEncode(config.toJson()));
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setString(
+      key: SharedPreferencesKey.ntpConfig,
+      value: jsonEncode(config.toJson()),
+    );
   }
 }

--- a/app/lib/core/provider/ntp/ntp_config_provider.g.dart
+++ b/app/lib/core/provider/ntp/ntp_config_provider.g.dart
@@ -15,7 +15,7 @@ part of 'ntp_config_provider.dart';
 final ntpConfigProvider = NtpConfigProvider._();
 
 final class NtpConfigProvider
-    extends $NotifierProvider<NtpConfig, NtpConfigModel> {
+    extends $AsyncNotifierProvider<NtpConfig, NtpConfigModel> {
   NtpConfigProvider._()
     : super(
         from: null,
@@ -33,29 +33,21 @@ final class NtpConfigProvider
   @$internal
   @override
   NtpConfig create() => NtpConfig();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(NtpConfigModel value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<NtpConfigModel>(value),
-    );
-  }
 }
 
-String _$ntpConfigHash() => r'ea839c3c8aa2d5b12e392bacb05eb123541d753b';
+String _$ntpConfigHash() => r'459c8b150322a62b39d1013b395e17beab64d1e0';
 
-abstract class _$NtpConfig extends $Notifier<NtpConfigModel> {
-  NtpConfigModel build();
+abstract class _$NtpConfig extends $AsyncNotifier<NtpConfigModel> {
+  FutureOr<NtpConfigModel> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<NtpConfigModel, NtpConfigModel>;
+    final ref = this.ref as $Ref<AsyncValue<NtpConfigModel>, NtpConfigModel>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<NtpConfigModel, NtpConfigModel>,
-              NtpConfigModel,
+              AnyNotifier<AsyncValue<NtpConfigModel>, NtpConfigModel>,
+              AsyncValue<NtpConfigModel>,
               Object?,
               Object?
             >;

--- a/app/lib/core/provider/shared_preferences.dart
+++ b/app/lib/core/provider/shared_preferences.dart
@@ -3,5 +3,32 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 part 'shared_preferences.g.dart';
 
+/// SharedPreferences のラッパー。参照プロジェクトとの API 互換のため。
+class SharedPreferencesAsync {
+  SharedPreferencesAsync(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  String? getString(String key) => _prefs.getString(key);
+  Future<void> setString(String key, String value) =>
+      _prefs.setString(key, value);
+
+  int? getInt(String key) => _prefs.getInt(key);
+  Future<void> setInt(String key, int value) => _prefs.setInt(key, value);
+
+  double? getDouble(String key) => _prefs.getDouble(key);
+  Future<void> setDouble(String key, double value) =>
+      _prefs.setDouble(key, value);
+
+  bool? getBool(String key) => _prefs.getBool(key);
+  Future<void> setBool(String key, bool value) => _prefs.setBool(key, value);
+
+  Future<void> remove(String key) => _prefs.remove(key);
+  Future<void> clear() => _prefs.clear();
+}
+
 @Riverpod(keepAlive: true)
-SharedPreferences sharedPreferences(Ref ref) => throw UnimplementedError();
+SharedPreferencesAsync sharedPreferences(Ref ref) =>
+    throw UnimplementedError(
+      'sharedPreferencesProvider must be overridden in main',
+    );

--- a/app/lib/core/provider/shared_preferences.g.dart
+++ b/app/lib/core/provider/shared_preferences.g.dart
@@ -17,11 +17,11 @@ final sharedPreferencesProvider = SharedPreferencesProvider._();
 final class SharedPreferencesProvider
     extends
         $FunctionalProvider<
-          SharedPreferences,
-          SharedPreferences,
-          SharedPreferences
+          SharedPreferencesAsync,
+          SharedPreferencesAsync,
+          SharedPreferencesAsync
         >
-    with $Provider<SharedPreferences> {
+    with $Provider<SharedPreferencesAsync> {
   SharedPreferencesProvider._()
     : super(
         from: null,
@@ -38,22 +38,22 @@ final class SharedPreferencesProvider
 
   @$internal
   @override
-  $ProviderElement<SharedPreferences> $createElement(
+  $ProviderElement<SharedPreferencesAsync> $createElement(
     $ProviderPointer pointer,
   ) => $ProviderElement(pointer);
 
   @override
-  SharedPreferences create(Ref ref) {
+  SharedPreferencesAsync create(Ref ref) {
     return sharedPreferences(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(SharedPreferences value) {
+  Override overrideWithValue(SharedPreferencesAsync value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<SharedPreferences>(value),
+      providerOverride: $SyncValueProvider<SharedPreferencesAsync>(value),
     );
   }
 }
 
-String _$sharedPreferencesHash() => r'6bbc55d4dc38d5979ff916112845bcc4a4a3a1ea';
+String _$sharedPreferencesHash() => r'f92279102944d7d3bcaba3d20211fb6f784beb1f';

--- a/app/lib/core/provider/telegram_url/provider/telegram_url_provider.dart
+++ b/app/lib/core/provider/telegram_url/provider/telegram_url_provider.dart
@@ -1,36 +1,29 @@
 import 'dart:convert';
 
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:eqmonitor/core/provider/telegram_url/model/telegram_url_model.dart';
 import 'package:eqmonitor/core/util/env.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'telegram_url_provider.g.dart';
 
+const _defaultTelegramUrl = TelegramUrlModel(
+  restApiUrl: Env.restApiUrl,
+  wsApiUrl: Env.wsApiUrl,
+);
+
 @Riverpod(keepAlive: true)
 class TelegramUrl extends _$TelegramUrl {
   @override
-  TelegramUrlModel build() {
-    final result = _load();
-    if (result != null) {
-      return result;
-    }
+  Future<TelegramUrlModel> build() async => _load();
 
-    return const TelegramUrlModel(
-      restApiUrl: Env.restApiUrl,
-      wsApiUrl: Env.wsApiUrl,
-    );
-  }
-
-  static const _key = 'telegram_url';
-
-  Future<void> _save() =>
-      ref.read(sharedPreferencesProvider).setString(_key, jsonEncode(state));
-
-  TelegramUrlModel? _load() {
-    final jsonString = ref.read(sharedPreferencesProvider).getString(_key);
+  Future<TelegramUrlModel> _load() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final jsonString =
+        await ds.getString(key: SharedPreferencesKey.telegramUrl);
     if (jsonString == null) {
-      return null;
+      return _defaultTelegramUrl;
     }
     try {
       return TelegramUrlModel.fromJson(
@@ -38,17 +31,27 @@ class TelegramUrl extends _$TelegramUrl {
       );
       // ignore: avoid_catches_without_on_clauses
     } catch (e) {
-      return null;
+      return _defaultTelegramUrl;
     }
   }
 
+  Future<void> _save(TelegramUrlModel value) async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setString(
+      key: SharedPreferencesKey.telegramUrl,
+      value: jsonEncode(value.toJson()),
+    );
+  }
+
   Future<void> updateRestUrl(String url) async {
-    state = state.copyWith(restApiUrl: url);
-    await _save();
+    final current = state.valueOrNull ?? _defaultTelegramUrl;
+    state = AsyncValue.data(current.copyWith(restApiUrl: url));
+    await _save(state.valueOrNull!);
   }
 
   Future<void> updateWebSocketUrl(String url) async {
-    state = state.copyWith(wsApiUrl: url);
-    await _save();
+    final current = state.valueOrNull ?? _defaultTelegramUrl;
+    state = AsyncValue.data(current.copyWith(wsApiUrl: url));
+    await _save(state.valueOrNull!);
   }
 }

--- a/app/lib/core/provider/telegram_url/provider/telegram_url_provider.g.dart
+++ b/app/lib/core/provider/telegram_url/provider/telegram_url_provider.g.dart
@@ -15,7 +15,7 @@ part of 'telegram_url_provider.dart';
 final telegramUrlProvider = TelegramUrlProvider._();
 
 final class TelegramUrlProvider
-    extends $NotifierProvider<TelegramUrl, TelegramUrlModel> {
+    extends $AsyncNotifierProvider<TelegramUrl, TelegramUrlModel> {
   TelegramUrlProvider._()
     : super(
         from: null,
@@ -33,29 +33,22 @@ final class TelegramUrlProvider
   @$internal
   @override
   TelegramUrl create() => TelegramUrl();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(TelegramUrlModel value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<TelegramUrlModel>(value),
-    );
-  }
 }
 
-String _$telegramUrlHash() => r'5204d0f0332e2b25e011b31dc421f81ad92aee0a';
+String _$telegramUrlHash() => r'9c877595dea7e226275c0a9f6eb5cecef183a6be';
 
-abstract class _$TelegramUrl extends $Notifier<TelegramUrlModel> {
-  TelegramUrlModel build();
+abstract class _$TelegramUrl extends $AsyncNotifier<TelegramUrlModel> {
+  FutureOr<TelegramUrlModel> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<TelegramUrlModel, TelegramUrlModel>;
+    final ref =
+        this.ref as $Ref<AsyncValue<TelegramUrlModel>, TelegramUrlModel>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<TelegramUrlModel, TelegramUrlModel>,
-              TelegramUrlModel,
+              AnyNotifier<AsyncValue<TelegramUrlModel>, TelegramUrlModel>,
+              AsyncValue<TelegramUrlModel>,
               Object?,
               Object?
             >;

--- a/app/lib/core/provider/user_id.dart
+++ b/app/lib/core/provider/user_id.dart
@@ -1,30 +1,29 @@
-import 'package:eqmonitor/core/provider/secure_storage.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_id.g.dart';
-
-const _userIdKey = 'user_id';
 
 /// User IDを提供するProvider
 @Riverpod(keepAlive: true)
 class UserId extends _$UserId {
   @override
   Future<String?> build() async {
-    final storage = ref.watch(secureStorageProvider);
-    return storage.read(key: _userIdKey);
+    final ds = await ref.watch(securePreferencesDataSourceProvider.future);
+    return ds.getString(key: SecureStorageKey.userId);
   }
 
   /// User IDを保存
   Future<void> save(String userId) async {
-    final storage = ref.watch(secureStorageProvider);
-    await storage.write(key: _userIdKey, value: userId);
+    final ds = await ref.watch(securePreferencesDataSourceProvider.future);
+    await ds.setString(key: SecureStorageKey.userId, value: userId);
     state = AsyncValue.data(userId);
   }
 
   /// User IDを削除
   Future<void> clear() async {
-    final storage = ref.watch(secureStorageProvider);
-    await storage.delete(key: _userIdKey);
+    final ds = await ref.watch(securePreferencesDataSourceProvider.future);
+    await ds.remove(key: SecureStorageKey.userId);
     state = const AsyncValue.data(null);
   }
 }

--- a/app/lib/core/provider/user_id.g.dart
+++ b/app/lib/core/provider/user_id.g.dart
@@ -37,7 +37,7 @@ final class UserIdProvider extends $AsyncNotifierProvider<UserId, String?> {
   UserId create() => UserId();
 }
 
-String _$userIdHash() => r'a309578e13d437dc17eef69771e16f6dbf1753dc';
+String _$userIdHash() => r'264a20f277d3c6ab68996897a34d164d07db4493';
 
 /// User IDを提供するProvider
 

--- a/app/lib/core/theme/theme_provider.dart
+++ b/app/lib/core/theme/theme_provider.dart
@@ -15,8 +15,7 @@ class ThemeModeNotifier extends _$ThemeModeNotifier {
 
   Future<ThemeMode> _load() async {
     final ds = ref.read(sharedPreferencesDataSourceProvider);
-    final value =
-        await ds.getString(key: SharedPreferencesKey.themeMode);
+    final value = await ds.getString(key: SharedPreferencesKey.themeMode);
     if (value == null) {
       return ThemeMode.system;
     }
@@ -24,6 +23,7 @@ class ThemeModeNotifier extends _$ThemeModeNotifier {
         ThemeMode.system;
   }
 
+  @override
   Future<void> update(ThemeMode mode) async {
     state = AsyncValue.data(mode);
     final ds = ref.read(sharedPreferencesDataSourceProvider);

--- a/app/lib/core/theme/theme_provider.dart
+++ b/app/lib/core/theme/theme_provider.dart
@@ -1,7 +1,8 @@
 import 'dart:ui' as ui;
 
 import 'package:collection/collection.dart';
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:flutter/material.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,29 +11,24 @@ part 'theme_provider.g.dart';
 @Riverpod(keepAlive: true)
 class ThemeModeNotifier extends _$ThemeModeNotifier {
   @override
-  ThemeMode build() {
-    final result = _load();
-    if (result != null) {
-      return result;
+  Future<ThemeMode> build() async => _load();
+
+  Future<ThemeMode> _load() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final value =
+        await ds.getString(key: SharedPreferencesKey.themeMode);
+    if (value == null) {
+      return ThemeMode.system;
     }
-    return ThemeMode.system;
+    return ThemeMode.values.firstWhereOrNull((e) => e.name == value) ??
+        ThemeMode.system;
   }
 
   Future<void> update(ThemeMode mode) async {
-    state = mode;
-    await ref.read(sharedPreferencesProvider).setString(_prefsKey, mode.name);
+    state = AsyncValue.data(mode);
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setString(key: SharedPreferencesKey.themeMode, value: mode.name);
   }
-
-  ThemeMode? _load() {
-    final prefs = ref.read(sharedPreferencesProvider);
-    final value = prefs.getString(_prefsKey);
-    if (value == null) {
-      return null;
-    }
-    return ThemeMode.values.firstWhereOrNull((e) => e.name == value);
-  }
-
-  static const _prefsKey = 'theme_mode';
 }
 
 @Riverpod(keepAlive: true)

--- a/app/lib/core/theme/theme_provider.g.dart
+++ b/app/lib/core/theme/theme_provider.g.dart
@@ -15,7 +15,7 @@ part of 'theme_provider.dart';
 final themeModeProvider = ThemeModeNotifierProvider._();
 
 final class ThemeModeNotifierProvider
-    extends $NotifierProvider<ThemeModeNotifier, ThemeMode> {
+    extends $AsyncNotifierProvider<ThemeModeNotifier, ThemeMode> {
   ThemeModeNotifierProvider._()
     : super(
         from: null,
@@ -33,29 +33,21 @@ final class ThemeModeNotifierProvider
   @$internal
   @override
   ThemeModeNotifier create() => ThemeModeNotifier();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(ThemeMode value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<ThemeMode>(value),
-    );
-  }
 }
 
-String _$themeModeNotifierHash() => r'fc896b63bda7ea9e58659851b10234f4074bab94';
+String _$themeModeNotifierHash() => r'8a97cc2dc36fee99909d56e345847b5a97eae0ef';
 
-abstract class _$ThemeModeNotifier extends $Notifier<ThemeMode> {
-  ThemeMode build();
+abstract class _$ThemeModeNotifier extends $AsyncNotifier<ThemeMode> {
+  FutureOr<ThemeMode> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<ThemeMode, ThemeMode>;
+    final ref = this.ref as $Ref<AsyncValue<ThemeMode>, ThemeMode>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<ThemeMode, ThemeMode>,
-              ThemeMode,
+              AnyNotifier<AsyncValue<ThemeMode>, ThemeMode>,
+              AsyncValue<ThemeMode>,
               Object?,
               Object?
             >;

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart
@@ -1,35 +1,30 @@
 import 'dart:convert';
 
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'earthquake_history_config_notifier.g.dart';
 
+const _defaultEarthquakeHistoryConfig = EarthquakeHistoryConfig(
+  list: EarthquakeHistoryListConfig(),
+  detail: EarthquakeHistoryDetailConfig(),
+);
+
 @riverpod
 class EarthquakeHistoryConfigNotifier
     extends _$EarthquakeHistoryConfigNotifier {
   @override
-  EarthquakeHistoryConfig build() {
-    final result = _load();
-    if (result != null) {
-      return result;
-    }
-    return const EarthquakeHistoryConfig(
-      list: EarthquakeHistoryListConfig(),
-      detail: EarthquakeHistoryDetailConfig(),
+  Future<EarthquakeHistoryConfig> build() async => _load();
+
+  Future<EarthquakeHistoryConfig> _load() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final jsonString = await ds.getString(
+      key: SharedPreferencesKey.earthquakeHistoryConfig,
     );
-  }
-
-  static const _key = 'earthquake_history_config';
-
-  Future<void> _save() async =>
-      ref.read(sharedPreferencesProvider).setString(_key, jsonEncode(state));
-
-  EarthquakeHistoryConfig? _load() {
-    final jsonString = ref.read(sharedPreferencesProvider).getString(_key);
     if (jsonString == null) {
-      return null;
+      return _defaultEarthquakeHistoryConfig;
     }
     try {
       return EarthquakeHistoryConfig.fromJson(
@@ -37,24 +32,35 @@ class EarthquakeHistoryConfigNotifier
       );
       // ignore: avoid_catches_without_on_clauses
     } catch (e) {
-      return null;
+      return _defaultEarthquakeHistoryConfig;
     }
   }
 
+  Future<void> _save(EarthquakeHistoryConfig value) async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setString(
+      key: SharedPreferencesKey.earthquakeHistoryConfig,
+      value: jsonEncode(value.toJson()),
+    );
+  }
+
   Future<void> updateListConfig(EarthquakeHistoryListConfig config) async {
-    state = state.copyWith(list: config);
-    return _save();
+    final current = state.valueOrNull ?? _defaultEarthquakeHistoryConfig;
+    state = AsyncValue.data(current.copyWith(list: config));
+    await _save(state.valueOrNull!);
   }
 
   Future<void> updateDetailConfig(EarthquakeHistoryDetailConfig config) async {
-    state = state.copyWith(detail: config);
-    return _save();
+    final current = state.valueOrNull ?? _defaultEarthquakeHistoryConfig;
+    state = AsyncValue.data(current.copyWith(detail: config));
+    await _save(state.valueOrNull!);
   }
 
   Future<void> updateIntensityIcon({required bool value}) async {
-    state = state.copyWith(
-      detail: state.detail.copyWith(showIntensityIcon: value),
-    );
-    await _save();
+    final current = state.valueOrNull ?? _defaultEarthquakeHistoryConfig;
+    state = AsyncValue.data(current.copyWith(
+      detail: current.detail.copyWith(showIntensityIcon: value),
+    ));
+    await _save(state.valueOrNull!);
   }
 }

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.g.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.g.dart
@@ -17,7 +17,7 @@ final earthquakeHistoryConfigProvider =
 
 final class EarthquakeHistoryConfigNotifierProvider
     extends
-        $NotifierProvider<
+        $AsyncNotifierProvider<
           EarthquakeHistoryConfigNotifier,
           EarthquakeHistoryConfig
         > {
@@ -38,32 +38,31 @@ final class EarthquakeHistoryConfigNotifierProvider
   @$internal
   @override
   EarthquakeHistoryConfigNotifier create() => EarthquakeHistoryConfigNotifier();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(EarthquakeHistoryConfig value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<EarthquakeHistoryConfig>(value),
-    );
-  }
 }
 
 String _$earthquakeHistoryConfigNotifierHash() =>
-    r'c133b5e0380ca6ba952eedc00a37ae65284751cd';
+    r'82101ad1f4880a661d8c7ae067abbc5b56611704';
 
 abstract class _$EarthquakeHistoryConfigNotifier
-    extends $Notifier<EarthquakeHistoryConfig> {
-  EarthquakeHistoryConfig build();
+    extends $AsyncNotifier<EarthquakeHistoryConfig> {
+  FutureOr<EarthquakeHistoryConfig> build();
   @$mustCallSuper
   @override
   void runBuild() {
     final ref =
-        this.ref as $Ref<EarthquakeHistoryConfig, EarthquakeHistoryConfig>;
+        this.ref
+            as $Ref<
+              AsyncValue<EarthquakeHistoryConfig>,
+              EarthquakeHistoryConfig
+            >;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<EarthquakeHistoryConfig, EarthquakeHistoryConfig>,
-              EarthquakeHistoryConfig,
+              AnyNotifier<
+                AsyncValue<EarthquakeHistoryConfig>,
+                EarthquakeHistoryConfig
+              >,
+              AsyncValue<EarthquakeHistoryConfig>,
               Object?,
               Object?
             >;

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
@@ -100,7 +100,9 @@ class EarthquakeHistoryListTile extends HookConsumerWidget {
           null => '',
         };
 
-    final intensityColorState = ref.watch(intensityColorProvider);
+    final intensityColorState =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final intensityColor = maxIntensity != null
         ? intensityColorState.fromJmaIntensity(maxIntensity).background
         : null;

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart
@@ -19,7 +19,9 @@ class EarthquakeHypocenterInformationCard extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final intensityColorScheme = ref.watch(intensityColorProvider);
+    final intensityColorScheme =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final maxIntensity = item.intensity?.maxIntensity;
     final hypocenter = item.hypocenter;
 

--- a/app/lib/feature/earthquake_history/ui/components/modal/earthquake_history_details_map_layer_modal.dart
+++ b/app/lib/feature/earthquake_history/ui/components/modal/earthquake_history_details_map_layer_modal.dart
@@ -76,47 +76,51 @@ class _LocationSettingCards extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final config = ref.watch(homeConfigurationProvider);
+    final configAsync = ref.watch(homeConfigurationProvider);
 
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '現在位置マーカー',
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold,
+    return configAsync.when(
+      data: (config) => Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '現在位置マーカー',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
-          ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Expanded(
-                child: _LocationCard(
-                  title: '非表示',
-                  icon: Icons.location_off_outlined,
-                  isSelected: !config.showLocation,
-                  onTap: () => lightHapticFunction(
-                    () => ref
-                        .read(homeConfigurationProvider.notifier)
-                        .save(config.copyWith(showLocation: false)),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: _LocationCard(
+                    title: '非表示',
+                    icon: Icons.location_off_outlined,
+                    isSelected: !config.showLocation,
+                    onTap: () => lightHapticFunction(
+                      () => ref
+                          .read(homeConfigurationProvider.notifier)
+                          .save(config.copyWith(showLocation: false)),
+                    ),
                   ),
                 ),
-              ),
-              Expanded(
-                child: _LocationCard(
-                  title: '表示',
-                  icon: Icons.location_on_outlined,
-                  isSelected: config.showLocation,
-                  subtitle: 'NOT IMPLEMENTED',
-                  onTap: () => throw UnimplementedError(),
+                Expanded(
+                  child: _LocationCard(
+                    title: '表示',
+                    icon: Icons.location_on_outlined,
+                    isSelected: config.showLocation,
+                    subtitle: 'NOT IMPLEMENTED',
+                    onTap: () => throw UnimplementedError(),
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
+      loading: () => const Center(child: CircularProgressIndicator.adaptive()),
+      error: (error, _) => Center(child: Text('$error')),
     );
   }
 }

--- a/app/lib/feature/earthquake_search/ui/earthquake_search_result_page.dart
+++ b/app/lib/feature/earthquake_search/ui/earthquake_search_result_page.dart
@@ -271,15 +271,18 @@ class _EarthquakeSearchResultListTile extends HookConsumerWidget {
     };
 
     final maxIntensity = earthquake.intensity?.maxIntensity;
-    final maxIntensityText =
-        maxIntensity != null ? '最大震度 ${maxIntensity.label}' : null;
+    final maxIntensityText = maxIntensity != null
+        ? '最大震度 ${maxIntensity.label}'
+        : null;
 
     final subTitle = [
       dateText,
       maxIntensityText,
     ].where((e) => e != null && e.isNotEmpty).join('\n');
 
-    final intensityColorState = ref.watch(intensityColorProvider);
+    final intensityColorState =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
     final intensityColor = localIntensity != null
         ? intensityColorState.fromJmaIntensity(localIntensity).background
         : null;
@@ -325,8 +328,7 @@ class _EarthquakeSearchResultListTile extends HookConsumerWidget {
       return '';
     }
     return switch (magnitude) {
-      EarthquakeMagnitudeValue(:final value) =>
-        'M${value.toStringAsFixed(1)}',
+      EarthquakeMagnitudeValue(:final value) => 'M${value.toStringAsFixed(1)}',
       EarthquakeMagnitudeUnknown() => 'M不明',
       EarthquakeMagnitudeOverM8() => 'M8超',
     };

--- a/app/lib/feature/home/data/notifier/home_configuration_notifier.dart
+++ b/app/lib/feature/home/data/notifier/home_configuration_notifier.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'dart:developer';
 
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -10,34 +11,30 @@ part 'home_configuration_notifier.g.dart';
 @riverpod
 class HomeConfigurationNotifier extends _$HomeConfigurationNotifier {
   @override
-  HomeConfigurationModel build() {
-    final saved = load();
-    if (saved != null) {
-      return saved;
-    }
-    return const HomeConfigurationModel();
-  }
+  Future<HomeConfigurationModel> build() async => load();
 
-  static const _key = 'home_configuration';
-
-  HomeConfigurationModel? load() {
+  Future<HomeConfigurationModel> load() async {
     try {
-      final jsonString = ref.read(sharedPreferencesProvider).getString(_key);
+      final ds = ref.read(sharedPreferencesDataSourceProvider);
+      final jsonString =
+          await ds.getString(key: SharedPreferencesKey.homeConfiguration);
       if (jsonString == null) {
-        return null;
+        return const HomeConfigurationModel();
       }
       final json = jsonDecode(jsonString) as Map<String, dynamic>;
       return HomeConfigurationModel.fromJson(json);
     } on Exception catch (e) {
       log('load home configuration failed: $e');
-      return null;
+      return const HomeConfigurationModel();
     }
   }
 
   Future<void> save(HomeConfigurationModel configuration) async {
-    state = configuration;
-    await ref
-        .read(sharedPreferencesProvider)
-        .setString(_key, jsonEncode(configuration.toJson()));
+    state = AsyncValue.data(configuration);
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setString(
+      key: SharedPreferencesKey.homeConfiguration,
+      value: jsonEncode(configuration.toJson()),
+    );
   }
 }

--- a/app/lib/feature/home/data/notifier/home_configuration_notifier.dart
+++ b/app/lib/feature/home/data/notifier/home_configuration_notifier.dart
@@ -16,8 +16,9 @@ class HomeConfigurationNotifier extends _$HomeConfigurationNotifier {
   Future<HomeConfigurationModel> load() async {
     try {
       final ds = ref.read(sharedPreferencesDataSourceProvider);
-      final jsonString =
-          await ds.getString(key: SharedPreferencesKey.homeConfiguration);
+      final jsonString = await ds.getString(
+        key: SharedPreferencesKey.homeConfiguration,
+      );
       if (jsonString == null) {
         return const HomeConfigurationModel();
       }

--- a/app/lib/feature/home/data/notifier/home_configuration_notifier.g.dart
+++ b/app/lib/feature/home/data/notifier/home_configuration_notifier.g.dart
@@ -16,7 +16,10 @@ final homeConfigurationProvider = HomeConfigurationNotifierProvider._();
 
 final class HomeConfigurationNotifierProvider
     extends
-        $NotifierProvider<HomeConfigurationNotifier, HomeConfigurationModel> {
+        $AsyncNotifierProvider<
+          HomeConfigurationNotifier,
+          HomeConfigurationModel
+        > {
   HomeConfigurationNotifierProvider._()
     : super(
         from: null,
@@ -34,32 +37,28 @@ final class HomeConfigurationNotifierProvider
   @$internal
   @override
   HomeConfigurationNotifier create() => HomeConfigurationNotifier();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(HomeConfigurationModel value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<HomeConfigurationModel>(value),
-    );
-  }
 }
 
 String _$homeConfigurationNotifierHash() =>
-    r'd304e781e1d01913d5f9b3c16c3e8fb27541f88b';
+    r'77e3a236ddeb34fba40751b6bc6ceea83f99270b';
 
 abstract class _$HomeConfigurationNotifier
-    extends $Notifier<HomeConfigurationModel> {
-  HomeConfigurationModel build();
+    extends $AsyncNotifier<HomeConfigurationModel> {
+  FutureOr<HomeConfigurationModel> build();
   @$mustCallSuper
   @override
   void runBuild() {
     final ref =
-        this.ref as $Ref<HomeConfigurationModel, HomeConfigurationModel>;
+        this.ref
+            as $Ref<AsyncValue<HomeConfigurationModel>, HomeConfigurationModel>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<HomeConfigurationModel, HomeConfigurationModel>,
-              HomeConfigurationModel,
+              AnyNotifier<
+                AsyncValue<HomeConfigurationModel>,
+                HomeConfigurationModel
+              >,
+              AsyncValue<HomeConfigurationModel>,
               Object?,
               Object?
             >;

--- a/app/lib/feature/home/ui/component/eew/eew_widget.dart
+++ b/app/lib/feature/home/ui/component/eew/eew_widget.dart
@@ -48,7 +48,9 @@ class EewWidget extends ConsumerWidget {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final colorTheme = theme.colorScheme;
-    final intensityColorScheme = ref.watch(intensityColorProvider);
+    final intensityColorScheme =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
 
     if (eew.isCanceled) {
       return BorderedContainer(

--- a/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
@@ -18,7 +18,9 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final styleController = MapController.maybeOf(context)?.style;
-    final colorModel = ref.watch(intensityColorProvider);
+    final colorModel =
+        ref.watch(intensityColorProvider).asData?.value ??
+        IntensityColorModel.eqmonitor();
 
     final isInitialized = useRef(false);
 

--- a/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_settings.dart
+++ b/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_settings.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -9,21 +10,13 @@ part 'kyoshin_monitor_settings.g.dart';
 @Riverpod(keepAlive: true)
 class KyoshinMonitorSettings extends _$KyoshinMonitorSettings {
   @override
-  KyoshinMonitorSettingsModel build() {
-    final result = _load();
-    if (result != null) {
-      return result;
-    }
+  Future<KyoshinMonitorSettingsModel> build() async => _load();
 
-    return const KyoshinMonitorSettingsModel();
-  }
-
-  static const _prefsKey = '_kmoni_settings';
-
-  KyoshinMonitorSettingsModel? _load() {
-    final json = ref.read(sharedPreferencesProvider).getString(_prefsKey);
+  Future<KyoshinMonitorSettingsModel> _load() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final json = await ds.getString(key: SharedPreferencesKey.kmoniSettings);
     if (json == null) {
-      return null;
+      return const KyoshinMonitorSettingsModel();
     }
     try {
       return KyoshinMonitorSettingsModel.fromJson(
@@ -31,14 +24,16 @@ class KyoshinMonitorSettings extends _$KyoshinMonitorSettings {
       );
       // ignore: avoid_catches_without_on_clauses
     } catch (_) {
-      return null;
+      return const KyoshinMonitorSettingsModel();
     }
   }
 
   Future<void> save(KyoshinMonitorSettingsModel model) async {
-    state = model;
-    await ref
-        .read(sharedPreferencesProvider)
-        .setString(_prefsKey, jsonEncode(state.toJson()));
+    state = AsyncValue.data(model);
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setString(
+      key: SharedPreferencesKey.kmoniSettings,
+      value: jsonEncode(model.toJson()),
+    );
   }
 }

--- a/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_settings.g.dart
+++ b/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_settings.g.dart
@@ -16,7 +16,10 @@ final kyoshinMonitorSettingsProvider = KyoshinMonitorSettingsProvider._();
 
 final class KyoshinMonitorSettingsProvider
     extends
-        $NotifierProvider<KyoshinMonitorSettings, KyoshinMonitorSettingsModel> {
+        $AsyncNotifierProvider<
+          KyoshinMonitorSettings,
+          KyoshinMonitorSettingsModel
+        > {
   KyoshinMonitorSettingsProvider._()
     : super(
         from: null,
@@ -34,36 +37,31 @@ final class KyoshinMonitorSettingsProvider
   @$internal
   @override
   KyoshinMonitorSettings create() => KyoshinMonitorSettings();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(KyoshinMonitorSettingsModel value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<KyoshinMonitorSettingsModel>(value),
-    );
-  }
 }
 
 String _$kyoshinMonitorSettingsHash() =>
-    r'6e7b5c58da4f50177bda98f59deec91e8292a9db';
+    r'7e7a781294986f7ca6c8a3090562bef970b8d8dc';
 
 abstract class _$KyoshinMonitorSettings
-    extends $Notifier<KyoshinMonitorSettingsModel> {
-  KyoshinMonitorSettingsModel build();
+    extends $AsyncNotifier<KyoshinMonitorSettingsModel> {
+  FutureOr<KyoshinMonitorSettingsModel> build();
   @$mustCallSuper
   @override
   void runBuild() {
     final ref =
         this.ref
-            as $Ref<KyoshinMonitorSettingsModel, KyoshinMonitorSettingsModel>;
+            as $Ref<
+              AsyncValue<KyoshinMonitorSettingsModel>,
+              KyoshinMonitorSettingsModel
+            >;
     final element =
         ref.element
             as $ClassProviderElement<
               AnyNotifier<
-                KyoshinMonitorSettingsModel,
+                AsyncValue<KyoshinMonitorSettingsModel>,
                 KyoshinMonitorSettingsModel
               >,
-              KyoshinMonitorSettingsModel,
+              AsyncValue<KyoshinMonitorSettingsModel>,
               Object?,
               Object?
             >;

--- a/app/lib/feature/location/data/location_tracking_mode.dart
+++ b/app/lib/feature/location/data/location_tracking_mode.dart
@@ -11,14 +11,18 @@ class LocationTrackingMode extends _$LocationTrackingMode {
 
   Future<bool> get() async {
     final ds = ref.read(sharedPreferencesDataSourceProvider);
-    final value =
-        await ds.getBool(key: SharedPreferencesKey.locationTrackingMode);
+    final value = await ds.getBool(
+      key: SharedPreferencesKey.locationTrackingMode,
+    );
     return value ?? false;
   }
 
   Future<void> set({required bool value}) async {
     state = AsyncValue.data(value);
     final ds = ref.read(sharedPreferencesDataSourceProvider);
-    await ds.setBool(key: SharedPreferencesKey.locationTrackingMode, value: value);
+    await ds.setBool(
+      key: SharedPreferencesKey.locationTrackingMode,
+      value: value,
+    );
   }
 }

--- a/app/lib/feature/location/data/location_tracking_mode.dart
+++ b/app/lib/feature/location/data/location_tracking_mode.dart
@@ -1,4 +1,5 @@
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'location_tracking_mode.g.dart';
@@ -6,16 +7,18 @@ part 'location_tracking_mode.g.dart';
 @riverpod
 class LocationTrackingMode extends _$LocationTrackingMode {
   @override
-  bool build() => get();
+  Future<bool> build() async => get();
 
-  static const _key = 'location_tracking_mode';
-
-  Future<void> set({required bool value}) async {
-    state = value;
-    await ref.read(sharedPreferencesProvider).setBool(_key, value);
+  Future<bool> get() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final value =
+        await ds.getBool(key: SharedPreferencesKey.locationTrackingMode);
+    return value ?? false;
   }
 
-  bool get() {
-    return ref.read(sharedPreferencesProvider).getBool(_key) ?? false;
+  Future<void> set({required bool value}) async {
+    state = AsyncValue.data(value);
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setBool(key: SharedPreferencesKey.locationTrackingMode, value: value);
   }
 }

--- a/app/lib/feature/location/data/location_tracking_mode.g.dart
+++ b/app/lib/feature/location/data/location_tracking_mode.g.dart
@@ -15,7 +15,7 @@ part of 'location_tracking_mode.dart';
 final locationTrackingModeProvider = LocationTrackingModeProvider._();
 
 final class LocationTrackingModeProvider
-    extends $NotifierProvider<LocationTrackingMode, bool> {
+    extends $AsyncNotifierProvider<LocationTrackingMode, bool> {
   LocationTrackingModeProvider._()
     : super(
         from: null,
@@ -33,30 +33,22 @@ final class LocationTrackingModeProvider
   @$internal
   @override
   LocationTrackingMode create() => LocationTrackingMode();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(bool value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<bool>(value),
-    );
-  }
 }
 
 String _$locationTrackingModeHash() =>
-    r'8ad1dc68a71bc2c4324e184080a68ee6be3aacae';
+    r'aee3c9e2549037a3ba2c6566c3286539709d0f06';
 
-abstract class _$LocationTrackingMode extends $Notifier<bool> {
-  bool build();
+abstract class _$LocationTrackingMode extends $AsyncNotifier<bool> {
+  FutureOr<bool> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<bool, bool>;
+    final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<bool, bool>,
-              bool,
+              AnyNotifier<AsyncValue<bool>, bool>,
+              AsyncValue<bool>,
               Object?,
               Object?
             >;

--- a/app/lib/feature/map/data/notifier/map_configuration_notifier.dart
+++ b/app/lib/feature/map/data/notifier/map_configuration_notifier.dart
@@ -39,8 +39,7 @@ class MapConfigurationNotifier extends _$MapConfigurationNotifier {
 
   Future<MapConfiguration?> _load() async {
     final ds = ref.read(sharedPreferencesDataSourceProvider);
-    final json =
-        await ds.getString(key: SharedPreferencesKey.mapConfiguration);
+    final json = await ds.getString(key: SharedPreferencesKey.mapConfiguration);
     if (json == null) {
       return null;
     }

--- a/app/lib/feature/map/data/notifier/map_configuration_notifier.dart
+++ b/app/lib/feature/map/data/notifier/map_configuration_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:eqmonitor/core/theme/theme_provider.dart';
 import 'package:eqmonitor/feature/map/data/model/map_configuration.dart';
 import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
@@ -14,7 +15,8 @@ class MapConfigurationNotifier extends _$MapConfigurationNotifier {
   @override
   Future<MapConfiguration> build() async {
     final brightness = ref.watch(brightnessProvider);
-    var savedState = _load() ?? const MapConfiguration(theme: MapTheme.system);
+    var savedState =
+        await _load() ?? const MapConfiguration(theme: MapTheme.system);
     if (savedState.theme == MapTheme.system) {
       savedState = savedState.copyWith(
         theme: brightness == Brightness.dark ? MapTheme.dark : MapTheme.light,
@@ -35,11 +37,10 @@ class MapConfigurationNotifier extends _$MapConfigurationNotifier {
     return savedState.copyWith(styleString: styleString);
   }
 
-  static const _prefsKey = 'map_configuration';
-
-  MapConfiguration? _load() {
-    final prefs = ref.read(sharedPreferencesProvider);
-    final json = prefs.getString(_prefsKey);
+  Future<MapConfiguration?> _load() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final json =
+        await ds.getString(key: SharedPreferencesKey.mapConfiguration);
     if (json == null) {
       return null;
     }

--- a/app/lib/feature/map/data/notifier/map_configuration_notifier.g.dart
+++ b/app/lib/feature/map/data/notifier/map_configuration_notifier.g.dart
@@ -36,7 +36,7 @@ final class MapConfigurationNotifierProvider
 }
 
 String _$mapConfigurationNotifierHash() =>
-    r'983783ee8c85413b0e3fda079b180dd20a3c2fcb';
+    r'd777f0bcb7908153a85679f642365f2ec2c99c8e';
 
 abstract class _$MapConfigurationNotifier
     extends $AsyncNotifier<MapConfiguration> {

--- a/app/lib/feature/settings/features/debug/debug_provider.dart
+++ b/app/lib/feature/settings/features/debug/debug_provider.dart
@@ -1,4 +1,5 @@
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -7,25 +8,17 @@ part 'debug_provider.g.dart';
 @riverpod
 class Debug extends _$Debug {
   @override
-  bool build() {
-    final savedState = _getIsEnabled();
-    if (savedState == null) {
-      return kDebugMode;
-    }
-    return savedState;
-  }
+  Future<bool> build() async => _getIsEnabled();
 
-  static const _key = 'debug';
-
-  bool? _getIsEnabled() {
-    final prefs = ref.read(sharedPreferencesProvider);
-    return prefs.getBool(_key);
+  Future<bool> _getIsEnabled() async {
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    final value = await ds.getBool(key: SharedPreferencesKey.debug);
+    return value ?? kDebugMode;
   }
 
   Future<void> save({required bool isEnabled}) async {
-    state = isEnabled;
-
-    final prefs = ref.read(sharedPreferencesProvider);
-    await prefs.setBool(_key, isEnabled);
+    state = AsyncValue.data(isEnabled);
+    final ds = ref.read(sharedPreferencesDataSourceProvider);
+    await ds.setBool(key: SharedPreferencesKey.debug, value: isEnabled);
   }
 }

--- a/app/lib/feature/settings/features/debug/debug_provider.g.dart
+++ b/app/lib/feature/settings/features/debug/debug_provider.g.dart
@@ -14,7 +14,7 @@ part of 'debug_provider.dart';
 @ProviderFor(Debug)
 final debugProvider = DebugProvider._();
 
-final class DebugProvider extends $NotifierProvider<Debug, bool> {
+final class DebugProvider extends $AsyncNotifierProvider<Debug, bool> {
   DebugProvider._()
     : super(
         from: null,
@@ -32,29 +32,21 @@ final class DebugProvider extends $NotifierProvider<Debug, bool> {
   @$internal
   @override
   Debug create() => Debug();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(bool value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<bool>(value),
-    );
-  }
 }
 
-String _$debugHash() => r'85e7e71c874d4d76bf46d2d03c11826c40319162';
+String _$debugHash() => r'704137228970140848a40cb0e0bfe6b3673fe99a';
 
-abstract class _$Debug extends $Notifier<bool> {
-  bool build();
+abstract class _$Debug extends $AsyncNotifier<bool> {
+  FutureOr<bool> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<bool, bool>;
+    final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<bool, bool>,
-              bool,
+              AnyNotifier<AsyncValue<bool>, bool>,
+              AsyncValue<bool>,
               Object?,
               Object?
             >;

--- a/app/lib/feature/settings/features/display_settings/color_scheme/color_scheme_config_page.dart
+++ b/app/lib/feature/settings/features/display_settings/color_scheme/color_scheme_config_page.dart
@@ -13,47 +13,52 @@ class ColorSchemeConfigPage extends ConsumerWidget {
     final state = ref.watch(intensityColorProvider);
     return Scaffold(
       appBar: AppBar(title: const Text('震度配色設定')),
-      body: SingleChildScrollView(
-        child: RadioGroup(
-          onChanged: (value) async =>
-              ref.read(intensityColorProvider.notifier).update(value!),
-          groupValue: state,
-          child: Column(
-            children: [
-              RadioListTile.adaptive(
-                value: IntensityColorModel.eqmonitor(),
-                title: const Text('EQMonitor'),
-                subtitle: Padding(
-                  padding: const EdgeInsets.all(4),
-                  child: _IntensityWidgets(
-                    colorModel: IntensityColorModel.eqmonitor(),
+      body: state.when(
+        data: (groupValue) => SingleChildScrollView(
+          child: RadioGroup(
+            onChanged: (value) async =>
+                ref.read(intensityColorProvider.notifier).setModel(value!),
+            groupValue: groupValue,
+            child: Column(
+              children: [
+                RadioListTile.adaptive(
+                  value: IntensityColorModel.eqmonitor(),
+                  title: const Text('EQMonitor'),
+                  subtitle: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: _IntensityWidgets(
+                      colorModel: IntensityColorModel.eqmonitor(),
+                    ),
                   ),
                 ),
-              ),
-              RadioListTile.adaptive(
-                value: IntensityColorModel.jma(),
-                title: const Text('気象庁配色'),
-                subtitle: Padding(
-                  padding: const EdgeInsets.all(4),
-                  child: _IntensityWidgets(
-                    colorModel: IntensityColorModel.jma(),
+                RadioListTile.adaptive(
+                  value: IntensityColorModel.jma(),
+                  title: const Text('気象庁配色'),
+                  subtitle: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: _IntensityWidgets(
+                      colorModel: IntensityColorModel.jma(),
+                    ),
                   ),
                 ),
-              ),
-              RadioListTile.adaptive(
-                value: IntensityColorModel.earthQuickly(),
-                title: const Text('EarthQuickly'),
-                subtitle: Padding(
-                  padding: const EdgeInsets.all(4),
-                  child: _IntensityWidgets(
-                    colorModel: IntensityColorModel.earthQuickly(),
+                RadioListTile.adaptive(
+                  value: IntensityColorModel.earthQuickly(),
+                  title: const Text('EarthQuickly'),
+                  subtitle: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: _IntensityWidgets(
+                      colorModel: IntensityColorModel.earthQuickly(),
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: kFloatingActionButtonMargin * 4),
-            ],
+                const SizedBox(height: kFloatingActionButtonMargin * 4),
+              ],
+            ),
           ),
         ),
+        loading: () =>
+            const Center(child: CircularProgressIndicator.adaptive()),
+        error: (error, _) => Center(child: Text('$error')),
       ),
     );
   }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -15,6 +15,8 @@ import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
 import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshin_observation_points_provider.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences.dart'
+    as data_prefs;
 import 'package:eqmonitor/core/provider/shared_preferences.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
 import 'package:eqmonitor/core/util/license/init_licenses.dart';
@@ -31,7 +33,8 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart'
+    hide SharedPreferencesAsync;
 import 'package:talker_flutter/talker_flutter.dart';
 
 Future<void> main() async {
@@ -139,7 +142,12 @@ Future<void> main() async {
 
   final container = ProviderContainer(
     overrides: [
-      sharedPreferencesProvider.overrideWithValue(results.$1.$1),
+      data_prefs.sharedPreferencesProvider.overrideWithValue(
+        AsyncValue.data(results.$1.$1),
+      ),
+      sharedPreferencesProvider.overrideWithValue(
+        SharedPreferencesAsync(results.$1.$1),
+      ),
       packageInfoProvider.overrideWithValue(results.$1.$2),
       if (results.$1.$3 != null)
         androidDeviceInfoProvider.overrideWithValue(results.$1.$3!),


### PR DESCRIPTION
## 概要
Flutter認証アーキテクチャ設計の Step 0 として、Preferences 層をリファクタしました。

## 変更内容
- **Preferences データ層の追加**
  - `PreferencesDataSource<T>` 抽象クラス（set/get String/Int/Double/Bool, remove, clear）
  - `SharedPreferencesKey` / `SecureStorageKey` enum でキーを一元管理
  - `SharedPreferencesDataSource` / `SecurePreferencesDataSource` 実装
  - SecureStorage の初回初期化フラグ（iOS Keychain 再インストール対策）
- **既存利用箇所の移行**
  - user_id → SecurePreferencesDataSource + SecureStorageKey
  - NTP/Theme/TelegramUrl/EarthquakeHistoryConfig/Debug/Kmoni → SharedPreferencesDataSource + AsyncNotifier
  - MapConfig/IntensityColor/LocationTracking/HomeConfig → 同様に DataSource + AsyncNotifier
- **UI の AsyncValue 対応**
  - intensityColorProvider / homeConfigurationProvider 参照箇所で `.asData?.value` または `.when(data:, loading:, error:)` を使用

## コミット
- Add: Preferences層のDataSource抽象とShared/Secure実装を追加
- Refactor: mainのoverrideとSharedPreferencesAsyncラッパーを整備
- Refactor: user_idをSecurePreferencesDataSourceに移行
- Refactor: NTP/Theme/TelegramUrl等をDataSourceとAsyncNotifierに移行
- Refactor: MapConfig/IntensityColor/LocationTracking/HomeConfigを移行
- Refactor: intensityColor/homeConfig参照UIをAsyncValue対応に変更
- Style: フォーマット調整

Made with [Cursor](https://cursor.com)