### PR TITLE
feat: FlutterアプリにBetter Auth認証を統合

### DIFF
--- a/app/lib/core/auth/auth_client_provider.dart
+++ b/app/lib/core/auth/auth_client_provider.dart
@@ -1,0 +1,24 @@
+import 'package:better_auth_client/better_auth_client.dart';
+import 'package:eqmonitor/core/auth/secure_storage_token_store.dart';
+import 'package:eqmonitor/core/provider/secure_storage.dart';
+import 'package:eqmonitor/core/util/env.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auth_client_provider.g.dart';
+
+const _betterAuthBaseUrl = 'https://auth.eqmonitor.app/api/auth';
+
+String get _authCallbackScheme => Env.flavor == Flavor.dev
+    ? 'net.yumnumm.eqmonitor.dev'
+    : 'net.yumnumm.eqmonitor';
+
+@Riverpod(keepAlive: true)
+BetterAuthClient authClient(Ref ref) {
+  final storage = ref.watch(secureStorageProvider);
+  final tokenStore = SecureStorageTokenStore(storage);
+  return BetterAuthClient(
+    baseUrl: _betterAuthBaseUrl,
+    tokenStore: tokenStore,
+    scheme: '$_authCallbackScheme://',
+  );
+}

--- a/app/lib/core/auth/auth_client_provider.dart
+++ b/app/lib/core/auth/auth_client_provider.dart
@@ -1,4 +1,5 @@
-import 'package:better_auth_client/better_auth_client.dart';
+import 'package:better_auth_api_client/export.dart' as auth_api;
+import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/auth/secure_storage_token_store.dart';
 import 'package:eqmonitor/core/provider/secure_storage.dart';
 import 'package:eqmonitor/core/util/env.dart';
@@ -6,19 +7,21 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'auth_client_provider.g.dart';
 
-const _betterAuthBaseUrl = 'https://auth.eqmonitor.app/api/auth';
-
-String get _authCallbackScheme => Env.flavor == Flavor.dev
-    ? 'net.yumnumm.eqmonitor.dev'
-    : 'net.yumnumm.eqmonitor';
+@Riverpod(keepAlive: true)
+AuthTokenStore authTokenStore(Ref ref) {
+  final storage = ref.watch(secureStorageProvider);
+  return AuthTokenStore(storage);
+}
 
 @Riverpod(keepAlive: true)
-BetterAuthClient authClient(Ref ref) {
-  final storage = ref.watch(secureStorageProvider);
-  final tokenStore = SecureStorageTokenStore(storage);
-  return BetterAuthClient(
-    baseUrl: _betterAuthBaseUrl,
-    tokenStore: tokenStore,
-    scheme: '$_authCallbackScheme://',
+auth_api.ApiClient authApiClient(Ref ref) {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: Env.betterAuthUrl,
+      contentType: 'application/json',
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+    ),
   );
+  return auth_api.ApiClient(dio);
 }

--- a/app/lib/core/auth/auth_client_provider.g.dart
+++ b/app/lib/core/auth/auth_client_provider.g.dart
@@ -11,49 +11,90 @@ part of 'auth_client_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(authClient)
-final authClientProvider = AuthClientProvider._();
+@ProviderFor(authTokenStore)
+final authTokenStoreProvider = AuthTokenStoreProvider._();
 
-final class AuthClientProvider
-    extends
-        $FunctionalProvider<
-          BetterAuthClient<User>,
-          BetterAuthClient<User>,
-          BetterAuthClient<User>
-        >
-    with $Provider<BetterAuthClient<User>> {
-  AuthClientProvider._()
+final class AuthTokenStoreProvider
+    extends $FunctionalProvider<AuthTokenStore, AuthTokenStore, AuthTokenStore>
+    with $Provider<AuthTokenStore> {
+  AuthTokenStoreProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'authClientProvider',
+        name: r'authTokenStoreProvider',
         isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$authClientHash();
+  String debugGetCreateSourceHash() => _$authTokenStoreHash();
 
   @$internal
   @override
-  $ProviderElement<BetterAuthClient<User>> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
+  $ProviderElement<AuthTokenStore> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
-  BetterAuthClient<User> create(Ref ref) {
-    return authClient(ref);
+  AuthTokenStore create(Ref ref) {
+    return authTokenStore(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(BetterAuthClient<User> value) {
+  Override overrideWithValue(AuthTokenStore value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<BetterAuthClient<User>>(value),
+      providerOverride: $SyncValueProvider<AuthTokenStore>(value),
     );
   }
 }
 
-String _$authClientHash() => r'0c25dd8c6daa1bdcdc08ccd7717dd470bf68c4f0';
+String _$authTokenStoreHash() => r'6f411afa2574f45a75c232075512a269d2aa442d';
+
+@ProviderFor(authApiClient)
+final authApiClientProvider = AuthApiClientProvider._();
+
+final class AuthApiClientProvider
+    extends
+        $FunctionalProvider<
+          auth_api.ApiClient,
+          auth_api.ApiClient,
+          auth_api.ApiClient
+        >
+    with $Provider<auth_api.ApiClient> {
+  AuthApiClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'authApiClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$authApiClientHash();
+
+  @$internal
+  @override
+  $ProviderElement<auth_api.ApiClient> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  auth_api.ApiClient create(Ref ref) {
+    return authApiClient(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(auth_api.ApiClient value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<auth_api.ApiClient>(value),
+    );
+  }
+}
+
+String _$authApiClientHash() => r'9636aa64f977ade8ec5047ef3e94920ad975bb4f';

--- a/app/lib/core/auth/auth_client_provider.g.dart
+++ b/app/lib/core/auth/auth_client_provider.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'auth_client_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(authClient)
+final authClientProvider = AuthClientProvider._();
+
+final class AuthClientProvider
+    extends
+        $FunctionalProvider<
+          BetterAuthClient<User>,
+          BetterAuthClient<User>,
+          BetterAuthClient<User>
+        >
+    with $Provider<BetterAuthClient<User>> {
+  AuthClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'authClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$authClientHash();
+
+  @$internal
+  @override
+  $ProviderElement<BetterAuthClient<User>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  BetterAuthClient<User> create(Ref ref) {
+    return authClient(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BetterAuthClient<User> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BetterAuthClient<User>>(value),
+    );
+  }
+}
+
+String _$authClientHash() => r'0c25dd8c6daa1bdcdc08ccd7717dd470bf68c4f0';

--- a/app/lib/core/auth/auth_interceptor.dart
+++ b/app/lib/core/auth/auth_interceptor.dart
@@ -1,11 +1,12 @@
-import 'package:better_auth_client/better_auth_client.dart';
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/auth/secure_storage_token_store.dart';
 
-/// Better Auth のセッショントークンを `Authorization: Bearer` ヘッダに付与する。
+/// [AuthTokenStore] からセッショントークンを読み取り
+/// `Authorization: Bearer` ヘッダに付与する。
 class BearerAuthInterceptor extends Interceptor {
   BearerAuthInterceptor(this._tokenStore);
 
-  final TokenStore _tokenStore;
+  final AuthTokenStore _tokenStore;
 
   @override
   Future<void> onRequest(
@@ -13,7 +14,7 @@ class BearerAuthInterceptor extends Interceptor {
     RequestInterceptorHandler handler,
   ) async {
     final token = await _tokenStore.getToken();
-    if (token.isNotEmpty) {
+    if (token != null && token.isNotEmpty) {
       options.headers['Authorization'] = 'Bearer $token';
     }
     handler.next(options);

--- a/app/lib/core/auth/auth_interceptor.dart
+++ b/app/lib/core/auth/auth_interceptor.dart
@@ -1,0 +1,21 @@
+import 'package:better_auth_client/better_auth_client.dart';
+import 'package:dio/dio.dart';
+
+/// Better Auth のセッショントークンを `Authorization: Bearer` ヘッダに付与する。
+class BearerAuthInterceptor extends Interceptor {
+  BearerAuthInterceptor(this._tokenStore);
+
+  final TokenStore _tokenStore;
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final token = await _tokenStore.getToken();
+    if (token.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    handler.next(options);
+  }
+}

--- a/app/lib/core/auth/auth_notifier.dart
+++ b/app/lib/core/auth/auth_notifier.dart
@@ -1,0 +1,24 @@
+import 'package:eqmonitor/core/auth/auth_client_provider.dart';
+import 'package:riverpod/experimental/mutation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auth_notifier.g.dart';
+
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+@Riverpod(keepAlive: true)
+class AuthNotifier extends _$AuthNotifier {
+  /// 匿名サインインを行う [Mutation]。
+  ///
+  /// スプラッシュ画面から呼び出し、
+  /// 既存のセッションが無い場合に Better Auth `/sign-in/anonymous` を実行する。
+  static final signInAnonymously = Mutation<void>();
+
+  @override
+  Future<String?> build() async {
+    final tokenStore = ref.watch(authTokenStoreProvider);
+    return tokenStore.getToken();
+  }
+}

--- a/app/lib/core/auth/auth_notifier.g.dart
+++ b/app/lib/core/auth/auth_notifier.g.dart
@@ -1,0 +1,73 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'auth_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+
+@ProviderFor(AuthNotifier)
+final authProvider = AuthNotifierProvider._();
+
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+final class AuthNotifierProvider
+    extends $AsyncNotifierProvider<AuthNotifier, String?> {
+  /// 認証状態(セッショントークン)を管理する Notifier。
+  ///
+  /// [build] ではストレージからトークンの有無を確認するのみ。
+  /// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+  AuthNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'authProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$authNotifierHash();
+
+  @$internal
+  @override
+  AuthNotifier create() => AuthNotifier();
+}
+
+String _$authNotifierHash() => r'e9c3f30b9dd25d8fb957ad8d4c6845ce59925133';
+
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+
+abstract class _$AuthNotifier extends $AsyncNotifier<String?> {
+  FutureOr<String?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<String?>, String?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<String?>, String?>,
+              AsyncValue<String?>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/core/auth/secure_storage_token_store.dart
+++ b/app/lib/core/auth/secure_storage_token_store.dart
@@ -1,36 +1,17 @@
-import 'package:better_auth_client/better_auth_client.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-/// Better Auth の Bearer トークンを [FlutterSecureStorage] に永続化する [TokenStore]。
-class SecureStorageTokenStore extends TokenStore {
-  SecureStorageTokenStore(this._storage);
+/// Better Auth の Bearer トークンを [FlutterSecureStorage] に永続化する。
+class AuthTokenStore {
+  AuthTokenStore(this._storage);
 
   final FlutterSecureStorage _storage;
 
   static const _tokenKey = 'better_auth_bearer_token';
-  static const _adminTokenKey = 'better_auth_admin_token';
 
-  @override
-  Future<String> getToken() =>
-      _storage.read(key: _tokenKey).then((v) => v ?? '');
+  Future<String?> getToken() => _storage.read(key: _tokenKey);
 
-  @override
-  Future<void> saveToken(String? token) {
-    if (token == null || token.isEmpty) {
-      return _storage.delete(key: _tokenKey);
-    }
-    return _storage.write(key: _tokenKey, value: token);
-  }
+  Future<void> saveToken(String token) =>
+      _storage.write(key: _tokenKey, value: token);
 
-  @override
-  Future<String> getAdminToken() =>
-      _storage.read(key: _adminTokenKey).then((v) => v ?? '');
-
-  @override
-  Future<void> saveAdminToken(String? token) {
-    if (token == null || token.isEmpty) {
-      return _storage.delete(key: _adminTokenKey);
-    }
-    return _storage.write(key: _adminTokenKey, value: token);
-  }
+  Future<void> deleteToken() => _storage.delete(key: _tokenKey);
 }

--- a/app/lib/core/auth/secure_storage_token_store.dart
+++ b/app/lib/core/auth/secure_storage_token_store.dart
@@ -1,0 +1,36 @@
+import 'package:better_auth_client/better_auth_client.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Better Auth の Bearer トークンを [FlutterSecureStorage] に永続化する [TokenStore]。
+class SecureStorageTokenStore extends TokenStore {
+  SecureStorageTokenStore(this._storage);
+
+  final FlutterSecureStorage _storage;
+
+  static const _tokenKey = 'better_auth_bearer_token';
+  static const _adminTokenKey = 'better_auth_admin_token';
+
+  @override
+  Future<String> getToken() =>
+      _storage.read(key: _tokenKey).then((v) => v ?? '');
+
+  @override
+  Future<void> saveToken(String? token) {
+    if (token == null || token.isEmpty) {
+      return _storage.delete(key: _tokenKey);
+    }
+    return _storage.write(key: _tokenKey, value: token);
+  }
+
+  @override
+  Future<String> getAdminToken() =>
+      _storage.read(key: _adminTokenKey).then((v) => v ?? '');
+
+  @override
+  Future<void> saveAdminToken(String? token) {
+    if (token == null || token.isEmpty) {
+      return _storage.delete(key: _adminTokenKey);
+    }
+    return _storage.write(key: _adminTokenKey, value: token);
+  }
+}

--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/auth/auth_client_provider.dart';
+import 'package:eqmonitor/core/auth/auth_interceptor.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
@@ -26,6 +28,9 @@ Dio dio(Ref ref) {
       connectTimeout: const Duration(milliseconds: 5000),
       sendTimeout: const Duration(milliseconds: 5000),
     ),
+  );
+  dio.interceptors.add(
+    BearerAuthInterceptor(ref.watch(authClientProvider).tokenStore),
   );
   dio.interceptors.add(
     TalkerDioLogger(

--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -30,7 +30,7 @@ Dio dio(Ref ref) {
     ),
   );
   dio.interceptors.add(
-    BearerAuthInterceptor(ref.watch(authClientProvider).tokenStore),
+    BearerAuthInterceptor(ref.watch(authTokenStoreProvider)),
   );
   dio.interceptors.add(
     TalkerDioLogger(

--- a/app/lib/core/provider/dio_provider.g.dart
+++ b/app/lib/core/provider/dio_provider.g.dart
@@ -49,4 +49,4 @@ final class DioProvider extends $FunctionalProvider<Dio, Dio, Dio>
   }
 }
 
-String _$dioHash() => r'217681bb3e86b36ae21b12c5278db2f19391dc12';
+String _$dioHash() => r'7326321bb56ba3d5290153322fb9fc47f0ab5bef';

--- a/app/lib/core/provider/dio_provider.g.dart
+++ b/app/lib/core/provider/dio_provider.g.dart
@@ -49,4 +49,4 @@ final class DioProvider extends $FunctionalProvider<Dio, Dio, Dio>
   }
 }
 
-String _$dioHash() => r'8b95b357246e9b381b35ed607545bcf3b748384b';
+String _$dioHash() => r'217681bb3e86b36ae21b12c5278db2f19391dc12';

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -30,6 +30,7 @@ import 'package:eqmonitor/feature/settings/children/config/earthquake_history/ea
 import 'package:eqmonitor/feature/settings/features/display_settings/color_scheme/color_scheme_config_page.dart';
 import 'package:eqmonitor/feature/settings/features/display_settings/ui/display_settings.dart';
 import 'package:eqmonitor/feature/settings/settings_screen.dart';
+import 'package:eqmonitor/feature/splash/ui/splash_page.dart';
 import 'package:eqmonitor/feature/telegram_list/ui/telegram_list_by_event_id_page.dart';
 import 'package:eqmonitor/page/home_page.dart';
 import 'package:eqmonitor/page/talker/talker_page.dart';
@@ -47,7 +48,7 @@ part 'router.g.dart';
 GoRouter goRouter(Ref ref) => GoRouter(
   routes: $appRoutes,
   navigatorKey: App.navigatorKey,
-  initialLocation: const HomeRoute().location,
+  initialLocation: const SplashRoute().location,
   observers: [
     _NavigatorObserver(talker),
     FirebaseAnalyticsObserver(analytics: FirebaseAnalytics.instance),
@@ -59,6 +60,15 @@ class GoRouterRedirectException implements Exception {
   GoRouterRedirectException(this.message);
 
   final String message;
+}
+
+@TypedGoRoute<SplashRoute>(path: '/splash')
+class SplashRoute extends GoRouteData with $SplashRoute {
+  const SplashRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const SplashPage();
 }
 
 @TypedGoRoute<EarthquakeHistoryRoute>(path: '/earthquake-history')

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -9,6 +9,7 @@ part of 'router.dart';
 // **************************************************************************
 
 List<RouteBase> get $appRoutes => [
+  $splashRoute,
   $earthquakeHistoryRoute,
   $earthquakeSearchSelectionRoute,
   $earthquakeSearchResultRoute,
@@ -18,6 +19,29 @@ List<RouteBase> get $appRoutes => [
   $talkerRoute,
   $settingsRoute,
 ];
+
+RouteBase get $splashRoute =>
+    GoRouteData.$route(path: '/splash', factory: $SplashRoute._fromState);
+
+mixin $SplashRoute on GoRouteData {
+  static SplashRoute _fromState(GoRouterState state) => const SplashRoute();
+
+  @override
+  String get location => GoRouteData.$location('/splash');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
 
 RouteBase get $earthquakeHistoryRoute => GoRouteData.$route(
   path: '/earthquake-history',
@@ -916,4 +940,4 @@ final class GoRouterProvider
   }
 }
 
-String _$goRouterHash() => r'8a62453a9e9e24d88c219ecf204af1cc7658b177';
+String _$goRouterHash() => r'3888af6622fff60a0b0e8a0dc2c86bfa0efc4f30';

--- a/app/lib/core/util/env.dart
+++ b/app/lib/core/util/env.dart
@@ -10,6 +10,7 @@ class Env {
   static const apiAuthorization = String.fromEnvironment(
     'API_AUTHORIZATION',
   );
+  static const betterAuthUrl = String.fromEnvironment('BETTER_AUTH_URL');
 }
 
 enum Flavor { dev, prod }

--- a/app/lib/feature/splash/ui/splash_page.dart
+++ b/app/lib/feature/splash/ui/splash_page.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/auth/auth_client_provider.dart';
+import 'package:eqmonitor/core/auth/auth_notifier.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/experimental/mutation.dart';
+
+/// アプリ起動時に認証状態を確認し、
+/// 未ログインであれば匿名認証を行うスプラッシュ画面。
+class SplashPage extends ConsumerStatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  ConsumerState<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends ConsumerState<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_checkAuth());
+  }
+
+  Future<void> _checkAuth() async {
+    final token = await ref.read(authProvider.future);
+    if (!mounted) {
+      return;
+    }
+
+    if (token != null) {
+      // 既にセッションがある → ホームへ遷移
+      const HomeRoute().go(context);
+      return;
+    }
+
+    // セッションが無い → 匿名認証を実行
+    _signInAnonymously();
+  }
+
+  void _signInAnonymously() {
+    unawaited(
+      AuthNotifier.signInAnonymously.run(ref, (tsx) async {
+        final apiClient = tsx.get(authApiClientProvider);
+        final tokenStore = tsx.get(authTokenStoreProvider);
+
+        final response = await apiClient.anonymous.postSignInAnonymous();
+        final session = response.data.session;
+        await tokenStore.saveToken(session.token);
+      }),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mutationState = ref.watch(AuthNotifier.signInAnonymously);
+
+    // 匿名認証が成功したらホームへ遷移
+    ref.listen(AuthNotifier.signInAnonymously, (prev, next) {
+      if (next is MutationSuccess) {
+        const HomeRoute().go(context);
+      }
+    });
+
+    return Scaffold(
+      body: Center(
+        child: switch (mutationState) {
+          MutationIdle() ||
+          MutationPending() ||
+          MutationSuccess() =>
+            const CircularProgressIndicator.adaptive(),
+          MutationError(:final error) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error_outline, size: 48, color: Colors.red),
+                  const SizedBox(height: 16),
+                  Text(
+                    '認証に失敗しました',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    error.toString(),
+                    style: Theme.of(context).textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton.icon(
+                    onPressed: _signInAnonymously,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('再試行'),
+                  ),
+                ],
+              ),
+            ),
+        },
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,8 @@ dependency_overrides:
 
 dependencies:
   app_settings: ^7.0.0
-  better_auth_client: ^0.12.1
+  better_auth_api_client:
+    path: ../../packages/better_auth_api_client
   cached_network_image: ^3.4.1
   clock: ^1.1.2
   collection: ^1.19.1

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -95,6 +95,7 @@ dependencies:
   package_info_plus: ^9.0.0
   path_provider: ^2.1.5
   purchases_flutter: ^9.1.0
+  riverpod: ^3.2.1
   riverpod_annotation: ^4.0.0
   screenshot: 3.0.0
   share_plus: ^12.0.0

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,6 +15,7 @@ dependency_overrides:
 
 dependencies:
   app_settings: ^7.0.0
+  better_auth_client: ^0.12.1
   cached_network_image: ^3.4.1
   clock: ^1.1.2
   collection: ^1.19.1

--- a/docs/design/earthquake_history_screen_stitch_prompt.md
+++ b/docs/design/earthquake_history_screen_stitch_prompt.md
@@ -1,0 +1,197 @@
+# 地震履歴画面 デザインリファクタ用プロンプト（Stitch向け）
+
+このドキュメントは、地震監視アプリ「EQMonitor」の**地震履歴画面**のデザインをリファクタするために、Stitchへ渡すプロンプトとして使う想定でまとめています。そのままコピーしてStitchに貼り付けてください。
+
+---
+
+## 1. アプリの概要
+
+- **アプリ名**: EQMonitor
+- **ジャンル**: 地震監視・地震情報アプリ（日本向け）
+- **プラットフォーム**: Flutter（iOS / Android）
+- **デザイン基盤**: Material 3、useMaterial3: true
+- **フォント**: Noto Sans JP（本文）、Noto Sans Mono（日時・数値）
+- **テーマ**: ColorScheme ベース、ダーク/ライト対応、震度に応じたカスタム色（ユーザー設定で変更可）あり
+
+---
+
+## 2. 地震履歴画面の役割
+
+- 過去の地震一覧を**日付ごとにグループ化**して表示する
+- **検索条件**（期間・震央・最大震度・地域の震度・深さ・マグニチュード）で絞り込み可能
+- 各項目タップで**詳細画面**へ遷移
+- **プルダウンで更新**、**末尾スクロールで追加取得**（無限スクロール）
+
+---
+
+## 3. 現在の画面構成（リファクタ対象）
+
+### 3.1 レイアウト構造
+
+- **Scaffold** → **RefreshIndicator** → **CustomScrollView**
+  - **SliverAppBar**（pinned）
+    - タイトル: 「地震履歴」
+    - アクション: 「検索条件」ボタン（OutlinedButton + Icons.search）
+  - **日付ごとのセクション**（Sticky Header）
+    - 各セクション: **日付ヘッダー**（例: 2025/03/19）+ **リスト**
+  - 日付ヘッダー: `surfaceContainerHighest` 背景、`titleSmall` 太字、`onSurfaceVariant` 色、横16・縦8 padding
+  - リスト各項目: **EarthquakeHistoryListTile** + 高さ0の **Divider**（`onInverseSurface`）
+  - 末尾: **ローディング/エラー/「全件取得済み」** のいずれか
+
+### 3.2 一覧アイテム（EarthquakeHistoryListTile）の内容
+
+各項目に表示する情報:
+
+| 要素 | 内容 | 備考 |
+|------|------|------|
+| **Leading** | 最大震度アイコン | 震度1〜7のアイコン（約40px）、震度に応じた色 |
+| **Title** | 震央・震度のテキスト | 例: 「○○沖(○○)」「最大震度5強を○○で観測」、titleMedium・太字 |
+| **Subtitle** | 日時 + 深さ | 「yyyy/MM/dd HH:mm頃発生 深さ 10km」、等幅フォント。長周期階級がある場合は Chip |
+| **Trailing** | マグニチュード | 「M7.2」など、labelLarge・太字・等幅 |
+| **背景** | 任意 | 最大震度に応じた色の薄い背景（alpha 0.4）をオプションで表示 |
+
+- タップで詳細画面へ遷移
+- `VisualDensity.compact` でコンパクト表示
+
+### 3.3 空状態・エラー・完了状態
+
+- **条件に合う地震が0件**: 中央にアイコン（Icons.search_off）+ 「条件を満たす地震情報は見つかりませんでした」（太字・中央揃え）
+- **エラー**: カード型の ErrorCard（エラーメッセージ + 再読み込みボタン）
+- **全件取得済み**: SafeArea内でアイコン（Icons.search）+ 「全件取得済みです」（太字・中央揃え）
+
+### 3.4 検索条件モーダル（ボトムシート）
+
+「検索条件」タップで開くモーダル:
+
+- **タイトル**: 「検索条件」
+- **背景**: `surfaceContainerLow`
+- **各セクション**: チェックボックスで有効/無効 + タイトル + 説明文 + 有効時のみ子UI
+  - 期間（日付範囲）
+  - 震央地名（ドロップダウン）
+  - 最大震度（RangeSlider、震度1〜7）
+  - 地域の震度（都道府県/市区町村切り替え、地域選択、震度範囲、地図から選択・現在地はTODO）
+  - 震源の深さ（0〜700km、RangeSlider）
+  - マグニチュード（0〜9、RangeSlider）
+- **フッター**: キャンセル / 適用（FilledButton）
+
+---
+
+## 4. APIレスポンスの型
+
+地震履歴画面で利用しているAPIのレスポンス型（バックエンド eqmonitor_api パッケージの型定義ベース）です。デザイン時に「どの情報が必ずあるか」「どこが null になり得るか」の参考にしてください。
+
+### 4.1 一覧取得 `GET /v2/earthquake` → EarthquakeListResponse
+
+```ts
+// リスト1ページ分のレスポンス
+EarthquakeListResponse {
+  items: EarthquakePartial[];      // 地震の配列
+  next_token?: string;             // 次ページ用カーソル（base64）。無い場合は全件取得済み
+  next_pooling?: string;          // ポーリング用カーソル（base64）
+}
+```
+
+### 4.2 一覧アイテム EarthquakePartial（表示の元データ）
+
+```ts
+EarthquakePartial {
+  event_id: string;                // イベントID（yyyyMMddHHmmss形式）
+  status: TelegramStatus;         // NORMAL | TRAINING | TEST
+  origin_time_precision: OriginTimePrecision;  // MILLISECOND | SECOND | MINUTE | HOUR | DAY | MONTH
+  datasource: EarthquakeDatasource;  // JMA_INTENSITY_DATABASE | JMA_DISASTER_INFORMATION_XML
+  origin_time?: DateTime;        // 発震時刻（null のときは arrival_time を表示に使う）
+  arrival_time?: DateTime;        // 検知時刻
+  hypocenter?: Hypocenter;       // 震源情報（震央名・座標・マグニチュード・深さ）
+  intensity?: Intensity;          // 震度情報（最大震度・都道府県別・長周期階級など）
+  estimated_intensity_tile?: string;  // 推計震度PMTilesのURL
+}
+```
+
+### 4.3 震源 Hypocenter
+
+```ts
+Hypocenter {
+  value: CodeName;                 // { code, name } 震央地名（例: 〇〇沖）
+  coordinates: Coordinate;        // 緯度・経度
+  magnitude: Magnitude;           // { type, value? } マグニチュード（type=NORMAL のとき value が M値）
+  depth: Depth;                   // { type, value? } 深さ（type=NORMAL のとき value が km）
+  detailed?: CodeName;            // 震央の詳細地名（例: 〇〇）
+  auxiliary?: HypocenterAuxiliary;
+}
+// CodeName = { code: string, name: string }
+// Magnitude.value / Depth.value が無い場合は「不明」「700km以上」等の表現になる
+```
+
+### 4.4 震度 Intensity
+
+```ts
+Intensity {
+  max_intensity: JmaIntensity;     // 最大震度（1〜7の階級、例: 5強）
+  prefectures: IntensityItem[];   // 都道府県別震度
+  regions: IntensityItem[];       // 地域別
+  max_lpgm_intensity?: JmaLpgmIntensity;  // 最大長周期地震動階級（任意）
+}
+// IntensityItem = { value: CodeName, max_intensity?, max_lpgm_intensity? }
+```
+
+### 4.5 詳細取得 `GET /v2/earthquake/:eventId` → EarthquakeDetailResponse
+
+```ts
+EarthquakeDetailResponse {
+  earthquake: Earthquake;  // EarthquakePartial に telegrams[] が加わった詳細型
+}
+// Earthquake = EarthquakePartial の拡張（telegrams で電文履歴を持つ）
+```
+
+- 一覧では **EarthquakePartial** のみ使用。表示に使うのは `event_id`, `origin_time`/`arrival_time`, `hypocenter`, `intensity`, `datasource` など。
+- `hypocenter` / `intensity` は **null になり得る**（震源・震度未確定の電文など）。その場合は震央名・震度・M・深さを表示しないか「不明」扱い。
+
+---
+
+## 5. デザイン上の制約・方針（リファクタ後も維持したい点）
+
+- **Material 3** のコンポーネントと ColorScheme を前提とする
+- **アクセシビリティ**: 十分なコントラスト、タップ領域、読み上げを考慮
+- **震度色**: アプリ内で震度ごとの色が定義されており、一覧の背景やアイコンに利用している（リファクタ後も「震度で色分け」の概念は維持したい）
+- **情報の優先度**: 震央・発震時刻・最大震度・マグニチュードが主要。長周期階級は補足
+- **日本語**: すべてのラベル・メッセージは日本語
+
+---
+
+## 6. リファクタで検討してほしい観点（例）
+
+- 一覧アイテムの**情報階層**と**視認性**の改善（震度・時刻・Mをよりスキャンしやすく）
+- **日付セクション**の見せ方（ストickyヘッダーのスタイル、日付のフォーマット）
+- **空状態・エラー・完了**の表現（アイコン・コピー・レイアウト）
+- **検索条件**の開き方とシート内の情報設計（項目数が多いためグルーピングやナビゲーションの検討）
+- **プルトゥリフレッシュ**や**無限スクロール**のフィードバックの分かりやすさ
+- 他画面（ホームの地震履歴カード、詳細画面）との**一貫性**
+
+---
+
+## 7. 依頼文（Stitchにそのまま送る用）
+
+```
+地震監視アプリの「地震履歴」画面のデザインをリファクタしてほしいです。
+
+【画面の役割】
+- 過去の地震を日付ごとにグループ化して一覧表示
+- 検索条件（期間・震央・震度・地域・深さ・マグニチュード）で絞り込み可能
+- 各項目タップで詳細へ遷移。プルで更新・下方向スクロールで追加読み込み
+
+【現在の構成】
+- 画面上部: タイトル「地震履歴」+ 「検索条件」ボタン
+- 日付ごとのストickyヘッダー + リスト（各項目は「震度アイコン / 震央・震度テキスト / 日時・深さ / M」のListTile、震度に応じた薄い背景色あり）
+- 0件時・エラー時・全件取得済み時の状態表示あり
+- 検索条件はボトムシートで、期間・震央・最大震度・地域の震度・深さ・マグニチュードをチェックで有効化して設定
+
+【技術前提】
+- Material 3、ColorScheme、日本語、モバイル（iOS/Android）
+
+【お願い】
+上記を踏まえ、情報の見やすさ・操作の分かりやすさ・空/エラー/完了状態の表現・検索条件の使いやすさを改善するデザイン案（ワイヤーまたはUI案）を出してください。震度による色分けは維持したいです。
+```
+
+---
+
+以上です。必要に応じて「7. 依頼文」だけをStitchに送るか、2〜6を要約して添えると、より意図が伝わりやすくなります。

--- a/packages/better_auth_api_client/bin/generate.dart
+++ b/packages/better_auth_api_client/bin/generate.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+void main(List<String> args) async {
+  final packageDir = Directory.current;
+
+  await _step('swagger_parser でクライアントコードを生成', () async {
+    await _run('dart', ['run', 'swagger_parser'], packageDir.path);
+  });
+
+  await _step('Default クライアントを Auth にリネーム (Dart 予約語回避)', () async {
+    await _renameDefaultClientToAuth(packageDir);
+  });
+
+  await _step(r'$unknown 文字列補間パッチ', () async {
+    await _patchDollarUnknown(libDir: Directory('${packageDir.path}/lib'));
+  });
+
+  await _step('生成コードの型パッチ (redirect/session)', () async {
+    await _patchGeneratedTypes(packageDir);
+  });
+
+  await _step('build_runner で Freezed / Retrofit コードを生成', () async {
+    await _run('dart', [
+      'run',
+      'build_runner',
+      'build',
+      '--delete-conflicting-outputs',
+    ], packageDir.path);
+  });
+
+  stdout.writeln('\n✅ コード生成が完了しました');
+}
+
+Future<void> _step(String label, Future<void> Function() action) async {
+  stdout.writeln('\n▶ $label ...');
+  final sw = Stopwatch()..start();
+  await action();
+  stdout.writeln(
+    '  Done (${(sw.elapsedMilliseconds / 1000).toStringAsFixed(1)}s)',
+  );
+}
+
+/// Dart の予約語 `default` を避けるため Default クライアントを Auth にリネームする。
+Future<void> _renameDefaultClientToAuth(Directory packageDir) async {
+  final defaultClientFile = File(
+    '${packageDir.path}/lib/clients/default_api_client.dart',
+  );
+  if (!defaultClientFile.existsSync()) return;
+
+  var content = defaultClientFile.readAsStringSync();
+  content = content
+      .replaceAll('DefaultApiClient', 'AuthApiClient')
+      .replaceAll('default_api_client', 'auth_api_client')
+      .replaceAll('_DefaultApiClient', '_AuthApiClient');
+  File(
+    '${packageDir.path}/lib/clients/auth_api_client.dart',
+  ).writeAsStringSync(content);
+  defaultClientFile.deleteSync();
+
+  final apiClientFile = File('${packageDir.path}/lib/api_client.dart');
+  if (apiClientFile.existsSync()) {
+    var ac = apiClientFile.readAsStringSync();
+    ac = ac
+        .replaceAll(
+          'clients/default_api_client.dart',
+          'clients/auth_api_client.dart',
+        )
+        .replaceAll('_default', '_auth')
+        .replaceAll('DefaultApiClient', 'AuthApiClient')
+        .replaceAll('get default ', 'get auth ');
+    apiClientFile.writeAsStringSync(ac);
+  }
+
+  final exportFile = File('${packageDir.path}/lib/export.dart');
+  if (exportFile.existsSync()) {
+    var ex = exportFile.readAsStringSync();
+    ex = ex.replaceAll(
+      "'clients/default_api_client.dart'",
+      "'clients/auth_api_client.dart'",
+    );
+    exportFile.writeAsStringSync(ex);
+  }
+}
+
+Future<void> _patchDollarUnknown({required Directory libDir}) async {
+  for (final f in libDir.listSync(recursive: true).whereType<File>()) {
+    if (!f.path.endsWith('.dart')) continue;
+    final original = f.readAsStringSync();
+    final patched = original.replaceAll(r'$unknown', r'\$unknown');
+    if (patched != original) {
+      f.writeAsStringSync(patched);
+      stdout.writeln('  Patched: ${f.path}');
+    }
+  }
+}
+
+Future<void> _patchGeneratedTypes(Directory packageDir) async {
+  final lib = packageDir.path + '/lib';
+
+  final redirectFile = File('$lib/models/redirect.dart');
+  if (redirectFile.existsSync()) {
+    var c = redirectFile.readAsStringSync();
+    c = c.replaceFirst('final bool? json;', 'final String json;');
+    c = c.replaceAll(
+      RegExp(
+        r'  bool toJson\(\) \{\s*final value = json;.*?return value as bool;\s*\}',
+        dotAll: true,
+      ),
+      '  String toJson() => json;',
+    );
+    c = c.replaceFirst('json?.toString()', 'json.toString()');
+    redirectFile.writeAsStringSync(c);
+    stdout.writeln('  Patched: redirect.dart');
+  }
+
+  final sessionFile = File('$lib/models/session.dart');
+  if (sessionFile.existsSync()) {
+    var c = sessionFile.readAsStringSync();
+    c = c.replaceAll(
+      "@Default('Generated at runtime')\n    DateTime createdAt,",
+      'DateTime? createdAt,',
+    );
+    sessionFile.writeAsStringSync(c);
+    stdout.writeln('  Patched: session.dart');
+  }
+}
+
+Future<void> _run(String exe, List<String> args, String cwd) async {
+  final process = await Process.start(exe, args, workingDirectory: cwd);
+  process.stdout.listen(stdout.add);
+  process.stderr.listen(stderr.add);
+  final code = await process.exitCode;
+  if (code != 0) {
+    exit(code);
+  }
+}

--- a/packages/better_auth_api_client/build.yaml
+++ b/packages/better_auth_api_client/build.yaml
@@ -1,0 +1,21 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          field_rename: snake
+          checked: true
+      source_gen:combining_builder:
+        options:
+          ignore_for_file:
+            - type=lint
+            - type=warning
+            - duplicate_ignore
+            - unused_element_parameter
+global_options:
+  freezed:
+    runs_before:
+      - json_serializable
+  json_serializable:
+    runs_before:
+      - retrofit_generator

--- a/packages/better_auth_api_client/lib/api_client.dart
+++ b/packages/better_auth_api_client/lib/api_client.dart
@@ -1,0 +1,31 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/auth_api_client.dart';
+import 'clients/anonymous_api_client.dart';
+
+/// Better Auth `v1.1.0`.
+///
+/// API Reference for your Better Auth Instance.
+class ApiClient {
+  ApiClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.1.0';
+
+  AuthApiClient? _auth;
+  AnonymousApiClient? _anonymous;
+
+  AuthApiClient get auth => _auth ??= AuthApiClient(_dio, baseUrl: _baseUrl);
+
+  AnonymousApiClient get anonymous => _anonymous ??= AnonymousApiClient(_dio, baseUrl: _baseUrl);
+}

--- a/packages/better_auth_api_client/lib/clients/anonymous_api_client.dart
+++ b/packages/better_auth_api_client/lib/clients/anonymous_api_client.dart
@@ -1,0 +1,33 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/post_delete_anonymous_user_response.dart';
+import '../models/post_sign_in_anonymous_response.dart';
+
+part 'anonymous_api_client.g.dart';
+
+@RestApi()
+abstract class AnonymousApiClient {
+  factory AnonymousApiClient(Dio dio, {String? baseUrl}) = _AnonymousApiClient;
+
+  /// Sign in anonymously
+  @POST(AnonymousApiClientUrls.postSignInAnonymous)
+  Future<HttpResponse<PostSignInAnonymousResponse>> postSignInAnonymous();
+
+  /// Delete an anonymous user
+  @POST(AnonymousApiClientUrls.postDeleteAnonymousUser)
+  Future<HttpResponse<PostDeleteAnonymousUserResponse>> postDeleteAnonymousUser();
+}
+
+
+abstract class AnonymousApiClientUrls {
+	/// /sign-in/anonymous
+	static const postSignInAnonymous = "/sign-in/anonymous";
+	/// /delete-anonymous-user
+	static const postDeleteAnonymousUser = "/delete-anonymous-user";
+}
+

--- a/packages/better_auth_api_client/lib/clients/anonymous_api_client.g.dart
+++ b/packages/better_auth_api_client/lib/clients/anonymous_api_client.g.dart
@@ -1,0 +1,113 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'anonymous_api_client.dart';
+
+// dart format off
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+
+class _AnonymousApiClient implements AnonymousApiClient {
+  _AnonymousApiClient(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<HttpResponse<PostSignInAnonymousResponse>>
+  postSignInAnonymous() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<PostSignInAnonymousResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/sign-in/anonymous',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostSignInAnonymousResponse _value;
+    try {
+      _value = PostSignInAnonymousResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostDeleteAnonymousUserResponse>>
+  postDeleteAnonymousUser() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options =
+        _setStreamType<HttpResponse<PostDeleteAnonymousUserResponse>>(
+          Options(method: 'POST', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                '/delete-anonymous-user',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostDeleteAnonymousUserResponse _value;
+    try {
+      _value = PostDeleteAnonymousUserResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/clients/auth_api_client.dart
+++ b/packages/better_auth_api_client/lib/clients/auth_api_client.dart
@@ -1,0 +1,314 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/change_email_request_body.dart';
+import '../models/change_password_request_body.dart';
+import '../models/delete_user_request_body.dart';
+import '../models/get_access_token_request_body.dart';
+import '../models/get_account_info_response.dart';
+import '../models/get_delete_user_callback_response.dart';
+import '../models/get_get_session_response.dart';
+import '../models/get_list_accounts_response.dart';
+import '../models/get_ok_response.dart';
+import '../models/get_reset_password_token_response.dart';
+import '../models/get_verify_email_response.dart';
+import '../models/link_social_request_body.dart';
+import '../models/post_change_email_response.dart';
+import '../models/post_change_password_response.dart';
+import '../models/post_delete_user_response.dart';
+import '../models/post_get_access_token_response.dart';
+import '../models/post_get_session_response.dart';
+import '../models/post_link_social_response.dart';
+import '../models/post_refresh_token_response.dart';
+import '../models/post_request_password_reset_response.dart';
+import '../models/post_reset_password_response.dart';
+import '../models/post_revoke_other_sessions_response.dart';
+import '../models/post_revoke_session_response.dart';
+import '../models/post_revoke_sessions_response.dart';
+import '../models/post_send_verification_email_response.dart';
+import '../models/post_sign_in_email_response.dart';
+import '../models/post_sign_in_social_response.dart';
+import '../models/post_sign_out_response.dart';
+import '../models/post_sign_up_email_response.dart';
+import '../models/post_unlink_account_response.dart';
+import '../models/post_update_session_response.dart';
+import '../models/post_update_user_response.dart';
+import '../models/post_verify_password_response.dart';
+import '../models/refresh_token_request_body.dart';
+import '../models/request_password_reset_request_body.dart';
+import '../models/reset_password_request_body.dart';
+import '../models/revoke_session_request_body.dart';
+import '../models/send_verification_email_request_body.dart';
+import '../models/session.dart';
+import '../models/sign_in_email_request_body.dart';
+import '../models/sign_in_social_request_body.dart';
+import '../models/sign_up_email_request_body.dart';
+import '../models/unlink_account_request_body.dart';
+import '../models/update_user_request_body.dart';
+import '../models/verify_password_request_body.dart';
+
+part 'auth_api_client.g.dart';
+
+@RestApi()
+abstract class AuthApiClient {
+  factory AuthApiClient(Dio dio, {String? baseUrl}) = _AuthApiClient;
+
+  /// Sign in with a social provider
+  @POST(AuthApiClientUrls.postSignInSocial)
+  Future<HttpResponse<PostSignInSocialResponse>> postSignInSocial({
+    @Body() required SignInSocialRequestBody body,
+  });
+
+  @GET(AuthApiClientUrls.getCallbackId)
+  Future<HttpResponse<void>> getCallbackId();
+
+  @POST(AuthApiClientUrls.postCallbackId)
+  Future<HttpResponse<void>> postCallbackId({
+    @Body() dynamic body,
+  });
+
+  /// Get the current session
+  @GET(AuthApiClientUrls.getGetSession)
+  Future<HttpResponse<GetGetSessionResponse?>> getGetSession();
+
+  /// Get the current session
+  @POST(AuthApiClientUrls.postGetSession)
+  Future<HttpResponse<PostGetSessionResponse?>> postGetSession({
+    @Body() dynamic body,
+  });
+
+  /// Sign out the current user
+  @POST(AuthApiClientUrls.postSignOut)
+  Future<HttpResponse<PostSignOutResponse>> postSignOut({
+    @Body() dynamic body,
+  });
+
+  /// Sign up a user using email and password
+  @POST(AuthApiClientUrls.postSignUpEmail)
+  Future<HttpResponse<PostSignUpEmailResponse>> postSignUpEmail({
+    @Body() SignUpEmailRequestBody? body,
+  });
+
+  /// Sign in with email and password
+  @POST(AuthApiClientUrls.postSignInEmail)
+  Future<HttpResponse<PostSignInEmailResponse>> postSignInEmail({
+    @Body() required SignInEmailRequestBody body,
+  });
+
+  /// Reset the password for a user
+  @POST(AuthApiClientUrls.postResetPassword)
+  Future<HttpResponse<PostResetPasswordResponse>> postResetPassword({
+    @Body() required ResetPasswordRequestBody body,
+  });
+
+  /// Verify the current user's password
+  @POST(AuthApiClientUrls.postVerifyPassword)
+  Future<HttpResponse<PostVerifyPasswordResponse>> postVerifyPassword({
+    @Body() required VerifyPasswordRequestBody body,
+  });
+
+  /// Verify the email of the user.
+  ///
+  /// [token] - The token to verify the email.
+  ///
+  /// [callbackUrl] - The URL to redirect to after email verification.
+  @GET(AuthApiClientUrls.getVerifyEmail)
+  Future<HttpResponse<GetVerifyEmailResponse>> getVerifyEmail({
+    @Query('token') required String token,
+    @Query('callbackURL') String? callbackUrl,
+  });
+
+  /// Send a verification email to the user
+  @POST(AuthApiClientUrls.postSendVerificationEmail)
+  Future<HttpResponse<PostSendVerificationEmailResponse>> postSendVerificationEmail({
+    @Body() SendVerificationEmailRequestBody? body,
+  });
+
+  @POST(AuthApiClientUrls.postChangeEmail)
+  Future<HttpResponse<PostChangeEmailResponse>> postChangeEmail({
+    @Body() required ChangeEmailRequestBody body,
+  });
+
+  /// Change the password of the user
+  @POST(AuthApiClientUrls.postChangePassword)
+  Future<HttpResponse<PostChangePasswordResponse>> postChangePassword({
+    @Body() required ChangePasswordRequestBody body,
+  });
+
+  /// Update the current session
+  @POST(AuthApiClientUrls.postUpdateSession)
+  Future<HttpResponse<PostUpdateSessionResponse>> postUpdateSession({
+    @Body() dynamic body,
+  });
+
+  /// Update the current user
+  @POST(AuthApiClientUrls.postUpdateUser)
+  Future<HttpResponse<PostUpdateUserResponse>> postUpdateUser({
+    @Body() UpdateUserRequestBody? body,
+  });
+
+  /// Delete the user
+  @POST(AuthApiClientUrls.postDeleteUser)
+  Future<HttpResponse<PostDeleteUserResponse>> postDeleteUser({
+    @Body() DeleteUserRequestBody? body,
+  });
+
+  /// Send a password reset email to the user
+  @POST(AuthApiClientUrls.postRequestPasswordReset)
+  Future<HttpResponse<PostRequestPasswordResetResponse>> postRequestPasswordReset({
+    @Body() required RequestPasswordResetRequestBody body,
+  });
+
+  /// Redirects the user to the callback URL with the token.
+  ///
+  /// [token] - The token to reset the password.
+  ///
+  /// [callbackUrl] - The URL to redirect the user to reset their password.
+  @GET(AuthApiClientUrls.getResetPasswordToken)
+  Future<HttpResponse<GetResetPasswordTokenResponse>> getResetPasswordToken({
+    @Path('token') required String token,
+    @Query('callbackURL') required String callbackUrl,
+  });
+
+  /// List all active sessions for the user
+  @GET(AuthApiClientUrls.getListSessions)
+  Future<HttpResponse<List<Session>>> getListSessions();
+
+  /// Revoke a single session
+  @POST(AuthApiClientUrls.postRevokeSession)
+  Future<HttpResponse<PostRevokeSessionResponse>> postRevokeSession({
+    @Body() RevokeSessionRequestBody? body,
+  });
+
+  /// Revoke all sessions for the user
+  @POST(AuthApiClientUrls.postRevokeSessions)
+  Future<HttpResponse<PostRevokeSessionsResponse>> postRevokeSessions({
+    @Body() dynamic body,
+  });
+
+  /// Revoke all other sessions for the user except the current one
+  @POST(AuthApiClientUrls.postRevokeOtherSessions)
+  Future<HttpResponse<PostRevokeOtherSessionsResponse>> postRevokeOtherSessions({
+    @Body() dynamic body,
+  });
+
+  /// Link a social account to the user
+  @POST(AuthApiClientUrls.postLinkSocial)
+  Future<HttpResponse<PostLinkSocialResponse>> postLinkSocial({
+    @Body() required LinkSocialRequestBody body,
+  });
+
+  /// List all accounts linked to the user
+  @GET(AuthApiClientUrls.getListAccounts)
+  Future<HttpResponse<List<GetListAccountsResponse>>> getListAccounts();
+
+  /// Callback to complete user deletion with verification token
+  @GET(AuthApiClientUrls.getDeleteUserCallback)
+  Future<HttpResponse<GetDeleteUserCallbackResponse>> getDeleteUserCallback({
+    @Query('token') String? token,
+    @Query('callbackURL') String? callbackUrl,
+  });
+
+  /// Unlink an account
+  @POST(AuthApiClientUrls.postUnlinkAccount)
+  Future<HttpResponse<PostUnlinkAccountResponse>> postUnlinkAccount({
+    @Body() required UnlinkAccountRequestBody body,
+  });
+
+  /// Refresh the access token using a refresh token
+  @POST(AuthApiClientUrls.postRefreshToken)
+  Future<HttpResponse<PostRefreshTokenResponse>> postRefreshToken({
+    @Body() required RefreshTokenRequestBody body,
+  });
+
+  /// Get a valid access token, doing a refresh if needed
+  @POST(AuthApiClientUrls.postGetAccessToken)
+  Future<HttpResponse<PostGetAccessTokenResponse>> postGetAccessToken({
+    @Body() required GetAccessTokenRequestBody body,
+  });
+
+  /// Get the account info provided by the provider
+  @GET(AuthApiClientUrls.getAccountInfo)
+  Future<HttpResponse<GetAccountInfoResponse>> getAccountInfo();
+
+  /// Check if the API is working
+  @GET(AuthApiClientUrls.getOk)
+  Future<HttpResponse<GetOkResponse>> getOk();
+
+  /// Displays an error page
+  @GET(AuthApiClientUrls.getError)
+  Future<HttpResponse<String>> getError();
+}
+
+
+abstract class AuthApiClientUrls {
+	/// /sign-in/social
+	static const postSignInSocial = "/sign-in/social";
+	/// /callback/{id}
+	static const getCallbackId = "/callback/{id}";
+	/// /callback/{id}
+	static const postCallbackId = "/callback/{id}";
+	/// /get-session
+	static const getGetSession = "/get-session";
+	/// /get-session
+	static const postGetSession = "/get-session";
+	/// /sign-out
+	static const postSignOut = "/sign-out";
+	/// /sign-up/email
+	static const postSignUpEmail = "/sign-up/email";
+	/// /sign-in/email
+	static const postSignInEmail = "/sign-in/email";
+	/// /reset-password
+	static const postResetPassword = "/reset-password";
+	/// /verify-password
+	static const postVerifyPassword = "/verify-password";
+	/// /verify-email
+	static const getVerifyEmail = "/verify-email";
+	/// /send-verification-email
+	static const postSendVerificationEmail = "/send-verification-email";
+	/// /change-email
+	static const postChangeEmail = "/change-email";
+	/// /change-password
+	static const postChangePassword = "/change-password";
+	/// /update-session
+	static const postUpdateSession = "/update-session";
+	/// /update-user
+	static const postUpdateUser = "/update-user";
+	/// /delete-user
+	static const postDeleteUser = "/delete-user";
+	/// /request-password-reset
+	static const postRequestPasswordReset = "/request-password-reset";
+	/// /reset-password/{token}
+	static const getResetPasswordToken = "/reset-password/{token}";
+	/// /list-sessions
+	static const getListSessions = "/list-sessions";
+	/// /revoke-session
+	static const postRevokeSession = "/revoke-session";
+	/// /revoke-sessions
+	static const postRevokeSessions = "/revoke-sessions";
+	/// /revoke-other-sessions
+	static const postRevokeOtherSessions = "/revoke-other-sessions";
+	/// /link-social
+	static const postLinkSocial = "/link-social";
+	/// /list-accounts
+	static const getListAccounts = "/list-accounts";
+	/// /delete-user/callback
+	static const getDeleteUserCallback = "/delete-user/callback";
+	/// /unlink-account
+	static const postUnlinkAccount = "/unlink-account";
+	/// /refresh-token
+	static const postRefreshToken = "/refresh-token";
+	/// /get-access-token
+	static const postGetAccessToken = "/get-access-token";
+	/// /account-info
+	static const getAccountInfo = "/account-info";
+	/// /ok
+	static const getOk = "/ok";
+	/// /error
+	static const getError = "/error";
+}
+

--- a/packages/better_auth_api_client/lib/clients/auth_api_client.g.dart
+++ b/packages/better_auth_api_client/lib/clients/auth_api_client.g.dart
@@ -1,0 +1,1040 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'auth_api_client.dart';
+
+// dart format off
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+
+class _AuthApiClient implements AuthApiClient {
+  _AuthApiClient(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<HttpResponse<PostSignInSocialResponse>> postSignInSocial({
+    required SignInSocialRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostSignInSocialResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/sign-in/social',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostSignInSocialResponse _value;
+    try {
+      _value = PostSignInSocialResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<void>> getCallbackId() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<void>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/callback/{id}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<void>(_options);
+    final httpResponse = HttpResponse(null, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<void>> postCallbackId({dynamic body}) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = body;
+    final _options = _setStreamType<HttpResponse<void>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/callback/{id}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<void>(_options);
+    final httpResponse = HttpResponse(null, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<GetGetSessionResponse?>> getGetSession() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<GetGetSessionResponse?>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/get-session',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>?>(_options);
+    late GetGetSessionResponse? _value;
+    try {
+      _value = _result.data == null
+          ? null
+          : GetGetSessionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostGetSessionResponse?>> postGetSession({
+    dynamic body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = body;
+    final _options = _setStreamType<HttpResponse<PostGetSessionResponse?>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/get-session',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>?>(_options);
+    late PostGetSessionResponse? _value;
+    try {
+      _value = _result.data == null
+          ? null
+          : PostGetSessionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostSignOutResponse>> postSignOut({dynamic body}) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = body;
+    final _options = _setStreamType<HttpResponse<PostSignOutResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/sign-out',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostSignOutResponse _value;
+    try {
+      _value = PostSignOutResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostSignUpEmailResponse>> postSignUpEmail({
+    SignUpEmailRequestBody? body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body?.toJson() ?? <String, dynamic>{});
+    final _options = _setStreamType<HttpResponse<PostSignUpEmailResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/sign-up/email',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostSignUpEmailResponse _value;
+    try {
+      _value = PostSignUpEmailResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostSignInEmailResponse>> postSignInEmail({
+    required SignInEmailRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostSignInEmailResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/sign-in/email',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostSignInEmailResponse _value;
+    try {
+      _value = PostSignInEmailResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostResetPasswordResponse>> postResetPassword({
+    required ResetPasswordRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostResetPasswordResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/reset-password',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostResetPasswordResponse _value;
+    try {
+      _value = PostResetPasswordResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostVerifyPasswordResponse>> postVerifyPassword({
+    required VerifyPasswordRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostVerifyPasswordResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/verify-password',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostVerifyPasswordResponse _value;
+    try {
+      _value = PostVerifyPasswordResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<GetVerifyEmailResponse>> getVerifyEmail({
+    required String token,
+    String? callbackUrl,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'token': token,
+      r'callbackURL': callbackUrl,
+    };
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<GetVerifyEmailResponse>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/verify-email',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late GetVerifyEmailResponse _value;
+    try {
+      _value = GetVerifyEmailResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostSendVerificationEmailResponse>>
+  postSendVerificationEmail({SendVerificationEmailRequestBody? body}) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body?.toJson() ?? <String, dynamic>{});
+    final _options =
+        _setStreamType<HttpResponse<PostSendVerificationEmailResponse>>(
+          Options(method: 'POST', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                '/send-verification-email',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostSendVerificationEmailResponse _value;
+    try {
+      _value = PostSendVerificationEmailResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostChangeEmailResponse>> postChangeEmail({
+    required ChangeEmailRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostChangeEmailResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/change-email',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostChangeEmailResponse _value;
+    try {
+      _value = PostChangeEmailResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostChangePasswordResponse>> postChangePassword({
+    required ChangePasswordRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostChangePasswordResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/change-password',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostChangePasswordResponse _value;
+    try {
+      _value = PostChangePasswordResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostUpdateSessionResponse>> postUpdateSession({
+    dynamic body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = body;
+    final _options = _setStreamType<HttpResponse<PostUpdateSessionResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/update-session',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostUpdateSessionResponse _value;
+    try {
+      _value = PostUpdateSessionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostUpdateUserResponse>> postUpdateUser({
+    UpdateUserRequestBody? body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body?.toJson() ?? <String, dynamic>{});
+    final _options = _setStreamType<HttpResponse<PostUpdateUserResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/update-user',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostUpdateUserResponse _value;
+    try {
+      _value = PostUpdateUserResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostDeleteUserResponse>> postDeleteUser({
+    DeleteUserRequestBody? body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body?.toJson() ?? <String, dynamic>{});
+    final _options = _setStreamType<HttpResponse<PostDeleteUserResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/delete-user',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostDeleteUserResponse _value;
+    try {
+      _value = PostDeleteUserResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostRequestPasswordResetResponse>>
+  postRequestPasswordReset({
+    required RequestPasswordResetRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options =
+        _setStreamType<HttpResponse<PostRequestPasswordResetResponse>>(
+          Options(method: 'POST', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                '/request-password-reset',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostRequestPasswordResetResponse _value;
+    try {
+      _value = PostRequestPasswordResetResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<GetResetPasswordTokenResponse>> getResetPasswordToken({
+    required String token,
+    required String callbackUrl,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'callbackURL': callbackUrl};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options =
+        _setStreamType<HttpResponse<GetResetPasswordTokenResponse>>(
+          Options(method: 'GET', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                '/reset-password/${token}',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late GetResetPasswordTokenResponse _value;
+    try {
+      _value = GetResetPasswordTokenResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<List<Session>>> getListSessions() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<List<Session>>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/list-sessions',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<Session> _value;
+    try {
+      _value = _result.data!
+          .map((dynamic i) => Session.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostRevokeSessionResponse>> postRevokeSession({
+    RevokeSessionRequestBody? body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body?.toJson() ?? <String, dynamic>{});
+    final _options = _setStreamType<HttpResponse<PostRevokeSessionResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/revoke-session',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostRevokeSessionResponse _value;
+    try {
+      _value = PostRevokeSessionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostRevokeSessionsResponse>> postRevokeSessions({
+    dynamic body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = body;
+    final _options = _setStreamType<HttpResponse<PostRevokeSessionsResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/revoke-sessions',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostRevokeSessionsResponse _value;
+    try {
+      _value = PostRevokeSessionsResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostRevokeOtherSessionsResponse>>
+  postRevokeOtherSessions({dynamic body}) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = body;
+    final _options =
+        _setStreamType<HttpResponse<PostRevokeOtherSessionsResponse>>(
+          Options(method: 'POST', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                '/revoke-other-sessions',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostRevokeOtherSessionsResponse _value;
+    try {
+      _value = PostRevokeOtherSessionsResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostLinkSocialResponse>> postLinkSocial({
+    required LinkSocialRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostLinkSocialResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/link-social',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostLinkSocialResponse _value;
+    try {
+      _value = PostLinkSocialResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<List<GetListAccountsResponse>>> getListAccounts() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options =
+        _setStreamType<HttpResponse<List<GetListAccountsResponse>>>(
+          Options(method: 'GET', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                '/list-accounts',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<GetListAccountsResponse> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) =>
+                GetListAccountsResponse.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<GetDeleteUserCallbackResponse>> getDeleteUserCallback({
+    String? token,
+    String? callbackUrl,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'token': token,
+      r'callbackURL': callbackUrl,
+    };
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options =
+        _setStreamType<HttpResponse<GetDeleteUserCallbackResponse>>(
+          Options(method: 'GET', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                '/delete-user/callback',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late GetDeleteUserCallbackResponse _value;
+    try {
+      _value = GetDeleteUserCallbackResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostUnlinkAccountResponse>> postUnlinkAccount({
+    required UnlinkAccountRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostUnlinkAccountResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/unlink-account',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostUnlinkAccountResponse _value;
+    try {
+      _value = PostUnlinkAccountResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostRefreshTokenResponse>> postRefreshToken({
+    required RefreshTokenRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostRefreshTokenResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/refresh-token',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostRefreshTokenResponse _value;
+    try {
+      _value = PostRefreshTokenResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<PostGetAccessTokenResponse>> postGetAccessToken({
+    required GetAccessTokenRequestBody body,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _options = _setStreamType<HttpResponse<PostGetAccessTokenResponse>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/get-access-token',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late PostGetAccessTokenResponse _value;
+    try {
+      _value = PostGetAccessTokenResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<GetAccountInfoResponse>> getAccountInfo() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<GetAccountInfoResponse>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/account-info',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late GetAccountInfoResponse _value;
+    try {
+      _value = GetAccountInfoResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<GetOkResponse>> getOk() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<GetOkResponse>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/ok',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late GetOkResponse _value;
+    try {
+      _value = GetOkResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<String>> getError() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<String>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/error',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<String>(_options);
+    late String _value;
+    try {
+      _value = _result.data!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/export.dart
+++ b/packages/better_auth_api_client/lib/export.dart
@@ -1,0 +1,69 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+// Clients
+export 'clients/auth_api_client.dart';
+export 'clients/anonymous_api_client.dart';
+// Data classes
+export 'models/user.dart';
+export 'models/session.dart';
+export 'models/post_sign_in_social_response.dart';
+export 'models/name.dart';
+export 'models/id_token.dart';
+export 'models/sign_in_social_request_body.dart';
+export 'models/get_get_session_response.dart';
+export 'models/post_get_session_response.dart';
+export 'models/post_sign_out_response.dart';
+export 'models/user2.dart';
+export 'models/post_sign_up_email_response.dart';
+export 'models/sign_up_email_request_body.dart';
+export 'models/post_sign_in_email_response.dart';
+export 'models/sign_in_email_request_body.dart';
+export 'models/post_reset_password_response.dart';
+export 'models/reset_password_request_body.dart';
+export 'models/post_verify_password_response.dart';
+export 'models/verify_password_request_body.dart';
+export 'models/get_verify_email_response.dart';
+export 'models/post_send_verification_email_response.dart';
+export 'models/send_verification_email_request_body.dart';
+export 'models/post_change_email_response.dart';
+export 'models/change_email_request_body.dart';
+export 'models/user3.dart';
+export 'models/post_change_password_response.dart';
+export 'models/change_password_request_body.dart';
+export 'models/post_update_session_response.dart';
+export 'models/post_update_user_response.dart';
+export 'models/update_user_request_body.dart';
+export 'models/post_delete_user_response.dart';
+export 'models/delete_user_request_body.dart';
+export 'models/post_request_password_reset_response.dart';
+export 'models/request_password_reset_request_body.dart';
+export 'models/get_reset_password_token_response.dart';
+export 'models/post_revoke_session_response.dart';
+export 'models/revoke_session_request_body.dart';
+export 'models/post_revoke_sessions_response.dart';
+export 'models/post_revoke_other_sessions_response.dart';
+export 'models/post_link_social_response.dart';
+export 'models/id_token2.dart';
+export 'models/link_social_request_body.dart';
+export 'models/get_list_accounts_response.dart';
+export 'models/get_delete_user_callback_response.dart';
+export 'models/post_unlink_account_response.dart';
+export 'models/unlink_account_request_body.dart';
+export 'models/post_refresh_token_response.dart';
+export 'models/refresh_token_request_body.dart';
+export 'models/post_get_access_token_response.dart';
+export 'models/get_access_token_request_body.dart';
+export 'models/user4.dart';
+export 'models/get_account_info_response.dart';
+export 'models/get_ok_response.dart';
+export 'models/post_sign_in_anonymous_response.dart';
+export 'models/post_delete_anonymous_user_response.dart';
+export 'models/redirect.dart';
+export 'models/message.dart';
+export 'models/message2.dart';
+export 'models/message3.dart';
+// Root client
+export 'api_client.dart';
+

--- a/packages/better_auth_api_client/lib/models/change_email_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/change_email_request_body.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'change_email_request_body.freezed.dart';
+part 'change_email_request_body.g.dart';
+
+@Freezed()
+abstract class ChangeEmailRequestBody with _$ChangeEmailRequestBody {
+  const factory ChangeEmailRequestBody({
+    /// The new email address to set must be a valid email address
+    required String newEmail,
+
+    /// The URL to redirect to after email verification
+    @JsonKey(includeIfNull: false,name: 'callbackURL')
+    String? callbackUrl,
+  }) = _ChangeEmailRequestBody;
+  
+  factory ChangeEmailRequestBody.fromJson(Map<String, Object?> json) => _$ChangeEmailRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/change_email_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/change_email_request_body.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'change_email_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChangeEmailRequestBody {
+
+/// The new email address to set must be a valid email address
+ String get newEmail;/// The URL to redirect to after email verification
+@JsonKey(includeIfNull: false, name: 'callbackURL') String? get callbackUrl;
+/// Create a copy of ChangeEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChangeEmailRequestBodyCopyWith<ChangeEmailRequestBody> get copyWith => _$ChangeEmailRequestBodyCopyWithImpl<ChangeEmailRequestBody>(this as ChangeEmailRequestBody, _$identity);
+
+  /// Serializes this ChangeEmailRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChangeEmailRequestBody&&(identical(other.newEmail, newEmail) || other.newEmail == newEmail)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newEmail,callbackUrl);
+
+@override
+String toString() {
+  return 'ChangeEmailRequestBody(newEmail: $newEmail, callbackUrl: $callbackUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChangeEmailRequestBodyCopyWith<$Res>  {
+  factory $ChangeEmailRequestBodyCopyWith(ChangeEmailRequestBody value, $Res Function(ChangeEmailRequestBody) _then) = _$ChangeEmailRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String newEmail,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChangeEmailRequestBodyCopyWithImpl<$Res>
+    implements $ChangeEmailRequestBodyCopyWith<$Res> {
+  _$ChangeEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final ChangeEmailRequestBody _self;
+  final $Res Function(ChangeEmailRequestBody) _then;
+
+/// Create a copy of ChangeEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? newEmail = null,Object? callbackUrl = freezed,}) {
+  return _then(_self.copyWith(
+newEmail: null == newEmail ? _self.newEmail : newEmail // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChangeEmailRequestBody].
+extension ChangeEmailRequestBodyPatterns on ChangeEmailRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChangeEmailRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChangeEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChangeEmailRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChangeEmailRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChangeEmailRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChangeEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String newEmail, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChangeEmailRequestBody() when $default != null:
+return $default(_that.newEmail,_that.callbackUrl);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String newEmail, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)  $default,) {final _that = this;
+switch (_that) {
+case _ChangeEmailRequestBody():
+return $default(_that.newEmail,_that.callbackUrl);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String newEmail, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)?  $default,) {final _that = this;
+switch (_that) {
+case _ChangeEmailRequestBody() when $default != null:
+return $default(_that.newEmail,_that.callbackUrl);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ChangeEmailRequestBody implements ChangeEmailRequestBody {
+  const _ChangeEmailRequestBody({required this.newEmail, @JsonKey(includeIfNull: false, name: 'callbackURL') this.callbackUrl});
+  factory _ChangeEmailRequestBody.fromJson(Map<String, dynamic> json) => _$ChangeEmailRequestBodyFromJson(json);
+
+/// The new email address to set must be a valid email address
+@override final  String newEmail;
+/// The URL to redirect to after email verification
+@override@JsonKey(includeIfNull: false, name: 'callbackURL') final  String? callbackUrl;
+
+/// Create a copy of ChangeEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChangeEmailRequestBodyCopyWith<_ChangeEmailRequestBody> get copyWith => __$ChangeEmailRequestBodyCopyWithImpl<_ChangeEmailRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ChangeEmailRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChangeEmailRequestBody&&(identical(other.newEmail, newEmail) || other.newEmail == newEmail)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newEmail,callbackUrl);
+
+@override
+String toString() {
+  return 'ChangeEmailRequestBody(newEmail: $newEmail, callbackUrl: $callbackUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChangeEmailRequestBodyCopyWith<$Res> implements $ChangeEmailRequestBodyCopyWith<$Res> {
+  factory _$ChangeEmailRequestBodyCopyWith(_ChangeEmailRequestBody value, $Res Function(_ChangeEmailRequestBody) _then) = __$ChangeEmailRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String newEmail,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChangeEmailRequestBodyCopyWithImpl<$Res>
+    implements _$ChangeEmailRequestBodyCopyWith<$Res> {
+  __$ChangeEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _ChangeEmailRequestBody _self;
+  final $Res Function(_ChangeEmailRequestBody) _then;
+
+/// Create a copy of ChangeEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? newEmail = null,Object? callbackUrl = freezed,}) {
+  return _then(_ChangeEmailRequestBody(
+newEmail: null == newEmail ? _self.newEmail : newEmail // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/change_email_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/change_email_request_body.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'change_email_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChangeEmailRequestBody _$ChangeEmailRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_ChangeEmailRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _ChangeEmailRequestBody(
+      newEmail: $checkedConvert('new_email', (v) => v as String),
+      callbackUrl: $checkedConvert('callbackURL', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'newEmail': 'new_email', 'callbackUrl': 'callbackURL'},
+);
+
+Map<String, dynamic> _$ChangeEmailRequestBodyToJson(
+  _ChangeEmailRequestBody instance,
+) => <String, dynamic>{
+  'new_email': instance.newEmail,
+  'callbackURL': ?instance.callbackUrl,
+};

--- a/packages/better_auth_api_client/lib/models/change_password_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/change_password_request_body.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'change_password_request_body.freezed.dart';
+part 'change_password_request_body.g.dart';
+
+@Freezed()
+abstract class ChangePasswordRequestBody with _$ChangePasswordRequestBody {
+  const factory ChangePasswordRequestBody({
+    /// The new password to set
+    required String newPassword,
+
+    /// The current password is required
+    required String currentPassword,
+
+    /// Must be a boolean value
+    @JsonKey(includeIfNull: false)
+    bool? revokeOtherSessions,
+  }) = _ChangePasswordRequestBody;
+  
+  factory ChangePasswordRequestBody.fromJson(Map<String, Object?> json) => _$ChangePasswordRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/change_password_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/change_password_request_body.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'change_password_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ChangePasswordRequestBody {
+
+/// The new password to set
+ String get newPassword;/// The current password is required
+ String get currentPassword;/// Must be a boolean value
+@JsonKey(includeIfNull: false) bool? get revokeOtherSessions;
+/// Create a copy of ChangePasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChangePasswordRequestBodyCopyWith<ChangePasswordRequestBody> get copyWith => _$ChangePasswordRequestBodyCopyWithImpl<ChangePasswordRequestBody>(this as ChangePasswordRequestBody, _$identity);
+
+  /// Serializes this ChangePasswordRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChangePasswordRequestBody&&(identical(other.newPassword, newPassword) || other.newPassword == newPassword)&&(identical(other.currentPassword, currentPassword) || other.currentPassword == currentPassword)&&(identical(other.revokeOtherSessions, revokeOtherSessions) || other.revokeOtherSessions == revokeOtherSessions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newPassword,currentPassword,revokeOtherSessions);
+
+@override
+String toString() {
+  return 'ChangePasswordRequestBody(newPassword: $newPassword, currentPassword: $currentPassword, revokeOtherSessions: $revokeOtherSessions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChangePasswordRequestBodyCopyWith<$Res>  {
+  factory $ChangePasswordRequestBodyCopyWith(ChangePasswordRequestBody value, $Res Function(ChangePasswordRequestBody) _then) = _$ChangePasswordRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String newPassword, String currentPassword,@JsonKey(includeIfNull: false) bool? revokeOtherSessions
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChangePasswordRequestBodyCopyWithImpl<$Res>
+    implements $ChangePasswordRequestBodyCopyWith<$Res> {
+  _$ChangePasswordRequestBodyCopyWithImpl(this._self, this._then);
+
+  final ChangePasswordRequestBody _self;
+  final $Res Function(ChangePasswordRequestBody) _then;
+
+/// Create a copy of ChangePasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? newPassword = null,Object? currentPassword = null,Object? revokeOtherSessions = freezed,}) {
+  return _then(_self.copyWith(
+newPassword: null == newPassword ? _self.newPassword : newPassword // ignore: cast_nullable_to_non_nullable
+as String,currentPassword: null == currentPassword ? _self.currentPassword : currentPassword // ignore: cast_nullable_to_non_nullable
+as String,revokeOtherSessions: freezed == revokeOtherSessions ? _self.revokeOtherSessions : revokeOtherSessions // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChangePasswordRequestBody].
+extension ChangePasswordRequestBodyPatterns on ChangePasswordRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChangePasswordRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChangePasswordRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChangePasswordRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChangePasswordRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChangePasswordRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChangePasswordRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String newPassword,  String currentPassword, @JsonKey(includeIfNull: false)  bool? revokeOtherSessions)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChangePasswordRequestBody() when $default != null:
+return $default(_that.newPassword,_that.currentPassword,_that.revokeOtherSessions);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String newPassword,  String currentPassword, @JsonKey(includeIfNull: false)  bool? revokeOtherSessions)  $default,) {final _that = this;
+switch (_that) {
+case _ChangePasswordRequestBody():
+return $default(_that.newPassword,_that.currentPassword,_that.revokeOtherSessions);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String newPassword,  String currentPassword, @JsonKey(includeIfNull: false)  bool? revokeOtherSessions)?  $default,) {final _that = this;
+switch (_that) {
+case _ChangePasswordRequestBody() when $default != null:
+return $default(_that.newPassword,_that.currentPassword,_that.revokeOtherSessions);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ChangePasswordRequestBody implements ChangePasswordRequestBody {
+  const _ChangePasswordRequestBody({required this.newPassword, required this.currentPassword, @JsonKey(includeIfNull: false) this.revokeOtherSessions});
+  factory _ChangePasswordRequestBody.fromJson(Map<String, dynamic> json) => _$ChangePasswordRequestBodyFromJson(json);
+
+/// The new password to set
+@override final  String newPassword;
+/// The current password is required
+@override final  String currentPassword;
+/// Must be a boolean value
+@override@JsonKey(includeIfNull: false) final  bool? revokeOtherSessions;
+
+/// Create a copy of ChangePasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChangePasswordRequestBodyCopyWith<_ChangePasswordRequestBody> get copyWith => __$ChangePasswordRequestBodyCopyWithImpl<_ChangePasswordRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ChangePasswordRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChangePasswordRequestBody&&(identical(other.newPassword, newPassword) || other.newPassword == newPassword)&&(identical(other.currentPassword, currentPassword) || other.currentPassword == currentPassword)&&(identical(other.revokeOtherSessions, revokeOtherSessions) || other.revokeOtherSessions == revokeOtherSessions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newPassword,currentPassword,revokeOtherSessions);
+
+@override
+String toString() {
+  return 'ChangePasswordRequestBody(newPassword: $newPassword, currentPassword: $currentPassword, revokeOtherSessions: $revokeOtherSessions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChangePasswordRequestBodyCopyWith<$Res> implements $ChangePasswordRequestBodyCopyWith<$Res> {
+  factory _$ChangePasswordRequestBodyCopyWith(_ChangePasswordRequestBody value, $Res Function(_ChangePasswordRequestBody) _then) = __$ChangePasswordRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String newPassword, String currentPassword,@JsonKey(includeIfNull: false) bool? revokeOtherSessions
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChangePasswordRequestBodyCopyWithImpl<$Res>
+    implements _$ChangePasswordRequestBodyCopyWith<$Res> {
+  __$ChangePasswordRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _ChangePasswordRequestBody _self;
+  final $Res Function(_ChangePasswordRequestBody) _then;
+
+/// Create a copy of ChangePasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? newPassword = null,Object? currentPassword = null,Object? revokeOtherSessions = freezed,}) {
+  return _then(_ChangePasswordRequestBody(
+newPassword: null == newPassword ? _self.newPassword : newPassword // ignore: cast_nullable_to_non_nullable
+as String,currentPassword: null == currentPassword ? _self.currentPassword : currentPassword // ignore: cast_nullable_to_non_nullable
+as String,revokeOtherSessions: freezed == revokeOtherSessions ? _self.revokeOtherSessions : revokeOtherSessions // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/change_password_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/change_password_request_body.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'change_password_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ChangePasswordRequestBody _$ChangePasswordRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_ChangePasswordRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _ChangePasswordRequestBody(
+      newPassword: $checkedConvert('new_password', (v) => v as String),
+      currentPassword: $checkedConvert('current_password', (v) => v as String),
+      revokeOtherSessions: $checkedConvert(
+        'revoke_other_sessions',
+        (v) => v as bool?,
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'newPassword': 'new_password',
+    'currentPassword': 'current_password',
+    'revokeOtherSessions': 'revoke_other_sessions',
+  },
+);
+
+Map<String, dynamic> _$ChangePasswordRequestBodyToJson(
+  _ChangePasswordRequestBody instance,
+) => <String, dynamic>{
+  'new_password': instance.newPassword,
+  'current_password': instance.currentPassword,
+  'revoke_other_sessions': ?instance.revokeOtherSessions,
+};

--- a/packages/better_auth_api_client/lib/models/delete_user_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/delete_user_request_body.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'delete_user_request_body.freezed.dart';
+part 'delete_user_request_body.g.dart';
+
+@Freezed()
+abstract class DeleteUserRequestBody with _$DeleteUserRequestBody {
+  const factory DeleteUserRequestBody({
+    /// The callback URL to redirect to after the user is deleted
+    @JsonKey(name: 'callbackURL')
+    required String callbackUrl,
+
+    /// The user's password. Required if session is not fresh
+    required String password,
+
+    /// The deletion verification token
+    required String token,
+  }) = _DeleteUserRequestBody;
+  
+  factory DeleteUserRequestBody.fromJson(Map<String, Object?> json) => _$DeleteUserRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/delete_user_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/delete_user_request_body.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'delete_user_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$DeleteUserRequestBody {
+
+/// The callback URL to redirect to after the user is deleted
+@JsonKey(name: 'callbackURL') String get callbackUrl;/// The user's password. Required if session is not fresh
+ String get password;/// The deletion verification token
+ String get token;
+/// Create a copy of DeleteUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DeleteUserRequestBodyCopyWith<DeleteUserRequestBody> get copyWith => _$DeleteUserRequestBodyCopyWithImpl<DeleteUserRequestBody>(this as DeleteUserRequestBody, _$identity);
+
+  /// Serializes this DeleteUserRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeleteUserRequestBody&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.password, password) || other.password == password)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,callbackUrl,password,token);
+
+@override
+String toString() {
+  return 'DeleteUserRequestBody(callbackUrl: $callbackUrl, password: $password, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DeleteUserRequestBodyCopyWith<$Res>  {
+  factory $DeleteUserRequestBodyCopyWith(DeleteUserRequestBody value, $Res Function(DeleteUserRequestBody) _then) = _$DeleteUserRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'callbackURL') String callbackUrl, String password, String token
+});
+
+
+
+
+}
+/// @nodoc
+class _$DeleteUserRequestBodyCopyWithImpl<$Res>
+    implements $DeleteUserRequestBodyCopyWith<$Res> {
+  _$DeleteUserRequestBodyCopyWithImpl(this._self, this._then);
+
+  final DeleteUserRequestBody _self;
+  final $Res Function(DeleteUserRequestBody) _then;
+
+/// Create a copy of DeleteUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? callbackUrl = null,Object? password = null,Object? token = null,}) {
+  return _then(_self.copyWith(
+callbackUrl: null == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [DeleteUserRequestBody].
+extension DeleteUserRequestBodyPatterns on DeleteUserRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DeleteUserRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DeleteUserRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DeleteUserRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _DeleteUserRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DeleteUserRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DeleteUserRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'callbackURL')  String callbackUrl,  String password,  String token)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DeleteUserRequestBody() when $default != null:
+return $default(_that.callbackUrl,_that.password,_that.token);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'callbackURL')  String callbackUrl,  String password,  String token)  $default,) {final _that = this;
+switch (_that) {
+case _DeleteUserRequestBody():
+return $default(_that.callbackUrl,_that.password,_that.token);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'callbackURL')  String callbackUrl,  String password,  String token)?  $default,) {final _that = this;
+switch (_that) {
+case _DeleteUserRequestBody() when $default != null:
+return $default(_that.callbackUrl,_that.password,_that.token);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _DeleteUserRequestBody implements DeleteUserRequestBody {
+  const _DeleteUserRequestBody({@JsonKey(name: 'callbackURL') required this.callbackUrl, required this.password, required this.token});
+  factory _DeleteUserRequestBody.fromJson(Map<String, dynamic> json) => _$DeleteUserRequestBodyFromJson(json);
+
+/// The callback URL to redirect to after the user is deleted
+@override@JsonKey(name: 'callbackURL') final  String callbackUrl;
+/// The user's password. Required if session is not fresh
+@override final  String password;
+/// The deletion verification token
+@override final  String token;
+
+/// Create a copy of DeleteUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DeleteUserRequestBodyCopyWith<_DeleteUserRequestBody> get copyWith => __$DeleteUserRequestBodyCopyWithImpl<_DeleteUserRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$DeleteUserRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DeleteUserRequestBody&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.password, password) || other.password == password)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,callbackUrl,password,token);
+
+@override
+String toString() {
+  return 'DeleteUserRequestBody(callbackUrl: $callbackUrl, password: $password, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$DeleteUserRequestBodyCopyWith<$Res> implements $DeleteUserRequestBodyCopyWith<$Res> {
+  factory _$DeleteUserRequestBodyCopyWith(_DeleteUserRequestBody value, $Res Function(_DeleteUserRequestBody) _then) = __$DeleteUserRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'callbackURL') String callbackUrl, String password, String token
+});
+
+
+
+
+}
+/// @nodoc
+class __$DeleteUserRequestBodyCopyWithImpl<$Res>
+    implements _$DeleteUserRequestBodyCopyWith<$Res> {
+  __$DeleteUserRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _DeleteUserRequestBody _self;
+  final $Res Function(_DeleteUserRequestBody) _then;
+
+/// Create a copy of DeleteUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? callbackUrl = null,Object? password = null,Object? token = null,}) {
+  return _then(_DeleteUserRequestBody(
+callbackUrl: null == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/delete_user_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/delete_user_request_body.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'delete_user_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_DeleteUserRequestBody _$DeleteUserRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_DeleteUserRequestBody', json, ($checkedConvert) {
+  final val = _DeleteUserRequestBody(
+    callbackUrl: $checkedConvert('callbackURL', (v) => v as String),
+    password: $checkedConvert('password', (v) => v as String),
+    token: $checkedConvert('token', (v) => v as String),
+  );
+  return val;
+}, fieldKeyMap: const {'callbackUrl': 'callbackURL'});
+
+Map<String, dynamic> _$DeleteUserRequestBodyToJson(
+  _DeleteUserRequestBody instance,
+) => <String, dynamic>{
+  'callbackURL': instance.callbackUrl,
+  'password': instance.password,
+  'token': instance.token,
+};

--- a/packages/better_auth_api_client/lib/models/get_access_token_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/get_access_token_request_body.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_access_token_request_body.freezed.dart';
+part 'get_access_token_request_body.g.dart';
+
+@Freezed()
+abstract class GetAccessTokenRequestBody with _$GetAccessTokenRequestBody {
+  const factory GetAccessTokenRequestBody({
+    /// The provider ID for the OAuth provider
+    required String providerId,
+
+    /// The account ID associated with the refresh token
+    @JsonKey(includeIfNull: false)
+    String? accountId,
+
+    /// The user ID associated with the account
+    @JsonKey(includeIfNull: false)
+    String? userId,
+  }) = _GetAccessTokenRequestBody;
+  
+  factory GetAccessTokenRequestBody.fromJson(Map<String, Object?> json) => _$GetAccessTokenRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_access_token_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_access_token_request_body.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_access_token_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetAccessTokenRequestBody {
+
+/// The provider ID for the OAuth provider
+ String get providerId;/// The account ID associated with the refresh token
+@JsonKey(includeIfNull: false) String? get accountId;/// The user ID associated with the account
+@JsonKey(includeIfNull: false) String? get userId;
+/// Create a copy of GetAccessTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetAccessTokenRequestBodyCopyWith<GetAccessTokenRequestBody> get copyWith => _$GetAccessTokenRequestBodyCopyWithImpl<GetAccessTokenRequestBody>(this as GetAccessTokenRequestBody, _$identity);
+
+  /// Serializes this GetAccessTokenRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetAccessTokenRequestBody&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.userId, userId) || other.userId == userId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,providerId,accountId,userId);
+
+@override
+String toString() {
+  return 'GetAccessTokenRequestBody(providerId: $providerId, accountId: $accountId, userId: $userId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetAccessTokenRequestBodyCopyWith<$Res>  {
+  factory $GetAccessTokenRequestBodyCopyWith(GetAccessTokenRequestBody value, $Res Function(GetAccessTokenRequestBody) _then) = _$GetAccessTokenRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String providerId,@JsonKey(includeIfNull: false) String? accountId,@JsonKey(includeIfNull: false) String? userId
+});
+
+
+
+
+}
+/// @nodoc
+class _$GetAccessTokenRequestBodyCopyWithImpl<$Res>
+    implements $GetAccessTokenRequestBodyCopyWith<$Res> {
+  _$GetAccessTokenRequestBodyCopyWithImpl(this._self, this._then);
+
+  final GetAccessTokenRequestBody _self;
+  final $Res Function(GetAccessTokenRequestBody) _then;
+
+/// Create a copy of GetAccessTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? providerId = null,Object? accountId = freezed,Object? userId = freezed,}) {
+  return _then(_self.copyWith(
+providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GetAccessTokenRequestBody].
+extension GetAccessTokenRequestBodyPatterns on GetAccessTokenRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetAccessTokenRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetAccessTokenRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetAccessTokenRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetAccessTokenRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetAccessTokenRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetAccessTokenRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId, @JsonKey(includeIfNull: false)  String? userId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetAccessTokenRequestBody() when $default != null:
+return $default(_that.providerId,_that.accountId,_that.userId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId, @JsonKey(includeIfNull: false)  String? userId)  $default,) {final _that = this;
+switch (_that) {
+case _GetAccessTokenRequestBody():
+return $default(_that.providerId,_that.accountId,_that.userId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId, @JsonKey(includeIfNull: false)  String? userId)?  $default,) {final _that = this;
+switch (_that) {
+case _GetAccessTokenRequestBody() when $default != null:
+return $default(_that.providerId,_that.accountId,_that.userId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetAccessTokenRequestBody implements GetAccessTokenRequestBody {
+  const _GetAccessTokenRequestBody({required this.providerId, @JsonKey(includeIfNull: false) this.accountId, @JsonKey(includeIfNull: false) this.userId});
+  factory _GetAccessTokenRequestBody.fromJson(Map<String, dynamic> json) => _$GetAccessTokenRequestBodyFromJson(json);
+
+/// The provider ID for the OAuth provider
+@override final  String providerId;
+/// The account ID associated with the refresh token
+@override@JsonKey(includeIfNull: false) final  String? accountId;
+/// The user ID associated with the account
+@override@JsonKey(includeIfNull: false) final  String? userId;
+
+/// Create a copy of GetAccessTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetAccessTokenRequestBodyCopyWith<_GetAccessTokenRequestBody> get copyWith => __$GetAccessTokenRequestBodyCopyWithImpl<_GetAccessTokenRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetAccessTokenRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetAccessTokenRequestBody&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.userId, userId) || other.userId == userId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,providerId,accountId,userId);
+
+@override
+String toString() {
+  return 'GetAccessTokenRequestBody(providerId: $providerId, accountId: $accountId, userId: $userId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetAccessTokenRequestBodyCopyWith<$Res> implements $GetAccessTokenRequestBodyCopyWith<$Res> {
+  factory _$GetAccessTokenRequestBodyCopyWith(_GetAccessTokenRequestBody value, $Res Function(_GetAccessTokenRequestBody) _then) = __$GetAccessTokenRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String providerId,@JsonKey(includeIfNull: false) String? accountId,@JsonKey(includeIfNull: false) String? userId
+});
+
+
+
+
+}
+/// @nodoc
+class __$GetAccessTokenRequestBodyCopyWithImpl<$Res>
+    implements _$GetAccessTokenRequestBodyCopyWith<$Res> {
+  __$GetAccessTokenRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _GetAccessTokenRequestBody _self;
+  final $Res Function(_GetAccessTokenRequestBody) _then;
+
+/// Create a copy of GetAccessTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? providerId = null,Object? accountId = freezed,Object? userId = freezed,}) {
+  return _then(_GetAccessTokenRequestBody(
+providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_access_token_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_access_token_request_body.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_access_token_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetAccessTokenRequestBody _$GetAccessTokenRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_GetAccessTokenRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _GetAccessTokenRequestBody(
+      providerId: $checkedConvert('provider_id', (v) => v as String),
+      accountId: $checkedConvert('account_id', (v) => v as String?),
+      userId: $checkedConvert('user_id', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'providerId': 'provider_id',
+    'accountId': 'account_id',
+    'userId': 'user_id',
+  },
+);
+
+Map<String, dynamic> _$GetAccessTokenRequestBodyToJson(
+  _GetAccessTokenRequestBody instance,
+) => <String, dynamic>{
+  'provider_id': instance.providerId,
+  'account_id': ?instance.accountId,
+  'user_id': ?instance.userId,
+};

--- a/packages/better_auth_api_client/lib/models/get_account_info_response.dart
+++ b/packages/better_auth_api_client/lib/models/get_account_info_response.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user4.dart';
+
+part 'get_account_info_response.freezed.dart';
+part 'get_account_info_response.g.dart';
+
+@Freezed()
+abstract class GetAccountInfoResponse with _$GetAccountInfoResponse {
+  const factory GetAccountInfoResponse({
+    required User4 user,
+    required dynamic data,
+  }) = _GetAccountInfoResponse;
+  
+  factory GetAccountInfoResponse.fromJson(Map<String, Object?> json) => _$GetAccountInfoResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_account_info_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_account_info_response.freezed.dart
@@ -1,0 +1,298 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_account_info_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetAccountInfoResponse {
+
+ User4 get user; dynamic get data;
+/// Create a copy of GetAccountInfoResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetAccountInfoResponseCopyWith<GetAccountInfoResponse> get copyWith => _$GetAccountInfoResponseCopyWithImpl<GetAccountInfoResponse>(this as GetAccountInfoResponse, _$identity);
+
+  /// Serializes this GetAccountInfoResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetAccountInfoResponse&&(identical(other.user, user) || other.user == user)&&const DeepCollectionEquality().equals(other.data, data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,const DeepCollectionEquality().hash(data));
+
+@override
+String toString() {
+  return 'GetAccountInfoResponse(user: $user, data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetAccountInfoResponseCopyWith<$Res>  {
+  factory $GetAccountInfoResponseCopyWith(GetAccountInfoResponse value, $Res Function(GetAccountInfoResponse) _then) = _$GetAccountInfoResponseCopyWithImpl;
+@useResult
+$Res call({
+ User4 user, dynamic data
+});
+
+
+$User4CopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$GetAccountInfoResponseCopyWithImpl<$Res>
+    implements $GetAccountInfoResponseCopyWith<$Res> {
+  _$GetAccountInfoResponseCopyWithImpl(this._self, this._then);
+
+  final GetAccountInfoResponse _self;
+  final $Res Function(GetAccountInfoResponse) _then;
+
+/// Create a copy of GetAccountInfoResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? data = freezed,}) {
+  return _then(_self.copyWith(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User4,data: freezed == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as dynamic,
+  ));
+}
+/// Create a copy of GetAccountInfoResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$User4CopyWith<$Res> get user {
+  
+  return $User4CopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [GetAccountInfoResponse].
+extension GetAccountInfoResponsePatterns on GetAccountInfoResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetAccountInfoResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetAccountInfoResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetAccountInfoResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetAccountInfoResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetAccountInfoResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetAccountInfoResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( User4 user,  dynamic data)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetAccountInfoResponse() when $default != null:
+return $default(_that.user,_that.data);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( User4 user,  dynamic data)  $default,) {final _that = this;
+switch (_that) {
+case _GetAccountInfoResponse():
+return $default(_that.user,_that.data);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( User4 user,  dynamic data)?  $default,) {final _that = this;
+switch (_that) {
+case _GetAccountInfoResponse() when $default != null:
+return $default(_that.user,_that.data);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetAccountInfoResponse implements GetAccountInfoResponse {
+  const _GetAccountInfoResponse({required this.user, required this.data});
+  factory _GetAccountInfoResponse.fromJson(Map<String, dynamic> json) => _$GetAccountInfoResponseFromJson(json);
+
+@override final  User4 user;
+@override final  dynamic data;
+
+/// Create a copy of GetAccountInfoResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetAccountInfoResponseCopyWith<_GetAccountInfoResponse> get copyWith => __$GetAccountInfoResponseCopyWithImpl<_GetAccountInfoResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetAccountInfoResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetAccountInfoResponse&&(identical(other.user, user) || other.user == user)&&const DeepCollectionEquality().equals(other.data, data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,const DeepCollectionEquality().hash(data));
+
+@override
+String toString() {
+  return 'GetAccountInfoResponse(user: $user, data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetAccountInfoResponseCopyWith<$Res> implements $GetAccountInfoResponseCopyWith<$Res> {
+  factory _$GetAccountInfoResponseCopyWith(_GetAccountInfoResponse value, $Res Function(_GetAccountInfoResponse) _then) = __$GetAccountInfoResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ User4 user, dynamic data
+});
+
+
+@override $User4CopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$GetAccountInfoResponseCopyWithImpl<$Res>
+    implements _$GetAccountInfoResponseCopyWith<$Res> {
+  __$GetAccountInfoResponseCopyWithImpl(this._self, this._then);
+
+  final _GetAccountInfoResponse _self;
+  final $Res Function(_GetAccountInfoResponse) _then;
+
+/// Create a copy of GetAccountInfoResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? data = freezed,}) {
+  return _then(_GetAccountInfoResponse(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User4,data: freezed == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as dynamic,
+  ));
+}
+
+/// Create a copy of GetAccountInfoResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$User4CopyWith<$Res> get user {
+  
+  return $User4CopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_account_info_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_account_info_response.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_account_info_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetAccountInfoResponse _$GetAccountInfoResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_GetAccountInfoResponse', json, ($checkedConvert) {
+  final val = _GetAccountInfoResponse(
+    user: $checkedConvert(
+      'user',
+      (v) => User4.fromJson(v as Map<String, dynamic>),
+    ),
+    data: $checkedConvert('data', (v) => v),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$GetAccountInfoResponseToJson(
+  _GetAccountInfoResponse instance,
+) => <String, dynamic>{'user': instance.user, 'data': instance.data};

--- a/packages/better_auth_api_client/lib/models/get_delete_user_callback_response.dart
+++ b/packages/better_auth_api_client/lib/models/get_delete_user_callback_response.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'message3.dart';
+
+part 'get_delete_user_callback_response.freezed.dart';
+part 'get_delete_user_callback_response.g.dart';
+
+@Freezed()
+abstract class GetDeleteUserCallbackResponse with _$GetDeleteUserCallbackResponse {
+  const factory GetDeleteUserCallbackResponse({
+    /// Indicates if the deletion was successful
+    required bool success,
+
+    /// Confirmation message
+    required Message3 message,
+  }) = _GetDeleteUserCallbackResponse;
+  
+  factory GetDeleteUserCallbackResponse.fromJson(Map<String, Object?> json) => _$GetDeleteUserCallbackResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_delete_user_callback_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_delete_user_callback_response.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_delete_user_callback_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetDeleteUserCallbackResponse {
+
+/// Indicates if the deletion was successful
+ bool get success;/// Confirmation message
+ Message3 get message;
+/// Create a copy of GetDeleteUserCallbackResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetDeleteUserCallbackResponseCopyWith<GetDeleteUserCallbackResponse> get copyWith => _$GetDeleteUserCallbackResponseCopyWithImpl<GetDeleteUserCallbackResponse>(this as GetDeleteUserCallbackResponse, _$identity);
+
+  /// Serializes this GetDeleteUserCallbackResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetDeleteUserCallbackResponse&&(identical(other.success, success) || other.success == success)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success,message);
+
+@override
+String toString() {
+  return 'GetDeleteUserCallbackResponse(success: $success, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetDeleteUserCallbackResponseCopyWith<$Res>  {
+  factory $GetDeleteUserCallbackResponseCopyWith(GetDeleteUserCallbackResponse value, $Res Function(GetDeleteUserCallbackResponse) _then) = _$GetDeleteUserCallbackResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool success, Message3 message
+});
+
+
+
+
+}
+/// @nodoc
+class _$GetDeleteUserCallbackResponseCopyWithImpl<$Res>
+    implements $GetDeleteUserCallbackResponseCopyWith<$Res> {
+  _$GetDeleteUserCallbackResponseCopyWithImpl(this._self, this._then);
+
+  final GetDeleteUserCallbackResponse _self;
+  final $Res Function(GetDeleteUserCallbackResponse) _then;
+
+/// Create a copy of GetDeleteUserCallbackResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? success = null,Object? message = null,}) {
+  return _then(_self.copyWith(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as Message3,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GetDeleteUserCallbackResponse].
+extension GetDeleteUserCallbackResponsePatterns on GetDeleteUserCallbackResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetDeleteUserCallbackResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetDeleteUserCallbackResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetDeleteUserCallbackResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetDeleteUserCallbackResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetDeleteUserCallbackResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetDeleteUserCallbackResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool success,  Message3 message)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetDeleteUserCallbackResponse() when $default != null:
+return $default(_that.success,_that.message);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool success,  Message3 message)  $default,) {final _that = this;
+switch (_that) {
+case _GetDeleteUserCallbackResponse():
+return $default(_that.success,_that.message);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool success,  Message3 message)?  $default,) {final _that = this;
+switch (_that) {
+case _GetDeleteUserCallbackResponse() when $default != null:
+return $default(_that.success,_that.message);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetDeleteUserCallbackResponse implements GetDeleteUserCallbackResponse {
+  const _GetDeleteUserCallbackResponse({required this.success, required this.message});
+  factory _GetDeleteUserCallbackResponse.fromJson(Map<String, dynamic> json) => _$GetDeleteUserCallbackResponseFromJson(json);
+
+/// Indicates if the deletion was successful
+@override final  bool success;
+/// Confirmation message
+@override final  Message3 message;
+
+/// Create a copy of GetDeleteUserCallbackResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetDeleteUserCallbackResponseCopyWith<_GetDeleteUserCallbackResponse> get copyWith => __$GetDeleteUserCallbackResponseCopyWithImpl<_GetDeleteUserCallbackResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetDeleteUserCallbackResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetDeleteUserCallbackResponse&&(identical(other.success, success) || other.success == success)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success,message);
+
+@override
+String toString() {
+  return 'GetDeleteUserCallbackResponse(success: $success, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetDeleteUserCallbackResponseCopyWith<$Res> implements $GetDeleteUserCallbackResponseCopyWith<$Res> {
+  factory _$GetDeleteUserCallbackResponseCopyWith(_GetDeleteUserCallbackResponse value, $Res Function(_GetDeleteUserCallbackResponse) _then) = __$GetDeleteUserCallbackResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool success, Message3 message
+});
+
+
+
+
+}
+/// @nodoc
+class __$GetDeleteUserCallbackResponseCopyWithImpl<$Res>
+    implements _$GetDeleteUserCallbackResponseCopyWith<$Res> {
+  __$GetDeleteUserCallbackResponseCopyWithImpl(this._self, this._then);
+
+  final _GetDeleteUserCallbackResponse _self;
+  final $Res Function(_GetDeleteUserCallbackResponse) _then;
+
+/// Create a copy of GetDeleteUserCallbackResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? success = null,Object? message = null,}) {
+  return _then(_GetDeleteUserCallbackResponse(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as Message3,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_delete_user_callback_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_delete_user_callback_response.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_delete_user_callback_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetDeleteUserCallbackResponse _$GetDeleteUserCallbackResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_GetDeleteUserCallbackResponse', json, ($checkedConvert) {
+  final val = _GetDeleteUserCallbackResponse(
+    success: $checkedConvert('success', (v) => v as bool),
+    message: $checkedConvert(
+      'message',
+      (v) => $enumDecode(_$Message3EnumMap, v),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$GetDeleteUserCallbackResponseToJson(
+  _GetDeleteUserCallbackResponse instance,
+) => <String, dynamic>{
+  'success': instance.success,
+  'message': instance.message,
+};
+
+const _$Message3EnumMap = {Message3.userDeleted: 'User deleted'};

--- a/packages/better_auth_api_client/lib/models/get_get_session_response.dart
+++ b/packages/better_auth_api_client/lib/models/get_get_session_response.dart
@@ -1,0 +1,21 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'session.dart';
+import 'user.dart';
+
+part 'get_get_session_response.freezed.dart';
+part 'get_get_session_response.g.dart';
+
+@Freezed()
+abstract class GetGetSessionResponse with _$GetGetSessionResponse {
+  const factory GetGetSessionResponse({
+    required Session session,
+    required User user,
+  }) = _GetGetSessionResponse;
+  
+  factory GetGetSessionResponse.fromJson(Map<String, Object?> json) => _$GetGetSessionResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_get_session_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_get_session_response.freezed.dart
@@ -1,0 +1,316 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_get_session_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetGetSessionResponse {
+
+ Session get session; User get user;
+/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetGetSessionResponseCopyWith<GetGetSessionResponse> get copyWith => _$GetGetSessionResponseCopyWithImpl<GetGetSessionResponse>(this as GetGetSessionResponse, _$identity);
+
+  /// Serializes this GetGetSessionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetGetSessionResponse&&(identical(other.session, session) || other.session == session)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,session,user);
+
+@override
+String toString() {
+  return 'GetGetSessionResponse(session: $session, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetGetSessionResponseCopyWith<$Res>  {
+  factory $GetGetSessionResponseCopyWith(GetGetSessionResponse value, $Res Function(GetGetSessionResponse) _then) = _$GetGetSessionResponseCopyWithImpl;
+@useResult
+$Res call({
+ Session session, User user
+});
+
+
+$SessionCopyWith<$Res> get session;$UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$GetGetSessionResponseCopyWithImpl<$Res>
+    implements $GetGetSessionResponseCopyWith<$Res> {
+  _$GetGetSessionResponseCopyWithImpl(this._self, this._then);
+
+  final GetGetSessionResponse _self;
+  final $Res Function(GetGetSessionResponse) _then;
+
+/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? session = null,Object? user = null,}) {
+  return _then(_self.copyWith(
+session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [GetGetSessionResponse].
+extension GetGetSessionResponsePatterns on GetGetSessionResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetGetSessionResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetGetSessionResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetGetSessionResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetGetSessionResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetGetSessionResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetGetSessionResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Session session,  User user)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetGetSessionResponse() when $default != null:
+return $default(_that.session,_that.user);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Session session,  User user)  $default,) {final _that = this;
+switch (_that) {
+case _GetGetSessionResponse():
+return $default(_that.session,_that.user);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Session session,  User user)?  $default,) {final _that = this;
+switch (_that) {
+case _GetGetSessionResponse() when $default != null:
+return $default(_that.session,_that.user);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetGetSessionResponse implements GetGetSessionResponse {
+  const _GetGetSessionResponse({required this.session, required this.user});
+  factory _GetGetSessionResponse.fromJson(Map<String, dynamic> json) => _$GetGetSessionResponseFromJson(json);
+
+@override final  Session session;
+@override final  User user;
+
+/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetGetSessionResponseCopyWith<_GetGetSessionResponse> get copyWith => __$GetGetSessionResponseCopyWithImpl<_GetGetSessionResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetGetSessionResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetGetSessionResponse&&(identical(other.session, session) || other.session == session)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,session,user);
+
+@override
+String toString() {
+  return 'GetGetSessionResponse(session: $session, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetGetSessionResponseCopyWith<$Res> implements $GetGetSessionResponseCopyWith<$Res> {
+  factory _$GetGetSessionResponseCopyWith(_GetGetSessionResponse value, $Res Function(_GetGetSessionResponse) _then) = __$GetGetSessionResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ Session session, User user
+});
+
+
+@override $SessionCopyWith<$Res> get session;@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$GetGetSessionResponseCopyWithImpl<$Res>
+    implements _$GetGetSessionResponseCopyWith<$Res> {
+  __$GetGetSessionResponseCopyWithImpl(this._self, this._then);
+
+  final _GetGetSessionResponse _self;
+  final $Res Function(_GetGetSessionResponse) _then;
+
+/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? session = null,Object? user = null,}) {
+  return _then(_GetGetSessionResponse(
+session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+
+/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}/// Create a copy of GetGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_get_session_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_get_session_response.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_get_session_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetGetSessionResponse _$GetGetSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_GetGetSessionResponse', json, ($checkedConvert) {
+  final val = _GetGetSessionResponse(
+    session: $checkedConvert(
+      'session',
+      (v) => Session.fromJson(v as Map<String, dynamic>),
+    ),
+    user: $checkedConvert(
+      'user',
+      (v) => User.fromJson(v as Map<String, dynamic>),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$GetGetSessionResponseToJson(
+  _GetGetSessionResponse instance,
+) => <String, dynamic>{'session': instance.session, 'user': instance.user};

--- a/packages/better_auth_api_client/lib/models/get_list_accounts_response.dart
+++ b/packages/better_auth_api_client/lib/models/get_list_accounts_response.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_list_accounts_response.freezed.dart';
+part 'get_list_accounts_response.g.dart';
+
+@Freezed()
+abstract class GetListAccountsResponse with _$GetListAccountsResponse {
+  const factory GetListAccountsResponse({
+    required String id,
+    required String providerId,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required String accountId,
+    required String userId,
+    required List<String> scopes,
+  }) = _GetListAccountsResponse;
+  
+  factory GetListAccountsResponse.fromJson(Map<String, Object?> json) => _$GetListAccountsResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_list_accounts_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_list_accounts_response.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_list_accounts_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetListAccountsResponse {
+
+ String get id; String get providerId; DateTime get createdAt; DateTime get updatedAt; String get accountId; String get userId; List<String> get scopes;
+/// Create a copy of GetListAccountsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetListAccountsResponseCopyWith<GetListAccountsResponse> get copyWith => _$GetListAccountsResponseCopyWithImpl<GetListAccountsResponse>(this as GetListAccountsResponse, _$identity);
+
+  /// Serializes this GetListAccountsResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetListAccountsResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.userId, userId) || other.userId == userId)&&const DeepCollectionEquality().equals(other.scopes, scopes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,providerId,createdAt,updatedAt,accountId,userId,const DeepCollectionEquality().hash(scopes));
+
+@override
+String toString() {
+  return 'GetListAccountsResponse(id: $id, providerId: $providerId, createdAt: $createdAt, updatedAt: $updatedAt, accountId: $accountId, userId: $userId, scopes: $scopes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetListAccountsResponseCopyWith<$Res>  {
+  factory $GetListAccountsResponseCopyWith(GetListAccountsResponse value, $Res Function(GetListAccountsResponse) _then) = _$GetListAccountsResponseCopyWithImpl;
+@useResult
+$Res call({
+ String id, String providerId, DateTime createdAt, DateTime updatedAt, String accountId, String userId, List<String> scopes
+});
+
+
+
+
+}
+/// @nodoc
+class _$GetListAccountsResponseCopyWithImpl<$Res>
+    implements $GetListAccountsResponseCopyWith<$Res> {
+  _$GetListAccountsResponseCopyWithImpl(this._self, this._then);
+
+  final GetListAccountsResponse _self;
+  final $Res Function(GetListAccountsResponse) _then;
+
+/// Create a copy of GetListAccountsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? providerId = null,Object? createdAt = null,Object? updatedAt = null,Object? accountId = null,Object? userId = null,Object? scopes = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,scopes: null == scopes ? _self.scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GetListAccountsResponse].
+extension GetListAccountsResponsePatterns on GetListAccountsResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetListAccountsResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetListAccountsResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetListAccountsResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetListAccountsResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetListAccountsResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetListAccountsResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String providerId,  DateTime createdAt,  DateTime updatedAt,  String accountId,  String userId,  List<String> scopes)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetListAccountsResponse() when $default != null:
+return $default(_that.id,_that.providerId,_that.createdAt,_that.updatedAt,_that.accountId,_that.userId,_that.scopes);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String providerId,  DateTime createdAt,  DateTime updatedAt,  String accountId,  String userId,  List<String> scopes)  $default,) {final _that = this;
+switch (_that) {
+case _GetListAccountsResponse():
+return $default(_that.id,_that.providerId,_that.createdAt,_that.updatedAt,_that.accountId,_that.userId,_that.scopes);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String providerId,  DateTime createdAt,  DateTime updatedAt,  String accountId,  String userId,  List<String> scopes)?  $default,) {final _that = this;
+switch (_that) {
+case _GetListAccountsResponse() when $default != null:
+return $default(_that.id,_that.providerId,_that.createdAt,_that.updatedAt,_that.accountId,_that.userId,_that.scopes);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetListAccountsResponse implements GetListAccountsResponse {
+  const _GetListAccountsResponse({required this.id, required this.providerId, required this.createdAt, required this.updatedAt, required this.accountId, required this.userId, required final  List<String> scopes}): _scopes = scopes;
+  factory _GetListAccountsResponse.fromJson(Map<String, dynamic> json) => _$GetListAccountsResponseFromJson(json);
+
+@override final  String id;
+@override final  String providerId;
+@override final  DateTime createdAt;
+@override final  DateTime updatedAt;
+@override final  String accountId;
+@override final  String userId;
+ final  List<String> _scopes;
+@override List<String> get scopes {
+  if (_scopes is EqualUnmodifiableListView) return _scopes;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_scopes);
+}
+
+
+/// Create a copy of GetListAccountsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetListAccountsResponseCopyWith<_GetListAccountsResponse> get copyWith => __$GetListAccountsResponseCopyWithImpl<_GetListAccountsResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetListAccountsResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetListAccountsResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.userId, userId) || other.userId == userId)&&const DeepCollectionEquality().equals(other._scopes, _scopes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,providerId,createdAt,updatedAt,accountId,userId,const DeepCollectionEquality().hash(_scopes));
+
+@override
+String toString() {
+  return 'GetListAccountsResponse(id: $id, providerId: $providerId, createdAt: $createdAt, updatedAt: $updatedAt, accountId: $accountId, userId: $userId, scopes: $scopes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetListAccountsResponseCopyWith<$Res> implements $GetListAccountsResponseCopyWith<$Res> {
+  factory _$GetListAccountsResponseCopyWith(_GetListAccountsResponse value, $Res Function(_GetListAccountsResponse) _then) = __$GetListAccountsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String providerId, DateTime createdAt, DateTime updatedAt, String accountId, String userId, List<String> scopes
+});
+
+
+
+
+}
+/// @nodoc
+class __$GetListAccountsResponseCopyWithImpl<$Res>
+    implements _$GetListAccountsResponseCopyWith<$Res> {
+  __$GetListAccountsResponseCopyWithImpl(this._self, this._then);
+
+  final _GetListAccountsResponse _self;
+  final $Res Function(_GetListAccountsResponse) _then;
+
+/// Create a copy of GetListAccountsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? providerId = null,Object? createdAt = null,Object? updatedAt = null,Object? accountId = null,Object? userId = null,Object? scopes = null,}) {
+  return _then(_GetListAccountsResponse(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,scopes: null == scopes ? _self._scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_list_accounts_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_list_accounts_response.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_list_accounts_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetListAccountsResponse _$GetListAccountsResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_GetListAccountsResponse',
+  json,
+  ($checkedConvert) {
+    final val = _GetListAccountsResponse(
+      id: $checkedConvert('id', (v) => v as String),
+      providerId: $checkedConvert('provider_id', (v) => v as String),
+      createdAt: $checkedConvert(
+        'created_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      updatedAt: $checkedConvert(
+        'updated_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      accountId: $checkedConvert('account_id', (v) => v as String),
+      userId: $checkedConvert('user_id', (v) => v as String),
+      scopes: $checkedConvert(
+        'scopes',
+        (v) => (v as List<dynamic>).map((e) => e as String).toList(),
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'providerId': 'provider_id',
+    'createdAt': 'created_at',
+    'updatedAt': 'updated_at',
+    'accountId': 'account_id',
+    'userId': 'user_id',
+  },
+);
+
+Map<String, dynamic> _$GetListAccountsResponseToJson(
+  _GetListAccountsResponse instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'provider_id': instance.providerId,
+  'created_at': instance.createdAt.toIso8601String(),
+  'updated_at': instance.updatedAt.toIso8601String(),
+  'account_id': instance.accountId,
+  'user_id': instance.userId,
+  'scopes': instance.scopes,
+};

--- a/packages/better_auth_api_client/lib/models/get_ok_response.dart
+++ b/packages/better_auth_api_client/lib/models/get_ok_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_ok_response.freezed.dart';
+part 'get_ok_response.g.dart';
+
+@Freezed()
+abstract class GetOkResponse with _$GetOkResponse {
+  const factory GetOkResponse({
+    /// Indicates if the API is working
+    required bool ok,
+  }) = _GetOkResponse;
+  
+  factory GetOkResponse.fromJson(Map<String, Object?> json) => _$GetOkResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_ok_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_ok_response.freezed.dart
@@ -1,0 +1,279 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_ok_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetOkResponse {
+
+/// Indicates if the API is working
+ bool get ok;
+/// Create a copy of GetOkResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetOkResponseCopyWith<GetOkResponse> get copyWith => _$GetOkResponseCopyWithImpl<GetOkResponse>(this as GetOkResponse, _$identity);
+
+  /// Serializes this GetOkResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetOkResponse&&(identical(other.ok, ok) || other.ok == ok));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,ok);
+
+@override
+String toString() {
+  return 'GetOkResponse(ok: $ok)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetOkResponseCopyWith<$Res>  {
+  factory $GetOkResponseCopyWith(GetOkResponse value, $Res Function(GetOkResponse) _then) = _$GetOkResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool ok
+});
+
+
+
+
+}
+/// @nodoc
+class _$GetOkResponseCopyWithImpl<$Res>
+    implements $GetOkResponseCopyWith<$Res> {
+  _$GetOkResponseCopyWithImpl(this._self, this._then);
+
+  final GetOkResponse _self;
+  final $Res Function(GetOkResponse) _then;
+
+/// Create a copy of GetOkResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? ok = null,}) {
+  return _then(_self.copyWith(
+ok: null == ok ? _self.ok : ok // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GetOkResponse].
+extension GetOkResponsePatterns on GetOkResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetOkResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetOkResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetOkResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetOkResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetOkResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetOkResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool ok)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetOkResponse() when $default != null:
+return $default(_that.ok);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool ok)  $default,) {final _that = this;
+switch (_that) {
+case _GetOkResponse():
+return $default(_that.ok);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool ok)?  $default,) {final _that = this;
+switch (_that) {
+case _GetOkResponse() when $default != null:
+return $default(_that.ok);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetOkResponse implements GetOkResponse {
+  const _GetOkResponse({required this.ok});
+  factory _GetOkResponse.fromJson(Map<String, dynamic> json) => _$GetOkResponseFromJson(json);
+
+/// Indicates if the API is working
+@override final  bool ok;
+
+/// Create a copy of GetOkResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetOkResponseCopyWith<_GetOkResponse> get copyWith => __$GetOkResponseCopyWithImpl<_GetOkResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetOkResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetOkResponse&&(identical(other.ok, ok) || other.ok == ok));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,ok);
+
+@override
+String toString() {
+  return 'GetOkResponse(ok: $ok)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetOkResponseCopyWith<$Res> implements $GetOkResponseCopyWith<$Res> {
+  factory _$GetOkResponseCopyWith(_GetOkResponse value, $Res Function(_GetOkResponse) _then) = __$GetOkResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool ok
+});
+
+
+
+
+}
+/// @nodoc
+class __$GetOkResponseCopyWithImpl<$Res>
+    implements _$GetOkResponseCopyWith<$Res> {
+  __$GetOkResponseCopyWithImpl(this._self, this._then);
+
+  final _GetOkResponse _self;
+  final $Res Function(_GetOkResponse) _then;
+
+/// Create a copy of GetOkResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? ok = null,}) {
+  return _then(_GetOkResponse(
+ok: null == ok ? _self.ok : ok // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_ok_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_ok_response.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_ok_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetOkResponse _$GetOkResponseFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('_GetOkResponse', json, ($checkedConvert) {
+      final val = _GetOkResponse(ok: $checkedConvert('ok', (v) => v as bool));
+      return val;
+    });
+
+Map<String, dynamic> _$GetOkResponseToJson(_GetOkResponse instance) =>
+    <String, dynamic>{'ok': instance.ok};

--- a/packages/better_auth_api_client/lib/models/get_reset_password_token_response.dart
+++ b/packages/better_auth_api_client/lib/models/get_reset_password_token_response.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_reset_password_token_response.freezed.dart';
+part 'get_reset_password_token_response.g.dart';
+
+@Freezed()
+abstract class GetResetPasswordTokenResponse with _$GetResetPasswordTokenResponse {
+  const factory GetResetPasswordTokenResponse({
+    required String token,
+  }) = _GetResetPasswordTokenResponse;
+  
+  factory GetResetPasswordTokenResponse.fromJson(Map<String, Object?> json) => _$GetResetPasswordTokenResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_reset_password_token_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_reset_password_token_response.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_reset_password_token_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetResetPasswordTokenResponse {
+
+ String get token;
+/// Create a copy of GetResetPasswordTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetResetPasswordTokenResponseCopyWith<GetResetPasswordTokenResponse> get copyWith => _$GetResetPasswordTokenResponseCopyWithImpl<GetResetPasswordTokenResponse>(this as GetResetPasswordTokenResponse, _$identity);
+
+  /// Serializes this GetResetPasswordTokenResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetResetPasswordTokenResponse&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token);
+
+@override
+String toString() {
+  return 'GetResetPasswordTokenResponse(token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetResetPasswordTokenResponseCopyWith<$Res>  {
+  factory $GetResetPasswordTokenResponseCopyWith(GetResetPasswordTokenResponse value, $Res Function(GetResetPasswordTokenResponse) _then) = _$GetResetPasswordTokenResponseCopyWithImpl;
+@useResult
+$Res call({
+ String token
+});
+
+
+
+
+}
+/// @nodoc
+class _$GetResetPasswordTokenResponseCopyWithImpl<$Res>
+    implements $GetResetPasswordTokenResponseCopyWith<$Res> {
+  _$GetResetPasswordTokenResponseCopyWithImpl(this._self, this._then);
+
+  final GetResetPasswordTokenResponse _self;
+  final $Res Function(GetResetPasswordTokenResponse) _then;
+
+/// Create a copy of GetResetPasswordTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? token = null,}) {
+  return _then(_self.copyWith(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GetResetPasswordTokenResponse].
+extension GetResetPasswordTokenResponsePatterns on GetResetPasswordTokenResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetResetPasswordTokenResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetResetPasswordTokenResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetResetPasswordTokenResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetResetPasswordTokenResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetResetPasswordTokenResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetResetPasswordTokenResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String token)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetResetPasswordTokenResponse() when $default != null:
+return $default(_that.token);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String token)  $default,) {final _that = this;
+switch (_that) {
+case _GetResetPasswordTokenResponse():
+return $default(_that.token);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String token)?  $default,) {final _that = this;
+switch (_that) {
+case _GetResetPasswordTokenResponse() when $default != null:
+return $default(_that.token);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetResetPasswordTokenResponse implements GetResetPasswordTokenResponse {
+  const _GetResetPasswordTokenResponse({required this.token});
+  factory _GetResetPasswordTokenResponse.fromJson(Map<String, dynamic> json) => _$GetResetPasswordTokenResponseFromJson(json);
+
+@override final  String token;
+
+/// Create a copy of GetResetPasswordTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetResetPasswordTokenResponseCopyWith<_GetResetPasswordTokenResponse> get copyWith => __$GetResetPasswordTokenResponseCopyWithImpl<_GetResetPasswordTokenResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetResetPasswordTokenResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetResetPasswordTokenResponse&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token);
+
+@override
+String toString() {
+  return 'GetResetPasswordTokenResponse(token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetResetPasswordTokenResponseCopyWith<$Res> implements $GetResetPasswordTokenResponseCopyWith<$Res> {
+  factory _$GetResetPasswordTokenResponseCopyWith(_GetResetPasswordTokenResponse value, $Res Function(_GetResetPasswordTokenResponse) _then) = __$GetResetPasswordTokenResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String token
+});
+
+
+
+
+}
+/// @nodoc
+class __$GetResetPasswordTokenResponseCopyWithImpl<$Res>
+    implements _$GetResetPasswordTokenResponseCopyWith<$Res> {
+  __$GetResetPasswordTokenResponseCopyWithImpl(this._self, this._then);
+
+  final _GetResetPasswordTokenResponse _self;
+  final $Res Function(_GetResetPasswordTokenResponse) _then;
+
+/// Create a copy of GetResetPasswordTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? token = null,}) {
+  return _then(_GetResetPasswordTokenResponse(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_reset_password_token_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_reset_password_token_response.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_reset_password_token_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetResetPasswordTokenResponse _$GetResetPasswordTokenResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_GetResetPasswordTokenResponse', json, ($checkedConvert) {
+  final val = _GetResetPasswordTokenResponse(
+    token: $checkedConvert('token', (v) => v as String),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$GetResetPasswordTokenResponseToJson(
+  _GetResetPasswordTokenResponse instance,
+) => <String, dynamic>{'token': instance.token};

--- a/packages/better_auth_api_client/lib/models/get_verify_email_response.dart
+++ b/packages/better_auth_api_client/lib/models/get_verify_email_response.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user.dart';
+
+part 'get_verify_email_response.freezed.dart';
+part 'get_verify_email_response.g.dart';
+
+@Freezed()
+abstract class GetVerifyEmailResponse with _$GetVerifyEmailResponse {
+  const factory GetVerifyEmailResponse({
+    required User user,
+
+    /// Indicates if the email was verified successfully
+    required bool status,
+  }) = _GetVerifyEmailResponse;
+  
+  factory GetVerifyEmailResponse.fromJson(Map<String, Object?> json) => _$GetVerifyEmailResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/get_verify_email_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/get_verify_email_response.freezed.dart
@@ -1,0 +1,300 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'get_verify_email_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GetVerifyEmailResponse {
+
+ User get user;/// Indicates if the email was verified successfully
+ bool get status;
+/// Create a copy of GetVerifyEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GetVerifyEmailResponseCopyWith<GetVerifyEmailResponse> get copyWith => _$GetVerifyEmailResponseCopyWithImpl<GetVerifyEmailResponse>(this as GetVerifyEmailResponse, _$identity);
+
+  /// Serializes this GetVerifyEmailResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GetVerifyEmailResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,status);
+
+@override
+String toString() {
+  return 'GetVerifyEmailResponse(user: $user, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GetVerifyEmailResponseCopyWith<$Res>  {
+  factory $GetVerifyEmailResponseCopyWith(GetVerifyEmailResponse value, $Res Function(GetVerifyEmailResponse) _then) = _$GetVerifyEmailResponseCopyWithImpl;
+@useResult
+$Res call({
+ User user, bool status
+});
+
+
+$UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$GetVerifyEmailResponseCopyWithImpl<$Res>
+    implements $GetVerifyEmailResponseCopyWith<$Res> {
+  _$GetVerifyEmailResponseCopyWithImpl(this._self, this._then);
+
+  final GetVerifyEmailResponse _self;
+  final $Res Function(GetVerifyEmailResponse) _then;
+
+/// Create a copy of GetVerifyEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? status = null,}) {
+  return _then(_self.copyWith(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+/// Create a copy of GetVerifyEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [GetVerifyEmailResponse].
+extension GetVerifyEmailResponsePatterns on GetVerifyEmailResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GetVerifyEmailResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GetVerifyEmailResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GetVerifyEmailResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _GetVerifyEmailResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GetVerifyEmailResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GetVerifyEmailResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( User user,  bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GetVerifyEmailResponse() when $default != null:
+return $default(_that.user,_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( User user,  bool status)  $default,) {final _that = this;
+switch (_that) {
+case _GetVerifyEmailResponse():
+return $default(_that.user,_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( User user,  bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _GetVerifyEmailResponse() when $default != null:
+return $default(_that.user,_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GetVerifyEmailResponse implements GetVerifyEmailResponse {
+  const _GetVerifyEmailResponse({required this.user, required this.status});
+  factory _GetVerifyEmailResponse.fromJson(Map<String, dynamic> json) => _$GetVerifyEmailResponseFromJson(json);
+
+@override final  User user;
+/// Indicates if the email was verified successfully
+@override final  bool status;
+
+/// Create a copy of GetVerifyEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GetVerifyEmailResponseCopyWith<_GetVerifyEmailResponse> get copyWith => __$GetVerifyEmailResponseCopyWithImpl<_GetVerifyEmailResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GetVerifyEmailResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GetVerifyEmailResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,status);
+
+@override
+String toString() {
+  return 'GetVerifyEmailResponse(user: $user, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GetVerifyEmailResponseCopyWith<$Res> implements $GetVerifyEmailResponseCopyWith<$Res> {
+  factory _$GetVerifyEmailResponseCopyWith(_GetVerifyEmailResponse value, $Res Function(_GetVerifyEmailResponse) _then) = __$GetVerifyEmailResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ User user, bool status
+});
+
+
+@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$GetVerifyEmailResponseCopyWithImpl<$Res>
+    implements _$GetVerifyEmailResponseCopyWith<$Res> {
+  __$GetVerifyEmailResponseCopyWithImpl(this._self, this._then);
+
+  final _GetVerifyEmailResponse _self;
+  final $Res Function(_GetVerifyEmailResponse) _then;
+
+/// Create a copy of GetVerifyEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? status = null,}) {
+  return _then(_GetVerifyEmailResponse(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+/// Create a copy of GetVerifyEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/get_verify_email_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/get_verify_email_response.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'get_verify_email_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GetVerifyEmailResponse _$GetVerifyEmailResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_GetVerifyEmailResponse', json, ($checkedConvert) {
+  final val = _GetVerifyEmailResponse(
+    user: $checkedConvert(
+      'user',
+      (v) => User.fromJson(v as Map<String, dynamic>),
+    ),
+    status: $checkedConvert('status', (v) => v as bool),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$GetVerifyEmailResponseToJson(
+  _GetVerifyEmailResponse instance,
+) => <String, dynamic>{'user': instance.user, 'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/id_token.dart
+++ b/packages/better_auth_api_client/lib/models/id_token.dart
@@ -1,0 +1,40 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user.dart';
+
+part 'id_token.freezed.dart';
+part 'id_token.g.dart';
+
+@Freezed()
+abstract class IdToken with _$IdToken {
+  const factory IdToken({
+    /// ID token from the provider
+    required String token,
+
+    /// Nonce used to generate the token
+    @JsonKey(includeIfNull: false)
+    String? nonce,
+
+    /// Access token from the provider
+    @JsonKey(includeIfNull: false)
+    String? accessToken,
+
+    /// Refresh token from the provider
+    @JsonKey(includeIfNull: false)
+    String? refreshToken,
+
+    /// Expiry date of the token
+    @JsonKey(includeIfNull: false)
+    num? expiresAt,
+
+    /// The user object from the provider. Only available for some providers like Apple.
+    @JsonKey(includeIfNull: false)
+    User? user,
+  }) = _IdToken;
+  
+  factory IdToken.fromJson(Map<String, Object?> json) => _$IdTokenFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/id_token.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/id_token.freezed.dart
@@ -1,0 +1,328 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'id_token.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$IdToken {
+
+/// ID token from the provider
+ String get token;/// Nonce used to generate the token
+@JsonKey(includeIfNull: false) String? get nonce;/// Access token from the provider
+@JsonKey(includeIfNull: false) String? get accessToken;/// Refresh token from the provider
+@JsonKey(includeIfNull: false) String? get refreshToken;/// Expiry date of the token
+@JsonKey(includeIfNull: false) num? get expiresAt;/// The user object from the provider. Only available for some providers like Apple.
+@JsonKey(includeIfNull: false) User? get user;
+/// Create a copy of IdToken
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$IdTokenCopyWith<IdToken> get copyWith => _$IdTokenCopyWithImpl<IdToken>(this as IdToken, _$identity);
+
+  /// Serializes this IdToken to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IdToken&&(identical(other.token, token) || other.token == token)&&(identical(other.nonce, nonce) || other.nonce == nonce)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,nonce,accessToken,refreshToken,expiresAt,user);
+
+@override
+String toString() {
+  return 'IdToken(token: $token, nonce: $nonce, accessToken: $accessToken, refreshToken: $refreshToken, expiresAt: $expiresAt, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $IdTokenCopyWith<$Res>  {
+  factory $IdTokenCopyWith(IdToken value, $Res Function(IdToken) _then) = _$IdTokenCopyWithImpl;
+@useResult
+$Res call({
+ String token,@JsonKey(includeIfNull: false) String? nonce,@JsonKey(includeIfNull: false) String? accessToken,@JsonKey(includeIfNull: false) String? refreshToken,@JsonKey(includeIfNull: false) num? expiresAt,@JsonKey(includeIfNull: false) User? user
+});
+
+
+$UserCopyWith<$Res>? get user;
+
+}
+/// @nodoc
+class _$IdTokenCopyWithImpl<$Res>
+    implements $IdTokenCopyWith<$Res> {
+  _$IdTokenCopyWithImpl(this._self, this._then);
+
+  final IdToken _self;
+  final $Res Function(IdToken) _then;
+
+/// Create a copy of IdToken
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? token = null,Object? nonce = freezed,Object? accessToken = freezed,Object? refreshToken = freezed,Object? expiresAt = freezed,Object? user = freezed,}) {
+  return _then(_self.copyWith(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,nonce: freezed == nonce ? _self.nonce : nonce // ignore: cast_nullable_to_non_nullable
+as String?,accessToken: freezed == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String?,refreshToken: freezed == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String?,expiresAt: freezed == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as num?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User?,
+  ));
+}
+/// Create a copy of IdToken
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res>? get user {
+    if (_self.user == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.user!, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [IdToken].
+extension IdTokenPatterns on IdToken {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _IdToken value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _IdToken() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _IdToken value)  $default,){
+final _that = this;
+switch (_that) {
+case _IdToken():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _IdToken value)?  $default,){
+final _that = this;
+switch (_that) {
+case _IdToken() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String token, @JsonKey(includeIfNull: false)  String? nonce, @JsonKey(includeIfNull: false)  String? accessToken, @JsonKey(includeIfNull: false)  String? refreshToken, @JsonKey(includeIfNull: false)  num? expiresAt, @JsonKey(includeIfNull: false)  User? user)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _IdToken() when $default != null:
+return $default(_that.token,_that.nonce,_that.accessToken,_that.refreshToken,_that.expiresAt,_that.user);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String token, @JsonKey(includeIfNull: false)  String? nonce, @JsonKey(includeIfNull: false)  String? accessToken, @JsonKey(includeIfNull: false)  String? refreshToken, @JsonKey(includeIfNull: false)  num? expiresAt, @JsonKey(includeIfNull: false)  User? user)  $default,) {final _that = this;
+switch (_that) {
+case _IdToken():
+return $default(_that.token,_that.nonce,_that.accessToken,_that.refreshToken,_that.expiresAt,_that.user);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String token, @JsonKey(includeIfNull: false)  String? nonce, @JsonKey(includeIfNull: false)  String? accessToken, @JsonKey(includeIfNull: false)  String? refreshToken, @JsonKey(includeIfNull: false)  num? expiresAt, @JsonKey(includeIfNull: false)  User? user)?  $default,) {final _that = this;
+switch (_that) {
+case _IdToken() when $default != null:
+return $default(_that.token,_that.nonce,_that.accessToken,_that.refreshToken,_that.expiresAt,_that.user);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _IdToken implements IdToken {
+  const _IdToken({required this.token, @JsonKey(includeIfNull: false) this.nonce, @JsonKey(includeIfNull: false) this.accessToken, @JsonKey(includeIfNull: false) this.refreshToken, @JsonKey(includeIfNull: false) this.expiresAt, @JsonKey(includeIfNull: false) this.user});
+  factory _IdToken.fromJson(Map<String, dynamic> json) => _$IdTokenFromJson(json);
+
+/// ID token from the provider
+@override final  String token;
+/// Nonce used to generate the token
+@override@JsonKey(includeIfNull: false) final  String? nonce;
+/// Access token from the provider
+@override@JsonKey(includeIfNull: false) final  String? accessToken;
+/// Refresh token from the provider
+@override@JsonKey(includeIfNull: false) final  String? refreshToken;
+/// Expiry date of the token
+@override@JsonKey(includeIfNull: false) final  num? expiresAt;
+/// The user object from the provider. Only available for some providers like Apple.
+@override@JsonKey(includeIfNull: false) final  User? user;
+
+/// Create a copy of IdToken
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$IdTokenCopyWith<_IdToken> get copyWith => __$IdTokenCopyWithImpl<_IdToken>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$IdTokenToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IdToken&&(identical(other.token, token) || other.token == token)&&(identical(other.nonce, nonce) || other.nonce == nonce)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,nonce,accessToken,refreshToken,expiresAt,user);
+
+@override
+String toString() {
+  return 'IdToken(token: $token, nonce: $nonce, accessToken: $accessToken, refreshToken: $refreshToken, expiresAt: $expiresAt, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$IdTokenCopyWith<$Res> implements $IdTokenCopyWith<$Res> {
+  factory _$IdTokenCopyWith(_IdToken value, $Res Function(_IdToken) _then) = __$IdTokenCopyWithImpl;
+@override @useResult
+$Res call({
+ String token,@JsonKey(includeIfNull: false) String? nonce,@JsonKey(includeIfNull: false) String? accessToken,@JsonKey(includeIfNull: false) String? refreshToken,@JsonKey(includeIfNull: false) num? expiresAt,@JsonKey(includeIfNull: false) User? user
+});
+
+
+@override $UserCopyWith<$Res>? get user;
+
+}
+/// @nodoc
+class __$IdTokenCopyWithImpl<$Res>
+    implements _$IdTokenCopyWith<$Res> {
+  __$IdTokenCopyWithImpl(this._self, this._then);
+
+  final _IdToken _self;
+  final $Res Function(_IdToken) _then;
+
+/// Create a copy of IdToken
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? token = null,Object? nonce = freezed,Object? accessToken = freezed,Object? refreshToken = freezed,Object? expiresAt = freezed,Object? user = freezed,}) {
+  return _then(_IdToken(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,nonce: freezed == nonce ? _self.nonce : nonce // ignore: cast_nullable_to_non_nullable
+as String?,accessToken: freezed == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String?,refreshToken: freezed == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String?,expiresAt: freezed == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as num?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User?,
+  ));
+}
+
+/// Create a copy of IdToken
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res>? get user {
+    if (_self.user == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.user!, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/id_token.g.dart
+++ b/packages/better_auth_api_client/lib/models/id_token.g.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'id_token.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_IdToken _$IdTokenFromJson(Map<String, dynamic> json) => $checkedCreate(
+  '_IdToken',
+  json,
+  ($checkedConvert) {
+    final val = _IdToken(
+      token: $checkedConvert('token', (v) => v as String),
+      nonce: $checkedConvert('nonce', (v) => v as String?),
+      accessToken: $checkedConvert('access_token', (v) => v as String?),
+      refreshToken: $checkedConvert('refresh_token', (v) => v as String?),
+      expiresAt: $checkedConvert('expires_at', (v) => v as num?),
+      user: $checkedConvert(
+        'user',
+        (v) => v == null ? null : User.fromJson(v as Map<String, dynamic>),
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'accessToken': 'access_token',
+    'refreshToken': 'refresh_token',
+    'expiresAt': 'expires_at',
+  },
+);
+
+Map<String, dynamic> _$IdTokenToJson(_IdToken instance) => <String, dynamic>{
+  'token': instance.token,
+  'nonce': ?instance.nonce,
+  'access_token': ?instance.accessToken,
+  'refresh_token': ?instance.refreshToken,
+  'expires_at': ?instance.expiresAt,
+  'user': ?instance.user,
+};

--- a/packages/better_auth_api_client/lib/models/id_token2.dart
+++ b/packages/better_auth_api_client/lib/models/id_token2.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'id_token2.freezed.dart';
+part 'id_token2.g.dart';
+
+@Freezed()
+abstract class IdToken2 with _$IdToken2 {
+  const factory IdToken2({
+    required String token,
+    @JsonKey(includeIfNull: false)
+    String? nonce,
+    @JsonKey(includeIfNull: false)
+    String? accessToken,
+    @JsonKey(includeIfNull: false)
+    String? refreshToken,
+    @JsonKey(includeIfNull: false)
+    List<dynamic>? scopes,
+  }) = _IdToken2;
+  
+  factory IdToken2.fromJson(Map<String, Object?> json) => _$IdToken2FromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/id_token2.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/id_token2.freezed.dart
@@ -1,0 +1,297 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'id_token2.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$IdToken2 {
+
+ String get token;@JsonKey(includeIfNull: false) String? get nonce;@JsonKey(includeIfNull: false) String? get accessToken;@JsonKey(includeIfNull: false) String? get refreshToken;@JsonKey(includeIfNull: false) List<dynamic>? get scopes;
+/// Create a copy of IdToken2
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$IdToken2CopyWith<IdToken2> get copyWith => _$IdToken2CopyWithImpl<IdToken2>(this as IdToken2, _$identity);
+
+  /// Serializes this IdToken2 to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IdToken2&&(identical(other.token, token) || other.token == token)&&(identical(other.nonce, nonce) || other.nonce == nonce)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&const DeepCollectionEquality().equals(other.scopes, scopes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,nonce,accessToken,refreshToken,const DeepCollectionEquality().hash(scopes));
+
+@override
+String toString() {
+  return 'IdToken2(token: $token, nonce: $nonce, accessToken: $accessToken, refreshToken: $refreshToken, scopes: $scopes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $IdToken2CopyWith<$Res>  {
+  factory $IdToken2CopyWith(IdToken2 value, $Res Function(IdToken2) _then) = _$IdToken2CopyWithImpl;
+@useResult
+$Res call({
+ String token,@JsonKey(includeIfNull: false) String? nonce,@JsonKey(includeIfNull: false) String? accessToken,@JsonKey(includeIfNull: false) String? refreshToken,@JsonKey(includeIfNull: false) List<dynamic>? scopes
+});
+
+
+
+
+}
+/// @nodoc
+class _$IdToken2CopyWithImpl<$Res>
+    implements $IdToken2CopyWith<$Res> {
+  _$IdToken2CopyWithImpl(this._self, this._then);
+
+  final IdToken2 _self;
+  final $Res Function(IdToken2) _then;
+
+/// Create a copy of IdToken2
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? token = null,Object? nonce = freezed,Object? accessToken = freezed,Object? refreshToken = freezed,Object? scopes = freezed,}) {
+  return _then(_self.copyWith(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,nonce: freezed == nonce ? _self.nonce : nonce // ignore: cast_nullable_to_non_nullable
+as String?,accessToken: freezed == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String?,refreshToken: freezed == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String?,scopes: freezed == scopes ? _self.scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [IdToken2].
+extension IdToken2Patterns on IdToken2 {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _IdToken2 value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _IdToken2() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _IdToken2 value)  $default,){
+final _that = this;
+switch (_that) {
+case _IdToken2():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _IdToken2 value)?  $default,){
+final _that = this;
+switch (_that) {
+case _IdToken2() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String token, @JsonKey(includeIfNull: false)  String? nonce, @JsonKey(includeIfNull: false)  String? accessToken, @JsonKey(includeIfNull: false)  String? refreshToken, @JsonKey(includeIfNull: false)  List<dynamic>? scopes)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _IdToken2() when $default != null:
+return $default(_that.token,_that.nonce,_that.accessToken,_that.refreshToken,_that.scopes);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String token, @JsonKey(includeIfNull: false)  String? nonce, @JsonKey(includeIfNull: false)  String? accessToken, @JsonKey(includeIfNull: false)  String? refreshToken, @JsonKey(includeIfNull: false)  List<dynamic>? scopes)  $default,) {final _that = this;
+switch (_that) {
+case _IdToken2():
+return $default(_that.token,_that.nonce,_that.accessToken,_that.refreshToken,_that.scopes);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String token, @JsonKey(includeIfNull: false)  String? nonce, @JsonKey(includeIfNull: false)  String? accessToken, @JsonKey(includeIfNull: false)  String? refreshToken, @JsonKey(includeIfNull: false)  List<dynamic>? scopes)?  $default,) {final _that = this;
+switch (_that) {
+case _IdToken2() when $default != null:
+return $default(_that.token,_that.nonce,_that.accessToken,_that.refreshToken,_that.scopes);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _IdToken2 implements IdToken2 {
+  const _IdToken2({required this.token, @JsonKey(includeIfNull: false) this.nonce, @JsonKey(includeIfNull: false) this.accessToken, @JsonKey(includeIfNull: false) this.refreshToken, @JsonKey(includeIfNull: false) final  List<dynamic>? scopes}): _scopes = scopes;
+  factory _IdToken2.fromJson(Map<String, dynamic> json) => _$IdToken2FromJson(json);
+
+@override final  String token;
+@override@JsonKey(includeIfNull: false) final  String? nonce;
+@override@JsonKey(includeIfNull: false) final  String? accessToken;
+@override@JsonKey(includeIfNull: false) final  String? refreshToken;
+ final  List<dynamic>? _scopes;
+@override@JsonKey(includeIfNull: false) List<dynamic>? get scopes {
+  final value = _scopes;
+  if (value == null) return null;
+  if (_scopes is EqualUnmodifiableListView) return _scopes;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+
+/// Create a copy of IdToken2
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$IdToken2CopyWith<_IdToken2> get copyWith => __$IdToken2CopyWithImpl<_IdToken2>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$IdToken2ToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IdToken2&&(identical(other.token, token) || other.token == token)&&(identical(other.nonce, nonce) || other.nonce == nonce)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&const DeepCollectionEquality().equals(other._scopes, _scopes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,nonce,accessToken,refreshToken,const DeepCollectionEquality().hash(_scopes));
+
+@override
+String toString() {
+  return 'IdToken2(token: $token, nonce: $nonce, accessToken: $accessToken, refreshToken: $refreshToken, scopes: $scopes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$IdToken2CopyWith<$Res> implements $IdToken2CopyWith<$Res> {
+  factory _$IdToken2CopyWith(_IdToken2 value, $Res Function(_IdToken2) _then) = __$IdToken2CopyWithImpl;
+@override @useResult
+$Res call({
+ String token,@JsonKey(includeIfNull: false) String? nonce,@JsonKey(includeIfNull: false) String? accessToken,@JsonKey(includeIfNull: false) String? refreshToken,@JsonKey(includeIfNull: false) List<dynamic>? scopes
+});
+
+
+
+
+}
+/// @nodoc
+class __$IdToken2CopyWithImpl<$Res>
+    implements _$IdToken2CopyWith<$Res> {
+  __$IdToken2CopyWithImpl(this._self, this._then);
+
+  final _IdToken2 _self;
+  final $Res Function(_IdToken2) _then;
+
+/// Create a copy of IdToken2
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? token = null,Object? nonce = freezed,Object? accessToken = freezed,Object? refreshToken = freezed,Object? scopes = freezed,}) {
+  return _then(_IdToken2(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,nonce: freezed == nonce ? _self.nonce : nonce // ignore: cast_nullable_to_non_nullable
+as String?,accessToken: freezed == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String?,refreshToken: freezed == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String?,scopes: freezed == scopes ? _self._scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/id_token2.g.dart
+++ b/packages/better_auth_api_client/lib/models/id_token2.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'id_token2.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_IdToken2 _$IdToken2FromJson(Map<String, dynamic> json) => $checkedCreate(
+  '_IdToken2',
+  json,
+  ($checkedConvert) {
+    final val = _IdToken2(
+      token: $checkedConvert('token', (v) => v as String),
+      nonce: $checkedConvert('nonce', (v) => v as String?),
+      accessToken: $checkedConvert('access_token', (v) => v as String?),
+      refreshToken: $checkedConvert('refresh_token', (v) => v as String?),
+      scopes: $checkedConvert('scopes', (v) => v as List<dynamic>?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'accessToken': 'access_token',
+    'refreshToken': 'refresh_token',
+  },
+);
+
+Map<String, dynamic> _$IdToken2ToJson(_IdToken2 instance) => <String, dynamic>{
+  'token': instance.token,
+  'nonce': ?instance.nonce,
+  'access_token': ?instance.accessToken,
+  'refresh_token': ?instance.refreshToken,
+  'scopes': ?instance.scopes,
+};

--- a/packages/better_auth_api_client/lib/models/link_social_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/link_social_request_body.dart
@@ -1,0 +1,41 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'id_token2.dart';
+
+part 'link_social_request_body.freezed.dart';
+part 'link_social_request_body.g.dart';
+
+@Freezed()
+abstract class LinkSocialRequestBody with _$LinkSocialRequestBody {
+  const factory LinkSocialRequestBody({
+    required String provider,
+
+    /// The URL to redirect to after the user has signed in
+    @JsonKey(includeIfNull: false,name: 'callbackURL')
+    String? callbackUrl,
+    @JsonKey(includeIfNull: false)
+    IdToken2? idToken,
+    @JsonKey(includeIfNull: false)
+    bool? requestSignUp,
+
+    /// Additional scopes to request from the provider
+    @JsonKey(includeIfNull: false)
+    List<dynamic>? scopes,
+
+    /// The URL to redirect to if there is an error during the link process
+    @JsonKey(includeIfNull: false,name: 'errorCallbackURL')
+    String? errorCallbackUrl,
+
+    /// Disable automatic redirection to the provider. Useful for handling the redirection yourself
+    @JsonKey(includeIfNull: false)
+    bool? disableRedirect,
+    @JsonKey(includeIfNull: false)
+    String? additionalData,
+  }) = _LinkSocialRequestBody;
+  
+  factory LinkSocialRequestBody.fromJson(Map<String, Object?> json) => _$LinkSocialRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/link_social_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/link_social_request_body.freezed.dart
@@ -1,0 +1,339 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'link_social_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$LinkSocialRequestBody {
+
+ String get provider;/// The URL to redirect to after the user has signed in
+@JsonKey(includeIfNull: false, name: 'callbackURL') String? get callbackUrl;@JsonKey(includeIfNull: false) IdToken2? get idToken;@JsonKey(includeIfNull: false) bool? get requestSignUp;/// Additional scopes to request from the provider
+@JsonKey(includeIfNull: false) List<dynamic>? get scopes;/// The URL to redirect to if there is an error during the link process
+@JsonKey(includeIfNull: false, name: 'errorCallbackURL') String? get errorCallbackUrl;/// Disable automatic redirection to the provider. Useful for handling the redirection yourself
+@JsonKey(includeIfNull: false) bool? get disableRedirect;@JsonKey(includeIfNull: false) String? get additionalData;
+/// Create a copy of LinkSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LinkSocialRequestBodyCopyWith<LinkSocialRequestBody> get copyWith => _$LinkSocialRequestBodyCopyWithImpl<LinkSocialRequestBody>(this as LinkSocialRequestBody, _$identity);
+
+  /// Serializes this LinkSocialRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LinkSocialRequestBody&&(identical(other.provider, provider) || other.provider == provider)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&(identical(other.requestSignUp, requestSignUp) || other.requestSignUp == requestSignUp)&&const DeepCollectionEquality().equals(other.scopes, scopes)&&(identical(other.errorCallbackUrl, errorCallbackUrl) || other.errorCallbackUrl == errorCallbackUrl)&&(identical(other.disableRedirect, disableRedirect) || other.disableRedirect == disableRedirect)&&(identical(other.additionalData, additionalData) || other.additionalData == additionalData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,provider,callbackUrl,idToken,requestSignUp,const DeepCollectionEquality().hash(scopes),errorCallbackUrl,disableRedirect,additionalData);
+
+@override
+String toString() {
+  return 'LinkSocialRequestBody(provider: $provider, callbackUrl: $callbackUrl, idToken: $idToken, requestSignUp: $requestSignUp, scopes: $scopes, errorCallbackUrl: $errorCallbackUrl, disableRedirect: $disableRedirect, additionalData: $additionalData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LinkSocialRequestBodyCopyWith<$Res>  {
+  factory $LinkSocialRequestBodyCopyWith(LinkSocialRequestBody value, $Res Function(LinkSocialRequestBody) _then) = _$LinkSocialRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String provider,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl,@JsonKey(includeIfNull: false) IdToken2? idToken,@JsonKey(includeIfNull: false) bool? requestSignUp,@JsonKey(includeIfNull: false) List<dynamic>? scopes,@JsonKey(includeIfNull: false, name: 'errorCallbackURL') String? errorCallbackUrl,@JsonKey(includeIfNull: false) bool? disableRedirect,@JsonKey(includeIfNull: false) String? additionalData
+});
+
+
+$IdToken2CopyWith<$Res>? get idToken;
+
+}
+/// @nodoc
+class _$LinkSocialRequestBodyCopyWithImpl<$Res>
+    implements $LinkSocialRequestBodyCopyWith<$Res> {
+  _$LinkSocialRequestBodyCopyWithImpl(this._self, this._then);
+
+  final LinkSocialRequestBody _self;
+  final $Res Function(LinkSocialRequestBody) _then;
+
+/// Create a copy of LinkSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? provider = null,Object? callbackUrl = freezed,Object? idToken = freezed,Object? requestSignUp = freezed,Object? scopes = freezed,Object? errorCallbackUrl = freezed,Object? disableRedirect = freezed,Object? additionalData = freezed,}) {
+  return _then(_self.copyWith(
+provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,idToken: freezed == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as IdToken2?,requestSignUp: freezed == requestSignUp ? _self.requestSignUp : requestSignUp // ignore: cast_nullable_to_non_nullable
+as bool?,scopes: freezed == scopes ? _self.scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,errorCallbackUrl: freezed == errorCallbackUrl ? _self.errorCallbackUrl : errorCallbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,disableRedirect: freezed == disableRedirect ? _self.disableRedirect : disableRedirect // ignore: cast_nullable_to_non_nullable
+as bool?,additionalData: freezed == additionalData ? _self.additionalData : additionalData // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of LinkSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$IdToken2CopyWith<$Res>? get idToken {
+    if (_self.idToken == null) {
+    return null;
+  }
+
+  return $IdToken2CopyWith<$Res>(_self.idToken!, (value) {
+    return _then(_self.copyWith(idToken: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [LinkSocialRequestBody].
+extension LinkSocialRequestBodyPatterns on LinkSocialRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _LinkSocialRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _LinkSocialRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _LinkSocialRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _LinkSocialRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _LinkSocialRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _LinkSocialRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String provider, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false)  IdToken2? idToken, @JsonKey(includeIfNull: false)  bool? requestSignUp, @JsonKey(includeIfNull: false)  List<dynamic>? scopes, @JsonKey(includeIfNull: false, name: 'errorCallbackURL')  String? errorCallbackUrl, @JsonKey(includeIfNull: false)  bool? disableRedirect, @JsonKey(includeIfNull: false)  String? additionalData)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _LinkSocialRequestBody() when $default != null:
+return $default(_that.provider,_that.callbackUrl,_that.idToken,_that.requestSignUp,_that.scopes,_that.errorCallbackUrl,_that.disableRedirect,_that.additionalData);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String provider, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false)  IdToken2? idToken, @JsonKey(includeIfNull: false)  bool? requestSignUp, @JsonKey(includeIfNull: false)  List<dynamic>? scopes, @JsonKey(includeIfNull: false, name: 'errorCallbackURL')  String? errorCallbackUrl, @JsonKey(includeIfNull: false)  bool? disableRedirect, @JsonKey(includeIfNull: false)  String? additionalData)  $default,) {final _that = this;
+switch (_that) {
+case _LinkSocialRequestBody():
+return $default(_that.provider,_that.callbackUrl,_that.idToken,_that.requestSignUp,_that.scopes,_that.errorCallbackUrl,_that.disableRedirect,_that.additionalData);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String provider, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false)  IdToken2? idToken, @JsonKey(includeIfNull: false)  bool? requestSignUp, @JsonKey(includeIfNull: false)  List<dynamic>? scopes, @JsonKey(includeIfNull: false, name: 'errorCallbackURL')  String? errorCallbackUrl, @JsonKey(includeIfNull: false)  bool? disableRedirect, @JsonKey(includeIfNull: false)  String? additionalData)?  $default,) {final _that = this;
+switch (_that) {
+case _LinkSocialRequestBody() when $default != null:
+return $default(_that.provider,_that.callbackUrl,_that.idToken,_that.requestSignUp,_that.scopes,_that.errorCallbackUrl,_that.disableRedirect,_that.additionalData);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _LinkSocialRequestBody implements LinkSocialRequestBody {
+  const _LinkSocialRequestBody({required this.provider, @JsonKey(includeIfNull: false, name: 'callbackURL') this.callbackUrl, @JsonKey(includeIfNull: false) this.idToken, @JsonKey(includeIfNull: false) this.requestSignUp, @JsonKey(includeIfNull: false) final  List<dynamic>? scopes, @JsonKey(includeIfNull: false, name: 'errorCallbackURL') this.errorCallbackUrl, @JsonKey(includeIfNull: false) this.disableRedirect, @JsonKey(includeIfNull: false) this.additionalData}): _scopes = scopes;
+  factory _LinkSocialRequestBody.fromJson(Map<String, dynamic> json) => _$LinkSocialRequestBodyFromJson(json);
+
+@override final  String provider;
+/// The URL to redirect to after the user has signed in
+@override@JsonKey(includeIfNull: false, name: 'callbackURL') final  String? callbackUrl;
+@override@JsonKey(includeIfNull: false) final  IdToken2? idToken;
+@override@JsonKey(includeIfNull: false) final  bool? requestSignUp;
+/// Additional scopes to request from the provider
+ final  List<dynamic>? _scopes;
+/// Additional scopes to request from the provider
+@override@JsonKey(includeIfNull: false) List<dynamic>? get scopes {
+  final value = _scopes;
+  if (value == null) return null;
+  if (_scopes is EqualUnmodifiableListView) return _scopes;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+/// The URL to redirect to if there is an error during the link process
+@override@JsonKey(includeIfNull: false, name: 'errorCallbackURL') final  String? errorCallbackUrl;
+/// Disable automatic redirection to the provider. Useful for handling the redirection yourself
+@override@JsonKey(includeIfNull: false) final  bool? disableRedirect;
+@override@JsonKey(includeIfNull: false) final  String? additionalData;
+
+/// Create a copy of LinkSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LinkSocialRequestBodyCopyWith<_LinkSocialRequestBody> get copyWith => __$LinkSocialRequestBodyCopyWithImpl<_LinkSocialRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$LinkSocialRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LinkSocialRequestBody&&(identical(other.provider, provider) || other.provider == provider)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&(identical(other.requestSignUp, requestSignUp) || other.requestSignUp == requestSignUp)&&const DeepCollectionEquality().equals(other._scopes, _scopes)&&(identical(other.errorCallbackUrl, errorCallbackUrl) || other.errorCallbackUrl == errorCallbackUrl)&&(identical(other.disableRedirect, disableRedirect) || other.disableRedirect == disableRedirect)&&(identical(other.additionalData, additionalData) || other.additionalData == additionalData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,provider,callbackUrl,idToken,requestSignUp,const DeepCollectionEquality().hash(_scopes),errorCallbackUrl,disableRedirect,additionalData);
+
+@override
+String toString() {
+  return 'LinkSocialRequestBody(provider: $provider, callbackUrl: $callbackUrl, idToken: $idToken, requestSignUp: $requestSignUp, scopes: $scopes, errorCallbackUrl: $errorCallbackUrl, disableRedirect: $disableRedirect, additionalData: $additionalData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LinkSocialRequestBodyCopyWith<$Res> implements $LinkSocialRequestBodyCopyWith<$Res> {
+  factory _$LinkSocialRequestBodyCopyWith(_LinkSocialRequestBody value, $Res Function(_LinkSocialRequestBody) _then) = __$LinkSocialRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String provider,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl,@JsonKey(includeIfNull: false) IdToken2? idToken,@JsonKey(includeIfNull: false) bool? requestSignUp,@JsonKey(includeIfNull: false) List<dynamic>? scopes,@JsonKey(includeIfNull: false, name: 'errorCallbackURL') String? errorCallbackUrl,@JsonKey(includeIfNull: false) bool? disableRedirect,@JsonKey(includeIfNull: false) String? additionalData
+});
+
+
+@override $IdToken2CopyWith<$Res>? get idToken;
+
+}
+/// @nodoc
+class __$LinkSocialRequestBodyCopyWithImpl<$Res>
+    implements _$LinkSocialRequestBodyCopyWith<$Res> {
+  __$LinkSocialRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _LinkSocialRequestBody _self;
+  final $Res Function(_LinkSocialRequestBody) _then;
+
+/// Create a copy of LinkSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? provider = null,Object? callbackUrl = freezed,Object? idToken = freezed,Object? requestSignUp = freezed,Object? scopes = freezed,Object? errorCallbackUrl = freezed,Object? disableRedirect = freezed,Object? additionalData = freezed,}) {
+  return _then(_LinkSocialRequestBody(
+provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,idToken: freezed == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as IdToken2?,requestSignUp: freezed == requestSignUp ? _self.requestSignUp : requestSignUp // ignore: cast_nullable_to_non_nullable
+as bool?,scopes: freezed == scopes ? _self._scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,errorCallbackUrl: freezed == errorCallbackUrl ? _self.errorCallbackUrl : errorCallbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,disableRedirect: freezed == disableRedirect ? _self.disableRedirect : disableRedirect // ignore: cast_nullable_to_non_nullable
+as bool?,additionalData: freezed == additionalData ? _self.additionalData : additionalData // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of LinkSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$IdToken2CopyWith<$Res>? get idToken {
+    if (_self.idToken == null) {
+    return null;
+  }
+
+  return $IdToken2CopyWith<$Res>(_self.idToken!, (value) {
+    return _then(_self.copyWith(idToken: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/link_social_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/link_social_request_body.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'link_social_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_LinkSocialRequestBody _$LinkSocialRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_LinkSocialRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _LinkSocialRequestBody(
+      provider: $checkedConvert('provider', (v) => v as String),
+      callbackUrl: $checkedConvert('callbackURL', (v) => v as String?),
+      idToken: $checkedConvert(
+        'id_token',
+        (v) => v == null ? null : IdToken2.fromJson(v as Map<String, dynamic>),
+      ),
+      requestSignUp: $checkedConvert('request_sign_up', (v) => v as bool?),
+      scopes: $checkedConvert('scopes', (v) => v as List<dynamic>?),
+      errorCallbackUrl: $checkedConvert(
+        'errorCallbackURL',
+        (v) => v as String?,
+      ),
+      disableRedirect: $checkedConvert('disable_redirect', (v) => v as bool?),
+      additionalData: $checkedConvert('additional_data', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'callbackUrl': 'callbackURL',
+    'idToken': 'id_token',
+    'requestSignUp': 'request_sign_up',
+    'errorCallbackUrl': 'errorCallbackURL',
+    'disableRedirect': 'disable_redirect',
+    'additionalData': 'additional_data',
+  },
+);
+
+Map<String, dynamic> _$LinkSocialRequestBodyToJson(
+  _LinkSocialRequestBody instance,
+) => <String, dynamic>{
+  'provider': instance.provider,
+  'callbackURL': ?instance.callbackUrl,
+  'id_token': ?instance.idToken,
+  'request_sign_up': ?instance.requestSignUp,
+  'scopes': ?instance.scopes,
+  'errorCallbackURL': ?instance.errorCallbackUrl,
+  'disable_redirect': ?instance.disableRedirect,
+  'additional_data': ?instance.additionalData,
+};

--- a/packages/better_auth_api_client/lib/models/message.dart
+++ b/packages/better_auth_api_client/lib/models/message.dart
@@ -1,0 +1,29 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// Status message of the email change process
+@JsonEnum()
+enum Message {
+  @JsonValue('Email updated')
+  emailUpdated('Email updated'),
+  @JsonValue('Verification email sent')
+  verificationEmailSent('Verification email sent');
+
+  const Message(this.json);
+
+  final String? json;
+  String toJson() {
+    final value = json;
+    if (value == null) {
+      throw StateError('Cannot convert enum value with null JSON representation to String. '
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
+    }
+    return value as String;
+  }
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+}

--- a/packages/better_auth_api_client/lib/models/message2.dart
+++ b/packages/better_auth_api_client/lib/models/message2.dart
@@ -1,0 +1,29 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// Status message of the deletion process
+@JsonEnum()
+enum Message2 {
+  @JsonValue('User deleted')
+  userDeleted('User deleted'),
+  @JsonValue('Verification email sent')
+  verificationEmailSent('Verification email sent');
+
+  const Message2(this.json);
+
+  final String? json;
+  String toJson() {
+    final value = json;
+    if (value == null) {
+      throw StateError('Cannot convert enum value with null JSON representation to String. '
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
+    }
+    return value as String;
+  }
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+}

--- a/packages/better_auth_api_client/lib/models/message3.dart
+++ b/packages/better_auth_api_client/lib/models/message3.dart
@@ -1,0 +1,27 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// Confirmation message
+@JsonEnum()
+enum Message3 {
+  @JsonValue('User deleted')
+  userDeleted('User deleted');
+
+  const Message3(this.json);
+
+  final String? json;
+  String toJson() {
+    final value = json;
+    if (value == null) {
+      throw StateError('Cannot convert enum value with null JSON representation to String. '
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
+    }
+    return value as String;
+  }
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+}

--- a/packages/better_auth_api_client/lib/models/name.dart
+++ b/packages/better_auth_api_client/lib/models/name.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'name.freezed.dart';
+part 'name.g.dart';
+
+@Freezed()
+abstract class Name with _$Name {
+  const factory Name({
+    @JsonKey(includeIfNull: true)
+    required String? firstName,
+    @JsonKey(includeIfNull: true)
+    required String? lastName,
+  }) = _Name;
+  
+  factory Name.fromJson(Map<String, Object?> json) => _$NameFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/name.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/name.freezed.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'name.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Name {
+
+@JsonKey(includeIfNull: true) String? get firstName;@JsonKey(includeIfNull: true) String? get lastName;
+/// Create a copy of Name
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NameCopyWith<Name> get copyWith => _$NameCopyWithImpl<Name>(this as Name, _$identity);
+
+  /// Serializes this Name to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Name&&(identical(other.firstName, firstName) || other.firstName == firstName)&&(identical(other.lastName, lastName) || other.lastName == lastName));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,firstName,lastName);
+
+@override
+String toString() {
+  return 'Name(firstName: $firstName, lastName: $lastName)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NameCopyWith<$Res>  {
+  factory $NameCopyWith(Name value, $Res Function(Name) _then) = _$NameCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(includeIfNull: true) String? firstName,@JsonKey(includeIfNull: true) String? lastName
+});
+
+
+
+
+}
+/// @nodoc
+class _$NameCopyWithImpl<$Res>
+    implements $NameCopyWith<$Res> {
+  _$NameCopyWithImpl(this._self, this._then);
+
+  final Name _self;
+  final $Res Function(Name) _then;
+
+/// Create a copy of Name
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? firstName = freezed,Object? lastName = freezed,}) {
+  return _then(_self.copyWith(
+firstName: freezed == firstName ? _self.firstName : firstName // ignore: cast_nullable_to_non_nullable
+as String?,lastName: freezed == lastName ? _self.lastName : lastName // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Name].
+extension NamePatterns on Name {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Name value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Name() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Name value)  $default,){
+final _that = this;
+switch (_that) {
+case _Name():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Name value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Name() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: true)  String? firstName, @JsonKey(includeIfNull: true)  String? lastName)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Name() when $default != null:
+return $default(_that.firstName,_that.lastName);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: true)  String? firstName, @JsonKey(includeIfNull: true)  String? lastName)  $default,) {final _that = this;
+switch (_that) {
+case _Name():
+return $default(_that.firstName,_that.lastName);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: true)  String? firstName, @JsonKey(includeIfNull: true)  String? lastName)?  $default,) {final _that = this;
+switch (_that) {
+case _Name() when $default != null:
+return $default(_that.firstName,_that.lastName);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _Name implements Name {
+  const _Name({@JsonKey(includeIfNull: true) required this.firstName, @JsonKey(includeIfNull: true) required this.lastName});
+  factory _Name.fromJson(Map<String, dynamic> json) => _$NameFromJson(json);
+
+@override@JsonKey(includeIfNull: true) final  String? firstName;
+@override@JsonKey(includeIfNull: true) final  String? lastName;
+
+/// Create a copy of Name
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NameCopyWith<_Name> get copyWith => __$NameCopyWithImpl<_Name>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$NameToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Name&&(identical(other.firstName, firstName) || other.firstName == firstName)&&(identical(other.lastName, lastName) || other.lastName == lastName));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,firstName,lastName);
+
+@override
+String toString() {
+  return 'Name(firstName: $firstName, lastName: $lastName)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$NameCopyWith<$Res> implements $NameCopyWith<$Res> {
+  factory _$NameCopyWith(_Name value, $Res Function(_Name) _then) = __$NameCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(includeIfNull: true) String? firstName,@JsonKey(includeIfNull: true) String? lastName
+});
+
+
+
+
+}
+/// @nodoc
+class __$NameCopyWithImpl<$Res>
+    implements _$NameCopyWith<$Res> {
+  __$NameCopyWithImpl(this._self, this._then);
+
+  final _Name _self;
+  final $Res Function(_Name) _then;
+
+/// Create a copy of Name
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? firstName = freezed,Object? lastName = freezed,}) {
+  return _then(_Name(
+firstName: freezed == firstName ? _self.firstName : firstName // ignore: cast_nullable_to_non_nullable
+as String?,lastName: freezed == lastName ? _self.lastName : lastName // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/name.g.dart
+++ b/packages/better_auth_api_client/lib/models/name.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'name.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Name _$NameFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('_Name', json, ($checkedConvert) {
+      final val = _Name(
+        firstName: $checkedConvert('first_name', (v) => v as String?),
+        lastName: $checkedConvert('last_name', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {'firstName': 'first_name', 'lastName': 'last_name'});
+
+Map<String, dynamic> _$NameToJson(_Name instance) => <String, dynamic>{
+  'first_name': instance.firstName,
+  'last_name': instance.lastName,
+};

--- a/packages/better_auth_api_client/lib/models/post_change_email_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_change_email_response.dart
@@ -1,0 +1,27 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user.dart';
+import 'message.dart';
+
+part 'post_change_email_response.freezed.dart';
+part 'post_change_email_response.g.dart';
+
+@Freezed()
+abstract class PostChangeEmailResponse with _$PostChangeEmailResponse {
+  const factory PostChangeEmailResponse({
+    /// Indicates if the request was successful
+    required bool status,
+    @JsonKey(includeIfNull: false)
+    User? user,
+
+    /// Status message of the email change process
+    @JsonKey(includeIfNull: false)
+    Message? message,
+  }) = _PostChangeEmailResponse;
+  
+  factory PostChangeEmailResponse.fromJson(Map<String, Object?> json) => _$PostChangeEmailResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_change_email_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_change_email_response.freezed.dart
@@ -1,0 +1,311 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_change_email_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostChangeEmailResponse {
+
+/// Indicates if the request was successful
+ bool get status;@JsonKey(includeIfNull: false) User? get user;/// Status message of the email change process
+@JsonKey(includeIfNull: false) Message? get message;
+/// Create a copy of PostChangeEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostChangeEmailResponseCopyWith<PostChangeEmailResponse> get copyWith => _$PostChangeEmailResponseCopyWithImpl<PostChangeEmailResponse>(this as PostChangeEmailResponse, _$identity);
+
+  /// Serializes this PostChangeEmailResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostChangeEmailResponse&&(identical(other.status, status) || other.status == status)&&(identical(other.user, user) || other.user == user)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,user,message);
+
+@override
+String toString() {
+  return 'PostChangeEmailResponse(status: $status, user: $user, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostChangeEmailResponseCopyWith<$Res>  {
+  factory $PostChangeEmailResponseCopyWith(PostChangeEmailResponse value, $Res Function(PostChangeEmailResponse) _then) = _$PostChangeEmailResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status,@JsonKey(includeIfNull: false) User? user,@JsonKey(includeIfNull: false) Message? message
+});
+
+
+$UserCopyWith<$Res>? get user;
+
+}
+/// @nodoc
+class _$PostChangeEmailResponseCopyWithImpl<$Res>
+    implements $PostChangeEmailResponseCopyWith<$Res> {
+  _$PostChangeEmailResponseCopyWithImpl(this._self, this._then);
+
+  final PostChangeEmailResponse _self;
+  final $Res Function(PostChangeEmailResponse) _then;
+
+/// Create a copy of PostChangeEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? user = freezed,Object? message = freezed,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as Message?,
+  ));
+}
+/// Create a copy of PostChangeEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res>? get user {
+    if (_self.user == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.user!, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostChangeEmailResponse].
+extension PostChangeEmailResponsePatterns on PostChangeEmailResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostChangeEmailResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostChangeEmailResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostChangeEmailResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostChangeEmailResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostChangeEmailResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostChangeEmailResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status, @JsonKey(includeIfNull: false)  User? user, @JsonKey(includeIfNull: false)  Message? message)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostChangeEmailResponse() when $default != null:
+return $default(_that.status,_that.user,_that.message);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status, @JsonKey(includeIfNull: false)  User? user, @JsonKey(includeIfNull: false)  Message? message)  $default,) {final _that = this;
+switch (_that) {
+case _PostChangeEmailResponse():
+return $default(_that.status,_that.user,_that.message);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status, @JsonKey(includeIfNull: false)  User? user, @JsonKey(includeIfNull: false)  Message? message)?  $default,) {final _that = this;
+switch (_that) {
+case _PostChangeEmailResponse() when $default != null:
+return $default(_that.status,_that.user,_that.message);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostChangeEmailResponse implements PostChangeEmailResponse {
+  const _PostChangeEmailResponse({required this.status, @JsonKey(includeIfNull: false) this.user, @JsonKey(includeIfNull: false) this.message});
+  factory _PostChangeEmailResponse.fromJson(Map<String, dynamic> json) => _$PostChangeEmailResponseFromJson(json);
+
+/// Indicates if the request was successful
+@override final  bool status;
+@override@JsonKey(includeIfNull: false) final  User? user;
+/// Status message of the email change process
+@override@JsonKey(includeIfNull: false) final  Message? message;
+
+/// Create a copy of PostChangeEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostChangeEmailResponseCopyWith<_PostChangeEmailResponse> get copyWith => __$PostChangeEmailResponseCopyWithImpl<_PostChangeEmailResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostChangeEmailResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostChangeEmailResponse&&(identical(other.status, status) || other.status == status)&&(identical(other.user, user) || other.user == user)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,user,message);
+
+@override
+String toString() {
+  return 'PostChangeEmailResponse(status: $status, user: $user, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostChangeEmailResponseCopyWith<$Res> implements $PostChangeEmailResponseCopyWith<$Res> {
+  factory _$PostChangeEmailResponseCopyWith(_PostChangeEmailResponse value, $Res Function(_PostChangeEmailResponse) _then) = __$PostChangeEmailResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status,@JsonKey(includeIfNull: false) User? user,@JsonKey(includeIfNull: false) Message? message
+});
+
+
+@override $UserCopyWith<$Res>? get user;
+
+}
+/// @nodoc
+class __$PostChangeEmailResponseCopyWithImpl<$Res>
+    implements _$PostChangeEmailResponseCopyWith<$Res> {
+  __$PostChangeEmailResponseCopyWithImpl(this._self, this._then);
+
+  final _PostChangeEmailResponse _self;
+  final $Res Function(_PostChangeEmailResponse) _then;
+
+/// Create a copy of PostChangeEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? user = freezed,Object? message = freezed,}) {
+  return _then(_PostChangeEmailResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as Message?,
+  ));
+}
+
+/// Create a copy of PostChangeEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res>? get user {
+    if (_self.user == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.user!, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_change_email_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_change_email_response.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_change_email_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostChangeEmailResponse _$PostChangeEmailResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostChangeEmailResponse', json, ($checkedConvert) {
+  final val = _PostChangeEmailResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+    user: $checkedConvert(
+      'user',
+      (v) => v == null ? null : User.fromJson(v as Map<String, dynamic>),
+    ),
+    message: $checkedConvert(
+      'message',
+      (v) => $enumDecodeNullable(_$MessageEnumMap, v),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostChangeEmailResponseToJson(
+  _PostChangeEmailResponse instance,
+) => <String, dynamic>{
+  'status': instance.status,
+  'user': ?instance.user,
+  'message': ?instance.message,
+};
+
+const _$MessageEnumMap = {
+  Message.emailUpdated: 'Email updated',
+  Message.verificationEmailSent: 'Verification email sent',
+};

--- a/packages/better_auth_api_client/lib/models/post_change_password_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_change_password_response.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user3.dart';
+
+part 'post_change_password_response.freezed.dart';
+part 'post_change_password_response.g.dart';
+
+@Freezed()
+abstract class PostChangePasswordResponse with _$PostChangePasswordResponse {
+  const factory PostChangePasswordResponse({
+    required User3 user,
+
+    /// New session token if other sessions were revoked
+    @JsonKey(includeIfNull: false)
+    String? token,
+  }) = _PostChangePasswordResponse;
+  
+  factory PostChangePasswordResponse.fromJson(Map<String, Object?> json) => _$PostChangePasswordResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_change_password_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_change_password_response.freezed.dart
@@ -1,0 +1,300 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_change_password_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostChangePasswordResponse {
+
+ User3 get user;/// New session token if other sessions were revoked
+@JsonKey(includeIfNull: false) String? get token;
+/// Create a copy of PostChangePasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostChangePasswordResponseCopyWith<PostChangePasswordResponse> get copyWith => _$PostChangePasswordResponseCopyWithImpl<PostChangePasswordResponse>(this as PostChangePasswordResponse, _$identity);
+
+  /// Serializes this PostChangePasswordResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostChangePasswordResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,token);
+
+@override
+String toString() {
+  return 'PostChangePasswordResponse(user: $user, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostChangePasswordResponseCopyWith<$Res>  {
+  factory $PostChangePasswordResponseCopyWith(PostChangePasswordResponse value, $Res Function(PostChangePasswordResponse) _then) = _$PostChangePasswordResponseCopyWithImpl;
+@useResult
+$Res call({
+ User3 user,@JsonKey(includeIfNull: false) String? token
+});
+
+
+$User3CopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$PostChangePasswordResponseCopyWithImpl<$Res>
+    implements $PostChangePasswordResponseCopyWith<$Res> {
+  _$PostChangePasswordResponseCopyWithImpl(this._self, this._then);
+
+  final PostChangePasswordResponse _self;
+  final $Res Function(PostChangePasswordResponse) _then;
+
+/// Create a copy of PostChangePasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? token = freezed,}) {
+  return _then(_self.copyWith(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User3,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of PostChangePasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$User3CopyWith<$Res> get user {
+  
+  return $User3CopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostChangePasswordResponse].
+extension PostChangePasswordResponsePatterns on PostChangePasswordResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostChangePasswordResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostChangePasswordResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostChangePasswordResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostChangePasswordResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostChangePasswordResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostChangePasswordResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( User3 user, @JsonKey(includeIfNull: false)  String? token)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostChangePasswordResponse() when $default != null:
+return $default(_that.user,_that.token);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( User3 user, @JsonKey(includeIfNull: false)  String? token)  $default,) {final _that = this;
+switch (_that) {
+case _PostChangePasswordResponse():
+return $default(_that.user,_that.token);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( User3 user, @JsonKey(includeIfNull: false)  String? token)?  $default,) {final _that = this;
+switch (_that) {
+case _PostChangePasswordResponse() when $default != null:
+return $default(_that.user,_that.token);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostChangePasswordResponse implements PostChangePasswordResponse {
+  const _PostChangePasswordResponse({required this.user, @JsonKey(includeIfNull: false) this.token});
+  factory _PostChangePasswordResponse.fromJson(Map<String, dynamic> json) => _$PostChangePasswordResponseFromJson(json);
+
+@override final  User3 user;
+/// New session token if other sessions were revoked
+@override@JsonKey(includeIfNull: false) final  String? token;
+
+/// Create a copy of PostChangePasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostChangePasswordResponseCopyWith<_PostChangePasswordResponse> get copyWith => __$PostChangePasswordResponseCopyWithImpl<_PostChangePasswordResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostChangePasswordResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostChangePasswordResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,token);
+
+@override
+String toString() {
+  return 'PostChangePasswordResponse(user: $user, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostChangePasswordResponseCopyWith<$Res> implements $PostChangePasswordResponseCopyWith<$Res> {
+  factory _$PostChangePasswordResponseCopyWith(_PostChangePasswordResponse value, $Res Function(_PostChangePasswordResponse) _then) = __$PostChangePasswordResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ User3 user,@JsonKey(includeIfNull: false) String? token
+});
+
+
+@override $User3CopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$PostChangePasswordResponseCopyWithImpl<$Res>
+    implements _$PostChangePasswordResponseCopyWith<$Res> {
+  __$PostChangePasswordResponseCopyWithImpl(this._self, this._then);
+
+  final _PostChangePasswordResponse _self;
+  final $Res Function(_PostChangePasswordResponse) _then;
+
+/// Create a copy of PostChangePasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? token = freezed,}) {
+  return _then(_PostChangePasswordResponse(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User3,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of PostChangePasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$User3CopyWith<$Res> get user {
+  
+  return $User3CopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_change_password_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_change_password_response.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_change_password_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostChangePasswordResponse _$PostChangePasswordResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostChangePasswordResponse', json, ($checkedConvert) {
+  final val = _PostChangePasswordResponse(
+    user: $checkedConvert(
+      'user',
+      (v) => User3.fromJson(v as Map<String, dynamic>),
+    ),
+    token: $checkedConvert('token', (v) => v as String?),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostChangePasswordResponseToJson(
+  _PostChangePasswordResponse instance,
+) => <String, dynamic>{'user': instance.user, 'token': ?instance.token};

--- a/packages/better_auth_api_client/lib/models/post_delete_anonymous_user_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_delete_anonymous_user_response.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_delete_anonymous_user_response.freezed.dart';
+part 'post_delete_anonymous_user_response.g.dart';
+
+@Freezed()
+abstract class PostDeleteAnonymousUserResponse with _$PostDeleteAnonymousUserResponse {
+  const factory PostDeleteAnonymousUserResponse({
+    required bool success,
+  }) = _PostDeleteAnonymousUserResponse;
+  
+  factory PostDeleteAnonymousUserResponse.fromJson(Map<String, Object?> json) => _$PostDeleteAnonymousUserResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_delete_anonymous_user_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_delete_anonymous_user_response.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_delete_anonymous_user_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostDeleteAnonymousUserResponse {
+
+ bool get success;
+/// Create a copy of PostDeleteAnonymousUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostDeleteAnonymousUserResponseCopyWith<PostDeleteAnonymousUserResponse> get copyWith => _$PostDeleteAnonymousUserResponseCopyWithImpl<PostDeleteAnonymousUserResponse>(this as PostDeleteAnonymousUserResponse, _$identity);
+
+  /// Serializes this PostDeleteAnonymousUserResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostDeleteAnonymousUserResponse&&(identical(other.success, success) || other.success == success));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success);
+
+@override
+String toString() {
+  return 'PostDeleteAnonymousUserResponse(success: $success)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostDeleteAnonymousUserResponseCopyWith<$Res>  {
+  factory $PostDeleteAnonymousUserResponseCopyWith(PostDeleteAnonymousUserResponse value, $Res Function(PostDeleteAnonymousUserResponse) _then) = _$PostDeleteAnonymousUserResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool success
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostDeleteAnonymousUserResponseCopyWithImpl<$Res>
+    implements $PostDeleteAnonymousUserResponseCopyWith<$Res> {
+  _$PostDeleteAnonymousUserResponseCopyWithImpl(this._self, this._then);
+
+  final PostDeleteAnonymousUserResponse _self;
+  final $Res Function(PostDeleteAnonymousUserResponse) _then;
+
+/// Create a copy of PostDeleteAnonymousUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? success = null,}) {
+  return _then(_self.copyWith(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostDeleteAnonymousUserResponse].
+extension PostDeleteAnonymousUserResponsePatterns on PostDeleteAnonymousUserResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostDeleteAnonymousUserResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostDeleteAnonymousUserResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostDeleteAnonymousUserResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostDeleteAnonymousUserResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostDeleteAnonymousUserResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostDeleteAnonymousUserResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool success)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostDeleteAnonymousUserResponse() when $default != null:
+return $default(_that.success);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool success)  $default,) {final _that = this;
+switch (_that) {
+case _PostDeleteAnonymousUserResponse():
+return $default(_that.success);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool success)?  $default,) {final _that = this;
+switch (_that) {
+case _PostDeleteAnonymousUserResponse() when $default != null:
+return $default(_that.success);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostDeleteAnonymousUserResponse implements PostDeleteAnonymousUserResponse {
+  const _PostDeleteAnonymousUserResponse({required this.success});
+  factory _PostDeleteAnonymousUserResponse.fromJson(Map<String, dynamic> json) => _$PostDeleteAnonymousUserResponseFromJson(json);
+
+@override final  bool success;
+
+/// Create a copy of PostDeleteAnonymousUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostDeleteAnonymousUserResponseCopyWith<_PostDeleteAnonymousUserResponse> get copyWith => __$PostDeleteAnonymousUserResponseCopyWithImpl<_PostDeleteAnonymousUserResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostDeleteAnonymousUserResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostDeleteAnonymousUserResponse&&(identical(other.success, success) || other.success == success));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success);
+
+@override
+String toString() {
+  return 'PostDeleteAnonymousUserResponse(success: $success)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostDeleteAnonymousUserResponseCopyWith<$Res> implements $PostDeleteAnonymousUserResponseCopyWith<$Res> {
+  factory _$PostDeleteAnonymousUserResponseCopyWith(_PostDeleteAnonymousUserResponse value, $Res Function(_PostDeleteAnonymousUserResponse) _then) = __$PostDeleteAnonymousUserResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool success
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostDeleteAnonymousUserResponseCopyWithImpl<$Res>
+    implements _$PostDeleteAnonymousUserResponseCopyWith<$Res> {
+  __$PostDeleteAnonymousUserResponseCopyWithImpl(this._self, this._then);
+
+  final _PostDeleteAnonymousUserResponse _self;
+  final $Res Function(_PostDeleteAnonymousUserResponse) _then;
+
+/// Create a copy of PostDeleteAnonymousUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? success = null,}) {
+  return _then(_PostDeleteAnonymousUserResponse(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_delete_anonymous_user_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_delete_anonymous_user_response.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_delete_anonymous_user_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostDeleteAnonymousUserResponse _$PostDeleteAnonymousUserResponseFromJson(
+  Map<String, dynamic> json,
+) =>
+    $checkedCreate('_PostDeleteAnonymousUserResponse', json, ($checkedConvert) {
+      final val = _PostDeleteAnonymousUserResponse(
+        success: $checkedConvert('success', (v) => v as bool),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$PostDeleteAnonymousUserResponseToJson(
+  _PostDeleteAnonymousUserResponse instance,
+) => <String, dynamic>{'success': instance.success};

--- a/packages/better_auth_api_client/lib/models/post_delete_user_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_delete_user_response.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'message2.dart';
+
+part 'post_delete_user_response.freezed.dart';
+part 'post_delete_user_response.g.dart';
+
+@Freezed()
+abstract class PostDeleteUserResponse with _$PostDeleteUserResponse {
+  const factory PostDeleteUserResponse({
+    /// Indicates if the operation was successful
+    required bool success,
+
+    /// Status message of the deletion process
+    required Message2 message,
+  }) = _PostDeleteUserResponse;
+  
+  factory PostDeleteUserResponse.fromJson(Map<String, Object?> json) => _$PostDeleteUserResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_delete_user_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_delete_user_response.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_delete_user_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostDeleteUserResponse {
+
+/// Indicates if the operation was successful
+ bool get success;/// Status message of the deletion process
+ Message2 get message;
+/// Create a copy of PostDeleteUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostDeleteUserResponseCopyWith<PostDeleteUserResponse> get copyWith => _$PostDeleteUserResponseCopyWithImpl<PostDeleteUserResponse>(this as PostDeleteUserResponse, _$identity);
+
+  /// Serializes this PostDeleteUserResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostDeleteUserResponse&&(identical(other.success, success) || other.success == success)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success,message);
+
+@override
+String toString() {
+  return 'PostDeleteUserResponse(success: $success, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostDeleteUserResponseCopyWith<$Res>  {
+  factory $PostDeleteUserResponseCopyWith(PostDeleteUserResponse value, $Res Function(PostDeleteUserResponse) _then) = _$PostDeleteUserResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool success, Message2 message
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostDeleteUserResponseCopyWithImpl<$Res>
+    implements $PostDeleteUserResponseCopyWith<$Res> {
+  _$PostDeleteUserResponseCopyWithImpl(this._self, this._then);
+
+  final PostDeleteUserResponse _self;
+  final $Res Function(PostDeleteUserResponse) _then;
+
+/// Create a copy of PostDeleteUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? success = null,Object? message = null,}) {
+  return _then(_self.copyWith(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as Message2,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostDeleteUserResponse].
+extension PostDeleteUserResponsePatterns on PostDeleteUserResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostDeleteUserResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostDeleteUserResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostDeleteUserResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostDeleteUserResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostDeleteUserResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostDeleteUserResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool success,  Message2 message)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostDeleteUserResponse() when $default != null:
+return $default(_that.success,_that.message);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool success,  Message2 message)  $default,) {final _that = this;
+switch (_that) {
+case _PostDeleteUserResponse():
+return $default(_that.success,_that.message);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool success,  Message2 message)?  $default,) {final _that = this;
+switch (_that) {
+case _PostDeleteUserResponse() when $default != null:
+return $default(_that.success,_that.message);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostDeleteUserResponse implements PostDeleteUserResponse {
+  const _PostDeleteUserResponse({required this.success, required this.message});
+  factory _PostDeleteUserResponse.fromJson(Map<String, dynamic> json) => _$PostDeleteUserResponseFromJson(json);
+
+/// Indicates if the operation was successful
+@override final  bool success;
+/// Status message of the deletion process
+@override final  Message2 message;
+
+/// Create a copy of PostDeleteUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostDeleteUserResponseCopyWith<_PostDeleteUserResponse> get copyWith => __$PostDeleteUserResponseCopyWithImpl<_PostDeleteUserResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostDeleteUserResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostDeleteUserResponse&&(identical(other.success, success) || other.success == success)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success,message);
+
+@override
+String toString() {
+  return 'PostDeleteUserResponse(success: $success, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostDeleteUserResponseCopyWith<$Res> implements $PostDeleteUserResponseCopyWith<$Res> {
+  factory _$PostDeleteUserResponseCopyWith(_PostDeleteUserResponse value, $Res Function(_PostDeleteUserResponse) _then) = __$PostDeleteUserResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool success, Message2 message
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostDeleteUserResponseCopyWithImpl<$Res>
+    implements _$PostDeleteUserResponseCopyWith<$Res> {
+  __$PostDeleteUserResponseCopyWithImpl(this._self, this._then);
+
+  final _PostDeleteUserResponse _self;
+  final $Res Function(_PostDeleteUserResponse) _then;
+
+/// Create a copy of PostDeleteUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? success = null,Object? message = null,}) {
+  return _then(_PostDeleteUserResponse(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as Message2,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_delete_user_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_delete_user_response.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_delete_user_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostDeleteUserResponse _$PostDeleteUserResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostDeleteUserResponse', json, ($checkedConvert) {
+  final val = _PostDeleteUserResponse(
+    success: $checkedConvert('success', (v) => v as bool),
+    message: $checkedConvert(
+      'message',
+      (v) => $enumDecode(_$Message2EnumMap, v),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostDeleteUserResponseToJson(
+  _PostDeleteUserResponse instance,
+) => <String, dynamic>{
+  'success': instance.success,
+  'message': instance.message,
+};
+
+const _$Message2EnumMap = {
+  Message2.userDeleted: 'User deleted',
+  Message2.verificationEmailSent: 'Verification email sent',
+};

--- a/packages/better_auth_api_client/lib/models/post_get_access_token_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_get_access_token_response.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_get_access_token_response.freezed.dart';
+part 'post_get_access_token_response.g.dart';
+
+@Freezed()
+abstract class PostGetAccessTokenResponse with _$PostGetAccessTokenResponse {
+  const factory PostGetAccessTokenResponse({
+    required String tokenType,
+    required String idToken,
+    required String accessToken,
+    required DateTime accessTokenExpiresAt,
+  }) = _PostGetAccessTokenResponse;
+  
+  factory PostGetAccessTokenResponse.fromJson(Map<String, Object?> json) => _$PostGetAccessTokenResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_get_access_token_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_get_access_token_response.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_get_access_token_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostGetAccessTokenResponse {
+
+ String get tokenType; String get idToken; String get accessToken; DateTime get accessTokenExpiresAt;
+/// Create a copy of PostGetAccessTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostGetAccessTokenResponseCopyWith<PostGetAccessTokenResponse> get copyWith => _$PostGetAccessTokenResponseCopyWithImpl<PostGetAccessTokenResponse>(this as PostGetAccessTokenResponse, _$identity);
+
+  /// Serializes this PostGetAccessTokenResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostGetAccessTokenResponse&&(identical(other.tokenType, tokenType) || other.tokenType == tokenType)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.accessTokenExpiresAt, accessTokenExpiresAt) || other.accessTokenExpiresAt == accessTokenExpiresAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tokenType,idToken,accessToken,accessTokenExpiresAt);
+
+@override
+String toString() {
+  return 'PostGetAccessTokenResponse(tokenType: $tokenType, idToken: $idToken, accessToken: $accessToken, accessTokenExpiresAt: $accessTokenExpiresAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostGetAccessTokenResponseCopyWith<$Res>  {
+  factory $PostGetAccessTokenResponseCopyWith(PostGetAccessTokenResponse value, $Res Function(PostGetAccessTokenResponse) _then) = _$PostGetAccessTokenResponseCopyWithImpl;
+@useResult
+$Res call({
+ String tokenType, String idToken, String accessToken, DateTime accessTokenExpiresAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostGetAccessTokenResponseCopyWithImpl<$Res>
+    implements $PostGetAccessTokenResponseCopyWith<$Res> {
+  _$PostGetAccessTokenResponseCopyWithImpl(this._self, this._then);
+
+  final PostGetAccessTokenResponse _self;
+  final $Res Function(PostGetAccessTokenResponse) _then;
+
+/// Create a copy of PostGetAccessTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? tokenType = null,Object? idToken = null,Object? accessToken = null,Object? accessTokenExpiresAt = null,}) {
+  return _then(_self.copyWith(
+tokenType: null == tokenType ? _self.tokenType : tokenType // ignore: cast_nullable_to_non_nullable
+as String,idToken: null == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as String,accessToken: null == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String,accessTokenExpiresAt: null == accessTokenExpiresAt ? _self.accessTokenExpiresAt : accessTokenExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostGetAccessTokenResponse].
+extension PostGetAccessTokenResponsePatterns on PostGetAccessTokenResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostGetAccessTokenResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostGetAccessTokenResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostGetAccessTokenResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostGetAccessTokenResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostGetAccessTokenResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostGetAccessTokenResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String tokenType,  String idToken,  String accessToken,  DateTime accessTokenExpiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostGetAccessTokenResponse() when $default != null:
+return $default(_that.tokenType,_that.idToken,_that.accessToken,_that.accessTokenExpiresAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String tokenType,  String idToken,  String accessToken,  DateTime accessTokenExpiresAt)  $default,) {final _that = this;
+switch (_that) {
+case _PostGetAccessTokenResponse():
+return $default(_that.tokenType,_that.idToken,_that.accessToken,_that.accessTokenExpiresAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String tokenType,  String idToken,  String accessToken,  DateTime accessTokenExpiresAt)?  $default,) {final _that = this;
+switch (_that) {
+case _PostGetAccessTokenResponse() when $default != null:
+return $default(_that.tokenType,_that.idToken,_that.accessToken,_that.accessTokenExpiresAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostGetAccessTokenResponse implements PostGetAccessTokenResponse {
+  const _PostGetAccessTokenResponse({required this.tokenType, required this.idToken, required this.accessToken, required this.accessTokenExpiresAt});
+  factory _PostGetAccessTokenResponse.fromJson(Map<String, dynamic> json) => _$PostGetAccessTokenResponseFromJson(json);
+
+@override final  String tokenType;
+@override final  String idToken;
+@override final  String accessToken;
+@override final  DateTime accessTokenExpiresAt;
+
+/// Create a copy of PostGetAccessTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostGetAccessTokenResponseCopyWith<_PostGetAccessTokenResponse> get copyWith => __$PostGetAccessTokenResponseCopyWithImpl<_PostGetAccessTokenResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostGetAccessTokenResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostGetAccessTokenResponse&&(identical(other.tokenType, tokenType) || other.tokenType == tokenType)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.accessTokenExpiresAt, accessTokenExpiresAt) || other.accessTokenExpiresAt == accessTokenExpiresAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tokenType,idToken,accessToken,accessTokenExpiresAt);
+
+@override
+String toString() {
+  return 'PostGetAccessTokenResponse(tokenType: $tokenType, idToken: $idToken, accessToken: $accessToken, accessTokenExpiresAt: $accessTokenExpiresAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostGetAccessTokenResponseCopyWith<$Res> implements $PostGetAccessTokenResponseCopyWith<$Res> {
+  factory _$PostGetAccessTokenResponseCopyWith(_PostGetAccessTokenResponse value, $Res Function(_PostGetAccessTokenResponse) _then) = __$PostGetAccessTokenResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String tokenType, String idToken, String accessToken, DateTime accessTokenExpiresAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostGetAccessTokenResponseCopyWithImpl<$Res>
+    implements _$PostGetAccessTokenResponseCopyWith<$Res> {
+  __$PostGetAccessTokenResponseCopyWithImpl(this._self, this._then);
+
+  final _PostGetAccessTokenResponse _self;
+  final $Res Function(_PostGetAccessTokenResponse) _then;
+
+/// Create a copy of PostGetAccessTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? tokenType = null,Object? idToken = null,Object? accessToken = null,Object? accessTokenExpiresAt = null,}) {
+  return _then(_PostGetAccessTokenResponse(
+tokenType: null == tokenType ? _self.tokenType : tokenType // ignore: cast_nullable_to_non_nullable
+as String,idToken: null == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as String,accessToken: null == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String,accessTokenExpiresAt: null == accessTokenExpiresAt ? _self.accessTokenExpiresAt : accessTokenExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_get_access_token_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_get_access_token_response.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_get_access_token_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostGetAccessTokenResponse _$PostGetAccessTokenResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_PostGetAccessTokenResponse',
+  json,
+  ($checkedConvert) {
+    final val = _PostGetAccessTokenResponse(
+      tokenType: $checkedConvert('token_type', (v) => v as String),
+      idToken: $checkedConvert('id_token', (v) => v as String),
+      accessToken: $checkedConvert('access_token', (v) => v as String),
+      accessTokenExpiresAt: $checkedConvert(
+        'access_token_expires_at',
+        (v) => DateTime.parse(v as String),
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'tokenType': 'token_type',
+    'idToken': 'id_token',
+    'accessToken': 'access_token',
+    'accessTokenExpiresAt': 'access_token_expires_at',
+  },
+);
+
+Map<String, dynamic> _$PostGetAccessTokenResponseToJson(
+  _PostGetAccessTokenResponse instance,
+) => <String, dynamic>{
+  'token_type': instance.tokenType,
+  'id_token': instance.idToken,
+  'access_token': instance.accessToken,
+  'access_token_expires_at': instance.accessTokenExpiresAt.toIso8601String(),
+};

--- a/packages/better_auth_api_client/lib/models/post_get_session_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_get_session_response.dart
@@ -1,0 +1,21 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'session.dart';
+import 'user.dart';
+
+part 'post_get_session_response.freezed.dart';
+part 'post_get_session_response.g.dart';
+
+@Freezed()
+abstract class PostGetSessionResponse with _$PostGetSessionResponse {
+  const factory PostGetSessionResponse({
+    required Session session,
+    required User user,
+  }) = _PostGetSessionResponse;
+  
+  factory PostGetSessionResponse.fromJson(Map<String, Object?> json) => _$PostGetSessionResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_get_session_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_get_session_response.freezed.dart
@@ -1,0 +1,316 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_get_session_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostGetSessionResponse {
+
+ Session get session; User get user;
+/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostGetSessionResponseCopyWith<PostGetSessionResponse> get copyWith => _$PostGetSessionResponseCopyWithImpl<PostGetSessionResponse>(this as PostGetSessionResponse, _$identity);
+
+  /// Serializes this PostGetSessionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostGetSessionResponse&&(identical(other.session, session) || other.session == session)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,session,user);
+
+@override
+String toString() {
+  return 'PostGetSessionResponse(session: $session, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostGetSessionResponseCopyWith<$Res>  {
+  factory $PostGetSessionResponseCopyWith(PostGetSessionResponse value, $Res Function(PostGetSessionResponse) _then) = _$PostGetSessionResponseCopyWithImpl;
+@useResult
+$Res call({
+ Session session, User user
+});
+
+
+$SessionCopyWith<$Res> get session;$UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$PostGetSessionResponseCopyWithImpl<$Res>
+    implements $PostGetSessionResponseCopyWith<$Res> {
+  _$PostGetSessionResponseCopyWithImpl(this._self, this._then);
+
+  final PostGetSessionResponse _self;
+  final $Res Function(PostGetSessionResponse) _then;
+
+/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? session = null,Object? user = null,}) {
+  return _then(_self.copyWith(
+session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostGetSessionResponse].
+extension PostGetSessionResponsePatterns on PostGetSessionResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostGetSessionResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostGetSessionResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostGetSessionResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostGetSessionResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostGetSessionResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostGetSessionResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Session session,  User user)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostGetSessionResponse() when $default != null:
+return $default(_that.session,_that.user);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Session session,  User user)  $default,) {final _that = this;
+switch (_that) {
+case _PostGetSessionResponse():
+return $default(_that.session,_that.user);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Session session,  User user)?  $default,) {final _that = this;
+switch (_that) {
+case _PostGetSessionResponse() when $default != null:
+return $default(_that.session,_that.user);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostGetSessionResponse implements PostGetSessionResponse {
+  const _PostGetSessionResponse({required this.session, required this.user});
+  factory _PostGetSessionResponse.fromJson(Map<String, dynamic> json) => _$PostGetSessionResponseFromJson(json);
+
+@override final  Session session;
+@override final  User user;
+
+/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostGetSessionResponseCopyWith<_PostGetSessionResponse> get copyWith => __$PostGetSessionResponseCopyWithImpl<_PostGetSessionResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostGetSessionResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostGetSessionResponse&&(identical(other.session, session) || other.session == session)&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,session,user);
+
+@override
+String toString() {
+  return 'PostGetSessionResponse(session: $session, user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostGetSessionResponseCopyWith<$Res> implements $PostGetSessionResponseCopyWith<$Res> {
+  factory _$PostGetSessionResponseCopyWith(_PostGetSessionResponse value, $Res Function(_PostGetSessionResponse) _then) = __$PostGetSessionResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ Session session, User user
+});
+
+
+@override $SessionCopyWith<$Res> get session;@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$PostGetSessionResponseCopyWithImpl<$Res>
+    implements _$PostGetSessionResponseCopyWith<$Res> {
+  __$PostGetSessionResponseCopyWithImpl(this._self, this._then);
+
+  final _PostGetSessionResponse _self;
+  final $Res Function(_PostGetSessionResponse) _then;
+
+/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? session = null,Object? user = null,}) {
+  return _then(_PostGetSessionResponse(
+session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+
+/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}/// Create a copy of PostGetSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_get_session_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_get_session_response.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_get_session_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostGetSessionResponse _$PostGetSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostGetSessionResponse', json, ($checkedConvert) {
+  final val = _PostGetSessionResponse(
+    session: $checkedConvert(
+      'session',
+      (v) => Session.fromJson(v as Map<String, dynamic>),
+    ),
+    user: $checkedConvert(
+      'user',
+      (v) => User.fromJson(v as Map<String, dynamic>),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostGetSessionResponseToJson(
+  _PostGetSessionResponse instance,
+) => <String, dynamic>{'session': instance.session, 'user': instance.user};

--- a/packages/better_auth_api_client/lib/models/post_link_social_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_link_social_response.dart
@@ -1,0 +1,24 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_link_social_response.freezed.dart';
+part 'post_link_social_response.g.dart';
+
+@Freezed()
+abstract class PostLinkSocialResponse with _$PostLinkSocialResponse {
+  const factory PostLinkSocialResponse({
+    /// Indicates if the user should be redirected to the authorization URL
+    required bool redirect,
+
+    /// The authorization URL to redirect the user to
+    @JsonKey(includeIfNull: false)
+    String? url,
+    @JsonKey(includeIfNull: false)
+    bool? status,
+  }) = _PostLinkSocialResponse;
+  
+  factory PostLinkSocialResponse.fromJson(Map<String, Object?> json) => _$PostLinkSocialResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_link_social_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_link_social_response.freezed.dart
@@ -1,0 +1,287 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_link_social_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostLinkSocialResponse {
+
+/// Indicates if the user should be redirected to the authorization URL
+ bool get redirect;/// The authorization URL to redirect the user to
+@JsonKey(includeIfNull: false) String? get url;@JsonKey(includeIfNull: false) bool? get status;
+/// Create a copy of PostLinkSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostLinkSocialResponseCopyWith<PostLinkSocialResponse> get copyWith => _$PostLinkSocialResponseCopyWithImpl<PostLinkSocialResponse>(this as PostLinkSocialResponse, _$identity);
+
+  /// Serializes this PostLinkSocialResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostLinkSocialResponse&&(identical(other.redirect, redirect) || other.redirect == redirect)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,redirect,url,status);
+
+@override
+String toString() {
+  return 'PostLinkSocialResponse(redirect: $redirect, url: $url, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostLinkSocialResponseCopyWith<$Res>  {
+  factory $PostLinkSocialResponseCopyWith(PostLinkSocialResponse value, $Res Function(PostLinkSocialResponse) _then) = _$PostLinkSocialResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool redirect,@JsonKey(includeIfNull: false) String? url,@JsonKey(includeIfNull: false) bool? status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostLinkSocialResponseCopyWithImpl<$Res>
+    implements $PostLinkSocialResponseCopyWith<$Res> {
+  _$PostLinkSocialResponseCopyWithImpl(this._self, this._then);
+
+  final PostLinkSocialResponse _self;
+  final $Res Function(PostLinkSocialResponse) _then;
+
+/// Create a copy of PostLinkSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? redirect = null,Object? url = freezed,Object? status = freezed,}) {
+  return _then(_self.copyWith(
+redirect: null == redirect ? _self.redirect : redirect // ignore: cast_nullable_to_non_nullable
+as bool,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostLinkSocialResponse].
+extension PostLinkSocialResponsePatterns on PostLinkSocialResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostLinkSocialResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostLinkSocialResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostLinkSocialResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostLinkSocialResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostLinkSocialResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostLinkSocialResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool redirect, @JsonKey(includeIfNull: false)  String? url, @JsonKey(includeIfNull: false)  bool? status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostLinkSocialResponse() when $default != null:
+return $default(_that.redirect,_that.url,_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool redirect, @JsonKey(includeIfNull: false)  String? url, @JsonKey(includeIfNull: false)  bool? status)  $default,) {final _that = this;
+switch (_that) {
+case _PostLinkSocialResponse():
+return $default(_that.redirect,_that.url,_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool redirect, @JsonKey(includeIfNull: false)  String? url, @JsonKey(includeIfNull: false)  bool? status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostLinkSocialResponse() when $default != null:
+return $default(_that.redirect,_that.url,_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostLinkSocialResponse implements PostLinkSocialResponse {
+  const _PostLinkSocialResponse({required this.redirect, @JsonKey(includeIfNull: false) this.url, @JsonKey(includeIfNull: false) this.status});
+  factory _PostLinkSocialResponse.fromJson(Map<String, dynamic> json) => _$PostLinkSocialResponseFromJson(json);
+
+/// Indicates if the user should be redirected to the authorization URL
+@override final  bool redirect;
+/// The authorization URL to redirect the user to
+@override@JsonKey(includeIfNull: false) final  String? url;
+@override@JsonKey(includeIfNull: false) final  bool? status;
+
+/// Create a copy of PostLinkSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostLinkSocialResponseCopyWith<_PostLinkSocialResponse> get copyWith => __$PostLinkSocialResponseCopyWithImpl<_PostLinkSocialResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostLinkSocialResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostLinkSocialResponse&&(identical(other.redirect, redirect) || other.redirect == redirect)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,redirect,url,status);
+
+@override
+String toString() {
+  return 'PostLinkSocialResponse(redirect: $redirect, url: $url, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostLinkSocialResponseCopyWith<$Res> implements $PostLinkSocialResponseCopyWith<$Res> {
+  factory _$PostLinkSocialResponseCopyWith(_PostLinkSocialResponse value, $Res Function(_PostLinkSocialResponse) _then) = __$PostLinkSocialResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool redirect,@JsonKey(includeIfNull: false) String? url,@JsonKey(includeIfNull: false) bool? status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostLinkSocialResponseCopyWithImpl<$Res>
+    implements _$PostLinkSocialResponseCopyWith<$Res> {
+  __$PostLinkSocialResponseCopyWithImpl(this._self, this._then);
+
+  final _PostLinkSocialResponse _self;
+  final $Res Function(_PostLinkSocialResponse) _then;
+
+/// Create a copy of PostLinkSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? redirect = null,Object? url = freezed,Object? status = freezed,}) {
+  return _then(_PostLinkSocialResponse(
+redirect: null == redirect ? _self.redirect : redirect // ignore: cast_nullable_to_non_nullable
+as bool,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_link_social_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_link_social_response.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_link_social_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostLinkSocialResponse _$PostLinkSocialResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostLinkSocialResponse', json, ($checkedConvert) {
+  final val = _PostLinkSocialResponse(
+    redirect: $checkedConvert('redirect', (v) => v as bool),
+    url: $checkedConvert('url', (v) => v as String?),
+    status: $checkedConvert('status', (v) => v as bool?),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostLinkSocialResponseToJson(
+  _PostLinkSocialResponse instance,
+) => <String, dynamic>{
+  'redirect': instance.redirect,
+  'url': ?instance.url,
+  'status': ?instance.status,
+};

--- a/packages/better_auth_api_client/lib/models/post_refresh_token_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_refresh_token_response.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_refresh_token_response.freezed.dart';
+part 'post_refresh_token_response.g.dart';
+
+@Freezed()
+abstract class PostRefreshTokenResponse with _$PostRefreshTokenResponse {
+  const factory PostRefreshTokenResponse({
+    required String tokenType,
+    required String idToken,
+    required String accessToken,
+    required String refreshToken,
+    required DateTime accessTokenExpiresAt,
+    required DateTime refreshTokenExpiresAt,
+  }) = _PostRefreshTokenResponse;
+  
+  factory PostRefreshTokenResponse.fromJson(Map<String, Object?> json) => _$PostRefreshTokenResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_refresh_token_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_refresh_token_response.freezed.dart
@@ -1,0 +1,292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_refresh_token_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostRefreshTokenResponse {
+
+ String get tokenType; String get idToken; String get accessToken; String get refreshToken; DateTime get accessTokenExpiresAt; DateTime get refreshTokenExpiresAt;
+/// Create a copy of PostRefreshTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostRefreshTokenResponseCopyWith<PostRefreshTokenResponse> get copyWith => _$PostRefreshTokenResponseCopyWithImpl<PostRefreshTokenResponse>(this as PostRefreshTokenResponse, _$identity);
+
+  /// Serializes this PostRefreshTokenResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostRefreshTokenResponse&&(identical(other.tokenType, tokenType) || other.tokenType == tokenType)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&(identical(other.accessTokenExpiresAt, accessTokenExpiresAt) || other.accessTokenExpiresAt == accessTokenExpiresAt)&&(identical(other.refreshTokenExpiresAt, refreshTokenExpiresAt) || other.refreshTokenExpiresAt == refreshTokenExpiresAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tokenType,idToken,accessToken,refreshToken,accessTokenExpiresAt,refreshTokenExpiresAt);
+
+@override
+String toString() {
+  return 'PostRefreshTokenResponse(tokenType: $tokenType, idToken: $idToken, accessToken: $accessToken, refreshToken: $refreshToken, accessTokenExpiresAt: $accessTokenExpiresAt, refreshTokenExpiresAt: $refreshTokenExpiresAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostRefreshTokenResponseCopyWith<$Res>  {
+  factory $PostRefreshTokenResponseCopyWith(PostRefreshTokenResponse value, $Res Function(PostRefreshTokenResponse) _then) = _$PostRefreshTokenResponseCopyWithImpl;
+@useResult
+$Res call({
+ String tokenType, String idToken, String accessToken, String refreshToken, DateTime accessTokenExpiresAt, DateTime refreshTokenExpiresAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostRefreshTokenResponseCopyWithImpl<$Res>
+    implements $PostRefreshTokenResponseCopyWith<$Res> {
+  _$PostRefreshTokenResponseCopyWithImpl(this._self, this._then);
+
+  final PostRefreshTokenResponse _self;
+  final $Res Function(PostRefreshTokenResponse) _then;
+
+/// Create a copy of PostRefreshTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? tokenType = null,Object? idToken = null,Object? accessToken = null,Object? refreshToken = null,Object? accessTokenExpiresAt = null,Object? refreshTokenExpiresAt = null,}) {
+  return _then(_self.copyWith(
+tokenType: null == tokenType ? _self.tokenType : tokenType // ignore: cast_nullable_to_non_nullable
+as String,idToken: null == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as String,accessToken: null == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String,refreshToken: null == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String,accessTokenExpiresAt: null == accessTokenExpiresAt ? _self.accessTokenExpiresAt : accessTokenExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,refreshTokenExpiresAt: null == refreshTokenExpiresAt ? _self.refreshTokenExpiresAt : refreshTokenExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostRefreshTokenResponse].
+extension PostRefreshTokenResponsePatterns on PostRefreshTokenResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostRefreshTokenResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostRefreshTokenResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostRefreshTokenResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostRefreshTokenResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostRefreshTokenResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostRefreshTokenResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String tokenType,  String idToken,  String accessToken,  String refreshToken,  DateTime accessTokenExpiresAt,  DateTime refreshTokenExpiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostRefreshTokenResponse() when $default != null:
+return $default(_that.tokenType,_that.idToken,_that.accessToken,_that.refreshToken,_that.accessTokenExpiresAt,_that.refreshTokenExpiresAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String tokenType,  String idToken,  String accessToken,  String refreshToken,  DateTime accessTokenExpiresAt,  DateTime refreshTokenExpiresAt)  $default,) {final _that = this;
+switch (_that) {
+case _PostRefreshTokenResponse():
+return $default(_that.tokenType,_that.idToken,_that.accessToken,_that.refreshToken,_that.accessTokenExpiresAt,_that.refreshTokenExpiresAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String tokenType,  String idToken,  String accessToken,  String refreshToken,  DateTime accessTokenExpiresAt,  DateTime refreshTokenExpiresAt)?  $default,) {final _that = this;
+switch (_that) {
+case _PostRefreshTokenResponse() when $default != null:
+return $default(_that.tokenType,_that.idToken,_that.accessToken,_that.refreshToken,_that.accessTokenExpiresAt,_that.refreshTokenExpiresAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostRefreshTokenResponse implements PostRefreshTokenResponse {
+  const _PostRefreshTokenResponse({required this.tokenType, required this.idToken, required this.accessToken, required this.refreshToken, required this.accessTokenExpiresAt, required this.refreshTokenExpiresAt});
+  factory _PostRefreshTokenResponse.fromJson(Map<String, dynamic> json) => _$PostRefreshTokenResponseFromJson(json);
+
+@override final  String tokenType;
+@override final  String idToken;
+@override final  String accessToken;
+@override final  String refreshToken;
+@override final  DateTime accessTokenExpiresAt;
+@override final  DateTime refreshTokenExpiresAt;
+
+/// Create a copy of PostRefreshTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostRefreshTokenResponseCopyWith<_PostRefreshTokenResponse> get copyWith => __$PostRefreshTokenResponseCopyWithImpl<_PostRefreshTokenResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostRefreshTokenResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostRefreshTokenResponse&&(identical(other.tokenType, tokenType) || other.tokenType == tokenType)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken)&&(identical(other.refreshToken, refreshToken) || other.refreshToken == refreshToken)&&(identical(other.accessTokenExpiresAt, accessTokenExpiresAt) || other.accessTokenExpiresAt == accessTokenExpiresAt)&&(identical(other.refreshTokenExpiresAt, refreshTokenExpiresAt) || other.refreshTokenExpiresAt == refreshTokenExpiresAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,tokenType,idToken,accessToken,refreshToken,accessTokenExpiresAt,refreshTokenExpiresAt);
+
+@override
+String toString() {
+  return 'PostRefreshTokenResponse(tokenType: $tokenType, idToken: $idToken, accessToken: $accessToken, refreshToken: $refreshToken, accessTokenExpiresAt: $accessTokenExpiresAt, refreshTokenExpiresAt: $refreshTokenExpiresAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostRefreshTokenResponseCopyWith<$Res> implements $PostRefreshTokenResponseCopyWith<$Res> {
+  factory _$PostRefreshTokenResponseCopyWith(_PostRefreshTokenResponse value, $Res Function(_PostRefreshTokenResponse) _then) = __$PostRefreshTokenResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String tokenType, String idToken, String accessToken, String refreshToken, DateTime accessTokenExpiresAt, DateTime refreshTokenExpiresAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostRefreshTokenResponseCopyWithImpl<$Res>
+    implements _$PostRefreshTokenResponseCopyWith<$Res> {
+  __$PostRefreshTokenResponseCopyWithImpl(this._self, this._then);
+
+  final _PostRefreshTokenResponse _self;
+  final $Res Function(_PostRefreshTokenResponse) _then;
+
+/// Create a copy of PostRefreshTokenResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? tokenType = null,Object? idToken = null,Object? accessToken = null,Object? refreshToken = null,Object? accessTokenExpiresAt = null,Object? refreshTokenExpiresAt = null,}) {
+  return _then(_PostRefreshTokenResponse(
+tokenType: null == tokenType ? _self.tokenType : tokenType // ignore: cast_nullable_to_non_nullable
+as String,idToken: null == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as String,accessToken: null == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String,refreshToken: null == refreshToken ? _self.refreshToken : refreshToken // ignore: cast_nullable_to_non_nullable
+as String,accessTokenExpiresAt: null == accessTokenExpiresAt ? _self.accessTokenExpiresAt : accessTokenExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,refreshTokenExpiresAt: null == refreshTokenExpiresAt ? _self.refreshTokenExpiresAt : refreshTokenExpiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_refresh_token_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_refresh_token_response.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_refresh_token_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostRefreshTokenResponse _$PostRefreshTokenResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_PostRefreshTokenResponse',
+  json,
+  ($checkedConvert) {
+    final val = _PostRefreshTokenResponse(
+      tokenType: $checkedConvert('token_type', (v) => v as String),
+      idToken: $checkedConvert('id_token', (v) => v as String),
+      accessToken: $checkedConvert('access_token', (v) => v as String),
+      refreshToken: $checkedConvert('refresh_token', (v) => v as String),
+      accessTokenExpiresAt: $checkedConvert(
+        'access_token_expires_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      refreshTokenExpiresAt: $checkedConvert(
+        'refresh_token_expires_at',
+        (v) => DateTime.parse(v as String),
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'tokenType': 'token_type',
+    'idToken': 'id_token',
+    'accessToken': 'access_token',
+    'refreshToken': 'refresh_token',
+    'accessTokenExpiresAt': 'access_token_expires_at',
+    'refreshTokenExpiresAt': 'refresh_token_expires_at',
+  },
+);
+
+Map<String, dynamic> _$PostRefreshTokenResponseToJson(
+  _PostRefreshTokenResponse instance,
+) => <String, dynamic>{
+  'token_type': instance.tokenType,
+  'id_token': instance.idToken,
+  'access_token': instance.accessToken,
+  'refresh_token': instance.refreshToken,
+  'access_token_expires_at': instance.accessTokenExpiresAt.toIso8601String(),
+  'refresh_token_expires_at': instance.refreshTokenExpiresAt.toIso8601String(),
+};

--- a/packages/better_auth_api_client/lib/models/post_request_password_reset_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_request_password_reset_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_request_password_reset_response.freezed.dart';
+part 'post_request_password_reset_response.g.dart';
+
+@Freezed()
+abstract class PostRequestPasswordResetResponse with _$PostRequestPasswordResetResponse {
+  const factory PostRequestPasswordResetResponse({
+    required bool status,
+    required String message,
+  }) = _PostRequestPasswordResetResponse;
+  
+  factory PostRequestPasswordResetResponse.fromJson(Map<String, Object?> json) => _$PostRequestPasswordResetResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_request_password_reset_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_request_password_reset_response.freezed.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_request_password_reset_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostRequestPasswordResetResponse {
+
+ bool get status; String get message;
+/// Create a copy of PostRequestPasswordResetResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostRequestPasswordResetResponseCopyWith<PostRequestPasswordResetResponse> get copyWith => _$PostRequestPasswordResetResponseCopyWithImpl<PostRequestPasswordResetResponse>(this as PostRequestPasswordResetResponse, _$identity);
+
+  /// Serializes this PostRequestPasswordResetResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostRequestPasswordResetResponse&&(identical(other.status, status) || other.status == status)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,message);
+
+@override
+String toString() {
+  return 'PostRequestPasswordResetResponse(status: $status, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostRequestPasswordResetResponseCopyWith<$Res>  {
+  factory $PostRequestPasswordResetResponseCopyWith(PostRequestPasswordResetResponse value, $Res Function(PostRequestPasswordResetResponse) _then) = _$PostRequestPasswordResetResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status, String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostRequestPasswordResetResponseCopyWithImpl<$Res>
+    implements $PostRequestPasswordResetResponseCopyWith<$Res> {
+  _$PostRequestPasswordResetResponseCopyWithImpl(this._self, this._then);
+
+  final PostRequestPasswordResetResponse _self;
+  final $Res Function(PostRequestPasswordResetResponse) _then;
+
+/// Create a copy of PostRequestPasswordResetResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? message = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostRequestPasswordResetResponse].
+extension PostRequestPasswordResetResponsePatterns on PostRequestPasswordResetResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostRequestPasswordResetResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostRequestPasswordResetResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostRequestPasswordResetResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostRequestPasswordResetResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostRequestPasswordResetResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostRequestPasswordResetResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status,  String message)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostRequestPasswordResetResponse() when $default != null:
+return $default(_that.status,_that.message);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status,  String message)  $default,) {final _that = this;
+switch (_that) {
+case _PostRequestPasswordResetResponse():
+return $default(_that.status,_that.message);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status,  String message)?  $default,) {final _that = this;
+switch (_that) {
+case _PostRequestPasswordResetResponse() when $default != null:
+return $default(_that.status,_that.message);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostRequestPasswordResetResponse implements PostRequestPasswordResetResponse {
+  const _PostRequestPasswordResetResponse({required this.status, required this.message});
+  factory _PostRequestPasswordResetResponse.fromJson(Map<String, dynamic> json) => _$PostRequestPasswordResetResponseFromJson(json);
+
+@override final  bool status;
+@override final  String message;
+
+/// Create a copy of PostRequestPasswordResetResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostRequestPasswordResetResponseCopyWith<_PostRequestPasswordResetResponse> get copyWith => __$PostRequestPasswordResetResponseCopyWithImpl<_PostRequestPasswordResetResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostRequestPasswordResetResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostRequestPasswordResetResponse&&(identical(other.status, status) || other.status == status)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,message);
+
+@override
+String toString() {
+  return 'PostRequestPasswordResetResponse(status: $status, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostRequestPasswordResetResponseCopyWith<$Res> implements $PostRequestPasswordResetResponseCopyWith<$Res> {
+  factory _$PostRequestPasswordResetResponseCopyWith(_PostRequestPasswordResetResponse value, $Res Function(_PostRequestPasswordResetResponse) _then) = __$PostRequestPasswordResetResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status, String message
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostRequestPasswordResetResponseCopyWithImpl<$Res>
+    implements _$PostRequestPasswordResetResponseCopyWith<$Res> {
+  __$PostRequestPasswordResetResponseCopyWithImpl(this._self, this._then);
+
+  final _PostRequestPasswordResetResponse _self;
+  final $Res Function(_PostRequestPasswordResetResponse) _then;
+
+/// Create a copy of PostRequestPasswordResetResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? message = null,}) {
+  return _then(_PostRequestPasswordResetResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_request_password_reset_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_request_password_reset_response.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_request_password_reset_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostRequestPasswordResetResponse _$PostRequestPasswordResetResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostRequestPasswordResetResponse', json, (
+  $checkedConvert,
+) {
+  final val = _PostRequestPasswordResetResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+    message: $checkedConvert('message', (v) => v as String),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostRequestPasswordResetResponseToJson(
+  _PostRequestPasswordResetResponse instance,
+) => <String, dynamic>{'status': instance.status, 'message': instance.message};

--- a/packages/better_auth_api_client/lib/models/post_reset_password_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_reset_password_response.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_reset_password_response.freezed.dart';
+part 'post_reset_password_response.g.dart';
+
+@Freezed()
+abstract class PostResetPasswordResponse with _$PostResetPasswordResponse {
+  const factory PostResetPasswordResponse({
+    required bool status,
+  }) = _PostResetPasswordResponse;
+  
+  factory PostResetPasswordResponse.fromJson(Map<String, Object?> json) => _$PostResetPasswordResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_reset_password_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_reset_password_response.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_reset_password_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostResetPasswordResponse {
+
+ bool get status;
+/// Create a copy of PostResetPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostResetPasswordResponseCopyWith<PostResetPasswordResponse> get copyWith => _$PostResetPasswordResponseCopyWithImpl<PostResetPasswordResponse>(this as PostResetPasswordResponse, _$identity);
+
+  /// Serializes this PostResetPasswordResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostResetPasswordResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostResetPasswordResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostResetPasswordResponseCopyWith<$Res>  {
+  factory $PostResetPasswordResponseCopyWith(PostResetPasswordResponse value, $Res Function(PostResetPasswordResponse) _then) = _$PostResetPasswordResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostResetPasswordResponseCopyWithImpl<$Res>
+    implements $PostResetPasswordResponseCopyWith<$Res> {
+  _$PostResetPasswordResponseCopyWithImpl(this._self, this._then);
+
+  final PostResetPasswordResponse _self;
+  final $Res Function(PostResetPasswordResponse) _then;
+
+/// Create a copy of PostResetPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostResetPasswordResponse].
+extension PostResetPasswordResponsePatterns on PostResetPasswordResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostResetPasswordResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostResetPasswordResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostResetPasswordResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostResetPasswordResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostResetPasswordResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostResetPasswordResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostResetPasswordResponse() when $default != null:
+return $default(_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status)  $default,) {final _that = this;
+switch (_that) {
+case _PostResetPasswordResponse():
+return $default(_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostResetPasswordResponse() when $default != null:
+return $default(_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostResetPasswordResponse implements PostResetPasswordResponse {
+  const _PostResetPasswordResponse({required this.status});
+  factory _PostResetPasswordResponse.fromJson(Map<String, dynamic> json) => _$PostResetPasswordResponseFromJson(json);
+
+@override final  bool status;
+
+/// Create a copy of PostResetPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostResetPasswordResponseCopyWith<_PostResetPasswordResponse> get copyWith => __$PostResetPasswordResponseCopyWithImpl<_PostResetPasswordResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostResetPasswordResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostResetPasswordResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostResetPasswordResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostResetPasswordResponseCopyWith<$Res> implements $PostResetPasswordResponseCopyWith<$Res> {
+  factory _$PostResetPasswordResponseCopyWith(_PostResetPasswordResponse value, $Res Function(_PostResetPasswordResponse) _then) = __$PostResetPasswordResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostResetPasswordResponseCopyWithImpl<$Res>
+    implements _$PostResetPasswordResponseCopyWith<$Res> {
+  __$PostResetPasswordResponseCopyWithImpl(this._self, this._then);
+
+  final _PostResetPasswordResponse _self;
+  final $Res Function(_PostResetPasswordResponse) _then;
+
+/// Create a copy of PostResetPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_PostResetPasswordResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_reset_password_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_reset_password_response.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_reset_password_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostResetPasswordResponse _$PostResetPasswordResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostResetPasswordResponse', json, ($checkedConvert) {
+  final val = _PostResetPasswordResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostResetPasswordResponseToJson(
+  _PostResetPasswordResponse instance,
+) => <String, dynamic>{'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/post_revoke_other_sessions_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_other_sessions_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_revoke_other_sessions_response.freezed.dart';
+part 'post_revoke_other_sessions_response.g.dart';
+
+@Freezed()
+abstract class PostRevokeOtherSessionsResponse with _$PostRevokeOtherSessionsResponse {
+  const factory PostRevokeOtherSessionsResponse({
+    /// Indicates if all other sessions were revoked successfully
+    required bool status,
+  }) = _PostRevokeOtherSessionsResponse;
+  
+  factory PostRevokeOtherSessionsResponse.fromJson(Map<String, Object?> json) => _$PostRevokeOtherSessionsResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_revoke_other_sessions_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_other_sessions_response.freezed.dart
@@ -1,0 +1,279 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_revoke_other_sessions_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostRevokeOtherSessionsResponse {
+
+/// Indicates if all other sessions were revoked successfully
+ bool get status;
+/// Create a copy of PostRevokeOtherSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostRevokeOtherSessionsResponseCopyWith<PostRevokeOtherSessionsResponse> get copyWith => _$PostRevokeOtherSessionsResponseCopyWithImpl<PostRevokeOtherSessionsResponse>(this as PostRevokeOtherSessionsResponse, _$identity);
+
+  /// Serializes this PostRevokeOtherSessionsResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostRevokeOtherSessionsResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostRevokeOtherSessionsResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostRevokeOtherSessionsResponseCopyWith<$Res>  {
+  factory $PostRevokeOtherSessionsResponseCopyWith(PostRevokeOtherSessionsResponse value, $Res Function(PostRevokeOtherSessionsResponse) _then) = _$PostRevokeOtherSessionsResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostRevokeOtherSessionsResponseCopyWithImpl<$Res>
+    implements $PostRevokeOtherSessionsResponseCopyWith<$Res> {
+  _$PostRevokeOtherSessionsResponseCopyWithImpl(this._self, this._then);
+
+  final PostRevokeOtherSessionsResponse _self;
+  final $Res Function(PostRevokeOtherSessionsResponse) _then;
+
+/// Create a copy of PostRevokeOtherSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostRevokeOtherSessionsResponse].
+extension PostRevokeOtherSessionsResponsePatterns on PostRevokeOtherSessionsResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostRevokeOtherSessionsResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostRevokeOtherSessionsResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostRevokeOtherSessionsResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostRevokeOtherSessionsResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostRevokeOtherSessionsResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostRevokeOtherSessionsResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostRevokeOtherSessionsResponse() when $default != null:
+return $default(_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status)  $default,) {final _that = this;
+switch (_that) {
+case _PostRevokeOtherSessionsResponse():
+return $default(_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostRevokeOtherSessionsResponse() when $default != null:
+return $default(_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostRevokeOtherSessionsResponse implements PostRevokeOtherSessionsResponse {
+  const _PostRevokeOtherSessionsResponse({required this.status});
+  factory _PostRevokeOtherSessionsResponse.fromJson(Map<String, dynamic> json) => _$PostRevokeOtherSessionsResponseFromJson(json);
+
+/// Indicates if all other sessions were revoked successfully
+@override final  bool status;
+
+/// Create a copy of PostRevokeOtherSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostRevokeOtherSessionsResponseCopyWith<_PostRevokeOtherSessionsResponse> get copyWith => __$PostRevokeOtherSessionsResponseCopyWithImpl<_PostRevokeOtherSessionsResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostRevokeOtherSessionsResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostRevokeOtherSessionsResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostRevokeOtherSessionsResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostRevokeOtherSessionsResponseCopyWith<$Res> implements $PostRevokeOtherSessionsResponseCopyWith<$Res> {
+  factory _$PostRevokeOtherSessionsResponseCopyWith(_PostRevokeOtherSessionsResponse value, $Res Function(_PostRevokeOtherSessionsResponse) _then) = __$PostRevokeOtherSessionsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostRevokeOtherSessionsResponseCopyWithImpl<$Res>
+    implements _$PostRevokeOtherSessionsResponseCopyWith<$Res> {
+  __$PostRevokeOtherSessionsResponseCopyWithImpl(this._self, this._then);
+
+  final _PostRevokeOtherSessionsResponse _self;
+  final $Res Function(_PostRevokeOtherSessionsResponse) _then;
+
+/// Create a copy of PostRevokeOtherSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_PostRevokeOtherSessionsResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_revoke_other_sessions_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_other_sessions_response.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_revoke_other_sessions_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostRevokeOtherSessionsResponse _$PostRevokeOtherSessionsResponseFromJson(
+  Map<String, dynamic> json,
+) =>
+    $checkedCreate('_PostRevokeOtherSessionsResponse', json, ($checkedConvert) {
+      final val = _PostRevokeOtherSessionsResponse(
+        status: $checkedConvert('status', (v) => v as bool),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$PostRevokeOtherSessionsResponseToJson(
+  _PostRevokeOtherSessionsResponse instance,
+) => <String, dynamic>{'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/post_revoke_session_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_session_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_revoke_session_response.freezed.dart';
+part 'post_revoke_session_response.g.dart';
+
+@Freezed()
+abstract class PostRevokeSessionResponse with _$PostRevokeSessionResponse {
+  const factory PostRevokeSessionResponse({
+    /// Indicates if the session was revoked successfully
+    required bool status,
+  }) = _PostRevokeSessionResponse;
+  
+  factory PostRevokeSessionResponse.fromJson(Map<String, Object?> json) => _$PostRevokeSessionResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_revoke_session_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_session_response.freezed.dart
@@ -1,0 +1,279 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_revoke_session_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostRevokeSessionResponse {
+
+/// Indicates if the session was revoked successfully
+ bool get status;
+/// Create a copy of PostRevokeSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostRevokeSessionResponseCopyWith<PostRevokeSessionResponse> get copyWith => _$PostRevokeSessionResponseCopyWithImpl<PostRevokeSessionResponse>(this as PostRevokeSessionResponse, _$identity);
+
+  /// Serializes this PostRevokeSessionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostRevokeSessionResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostRevokeSessionResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostRevokeSessionResponseCopyWith<$Res>  {
+  factory $PostRevokeSessionResponseCopyWith(PostRevokeSessionResponse value, $Res Function(PostRevokeSessionResponse) _then) = _$PostRevokeSessionResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostRevokeSessionResponseCopyWithImpl<$Res>
+    implements $PostRevokeSessionResponseCopyWith<$Res> {
+  _$PostRevokeSessionResponseCopyWithImpl(this._self, this._then);
+
+  final PostRevokeSessionResponse _self;
+  final $Res Function(PostRevokeSessionResponse) _then;
+
+/// Create a copy of PostRevokeSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostRevokeSessionResponse].
+extension PostRevokeSessionResponsePatterns on PostRevokeSessionResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostRevokeSessionResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostRevokeSessionResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostRevokeSessionResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostRevokeSessionResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostRevokeSessionResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostRevokeSessionResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostRevokeSessionResponse() when $default != null:
+return $default(_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status)  $default,) {final _that = this;
+switch (_that) {
+case _PostRevokeSessionResponse():
+return $default(_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostRevokeSessionResponse() when $default != null:
+return $default(_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostRevokeSessionResponse implements PostRevokeSessionResponse {
+  const _PostRevokeSessionResponse({required this.status});
+  factory _PostRevokeSessionResponse.fromJson(Map<String, dynamic> json) => _$PostRevokeSessionResponseFromJson(json);
+
+/// Indicates if the session was revoked successfully
+@override final  bool status;
+
+/// Create a copy of PostRevokeSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostRevokeSessionResponseCopyWith<_PostRevokeSessionResponse> get copyWith => __$PostRevokeSessionResponseCopyWithImpl<_PostRevokeSessionResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostRevokeSessionResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostRevokeSessionResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostRevokeSessionResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostRevokeSessionResponseCopyWith<$Res> implements $PostRevokeSessionResponseCopyWith<$Res> {
+  factory _$PostRevokeSessionResponseCopyWith(_PostRevokeSessionResponse value, $Res Function(_PostRevokeSessionResponse) _then) = __$PostRevokeSessionResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostRevokeSessionResponseCopyWithImpl<$Res>
+    implements _$PostRevokeSessionResponseCopyWith<$Res> {
+  __$PostRevokeSessionResponseCopyWithImpl(this._self, this._then);
+
+  final _PostRevokeSessionResponse _self;
+  final $Res Function(_PostRevokeSessionResponse) _then;
+
+/// Create a copy of PostRevokeSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_PostRevokeSessionResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_revoke_session_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_session_response.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_revoke_session_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostRevokeSessionResponse _$PostRevokeSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostRevokeSessionResponse', json, ($checkedConvert) {
+  final val = _PostRevokeSessionResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostRevokeSessionResponseToJson(
+  _PostRevokeSessionResponse instance,
+) => <String, dynamic>{'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/post_revoke_sessions_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_sessions_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_revoke_sessions_response.freezed.dart';
+part 'post_revoke_sessions_response.g.dart';
+
+@Freezed()
+abstract class PostRevokeSessionsResponse with _$PostRevokeSessionsResponse {
+  const factory PostRevokeSessionsResponse({
+    /// Indicates if all sessions were revoked successfully
+    required bool status,
+  }) = _PostRevokeSessionsResponse;
+  
+  factory PostRevokeSessionsResponse.fromJson(Map<String, Object?> json) => _$PostRevokeSessionsResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_revoke_sessions_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_sessions_response.freezed.dart
@@ -1,0 +1,279 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_revoke_sessions_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostRevokeSessionsResponse {
+
+/// Indicates if all sessions were revoked successfully
+ bool get status;
+/// Create a copy of PostRevokeSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostRevokeSessionsResponseCopyWith<PostRevokeSessionsResponse> get copyWith => _$PostRevokeSessionsResponseCopyWithImpl<PostRevokeSessionsResponse>(this as PostRevokeSessionsResponse, _$identity);
+
+  /// Serializes this PostRevokeSessionsResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostRevokeSessionsResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostRevokeSessionsResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostRevokeSessionsResponseCopyWith<$Res>  {
+  factory $PostRevokeSessionsResponseCopyWith(PostRevokeSessionsResponse value, $Res Function(PostRevokeSessionsResponse) _then) = _$PostRevokeSessionsResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostRevokeSessionsResponseCopyWithImpl<$Res>
+    implements $PostRevokeSessionsResponseCopyWith<$Res> {
+  _$PostRevokeSessionsResponseCopyWithImpl(this._self, this._then);
+
+  final PostRevokeSessionsResponse _self;
+  final $Res Function(PostRevokeSessionsResponse) _then;
+
+/// Create a copy of PostRevokeSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostRevokeSessionsResponse].
+extension PostRevokeSessionsResponsePatterns on PostRevokeSessionsResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostRevokeSessionsResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostRevokeSessionsResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostRevokeSessionsResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostRevokeSessionsResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostRevokeSessionsResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostRevokeSessionsResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostRevokeSessionsResponse() when $default != null:
+return $default(_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status)  $default,) {final _that = this;
+switch (_that) {
+case _PostRevokeSessionsResponse():
+return $default(_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostRevokeSessionsResponse() when $default != null:
+return $default(_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostRevokeSessionsResponse implements PostRevokeSessionsResponse {
+  const _PostRevokeSessionsResponse({required this.status});
+  factory _PostRevokeSessionsResponse.fromJson(Map<String, dynamic> json) => _$PostRevokeSessionsResponseFromJson(json);
+
+/// Indicates if all sessions were revoked successfully
+@override final  bool status;
+
+/// Create a copy of PostRevokeSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostRevokeSessionsResponseCopyWith<_PostRevokeSessionsResponse> get copyWith => __$PostRevokeSessionsResponseCopyWithImpl<_PostRevokeSessionsResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostRevokeSessionsResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostRevokeSessionsResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostRevokeSessionsResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostRevokeSessionsResponseCopyWith<$Res> implements $PostRevokeSessionsResponseCopyWith<$Res> {
+  factory _$PostRevokeSessionsResponseCopyWith(_PostRevokeSessionsResponse value, $Res Function(_PostRevokeSessionsResponse) _then) = __$PostRevokeSessionsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostRevokeSessionsResponseCopyWithImpl<$Res>
+    implements _$PostRevokeSessionsResponseCopyWith<$Res> {
+  __$PostRevokeSessionsResponseCopyWithImpl(this._self, this._then);
+
+  final _PostRevokeSessionsResponse _self;
+  final $Res Function(_PostRevokeSessionsResponse) _then;
+
+/// Create a copy of PostRevokeSessionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_PostRevokeSessionsResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_revoke_sessions_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_revoke_sessions_response.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_revoke_sessions_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostRevokeSessionsResponse _$PostRevokeSessionsResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostRevokeSessionsResponse', json, ($checkedConvert) {
+  final val = _PostRevokeSessionsResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostRevokeSessionsResponseToJson(
+  _PostRevokeSessionsResponse instance,
+) => <String, dynamic>{'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/post_send_verification_email_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_send_verification_email_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_send_verification_email_response.freezed.dart';
+part 'post_send_verification_email_response.g.dart';
+
+@Freezed()
+abstract class PostSendVerificationEmailResponse with _$PostSendVerificationEmailResponse {
+  const factory PostSendVerificationEmailResponse({
+    /// Indicates if the email was sent successfully
+    required bool status,
+  }) = _PostSendVerificationEmailResponse;
+  
+  factory PostSendVerificationEmailResponse.fromJson(Map<String, Object?> json) => _$PostSendVerificationEmailResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_send_verification_email_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_send_verification_email_response.freezed.dart
@@ -1,0 +1,279 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_send_verification_email_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostSendVerificationEmailResponse {
+
+/// Indicates if the email was sent successfully
+ bool get status;
+/// Create a copy of PostSendVerificationEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostSendVerificationEmailResponseCopyWith<PostSendVerificationEmailResponse> get copyWith => _$PostSendVerificationEmailResponseCopyWithImpl<PostSendVerificationEmailResponse>(this as PostSendVerificationEmailResponse, _$identity);
+
+  /// Serializes this PostSendVerificationEmailResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostSendVerificationEmailResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostSendVerificationEmailResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostSendVerificationEmailResponseCopyWith<$Res>  {
+  factory $PostSendVerificationEmailResponseCopyWith(PostSendVerificationEmailResponse value, $Res Function(PostSendVerificationEmailResponse) _then) = _$PostSendVerificationEmailResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostSendVerificationEmailResponseCopyWithImpl<$Res>
+    implements $PostSendVerificationEmailResponseCopyWith<$Res> {
+  _$PostSendVerificationEmailResponseCopyWithImpl(this._self, this._then);
+
+  final PostSendVerificationEmailResponse _self;
+  final $Res Function(PostSendVerificationEmailResponse) _then;
+
+/// Create a copy of PostSendVerificationEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostSendVerificationEmailResponse].
+extension PostSendVerificationEmailResponsePatterns on PostSendVerificationEmailResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostSendVerificationEmailResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostSendVerificationEmailResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostSendVerificationEmailResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostSendVerificationEmailResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostSendVerificationEmailResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostSendVerificationEmailResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostSendVerificationEmailResponse() when $default != null:
+return $default(_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status)  $default,) {final _that = this;
+switch (_that) {
+case _PostSendVerificationEmailResponse():
+return $default(_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostSendVerificationEmailResponse() when $default != null:
+return $default(_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostSendVerificationEmailResponse implements PostSendVerificationEmailResponse {
+  const _PostSendVerificationEmailResponse({required this.status});
+  factory _PostSendVerificationEmailResponse.fromJson(Map<String, dynamic> json) => _$PostSendVerificationEmailResponseFromJson(json);
+
+/// Indicates if the email was sent successfully
+@override final  bool status;
+
+/// Create a copy of PostSendVerificationEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostSendVerificationEmailResponseCopyWith<_PostSendVerificationEmailResponse> get copyWith => __$PostSendVerificationEmailResponseCopyWithImpl<_PostSendVerificationEmailResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostSendVerificationEmailResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostSendVerificationEmailResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostSendVerificationEmailResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostSendVerificationEmailResponseCopyWith<$Res> implements $PostSendVerificationEmailResponseCopyWith<$Res> {
+  factory _$PostSendVerificationEmailResponseCopyWith(_PostSendVerificationEmailResponse value, $Res Function(_PostSendVerificationEmailResponse) _then) = __$PostSendVerificationEmailResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostSendVerificationEmailResponseCopyWithImpl<$Res>
+    implements _$PostSendVerificationEmailResponseCopyWith<$Res> {
+  __$PostSendVerificationEmailResponseCopyWithImpl(this._self, this._then);
+
+  final _PostSendVerificationEmailResponse _self;
+  final $Res Function(_PostSendVerificationEmailResponse) _then;
+
+/// Create a copy of PostSendVerificationEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_PostSendVerificationEmailResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_send_verification_email_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_send_verification_email_response.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_send_verification_email_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostSendVerificationEmailResponse _$PostSendVerificationEmailResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostSendVerificationEmailResponse', json, (
+  $checkedConvert,
+) {
+  final val = _PostSendVerificationEmailResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostSendVerificationEmailResponseToJson(
+  _PostSendVerificationEmailResponse instance,
+) => <String, dynamic>{'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/post_sign_in_anonymous_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_anonymous_response.dart
@@ -1,0 +1,21 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user.dart';
+import 'session.dart';
+
+part 'post_sign_in_anonymous_response.freezed.dart';
+part 'post_sign_in_anonymous_response.g.dart';
+
+@Freezed()
+abstract class PostSignInAnonymousResponse with _$PostSignInAnonymousResponse {
+  const factory PostSignInAnonymousResponse({
+    required User user,
+    required Session session,
+  }) = _PostSignInAnonymousResponse;
+  
+  factory PostSignInAnonymousResponse.fromJson(Map<String, Object?> json) => _$PostSignInAnonymousResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_sign_in_anonymous_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_anonymous_response.freezed.dart
@@ -1,0 +1,316 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_sign_in_anonymous_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostSignInAnonymousResponse {
+
+ User get user; Session get session;
+/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostSignInAnonymousResponseCopyWith<PostSignInAnonymousResponse> get copyWith => _$PostSignInAnonymousResponseCopyWithImpl<PostSignInAnonymousResponse>(this as PostSignInAnonymousResponse, _$identity);
+
+  /// Serializes this PostSignInAnonymousResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostSignInAnonymousResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.session, session) || other.session == session));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,session);
+
+@override
+String toString() {
+  return 'PostSignInAnonymousResponse(user: $user, session: $session)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostSignInAnonymousResponseCopyWith<$Res>  {
+  factory $PostSignInAnonymousResponseCopyWith(PostSignInAnonymousResponse value, $Res Function(PostSignInAnonymousResponse) _then) = _$PostSignInAnonymousResponseCopyWithImpl;
+@useResult
+$Res call({
+ User user, Session session
+});
+
+
+$UserCopyWith<$Res> get user;$SessionCopyWith<$Res> get session;
+
+}
+/// @nodoc
+class _$PostSignInAnonymousResponseCopyWithImpl<$Res>
+    implements $PostSignInAnonymousResponseCopyWith<$Res> {
+  _$PostSignInAnonymousResponseCopyWithImpl(this._self, this._then);
+
+  final PostSignInAnonymousResponse _self;
+  final $Res Function(PostSignInAnonymousResponse) _then;
+
+/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? session = null,}) {
+  return _then(_self.copyWith(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,
+  ));
+}
+/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostSignInAnonymousResponse].
+extension PostSignInAnonymousResponsePatterns on PostSignInAnonymousResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostSignInAnonymousResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostSignInAnonymousResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostSignInAnonymousResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignInAnonymousResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostSignInAnonymousResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignInAnonymousResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( User user,  Session session)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostSignInAnonymousResponse() when $default != null:
+return $default(_that.user,_that.session);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( User user,  Session session)  $default,) {final _that = this;
+switch (_that) {
+case _PostSignInAnonymousResponse():
+return $default(_that.user,_that.session);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( User user,  Session session)?  $default,) {final _that = this;
+switch (_that) {
+case _PostSignInAnonymousResponse() when $default != null:
+return $default(_that.user,_that.session);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostSignInAnonymousResponse implements PostSignInAnonymousResponse {
+  const _PostSignInAnonymousResponse({required this.user, required this.session});
+  factory _PostSignInAnonymousResponse.fromJson(Map<String, dynamic> json) => _$PostSignInAnonymousResponseFromJson(json);
+
+@override final  User user;
+@override final  Session session;
+
+/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostSignInAnonymousResponseCopyWith<_PostSignInAnonymousResponse> get copyWith => __$PostSignInAnonymousResponseCopyWithImpl<_PostSignInAnonymousResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostSignInAnonymousResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostSignInAnonymousResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.session, session) || other.session == session));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,session);
+
+@override
+String toString() {
+  return 'PostSignInAnonymousResponse(user: $user, session: $session)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostSignInAnonymousResponseCopyWith<$Res> implements $PostSignInAnonymousResponseCopyWith<$Res> {
+  factory _$PostSignInAnonymousResponseCopyWith(_PostSignInAnonymousResponse value, $Res Function(_PostSignInAnonymousResponse) _then) = __$PostSignInAnonymousResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ User user, Session session
+});
+
+
+@override $UserCopyWith<$Res> get user;@override $SessionCopyWith<$Res> get session;
+
+}
+/// @nodoc
+class __$PostSignInAnonymousResponseCopyWithImpl<$Res>
+    implements _$PostSignInAnonymousResponseCopyWith<$Res> {
+  __$PostSignInAnonymousResponseCopyWithImpl(this._self, this._then);
+
+  final _PostSignInAnonymousResponse _self;
+  final $Res Function(_PostSignInAnonymousResponse) _then;
+
+/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? session = null,}) {
+  return _then(_PostSignInAnonymousResponse(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,
+  ));
+}
+
+/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}/// Create a copy of PostSignInAnonymousResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_sign_in_anonymous_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_anonymous_response.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_sign_in_anonymous_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostSignInAnonymousResponse _$PostSignInAnonymousResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostSignInAnonymousResponse', json, ($checkedConvert) {
+  final val = _PostSignInAnonymousResponse(
+    user: $checkedConvert(
+      'user',
+      (v) => User.fromJson(v as Map<String, dynamic>),
+    ),
+    session: $checkedConvert(
+      'session',
+      (v) => Session.fromJson(v as Map<String, dynamic>),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostSignInAnonymousResponseToJson(
+  _PostSignInAnonymousResponse instance,
+) => <String, dynamic>{'user': instance.user, 'session': instance.session};

--- a/packages/better_auth_api_client/lib/models/post_sign_in_email_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_email_response.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'redirect.dart';
+import 'user.dart';
+
+part 'post_sign_in_email_response.freezed.dart';
+part 'post_sign_in_email_response.g.dart';
+
+@Freezed()
+abstract class PostSignInEmailResponse with _$PostSignInEmailResponse {
+  const factory PostSignInEmailResponse({
+    required Redirect redirect,
+
+    /// Session token
+    required String token,
+    required User user,
+    @JsonKey(includeIfNull: false)
+    String? url,
+  }) = _PostSignInEmailResponse;
+  
+  factory PostSignInEmailResponse.fromJson(Map<String, Object?> json) => _$PostSignInEmailResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_sign_in_email_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_email_response.freezed.dart
@@ -1,0 +1,306 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_sign_in_email_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostSignInEmailResponse {
+
+ Redirect get redirect;/// Session token
+ String get token; User get user;@JsonKey(includeIfNull: false) String? get url;
+/// Create a copy of PostSignInEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostSignInEmailResponseCopyWith<PostSignInEmailResponse> get copyWith => _$PostSignInEmailResponseCopyWithImpl<PostSignInEmailResponse>(this as PostSignInEmailResponse, _$identity);
+
+  /// Serializes this PostSignInEmailResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostSignInEmailResponse&&(identical(other.redirect, redirect) || other.redirect == redirect)&&(identical(other.token, token) || other.token == token)&&(identical(other.user, user) || other.user == user)&&(identical(other.url, url) || other.url == url));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,redirect,token,user,url);
+
+@override
+String toString() {
+  return 'PostSignInEmailResponse(redirect: $redirect, token: $token, user: $user, url: $url)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostSignInEmailResponseCopyWith<$Res>  {
+  factory $PostSignInEmailResponseCopyWith(PostSignInEmailResponse value, $Res Function(PostSignInEmailResponse) _then) = _$PostSignInEmailResponseCopyWithImpl;
+@useResult
+$Res call({
+ Redirect redirect, String token, User user,@JsonKey(includeIfNull: false) String? url
+});
+
+
+$UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$PostSignInEmailResponseCopyWithImpl<$Res>
+    implements $PostSignInEmailResponseCopyWith<$Res> {
+  _$PostSignInEmailResponseCopyWithImpl(this._self, this._then);
+
+  final PostSignInEmailResponse _self;
+  final $Res Function(PostSignInEmailResponse) _then;
+
+/// Create a copy of PostSignInEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? redirect = null,Object? token = null,Object? user = null,Object? url = freezed,}) {
+  return _then(_self.copyWith(
+redirect: null == redirect ? _self.redirect : redirect // ignore: cast_nullable_to_non_nullable
+as Redirect,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of PostSignInEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostSignInEmailResponse].
+extension PostSignInEmailResponsePatterns on PostSignInEmailResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostSignInEmailResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostSignInEmailResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostSignInEmailResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignInEmailResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostSignInEmailResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignInEmailResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Redirect redirect,  String token,  User user, @JsonKey(includeIfNull: false)  String? url)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostSignInEmailResponse() when $default != null:
+return $default(_that.redirect,_that.token,_that.user,_that.url);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Redirect redirect,  String token,  User user, @JsonKey(includeIfNull: false)  String? url)  $default,) {final _that = this;
+switch (_that) {
+case _PostSignInEmailResponse():
+return $default(_that.redirect,_that.token,_that.user,_that.url);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Redirect redirect,  String token,  User user, @JsonKey(includeIfNull: false)  String? url)?  $default,) {final _that = this;
+switch (_that) {
+case _PostSignInEmailResponse() when $default != null:
+return $default(_that.redirect,_that.token,_that.user,_that.url);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostSignInEmailResponse implements PostSignInEmailResponse {
+  const _PostSignInEmailResponse({required this.redirect, required this.token, required this.user, @JsonKey(includeIfNull: false) this.url});
+  factory _PostSignInEmailResponse.fromJson(Map<String, dynamic> json) => _$PostSignInEmailResponseFromJson(json);
+
+@override final  Redirect redirect;
+/// Session token
+@override final  String token;
+@override final  User user;
+@override@JsonKey(includeIfNull: false) final  String? url;
+
+/// Create a copy of PostSignInEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostSignInEmailResponseCopyWith<_PostSignInEmailResponse> get copyWith => __$PostSignInEmailResponseCopyWithImpl<_PostSignInEmailResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostSignInEmailResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostSignInEmailResponse&&(identical(other.redirect, redirect) || other.redirect == redirect)&&(identical(other.token, token) || other.token == token)&&(identical(other.user, user) || other.user == user)&&(identical(other.url, url) || other.url == url));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,redirect,token,user,url);
+
+@override
+String toString() {
+  return 'PostSignInEmailResponse(redirect: $redirect, token: $token, user: $user, url: $url)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostSignInEmailResponseCopyWith<$Res> implements $PostSignInEmailResponseCopyWith<$Res> {
+  factory _$PostSignInEmailResponseCopyWith(_PostSignInEmailResponse value, $Res Function(_PostSignInEmailResponse) _then) = __$PostSignInEmailResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ Redirect redirect, String token, User user,@JsonKey(includeIfNull: false) String? url
+});
+
+
+@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$PostSignInEmailResponseCopyWithImpl<$Res>
+    implements _$PostSignInEmailResponseCopyWith<$Res> {
+  __$PostSignInEmailResponseCopyWithImpl(this._self, this._then);
+
+  final _PostSignInEmailResponse _self;
+  final $Res Function(_PostSignInEmailResponse) _then;
+
+/// Create a copy of PostSignInEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? redirect = null,Object? token = null,Object? user = null,Object? url = freezed,}) {
+  return _then(_PostSignInEmailResponse(
+redirect: null == redirect ? _self.redirect : redirect // ignore: cast_nullable_to_non_nullable
+as Redirect,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of PostSignInEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_sign_in_email_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_email_response.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_sign_in_email_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostSignInEmailResponse _$PostSignInEmailResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostSignInEmailResponse', json, ($checkedConvert) {
+  final val = _PostSignInEmailResponse(
+    redirect: $checkedConvert(
+      'redirect',
+      (v) => $enumDecode(_$RedirectEnumMap, v),
+    ),
+    token: $checkedConvert('token', (v) => v as String),
+    user: $checkedConvert(
+      'user',
+      (v) => User.fromJson(v as Map<String, dynamic>),
+    ),
+    url: $checkedConvert('url', (v) => v as String?),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostSignInEmailResponseToJson(
+  _PostSignInEmailResponse instance,
+) => <String, dynamic>{
+  'redirect': instance.redirect,
+  'token': instance.token,
+  'user': instance.user,
+  'url': ?instance.url,
+};
+
+const _$RedirectEnumMap = {Redirect.valueFalse: 'false'};

--- a/packages/better_auth_api_client/lib/models/post_sign_in_social_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_social_response.dart
@@ -1,0 +1,24 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user.dart';
+import 'redirect.dart';
+
+part 'post_sign_in_social_response.freezed.dart';
+part 'post_sign_in_social_response.g.dart';
+
+@Freezed()
+abstract class PostSignInSocialResponse with _$PostSignInSocialResponse {
+  const factory PostSignInSocialResponse({
+    required String token,
+    required User user,
+    required Redirect redirect,
+    @JsonKey(includeIfNull: false)
+    String? url,
+  }) = _PostSignInSocialResponse;
+  
+  factory PostSignInSocialResponse.fromJson(Map<String, Object?> json) => _$PostSignInSocialResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_sign_in_social_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_social_response.freezed.dart
@@ -1,0 +1,304 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_sign_in_social_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostSignInSocialResponse {
+
+ String get token; User get user; Redirect get redirect;@JsonKey(includeIfNull: false) String? get url;
+/// Create a copy of PostSignInSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostSignInSocialResponseCopyWith<PostSignInSocialResponse> get copyWith => _$PostSignInSocialResponseCopyWithImpl<PostSignInSocialResponse>(this as PostSignInSocialResponse, _$identity);
+
+  /// Serializes this PostSignInSocialResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostSignInSocialResponse&&(identical(other.token, token) || other.token == token)&&(identical(other.user, user) || other.user == user)&&(identical(other.redirect, redirect) || other.redirect == redirect)&&(identical(other.url, url) || other.url == url));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,user,redirect,url);
+
+@override
+String toString() {
+  return 'PostSignInSocialResponse(token: $token, user: $user, redirect: $redirect, url: $url)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostSignInSocialResponseCopyWith<$Res>  {
+  factory $PostSignInSocialResponseCopyWith(PostSignInSocialResponse value, $Res Function(PostSignInSocialResponse) _then) = _$PostSignInSocialResponseCopyWithImpl;
+@useResult
+$Res call({
+ String token, User user, Redirect redirect,@JsonKey(includeIfNull: false) String? url
+});
+
+
+$UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$PostSignInSocialResponseCopyWithImpl<$Res>
+    implements $PostSignInSocialResponseCopyWith<$Res> {
+  _$PostSignInSocialResponseCopyWithImpl(this._self, this._then);
+
+  final PostSignInSocialResponse _self;
+  final $Res Function(PostSignInSocialResponse) _then;
+
+/// Create a copy of PostSignInSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? token = null,Object? user = null,Object? redirect = null,Object? url = freezed,}) {
+  return _then(_self.copyWith(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,redirect: null == redirect ? _self.redirect : redirect // ignore: cast_nullable_to_non_nullable
+as Redirect,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of PostSignInSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostSignInSocialResponse].
+extension PostSignInSocialResponsePatterns on PostSignInSocialResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostSignInSocialResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostSignInSocialResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostSignInSocialResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignInSocialResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostSignInSocialResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignInSocialResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String token,  User user,  Redirect redirect, @JsonKey(includeIfNull: false)  String? url)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostSignInSocialResponse() when $default != null:
+return $default(_that.token,_that.user,_that.redirect,_that.url);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String token,  User user,  Redirect redirect, @JsonKey(includeIfNull: false)  String? url)  $default,) {final _that = this;
+switch (_that) {
+case _PostSignInSocialResponse():
+return $default(_that.token,_that.user,_that.redirect,_that.url);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String token,  User user,  Redirect redirect, @JsonKey(includeIfNull: false)  String? url)?  $default,) {final _that = this;
+switch (_that) {
+case _PostSignInSocialResponse() when $default != null:
+return $default(_that.token,_that.user,_that.redirect,_that.url);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostSignInSocialResponse implements PostSignInSocialResponse {
+  const _PostSignInSocialResponse({required this.token, required this.user, required this.redirect, @JsonKey(includeIfNull: false) this.url});
+  factory _PostSignInSocialResponse.fromJson(Map<String, dynamic> json) => _$PostSignInSocialResponseFromJson(json);
+
+@override final  String token;
+@override final  User user;
+@override final  Redirect redirect;
+@override@JsonKey(includeIfNull: false) final  String? url;
+
+/// Create a copy of PostSignInSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostSignInSocialResponseCopyWith<_PostSignInSocialResponse> get copyWith => __$PostSignInSocialResponseCopyWithImpl<_PostSignInSocialResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostSignInSocialResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostSignInSocialResponse&&(identical(other.token, token) || other.token == token)&&(identical(other.user, user) || other.user == user)&&(identical(other.redirect, redirect) || other.redirect == redirect)&&(identical(other.url, url) || other.url == url));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,user,redirect,url);
+
+@override
+String toString() {
+  return 'PostSignInSocialResponse(token: $token, user: $user, redirect: $redirect, url: $url)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostSignInSocialResponseCopyWith<$Res> implements $PostSignInSocialResponseCopyWith<$Res> {
+  factory _$PostSignInSocialResponseCopyWith(_PostSignInSocialResponse value, $Res Function(_PostSignInSocialResponse) _then) = __$PostSignInSocialResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String token, User user, Redirect redirect,@JsonKey(includeIfNull: false) String? url
+});
+
+
+@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$PostSignInSocialResponseCopyWithImpl<$Res>
+    implements _$PostSignInSocialResponseCopyWith<$Res> {
+  __$PostSignInSocialResponseCopyWithImpl(this._self, this._then);
+
+  final _PostSignInSocialResponse _self;
+  final $Res Function(_PostSignInSocialResponse) _then;
+
+/// Create a copy of PostSignInSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? token = null,Object? user = null,Object? redirect = null,Object? url = freezed,}) {
+  return _then(_PostSignInSocialResponse(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,redirect: null == redirect ? _self.redirect : redirect // ignore: cast_nullable_to_non_nullable
+as Redirect,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of PostSignInSocialResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_sign_in_social_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_in_social_response.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_sign_in_social_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostSignInSocialResponse _$PostSignInSocialResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostSignInSocialResponse', json, ($checkedConvert) {
+  final val = _PostSignInSocialResponse(
+    token: $checkedConvert('token', (v) => v as String),
+    user: $checkedConvert(
+      'user',
+      (v) => User.fromJson(v as Map<String, dynamic>),
+    ),
+    redirect: $checkedConvert(
+      'redirect',
+      (v) => $enumDecode(_$RedirectEnumMap, v),
+    ),
+    url: $checkedConvert('url', (v) => v as String?),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostSignInSocialResponseToJson(
+  _PostSignInSocialResponse instance,
+) => <String, dynamic>{
+  'token': instance.token,
+  'user': instance.user,
+  'redirect': instance.redirect,
+  'url': ?instance.url,
+};
+
+const _$RedirectEnumMap = {Redirect.valueFalse: 'false'};

--- a/packages/better_auth_api_client/lib/models/post_sign_out_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_out_response.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_sign_out_response.freezed.dart';
+part 'post_sign_out_response.g.dart';
+
+@Freezed()
+abstract class PostSignOutResponse with _$PostSignOutResponse {
+  const factory PostSignOutResponse({
+    required bool success,
+  }) = _PostSignOutResponse;
+  
+  factory PostSignOutResponse.fromJson(Map<String, Object?> json) => _$PostSignOutResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_sign_out_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_out_response.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_sign_out_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostSignOutResponse {
+
+ bool get success;
+/// Create a copy of PostSignOutResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostSignOutResponseCopyWith<PostSignOutResponse> get copyWith => _$PostSignOutResponseCopyWithImpl<PostSignOutResponse>(this as PostSignOutResponse, _$identity);
+
+  /// Serializes this PostSignOutResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostSignOutResponse&&(identical(other.success, success) || other.success == success));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success);
+
+@override
+String toString() {
+  return 'PostSignOutResponse(success: $success)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostSignOutResponseCopyWith<$Res>  {
+  factory $PostSignOutResponseCopyWith(PostSignOutResponse value, $Res Function(PostSignOutResponse) _then) = _$PostSignOutResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool success
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostSignOutResponseCopyWithImpl<$Res>
+    implements $PostSignOutResponseCopyWith<$Res> {
+  _$PostSignOutResponseCopyWithImpl(this._self, this._then);
+
+  final PostSignOutResponse _self;
+  final $Res Function(PostSignOutResponse) _then;
+
+/// Create a copy of PostSignOutResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? success = null,}) {
+  return _then(_self.copyWith(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostSignOutResponse].
+extension PostSignOutResponsePatterns on PostSignOutResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostSignOutResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostSignOutResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostSignOutResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignOutResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostSignOutResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignOutResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool success)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostSignOutResponse() when $default != null:
+return $default(_that.success);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool success)  $default,) {final _that = this;
+switch (_that) {
+case _PostSignOutResponse():
+return $default(_that.success);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool success)?  $default,) {final _that = this;
+switch (_that) {
+case _PostSignOutResponse() when $default != null:
+return $default(_that.success);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostSignOutResponse implements PostSignOutResponse {
+  const _PostSignOutResponse({required this.success});
+  factory _PostSignOutResponse.fromJson(Map<String, dynamic> json) => _$PostSignOutResponseFromJson(json);
+
+@override final  bool success;
+
+/// Create a copy of PostSignOutResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostSignOutResponseCopyWith<_PostSignOutResponse> get copyWith => __$PostSignOutResponseCopyWithImpl<_PostSignOutResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostSignOutResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostSignOutResponse&&(identical(other.success, success) || other.success == success));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,success);
+
+@override
+String toString() {
+  return 'PostSignOutResponse(success: $success)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostSignOutResponseCopyWith<$Res> implements $PostSignOutResponseCopyWith<$Res> {
+  factory _$PostSignOutResponseCopyWith(_PostSignOutResponse value, $Res Function(_PostSignOutResponse) _then) = __$PostSignOutResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool success
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostSignOutResponseCopyWithImpl<$Res>
+    implements _$PostSignOutResponseCopyWith<$Res> {
+  __$PostSignOutResponseCopyWithImpl(this._self, this._then);
+
+  final _PostSignOutResponse _self;
+  final $Res Function(_PostSignOutResponse) _then;
+
+/// Create a copy of PostSignOutResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? success = null,}) {
+  return _then(_PostSignOutResponse(
+success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_sign_out_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_out_response.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_sign_out_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostSignOutResponse _$PostSignOutResponseFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('_PostSignOutResponse', json, ($checkedConvert) {
+      final val = _PostSignOutResponse(
+        success: $checkedConvert('success', (v) => v as bool),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$PostSignOutResponseToJson(
+  _PostSignOutResponse instance,
+) => <String, dynamic>{'success': instance.success};

--- a/packages/better_auth_api_client/lib/models/post_sign_up_email_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_up_email_response.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user2.dart';
+
+part 'post_sign_up_email_response.freezed.dart';
+part 'post_sign_up_email_response.g.dart';
+
+@Freezed()
+abstract class PostSignUpEmailResponse with _$PostSignUpEmailResponse {
+  const factory PostSignUpEmailResponse({
+    required User2 user,
+
+    /// Authentication token for the session
+    @JsonKey(includeIfNull: false)
+    String? token,
+  }) = _PostSignUpEmailResponse;
+  
+  factory PostSignUpEmailResponse.fromJson(Map<String, Object?> json) => _$PostSignUpEmailResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_sign_up_email_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_up_email_response.freezed.dart
@@ -1,0 +1,300 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_sign_up_email_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostSignUpEmailResponse {
+
+ User2 get user;/// Authentication token for the session
+@JsonKey(includeIfNull: false) String? get token;
+/// Create a copy of PostSignUpEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostSignUpEmailResponseCopyWith<PostSignUpEmailResponse> get copyWith => _$PostSignUpEmailResponseCopyWithImpl<PostSignUpEmailResponse>(this as PostSignUpEmailResponse, _$identity);
+
+  /// Serializes this PostSignUpEmailResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostSignUpEmailResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,token);
+
+@override
+String toString() {
+  return 'PostSignUpEmailResponse(user: $user, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostSignUpEmailResponseCopyWith<$Res>  {
+  factory $PostSignUpEmailResponseCopyWith(PostSignUpEmailResponse value, $Res Function(PostSignUpEmailResponse) _then) = _$PostSignUpEmailResponseCopyWithImpl;
+@useResult
+$Res call({
+ User2 user,@JsonKey(includeIfNull: false) String? token
+});
+
+
+$User2CopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$PostSignUpEmailResponseCopyWithImpl<$Res>
+    implements $PostSignUpEmailResponseCopyWith<$Res> {
+  _$PostSignUpEmailResponseCopyWithImpl(this._self, this._then);
+
+  final PostSignUpEmailResponse _self;
+  final $Res Function(PostSignUpEmailResponse) _then;
+
+/// Create a copy of PostSignUpEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? token = freezed,}) {
+  return _then(_self.copyWith(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User2,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of PostSignUpEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$User2CopyWith<$Res> get user {
+  
+  return $User2CopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostSignUpEmailResponse].
+extension PostSignUpEmailResponsePatterns on PostSignUpEmailResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostSignUpEmailResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostSignUpEmailResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostSignUpEmailResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignUpEmailResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostSignUpEmailResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostSignUpEmailResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( User2 user, @JsonKey(includeIfNull: false)  String? token)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostSignUpEmailResponse() when $default != null:
+return $default(_that.user,_that.token);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( User2 user, @JsonKey(includeIfNull: false)  String? token)  $default,) {final _that = this;
+switch (_that) {
+case _PostSignUpEmailResponse():
+return $default(_that.user,_that.token);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( User2 user, @JsonKey(includeIfNull: false)  String? token)?  $default,) {final _that = this;
+switch (_that) {
+case _PostSignUpEmailResponse() when $default != null:
+return $default(_that.user,_that.token);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostSignUpEmailResponse implements PostSignUpEmailResponse {
+  const _PostSignUpEmailResponse({required this.user, @JsonKey(includeIfNull: false) this.token});
+  factory _PostSignUpEmailResponse.fromJson(Map<String, dynamic> json) => _$PostSignUpEmailResponseFromJson(json);
+
+@override final  User2 user;
+/// Authentication token for the session
+@override@JsonKey(includeIfNull: false) final  String? token;
+
+/// Create a copy of PostSignUpEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostSignUpEmailResponseCopyWith<_PostSignUpEmailResponse> get copyWith => __$PostSignUpEmailResponseCopyWithImpl<_PostSignUpEmailResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostSignUpEmailResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostSignUpEmailResponse&&(identical(other.user, user) || other.user == user)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user,token);
+
+@override
+String toString() {
+  return 'PostSignUpEmailResponse(user: $user, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostSignUpEmailResponseCopyWith<$Res> implements $PostSignUpEmailResponseCopyWith<$Res> {
+  factory _$PostSignUpEmailResponseCopyWith(_PostSignUpEmailResponse value, $Res Function(_PostSignUpEmailResponse) _then) = __$PostSignUpEmailResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ User2 user,@JsonKey(includeIfNull: false) String? token
+});
+
+
+@override $User2CopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$PostSignUpEmailResponseCopyWithImpl<$Res>
+    implements _$PostSignUpEmailResponseCopyWith<$Res> {
+  __$PostSignUpEmailResponseCopyWithImpl(this._self, this._then);
+
+  final _PostSignUpEmailResponse _self;
+  final $Res Function(_PostSignUpEmailResponse) _then;
+
+/// Create a copy of PostSignUpEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? token = freezed,}) {
+  return _then(_PostSignUpEmailResponse(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User2,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of PostSignUpEmailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$User2CopyWith<$Res> get user {
+  
+  return $User2CopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_sign_up_email_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_sign_up_email_response.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_sign_up_email_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostSignUpEmailResponse _$PostSignUpEmailResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostSignUpEmailResponse', json, ($checkedConvert) {
+  final val = _PostSignUpEmailResponse(
+    user: $checkedConvert(
+      'user',
+      (v) => User2.fromJson(v as Map<String, dynamic>),
+    ),
+    token: $checkedConvert('token', (v) => v as String?),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostSignUpEmailResponseToJson(
+  _PostSignUpEmailResponse instance,
+) => <String, dynamic>{'user': instance.user, 'token': ?instance.token};

--- a/packages/better_auth_api_client/lib/models/post_unlink_account_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_unlink_account_response.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_unlink_account_response.freezed.dart';
+part 'post_unlink_account_response.g.dart';
+
+@Freezed()
+abstract class PostUnlinkAccountResponse with _$PostUnlinkAccountResponse {
+  const factory PostUnlinkAccountResponse({
+    required bool status,
+  }) = _PostUnlinkAccountResponse;
+  
+  factory PostUnlinkAccountResponse.fromJson(Map<String, Object?> json) => _$PostUnlinkAccountResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_unlink_account_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_unlink_account_response.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_unlink_account_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostUnlinkAccountResponse {
+
+ bool get status;
+/// Create a copy of PostUnlinkAccountResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostUnlinkAccountResponseCopyWith<PostUnlinkAccountResponse> get copyWith => _$PostUnlinkAccountResponseCopyWithImpl<PostUnlinkAccountResponse>(this as PostUnlinkAccountResponse, _$identity);
+
+  /// Serializes this PostUnlinkAccountResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostUnlinkAccountResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostUnlinkAccountResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostUnlinkAccountResponseCopyWith<$Res>  {
+  factory $PostUnlinkAccountResponseCopyWith(PostUnlinkAccountResponse value, $Res Function(PostUnlinkAccountResponse) _then) = _$PostUnlinkAccountResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostUnlinkAccountResponseCopyWithImpl<$Res>
+    implements $PostUnlinkAccountResponseCopyWith<$Res> {
+  _$PostUnlinkAccountResponseCopyWithImpl(this._self, this._then);
+
+  final PostUnlinkAccountResponse _self;
+  final $Res Function(PostUnlinkAccountResponse) _then;
+
+/// Create a copy of PostUnlinkAccountResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostUnlinkAccountResponse].
+extension PostUnlinkAccountResponsePatterns on PostUnlinkAccountResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostUnlinkAccountResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostUnlinkAccountResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostUnlinkAccountResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostUnlinkAccountResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostUnlinkAccountResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostUnlinkAccountResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostUnlinkAccountResponse() when $default != null:
+return $default(_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status)  $default,) {final _that = this;
+switch (_that) {
+case _PostUnlinkAccountResponse():
+return $default(_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostUnlinkAccountResponse() when $default != null:
+return $default(_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostUnlinkAccountResponse implements PostUnlinkAccountResponse {
+  const _PostUnlinkAccountResponse({required this.status});
+  factory _PostUnlinkAccountResponse.fromJson(Map<String, dynamic> json) => _$PostUnlinkAccountResponseFromJson(json);
+
+@override final  bool status;
+
+/// Create a copy of PostUnlinkAccountResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostUnlinkAccountResponseCopyWith<_PostUnlinkAccountResponse> get copyWith => __$PostUnlinkAccountResponseCopyWithImpl<_PostUnlinkAccountResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostUnlinkAccountResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostUnlinkAccountResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostUnlinkAccountResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostUnlinkAccountResponseCopyWith<$Res> implements $PostUnlinkAccountResponseCopyWith<$Res> {
+  factory _$PostUnlinkAccountResponseCopyWith(_PostUnlinkAccountResponse value, $Res Function(_PostUnlinkAccountResponse) _then) = __$PostUnlinkAccountResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostUnlinkAccountResponseCopyWithImpl<$Res>
+    implements _$PostUnlinkAccountResponseCopyWith<$Res> {
+  __$PostUnlinkAccountResponseCopyWithImpl(this._self, this._then);
+
+  final _PostUnlinkAccountResponse _self;
+  final $Res Function(_PostUnlinkAccountResponse) _then;
+
+/// Create a copy of PostUnlinkAccountResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_PostUnlinkAccountResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_unlink_account_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_unlink_account_response.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_unlink_account_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostUnlinkAccountResponse _$PostUnlinkAccountResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostUnlinkAccountResponse', json, ($checkedConvert) {
+  final val = _PostUnlinkAccountResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostUnlinkAccountResponseToJson(
+  _PostUnlinkAccountResponse instance,
+) => <String, dynamic>{'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/post_update_session_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_update_session_response.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'session.dart';
+
+part 'post_update_session_response.freezed.dart';
+part 'post_update_session_response.g.dart';
+
+@Freezed()
+abstract class PostUpdateSessionResponse with _$PostUpdateSessionResponse {
+  const factory PostUpdateSessionResponse({
+    required Session session,
+  }) = _PostUpdateSessionResponse;
+  
+  factory PostUpdateSessionResponse.fromJson(Map<String, Object?> json) => _$PostUpdateSessionResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_update_session_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_update_session_response.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_update_session_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostUpdateSessionResponse {
+
+ Session get session;
+/// Create a copy of PostUpdateSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostUpdateSessionResponseCopyWith<PostUpdateSessionResponse> get copyWith => _$PostUpdateSessionResponseCopyWithImpl<PostUpdateSessionResponse>(this as PostUpdateSessionResponse, _$identity);
+
+  /// Serializes this PostUpdateSessionResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostUpdateSessionResponse&&(identical(other.session, session) || other.session == session));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,session);
+
+@override
+String toString() {
+  return 'PostUpdateSessionResponse(session: $session)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostUpdateSessionResponseCopyWith<$Res>  {
+  factory $PostUpdateSessionResponseCopyWith(PostUpdateSessionResponse value, $Res Function(PostUpdateSessionResponse) _then) = _$PostUpdateSessionResponseCopyWithImpl;
+@useResult
+$Res call({
+ Session session
+});
+
+
+$SessionCopyWith<$Res> get session;
+
+}
+/// @nodoc
+class _$PostUpdateSessionResponseCopyWithImpl<$Res>
+    implements $PostUpdateSessionResponseCopyWith<$Res> {
+  _$PostUpdateSessionResponseCopyWithImpl(this._self, this._then);
+
+  final PostUpdateSessionResponse _self;
+  final $Res Function(PostUpdateSessionResponse) _then;
+
+/// Create a copy of PostUpdateSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? session = null,}) {
+  return _then(_self.copyWith(
+session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,
+  ));
+}
+/// Create a copy of PostUpdateSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostUpdateSessionResponse].
+extension PostUpdateSessionResponsePatterns on PostUpdateSessionResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostUpdateSessionResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostUpdateSessionResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostUpdateSessionResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostUpdateSessionResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostUpdateSessionResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostUpdateSessionResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Session session)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostUpdateSessionResponse() when $default != null:
+return $default(_that.session);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Session session)  $default,) {final _that = this;
+switch (_that) {
+case _PostUpdateSessionResponse():
+return $default(_that.session);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Session session)?  $default,) {final _that = this;
+switch (_that) {
+case _PostUpdateSessionResponse() when $default != null:
+return $default(_that.session);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostUpdateSessionResponse implements PostUpdateSessionResponse {
+  const _PostUpdateSessionResponse({required this.session});
+  factory _PostUpdateSessionResponse.fromJson(Map<String, dynamic> json) => _$PostUpdateSessionResponseFromJson(json);
+
+@override final  Session session;
+
+/// Create a copy of PostUpdateSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostUpdateSessionResponseCopyWith<_PostUpdateSessionResponse> get copyWith => __$PostUpdateSessionResponseCopyWithImpl<_PostUpdateSessionResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostUpdateSessionResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostUpdateSessionResponse&&(identical(other.session, session) || other.session == session));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,session);
+
+@override
+String toString() {
+  return 'PostUpdateSessionResponse(session: $session)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostUpdateSessionResponseCopyWith<$Res> implements $PostUpdateSessionResponseCopyWith<$Res> {
+  factory _$PostUpdateSessionResponseCopyWith(_PostUpdateSessionResponse value, $Res Function(_PostUpdateSessionResponse) _then) = __$PostUpdateSessionResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ Session session
+});
+
+
+@override $SessionCopyWith<$Res> get session;
+
+}
+/// @nodoc
+class __$PostUpdateSessionResponseCopyWithImpl<$Res>
+    implements _$PostUpdateSessionResponseCopyWith<$Res> {
+  __$PostUpdateSessionResponseCopyWithImpl(this._self, this._then);
+
+  final _PostUpdateSessionResponse _self;
+  final $Res Function(_PostUpdateSessionResponse) _then;
+
+/// Create a copy of PostUpdateSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? session = null,}) {
+  return _then(_PostUpdateSessionResponse(
+session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,
+  ));
+}
+
+/// Create a copy of PostUpdateSessionResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_update_session_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_update_session_response.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_update_session_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostUpdateSessionResponse _$PostUpdateSessionResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostUpdateSessionResponse', json, ($checkedConvert) {
+  final val = _PostUpdateSessionResponse(
+    session: $checkedConvert(
+      'session',
+      (v) => Session.fromJson(v as Map<String, dynamic>),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostUpdateSessionResponseToJson(
+  _PostUpdateSessionResponse instance,
+) => <String, dynamic>{'session': instance.session};

--- a/packages/better_auth_api_client/lib/models/post_update_user_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_update_user_response.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'user.dart';
+
+part 'post_update_user_response.freezed.dart';
+part 'post_update_user_response.g.dart';
+
+@Freezed()
+abstract class PostUpdateUserResponse with _$PostUpdateUserResponse {
+  const factory PostUpdateUserResponse({
+    required User user,
+  }) = _PostUpdateUserResponse;
+  
+  factory PostUpdateUserResponse.fromJson(Map<String, Object?> json) => _$PostUpdateUserResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_update_user_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_update_user_response.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_update_user_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostUpdateUserResponse {
+
+ User get user;
+/// Create a copy of PostUpdateUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostUpdateUserResponseCopyWith<PostUpdateUserResponse> get copyWith => _$PostUpdateUserResponseCopyWithImpl<PostUpdateUserResponse>(this as PostUpdateUserResponse, _$identity);
+
+  /// Serializes this PostUpdateUserResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostUpdateUserResponse&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user);
+
+@override
+String toString() {
+  return 'PostUpdateUserResponse(user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostUpdateUserResponseCopyWith<$Res>  {
+  factory $PostUpdateUserResponseCopyWith(PostUpdateUserResponse value, $Res Function(PostUpdateUserResponse) _then) = _$PostUpdateUserResponseCopyWithImpl;
+@useResult
+$Res call({
+ User user
+});
+
+
+$UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class _$PostUpdateUserResponseCopyWithImpl<$Res>
+    implements $PostUpdateUserResponseCopyWith<$Res> {
+  _$PostUpdateUserResponseCopyWithImpl(this._self, this._then);
+
+  final PostUpdateUserResponse _self;
+  final $Res Function(PostUpdateUserResponse) _then;
+
+/// Create a copy of PostUpdateUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,}) {
+  return _then(_self.copyWith(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+/// Create a copy of PostUpdateUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PostUpdateUserResponse].
+extension PostUpdateUserResponsePatterns on PostUpdateUserResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostUpdateUserResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostUpdateUserResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostUpdateUserResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostUpdateUserResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostUpdateUserResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostUpdateUserResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( User user)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostUpdateUserResponse() when $default != null:
+return $default(_that.user);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( User user)  $default,) {final _that = this;
+switch (_that) {
+case _PostUpdateUserResponse():
+return $default(_that.user);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( User user)?  $default,) {final _that = this;
+switch (_that) {
+case _PostUpdateUserResponse() when $default != null:
+return $default(_that.user);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostUpdateUserResponse implements PostUpdateUserResponse {
+  const _PostUpdateUserResponse({required this.user});
+  factory _PostUpdateUserResponse.fromJson(Map<String, dynamic> json) => _$PostUpdateUserResponseFromJson(json);
+
+@override final  User user;
+
+/// Create a copy of PostUpdateUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostUpdateUserResponseCopyWith<_PostUpdateUserResponse> get copyWith => __$PostUpdateUserResponseCopyWithImpl<_PostUpdateUserResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostUpdateUserResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostUpdateUserResponse&&(identical(other.user, user) || other.user == user));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,user);
+
+@override
+String toString() {
+  return 'PostUpdateUserResponse(user: $user)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostUpdateUserResponseCopyWith<$Res> implements $PostUpdateUserResponseCopyWith<$Res> {
+  factory _$PostUpdateUserResponseCopyWith(_PostUpdateUserResponse value, $Res Function(_PostUpdateUserResponse) _then) = __$PostUpdateUserResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ User user
+});
+
+
+@override $UserCopyWith<$Res> get user;
+
+}
+/// @nodoc
+class __$PostUpdateUserResponseCopyWithImpl<$Res>
+    implements _$PostUpdateUserResponseCopyWith<$Res> {
+  __$PostUpdateUserResponseCopyWithImpl(this._self, this._then);
+
+  final _PostUpdateUserResponse _self;
+  final $Res Function(_PostUpdateUserResponse) _then;
+
+/// Create a copy of PostUpdateUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,}) {
+  return _then(_PostUpdateUserResponse(
+user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as User,
+  ));
+}
+
+/// Create a copy of PostUpdateUserResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserCopyWith<$Res> get user {
+  
+  return $UserCopyWith<$Res>(_self.user, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_update_user_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_update_user_response.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_update_user_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostUpdateUserResponse _$PostUpdateUserResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostUpdateUserResponse', json, ($checkedConvert) {
+  final val = _PostUpdateUserResponse(
+    user: $checkedConvert(
+      'user',
+      (v) => User.fromJson(v as Map<String, dynamic>),
+    ),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostUpdateUserResponseToJson(
+  _PostUpdateUserResponse instance,
+) => <String, dynamic>{'user': instance.user};

--- a/packages/better_auth_api_client/lib/models/post_verify_password_response.dart
+++ b/packages/better_auth_api_client/lib/models/post_verify_password_response.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post_verify_password_response.freezed.dart';
+part 'post_verify_password_response.g.dart';
+
+@Freezed()
+abstract class PostVerifyPasswordResponse with _$PostVerifyPasswordResponse {
+  const factory PostVerifyPasswordResponse({
+    required bool status,
+  }) = _PostVerifyPasswordResponse;
+  
+  factory PostVerifyPasswordResponse.fromJson(Map<String, Object?> json) => _$PostVerifyPasswordResponseFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/post_verify_password_response.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/post_verify_password_response.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'post_verify_password_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PostVerifyPasswordResponse {
+
+ bool get status;
+/// Create a copy of PostVerifyPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostVerifyPasswordResponseCopyWith<PostVerifyPasswordResponse> get copyWith => _$PostVerifyPasswordResponseCopyWithImpl<PostVerifyPasswordResponse>(this as PostVerifyPasswordResponse, _$identity);
+
+  /// Serializes this PostVerifyPasswordResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostVerifyPasswordResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostVerifyPasswordResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PostVerifyPasswordResponseCopyWith<$Res>  {
+  factory $PostVerifyPasswordResponseCopyWith(PostVerifyPasswordResponse value, $Res Function(PostVerifyPasswordResponse) _then) = _$PostVerifyPasswordResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class _$PostVerifyPasswordResponseCopyWithImpl<$Res>
+    implements $PostVerifyPasswordResponseCopyWith<$Res> {
+  _$PostVerifyPasswordResponseCopyWithImpl(this._self, this._then);
+
+  final PostVerifyPasswordResponse _self;
+  final $Res Function(PostVerifyPasswordResponse) _then;
+
+/// Create a copy of PostVerifyPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PostVerifyPasswordResponse].
+extension PostVerifyPasswordResponsePatterns on PostVerifyPasswordResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostVerifyPasswordResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostVerifyPasswordResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostVerifyPasswordResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostVerifyPasswordResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostVerifyPasswordResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostVerifyPasswordResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostVerifyPasswordResponse() when $default != null:
+return $default(_that.status);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool status)  $default,) {final _that = this;
+switch (_that) {
+case _PostVerifyPasswordResponse():
+return $default(_that.status);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool status)?  $default,) {final _that = this;
+switch (_that) {
+case _PostVerifyPasswordResponse() when $default != null:
+return $default(_that.status);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PostVerifyPasswordResponse implements PostVerifyPasswordResponse {
+  const _PostVerifyPasswordResponse({required this.status});
+  factory _PostVerifyPasswordResponse.fromJson(Map<String, dynamic> json) => _$PostVerifyPasswordResponseFromJson(json);
+
+@override final  bool status;
+
+/// Create a copy of PostVerifyPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostVerifyPasswordResponseCopyWith<_PostVerifyPasswordResponse> get copyWith => __$PostVerifyPasswordResponseCopyWithImpl<_PostVerifyPasswordResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostVerifyPasswordResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostVerifyPasswordResponse&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'PostVerifyPasswordResponse(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostVerifyPasswordResponseCopyWith<$Res> implements $PostVerifyPasswordResponseCopyWith<$Res> {
+  factory _$PostVerifyPasswordResponseCopyWith(_PostVerifyPasswordResponse value, $Res Function(_PostVerifyPasswordResponse) _then) = __$PostVerifyPasswordResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool status
+});
+
+
+
+
+}
+/// @nodoc
+class __$PostVerifyPasswordResponseCopyWithImpl<$Res>
+    implements _$PostVerifyPasswordResponseCopyWith<$Res> {
+  __$PostVerifyPasswordResponseCopyWithImpl(this._self, this._then);
+
+  final _PostVerifyPasswordResponse _self;
+  final $Res Function(_PostVerifyPasswordResponse) _then;
+
+/// Create a copy of PostVerifyPasswordResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_PostVerifyPasswordResponse(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/post_verify_password_response.g.dart
+++ b/packages/better_auth_api_client/lib/models/post_verify_password_response.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'post_verify_password_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PostVerifyPasswordResponse _$PostVerifyPasswordResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_PostVerifyPasswordResponse', json, ($checkedConvert) {
+  final val = _PostVerifyPasswordResponse(
+    status: $checkedConvert('status', (v) => v as bool),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$PostVerifyPasswordResponseToJson(
+  _PostVerifyPasswordResponse instance,
+) => <String, dynamic>{'status': instance.status};

--- a/packages/better_auth_api_client/lib/models/redirect.dart
+++ b/packages/better_auth_api_client/lib/models/redirect.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum Redirect {
+  /// The name has been replaced because it contains a keyword. Original name: `false`.
+  @JsonValue('false')
+  valueFalse('false');
+
+  const Redirect(this.json);
+
+  final String json;
+  String toJson() => json;
+
+  @override
+  String toString() => json.toString();
+}

--- a/packages/better_auth_api_client/lib/models/refresh_token_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/refresh_token_request_body.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'refresh_token_request_body.freezed.dart';
+part 'refresh_token_request_body.g.dart';
+
+@Freezed()
+abstract class RefreshTokenRequestBody with _$RefreshTokenRequestBody {
+  const factory RefreshTokenRequestBody({
+    /// The provider ID for the OAuth provider
+    required String providerId,
+
+    /// The account ID associated with the refresh token
+    @JsonKey(includeIfNull: false)
+    String? accountId,
+
+    /// The user ID associated with the account
+    @JsonKey(includeIfNull: false)
+    String? userId,
+  }) = _RefreshTokenRequestBody;
+  
+  factory RefreshTokenRequestBody.fromJson(Map<String, Object?> json) => _$RefreshTokenRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/refresh_token_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/refresh_token_request_body.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'refresh_token_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RefreshTokenRequestBody {
+
+/// The provider ID for the OAuth provider
+ String get providerId;/// The account ID associated with the refresh token
+@JsonKey(includeIfNull: false) String? get accountId;/// The user ID associated with the account
+@JsonKey(includeIfNull: false) String? get userId;
+/// Create a copy of RefreshTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RefreshTokenRequestBodyCopyWith<RefreshTokenRequestBody> get copyWith => _$RefreshTokenRequestBodyCopyWithImpl<RefreshTokenRequestBody>(this as RefreshTokenRequestBody, _$identity);
+
+  /// Serializes this RefreshTokenRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RefreshTokenRequestBody&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.userId, userId) || other.userId == userId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,providerId,accountId,userId);
+
+@override
+String toString() {
+  return 'RefreshTokenRequestBody(providerId: $providerId, accountId: $accountId, userId: $userId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RefreshTokenRequestBodyCopyWith<$Res>  {
+  factory $RefreshTokenRequestBodyCopyWith(RefreshTokenRequestBody value, $Res Function(RefreshTokenRequestBody) _then) = _$RefreshTokenRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String providerId,@JsonKey(includeIfNull: false) String? accountId,@JsonKey(includeIfNull: false) String? userId
+});
+
+
+
+
+}
+/// @nodoc
+class _$RefreshTokenRequestBodyCopyWithImpl<$Res>
+    implements $RefreshTokenRequestBodyCopyWith<$Res> {
+  _$RefreshTokenRequestBodyCopyWithImpl(this._self, this._then);
+
+  final RefreshTokenRequestBody _self;
+  final $Res Function(RefreshTokenRequestBody) _then;
+
+/// Create a copy of RefreshTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? providerId = null,Object? accountId = freezed,Object? userId = freezed,}) {
+  return _then(_self.copyWith(
+providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RefreshTokenRequestBody].
+extension RefreshTokenRequestBodyPatterns on RefreshTokenRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RefreshTokenRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RefreshTokenRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RefreshTokenRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _RefreshTokenRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RefreshTokenRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RefreshTokenRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId, @JsonKey(includeIfNull: false)  String? userId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RefreshTokenRequestBody() when $default != null:
+return $default(_that.providerId,_that.accountId,_that.userId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId, @JsonKey(includeIfNull: false)  String? userId)  $default,) {final _that = this;
+switch (_that) {
+case _RefreshTokenRequestBody():
+return $default(_that.providerId,_that.accountId,_that.userId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId, @JsonKey(includeIfNull: false)  String? userId)?  $default,) {final _that = this;
+switch (_that) {
+case _RefreshTokenRequestBody() when $default != null:
+return $default(_that.providerId,_that.accountId,_that.userId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RefreshTokenRequestBody implements RefreshTokenRequestBody {
+  const _RefreshTokenRequestBody({required this.providerId, @JsonKey(includeIfNull: false) this.accountId, @JsonKey(includeIfNull: false) this.userId});
+  factory _RefreshTokenRequestBody.fromJson(Map<String, dynamic> json) => _$RefreshTokenRequestBodyFromJson(json);
+
+/// The provider ID for the OAuth provider
+@override final  String providerId;
+/// The account ID associated with the refresh token
+@override@JsonKey(includeIfNull: false) final  String? accountId;
+/// The user ID associated with the account
+@override@JsonKey(includeIfNull: false) final  String? userId;
+
+/// Create a copy of RefreshTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RefreshTokenRequestBodyCopyWith<_RefreshTokenRequestBody> get copyWith => __$RefreshTokenRequestBodyCopyWithImpl<_RefreshTokenRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RefreshTokenRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RefreshTokenRequestBody&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.accountId, accountId) || other.accountId == accountId)&&(identical(other.userId, userId) || other.userId == userId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,providerId,accountId,userId);
+
+@override
+String toString() {
+  return 'RefreshTokenRequestBody(providerId: $providerId, accountId: $accountId, userId: $userId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RefreshTokenRequestBodyCopyWith<$Res> implements $RefreshTokenRequestBodyCopyWith<$Res> {
+  factory _$RefreshTokenRequestBodyCopyWith(_RefreshTokenRequestBody value, $Res Function(_RefreshTokenRequestBody) _then) = __$RefreshTokenRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String providerId,@JsonKey(includeIfNull: false) String? accountId,@JsonKey(includeIfNull: false) String? userId
+});
+
+
+
+
+}
+/// @nodoc
+class __$RefreshTokenRequestBodyCopyWithImpl<$Res>
+    implements _$RefreshTokenRequestBodyCopyWith<$Res> {
+  __$RefreshTokenRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _RefreshTokenRequestBody _self;
+  final $Res Function(_RefreshTokenRequestBody) _then;
+
+/// Create a copy of RefreshTokenRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? providerId = null,Object? accountId = freezed,Object? userId = freezed,}) {
+  return _then(_RefreshTokenRequestBody(
+providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/refresh_token_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/refresh_token_request_body.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'refresh_token_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RefreshTokenRequestBody _$RefreshTokenRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_RefreshTokenRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _RefreshTokenRequestBody(
+      providerId: $checkedConvert('provider_id', (v) => v as String),
+      accountId: $checkedConvert('account_id', (v) => v as String?),
+      userId: $checkedConvert('user_id', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'providerId': 'provider_id',
+    'accountId': 'account_id',
+    'userId': 'user_id',
+  },
+);
+
+Map<String, dynamic> _$RefreshTokenRequestBodyToJson(
+  _RefreshTokenRequestBody instance,
+) => <String, dynamic>{
+  'provider_id': instance.providerId,
+  'account_id': ?instance.accountId,
+  'user_id': ?instance.userId,
+};

--- a/packages/better_auth_api_client/lib/models/request_password_reset_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/request_password_reset_request_body.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'request_password_reset_request_body.freezed.dart';
+part 'request_password_reset_request_body.g.dart';
+
+@Freezed()
+abstract class RequestPasswordResetRequestBody with _$RequestPasswordResetRequestBody {
+  const factory RequestPasswordResetRequestBody({
+    /// The email address of the user to send a password reset email to
+    required String email,
+
+    /// The URL to redirect the user to reset their password. If the token isn't valid or expired, it'll be redirected with a query parameter `?error=INVALID_TOKEN`. If the token is valid, it'll be redirected with a query parameter `?token=VALID_TOKEN
+    @JsonKey(includeIfNull: false)
+    String? redirectTo,
+  }) = _RequestPasswordResetRequestBody;
+  
+  factory RequestPasswordResetRequestBody.fromJson(Map<String, Object?> json) => _$RequestPasswordResetRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/request_password_reset_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/request_password_reset_request_body.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'request_password_reset_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RequestPasswordResetRequestBody {
+
+/// The email address of the user to send a password reset email to
+ String get email;/// The URL to redirect the user to reset their password. If the token isn't valid or expired, it'll be redirected with a query parameter `?error=INVALID_TOKEN`. If the token is valid, it'll be redirected with a query parameter `?token=VALID_TOKEN
+@JsonKey(includeIfNull: false) String? get redirectTo;
+/// Create a copy of RequestPasswordResetRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RequestPasswordResetRequestBodyCopyWith<RequestPasswordResetRequestBody> get copyWith => _$RequestPasswordResetRequestBodyCopyWithImpl<RequestPasswordResetRequestBody>(this as RequestPasswordResetRequestBody, _$identity);
+
+  /// Serializes this RequestPasswordResetRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RequestPasswordResetRequestBody&&(identical(other.email, email) || other.email == email)&&(identical(other.redirectTo, redirectTo) || other.redirectTo == redirectTo));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,redirectTo);
+
+@override
+String toString() {
+  return 'RequestPasswordResetRequestBody(email: $email, redirectTo: $redirectTo)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RequestPasswordResetRequestBodyCopyWith<$Res>  {
+  factory $RequestPasswordResetRequestBodyCopyWith(RequestPasswordResetRequestBody value, $Res Function(RequestPasswordResetRequestBody) _then) = _$RequestPasswordResetRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String email,@JsonKey(includeIfNull: false) String? redirectTo
+});
+
+
+
+
+}
+/// @nodoc
+class _$RequestPasswordResetRequestBodyCopyWithImpl<$Res>
+    implements $RequestPasswordResetRequestBodyCopyWith<$Res> {
+  _$RequestPasswordResetRequestBodyCopyWithImpl(this._self, this._then);
+
+  final RequestPasswordResetRequestBody _self;
+  final $Res Function(RequestPasswordResetRequestBody) _then;
+
+/// Create a copy of RequestPasswordResetRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? email = null,Object? redirectTo = freezed,}) {
+  return _then(_self.copyWith(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,redirectTo: freezed == redirectTo ? _self.redirectTo : redirectTo // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RequestPasswordResetRequestBody].
+extension RequestPasswordResetRequestBodyPatterns on RequestPasswordResetRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RequestPasswordResetRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RequestPasswordResetRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RequestPasswordResetRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _RequestPasswordResetRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RequestPasswordResetRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RequestPasswordResetRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String email, @JsonKey(includeIfNull: false)  String? redirectTo)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RequestPasswordResetRequestBody() when $default != null:
+return $default(_that.email,_that.redirectTo);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String email, @JsonKey(includeIfNull: false)  String? redirectTo)  $default,) {final _that = this;
+switch (_that) {
+case _RequestPasswordResetRequestBody():
+return $default(_that.email,_that.redirectTo);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String email, @JsonKey(includeIfNull: false)  String? redirectTo)?  $default,) {final _that = this;
+switch (_that) {
+case _RequestPasswordResetRequestBody() when $default != null:
+return $default(_that.email,_that.redirectTo);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RequestPasswordResetRequestBody implements RequestPasswordResetRequestBody {
+  const _RequestPasswordResetRequestBody({required this.email, @JsonKey(includeIfNull: false) this.redirectTo});
+  factory _RequestPasswordResetRequestBody.fromJson(Map<String, dynamic> json) => _$RequestPasswordResetRequestBodyFromJson(json);
+
+/// The email address of the user to send a password reset email to
+@override final  String email;
+/// The URL to redirect the user to reset their password. If the token isn't valid or expired, it'll be redirected with a query parameter `?error=INVALID_TOKEN`. If the token is valid, it'll be redirected with a query parameter `?token=VALID_TOKEN
+@override@JsonKey(includeIfNull: false) final  String? redirectTo;
+
+/// Create a copy of RequestPasswordResetRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RequestPasswordResetRequestBodyCopyWith<_RequestPasswordResetRequestBody> get copyWith => __$RequestPasswordResetRequestBodyCopyWithImpl<_RequestPasswordResetRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RequestPasswordResetRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RequestPasswordResetRequestBody&&(identical(other.email, email) || other.email == email)&&(identical(other.redirectTo, redirectTo) || other.redirectTo == redirectTo));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,redirectTo);
+
+@override
+String toString() {
+  return 'RequestPasswordResetRequestBody(email: $email, redirectTo: $redirectTo)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RequestPasswordResetRequestBodyCopyWith<$Res> implements $RequestPasswordResetRequestBodyCopyWith<$Res> {
+  factory _$RequestPasswordResetRequestBodyCopyWith(_RequestPasswordResetRequestBody value, $Res Function(_RequestPasswordResetRequestBody) _then) = __$RequestPasswordResetRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String email,@JsonKey(includeIfNull: false) String? redirectTo
+});
+
+
+
+
+}
+/// @nodoc
+class __$RequestPasswordResetRequestBodyCopyWithImpl<$Res>
+    implements _$RequestPasswordResetRequestBodyCopyWith<$Res> {
+  __$RequestPasswordResetRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _RequestPasswordResetRequestBody _self;
+  final $Res Function(_RequestPasswordResetRequestBody) _then;
+
+/// Create a copy of RequestPasswordResetRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? email = null,Object? redirectTo = freezed,}) {
+  return _then(_RequestPasswordResetRequestBody(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,redirectTo: freezed == redirectTo ? _self.redirectTo : redirectTo // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/request_password_reset_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/request_password_reset_request_body.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'request_password_reset_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RequestPasswordResetRequestBody _$RequestPasswordResetRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_RequestPasswordResetRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _RequestPasswordResetRequestBody(
+      email: $checkedConvert('email', (v) => v as String),
+      redirectTo: $checkedConvert('redirect_to', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'redirectTo': 'redirect_to'},
+);
+
+Map<String, dynamic> _$RequestPasswordResetRequestBodyToJson(
+  _RequestPasswordResetRequestBody instance,
+) => <String, dynamic>{
+  'email': instance.email,
+  'redirect_to': ?instance.redirectTo,
+};

--- a/packages/better_auth_api_client/lib/models/reset_password_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/reset_password_request_body.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'reset_password_request_body.freezed.dart';
+part 'reset_password_request_body.g.dart';
+
+@Freezed()
+abstract class ResetPasswordRequestBody with _$ResetPasswordRequestBody {
+  const factory ResetPasswordRequestBody({
+    /// The new password to set
+    required String newPassword,
+
+    /// The token to reset the password
+    @JsonKey(includeIfNull: false)
+    String? token,
+  }) = _ResetPasswordRequestBody;
+  
+  factory ResetPasswordRequestBody.fromJson(Map<String, Object?> json) => _$ResetPasswordRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/reset_password_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/reset_password_request_body.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reset_password_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ResetPasswordRequestBody {
+
+/// The new password to set
+ String get newPassword;/// The token to reset the password
+@JsonKey(includeIfNull: false) String? get token;
+/// Create a copy of ResetPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ResetPasswordRequestBodyCopyWith<ResetPasswordRequestBody> get copyWith => _$ResetPasswordRequestBodyCopyWithImpl<ResetPasswordRequestBody>(this as ResetPasswordRequestBody, _$identity);
+
+  /// Serializes this ResetPasswordRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ResetPasswordRequestBody&&(identical(other.newPassword, newPassword) || other.newPassword == newPassword)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newPassword,token);
+
+@override
+String toString() {
+  return 'ResetPasswordRequestBody(newPassword: $newPassword, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ResetPasswordRequestBodyCopyWith<$Res>  {
+  factory $ResetPasswordRequestBodyCopyWith(ResetPasswordRequestBody value, $Res Function(ResetPasswordRequestBody) _then) = _$ResetPasswordRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String newPassword,@JsonKey(includeIfNull: false) String? token
+});
+
+
+
+
+}
+/// @nodoc
+class _$ResetPasswordRequestBodyCopyWithImpl<$Res>
+    implements $ResetPasswordRequestBodyCopyWith<$Res> {
+  _$ResetPasswordRequestBodyCopyWithImpl(this._self, this._then);
+
+  final ResetPasswordRequestBody _self;
+  final $Res Function(ResetPasswordRequestBody) _then;
+
+/// Create a copy of ResetPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? newPassword = null,Object? token = freezed,}) {
+  return _then(_self.copyWith(
+newPassword: null == newPassword ? _self.newPassword : newPassword // ignore: cast_nullable_to_non_nullable
+as String,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ResetPasswordRequestBody].
+extension ResetPasswordRequestBodyPatterns on ResetPasswordRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ResetPasswordRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ResetPasswordRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ResetPasswordRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _ResetPasswordRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ResetPasswordRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ResetPasswordRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String newPassword, @JsonKey(includeIfNull: false)  String? token)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ResetPasswordRequestBody() when $default != null:
+return $default(_that.newPassword,_that.token);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String newPassword, @JsonKey(includeIfNull: false)  String? token)  $default,) {final _that = this;
+switch (_that) {
+case _ResetPasswordRequestBody():
+return $default(_that.newPassword,_that.token);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String newPassword, @JsonKey(includeIfNull: false)  String? token)?  $default,) {final _that = this;
+switch (_that) {
+case _ResetPasswordRequestBody() when $default != null:
+return $default(_that.newPassword,_that.token);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ResetPasswordRequestBody implements ResetPasswordRequestBody {
+  const _ResetPasswordRequestBody({required this.newPassword, @JsonKey(includeIfNull: false) this.token});
+  factory _ResetPasswordRequestBody.fromJson(Map<String, dynamic> json) => _$ResetPasswordRequestBodyFromJson(json);
+
+/// The new password to set
+@override final  String newPassword;
+/// The token to reset the password
+@override@JsonKey(includeIfNull: false) final  String? token;
+
+/// Create a copy of ResetPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ResetPasswordRequestBodyCopyWith<_ResetPasswordRequestBody> get copyWith => __$ResetPasswordRequestBodyCopyWithImpl<_ResetPasswordRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ResetPasswordRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ResetPasswordRequestBody&&(identical(other.newPassword, newPassword) || other.newPassword == newPassword)&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newPassword,token);
+
+@override
+String toString() {
+  return 'ResetPasswordRequestBody(newPassword: $newPassword, token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ResetPasswordRequestBodyCopyWith<$Res> implements $ResetPasswordRequestBodyCopyWith<$Res> {
+  factory _$ResetPasswordRequestBodyCopyWith(_ResetPasswordRequestBody value, $Res Function(_ResetPasswordRequestBody) _then) = __$ResetPasswordRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String newPassword,@JsonKey(includeIfNull: false) String? token
+});
+
+
+
+
+}
+/// @nodoc
+class __$ResetPasswordRequestBodyCopyWithImpl<$Res>
+    implements _$ResetPasswordRequestBodyCopyWith<$Res> {
+  __$ResetPasswordRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _ResetPasswordRequestBody _self;
+  final $Res Function(_ResetPasswordRequestBody) _then;
+
+/// Create a copy of ResetPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? newPassword = null,Object? token = freezed,}) {
+  return _then(_ResetPasswordRequestBody(
+newPassword: null == newPassword ? _self.newPassword : newPassword // ignore: cast_nullable_to_non_nullable
+as String,token: freezed == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/reset_password_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/reset_password_request_body.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'reset_password_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ResetPasswordRequestBody _$ResetPasswordRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_ResetPasswordRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _ResetPasswordRequestBody(
+      newPassword: $checkedConvert('new_password', (v) => v as String),
+      token: $checkedConvert('token', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'newPassword': 'new_password'},
+);
+
+Map<String, dynamic> _$ResetPasswordRequestBodyToJson(
+  _ResetPasswordRequestBody instance,
+) => <String, dynamic>{
+  'new_password': instance.newPassword,
+  'token': ?instance.token,
+};

--- a/packages/better_auth_api_client/lib/models/revoke_session_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/revoke_session_request_body.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'revoke_session_request_body.freezed.dart';
+part 'revoke_session_request_body.g.dart';
+
+@Freezed()
+abstract class RevokeSessionRequestBody with _$RevokeSessionRequestBody {
+  const factory RevokeSessionRequestBody({
+    /// The token to revoke
+    required String token,
+  }) = _RevokeSessionRequestBody;
+  
+  factory RevokeSessionRequestBody.fromJson(Map<String, Object?> json) => _$RevokeSessionRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/revoke_session_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/revoke_session_request_body.freezed.dart
@@ -1,0 +1,279 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'revoke_session_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RevokeSessionRequestBody {
+
+/// The token to revoke
+ String get token;
+/// Create a copy of RevokeSessionRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RevokeSessionRequestBodyCopyWith<RevokeSessionRequestBody> get copyWith => _$RevokeSessionRequestBodyCopyWithImpl<RevokeSessionRequestBody>(this as RevokeSessionRequestBody, _$identity);
+
+  /// Serializes this RevokeSessionRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RevokeSessionRequestBody&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token);
+
+@override
+String toString() {
+  return 'RevokeSessionRequestBody(token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RevokeSessionRequestBodyCopyWith<$Res>  {
+  factory $RevokeSessionRequestBodyCopyWith(RevokeSessionRequestBody value, $Res Function(RevokeSessionRequestBody) _then) = _$RevokeSessionRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String token
+});
+
+
+
+
+}
+/// @nodoc
+class _$RevokeSessionRequestBodyCopyWithImpl<$Res>
+    implements $RevokeSessionRequestBodyCopyWith<$Res> {
+  _$RevokeSessionRequestBodyCopyWithImpl(this._self, this._then);
+
+  final RevokeSessionRequestBody _self;
+  final $Res Function(RevokeSessionRequestBody) _then;
+
+/// Create a copy of RevokeSessionRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? token = null,}) {
+  return _then(_self.copyWith(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RevokeSessionRequestBody].
+extension RevokeSessionRequestBodyPatterns on RevokeSessionRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RevokeSessionRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RevokeSessionRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RevokeSessionRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _RevokeSessionRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RevokeSessionRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RevokeSessionRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String token)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RevokeSessionRequestBody() when $default != null:
+return $default(_that.token);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String token)  $default,) {final _that = this;
+switch (_that) {
+case _RevokeSessionRequestBody():
+return $default(_that.token);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String token)?  $default,) {final _that = this;
+switch (_that) {
+case _RevokeSessionRequestBody() when $default != null:
+return $default(_that.token);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RevokeSessionRequestBody implements RevokeSessionRequestBody {
+  const _RevokeSessionRequestBody({required this.token});
+  factory _RevokeSessionRequestBody.fromJson(Map<String, dynamic> json) => _$RevokeSessionRequestBodyFromJson(json);
+
+/// The token to revoke
+@override final  String token;
+
+/// Create a copy of RevokeSessionRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RevokeSessionRequestBodyCopyWith<_RevokeSessionRequestBody> get copyWith => __$RevokeSessionRequestBodyCopyWithImpl<_RevokeSessionRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RevokeSessionRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RevokeSessionRequestBody&&(identical(other.token, token) || other.token == token));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token);
+
+@override
+String toString() {
+  return 'RevokeSessionRequestBody(token: $token)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RevokeSessionRequestBodyCopyWith<$Res> implements $RevokeSessionRequestBodyCopyWith<$Res> {
+  factory _$RevokeSessionRequestBodyCopyWith(_RevokeSessionRequestBody value, $Res Function(_RevokeSessionRequestBody) _then) = __$RevokeSessionRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String token
+});
+
+
+
+
+}
+/// @nodoc
+class __$RevokeSessionRequestBodyCopyWithImpl<$Res>
+    implements _$RevokeSessionRequestBodyCopyWith<$Res> {
+  __$RevokeSessionRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _RevokeSessionRequestBody _self;
+  final $Res Function(_RevokeSessionRequestBody) _then;
+
+/// Create a copy of RevokeSessionRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? token = null,}) {
+  return _then(_RevokeSessionRequestBody(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/revoke_session_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/revoke_session_request_body.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'revoke_session_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RevokeSessionRequestBody _$RevokeSessionRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_RevokeSessionRequestBody', json, ($checkedConvert) {
+  final val = _RevokeSessionRequestBody(
+    token: $checkedConvert('token', (v) => v as String),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$RevokeSessionRequestBodyToJson(
+  _RevokeSessionRequestBody instance,
+) => <String, dynamic>{'token': instance.token};

--- a/packages/better_auth_api_client/lib/models/send_verification_email_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/send_verification_email_request_body.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'send_verification_email_request_body.freezed.dart';
+part 'send_verification_email_request_body.g.dart';
+
+@Freezed()
+abstract class SendVerificationEmailRequestBody with _$SendVerificationEmailRequestBody {
+  const factory SendVerificationEmailRequestBody({
+    /// The email to send the verification email to
+    required String email,
+
+    /// The URL to use for email verification callback
+    @JsonKey(includeIfNull: false,name: 'callbackURL')
+    String? callbackUrl,
+  }) = _SendVerificationEmailRequestBody;
+  
+  factory SendVerificationEmailRequestBody.fromJson(Map<String, Object?> json) => _$SendVerificationEmailRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/send_verification_email_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/send_verification_email_request_body.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'send_verification_email_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SendVerificationEmailRequestBody {
+
+/// The email to send the verification email to
+ String get email;/// The URL to use for email verification callback
+@JsonKey(includeIfNull: false, name: 'callbackURL') String? get callbackUrl;
+/// Create a copy of SendVerificationEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SendVerificationEmailRequestBodyCopyWith<SendVerificationEmailRequestBody> get copyWith => _$SendVerificationEmailRequestBodyCopyWithImpl<SendVerificationEmailRequestBody>(this as SendVerificationEmailRequestBody, _$identity);
+
+  /// Serializes this SendVerificationEmailRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SendVerificationEmailRequestBody&&(identical(other.email, email) || other.email == email)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,callbackUrl);
+
+@override
+String toString() {
+  return 'SendVerificationEmailRequestBody(email: $email, callbackUrl: $callbackUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SendVerificationEmailRequestBodyCopyWith<$Res>  {
+  factory $SendVerificationEmailRequestBodyCopyWith(SendVerificationEmailRequestBody value, $Res Function(SendVerificationEmailRequestBody) _then) = _$SendVerificationEmailRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String email,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$SendVerificationEmailRequestBodyCopyWithImpl<$Res>
+    implements $SendVerificationEmailRequestBodyCopyWith<$Res> {
+  _$SendVerificationEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final SendVerificationEmailRequestBody _self;
+  final $Res Function(SendVerificationEmailRequestBody) _then;
+
+/// Create a copy of SendVerificationEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? email = null,Object? callbackUrl = freezed,}) {
+  return _then(_self.copyWith(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SendVerificationEmailRequestBody].
+extension SendVerificationEmailRequestBodyPatterns on SendVerificationEmailRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SendVerificationEmailRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SendVerificationEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SendVerificationEmailRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _SendVerificationEmailRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SendVerificationEmailRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SendVerificationEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String email, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SendVerificationEmailRequestBody() when $default != null:
+return $default(_that.email,_that.callbackUrl);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String email, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)  $default,) {final _that = this;
+switch (_that) {
+case _SendVerificationEmailRequestBody():
+return $default(_that.email,_that.callbackUrl);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String email, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)?  $default,) {final _that = this;
+switch (_that) {
+case _SendVerificationEmailRequestBody() when $default != null:
+return $default(_that.email,_that.callbackUrl);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SendVerificationEmailRequestBody implements SendVerificationEmailRequestBody {
+  const _SendVerificationEmailRequestBody({required this.email, @JsonKey(includeIfNull: false, name: 'callbackURL') this.callbackUrl});
+  factory _SendVerificationEmailRequestBody.fromJson(Map<String, dynamic> json) => _$SendVerificationEmailRequestBodyFromJson(json);
+
+/// The email to send the verification email to
+@override final  String email;
+/// The URL to use for email verification callback
+@override@JsonKey(includeIfNull: false, name: 'callbackURL') final  String? callbackUrl;
+
+/// Create a copy of SendVerificationEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SendVerificationEmailRequestBodyCopyWith<_SendVerificationEmailRequestBody> get copyWith => __$SendVerificationEmailRequestBodyCopyWithImpl<_SendVerificationEmailRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SendVerificationEmailRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SendVerificationEmailRequestBody&&(identical(other.email, email) || other.email == email)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,callbackUrl);
+
+@override
+String toString() {
+  return 'SendVerificationEmailRequestBody(email: $email, callbackUrl: $callbackUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SendVerificationEmailRequestBodyCopyWith<$Res> implements $SendVerificationEmailRequestBodyCopyWith<$Res> {
+  factory _$SendVerificationEmailRequestBodyCopyWith(_SendVerificationEmailRequestBody value, $Res Function(_SendVerificationEmailRequestBody) _then) = __$SendVerificationEmailRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String email,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl
+});
+
+
+
+
+}
+/// @nodoc
+class __$SendVerificationEmailRequestBodyCopyWithImpl<$Res>
+    implements _$SendVerificationEmailRequestBodyCopyWith<$Res> {
+  __$SendVerificationEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _SendVerificationEmailRequestBody _self;
+  final $Res Function(_SendVerificationEmailRequestBody) _then;
+
+/// Create a copy of SendVerificationEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? email = null,Object? callbackUrl = freezed,}) {
+  return _then(_SendVerificationEmailRequestBody(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/send_verification_email_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/send_verification_email_request_body.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'send_verification_email_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SendVerificationEmailRequestBody _$SendVerificationEmailRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_SendVerificationEmailRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _SendVerificationEmailRequestBody(
+      email: $checkedConvert('email', (v) => v as String),
+      callbackUrl: $checkedConvert('callbackURL', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'callbackUrl': 'callbackURL'},
+);
+
+Map<String, dynamic> _$SendVerificationEmailRequestBodyToJson(
+  _SendVerificationEmailRequestBody instance,
+) => <String, dynamic>{
+  'email': instance.email,
+  'callbackURL': ?instance.callbackUrl,
+};

--- a/packages/better_auth_api_client/lib/models/session.dart
+++ b/packages/better_auth_api_client/lib/models/session.dart
@@ -1,0 +1,29 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session.freezed.dart';
+part 'session.g.dart';
+
+@Freezed()
+abstract class Session with _$Session {
+  const factory Session({
+    required DateTime expiresAt,
+    required String token,
+    required DateTime updatedAt,
+    required String userId,
+    DateTime? createdAt,
+    @JsonKey(includeIfNull: false)
+    String? id,
+    @JsonKey(includeIfNull: false)
+    String? ipAddress,
+    @JsonKey(includeIfNull: false)
+    String? userAgent,
+    @JsonKey(includeIfNull: false)
+    String? impersonatedBy,
+  }) = _Session;
+  
+  factory Session.fromJson(Map<String, Object?> json) => _$SessionFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/session.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/session.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Session {
+
+ DateTime get expiresAt; String get token; DateTime get updatedAt; String get userId; DateTime? get createdAt;@JsonKey(includeIfNull: false) String? get id;@JsonKey(includeIfNull: false) String? get ipAddress;@JsonKey(includeIfNull: false) String? get userAgent;@JsonKey(includeIfNull: false) String? get impersonatedBy;
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionCopyWith<Session> get copyWith => _$SessionCopyWithImpl<Session>(this as Session, _$identity);
+
+  /// Serializes this Session to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Session&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.token, token) || other.token == token)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.id, id) || other.id == id)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.impersonatedBy, impersonatedBy) || other.impersonatedBy == impersonatedBy));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,expiresAt,token,updatedAt,userId,createdAt,id,ipAddress,userAgent,impersonatedBy);
+
+@override
+String toString() {
+  return 'Session(expiresAt: $expiresAt, token: $token, updatedAt: $updatedAt, userId: $userId, createdAt: $createdAt, id: $id, ipAddress: $ipAddress, userAgent: $userAgent, impersonatedBy: $impersonatedBy)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SessionCopyWith<$Res>  {
+  factory $SessionCopyWith(Session value, $Res Function(Session) _then) = _$SessionCopyWithImpl;
+@useResult
+$Res call({
+ DateTime expiresAt, String token, DateTime updatedAt, String userId, DateTime? createdAt,@JsonKey(includeIfNull: false) String? id,@JsonKey(includeIfNull: false) String? ipAddress,@JsonKey(includeIfNull: false) String? userAgent,@JsonKey(includeIfNull: false) String? impersonatedBy
+});
+
+
+
+
+}
+/// @nodoc
+class _$SessionCopyWithImpl<$Res>
+    implements $SessionCopyWith<$Res> {
+  _$SessionCopyWithImpl(this._self, this._then);
+
+  final Session _self;
+  final $Res Function(Session) _then;
+
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? expiresAt = null,Object? token = null,Object? updatedAt = null,Object? userId = null,Object? createdAt = freezed,Object? id = freezed,Object? ipAddress = freezed,Object? userAgent = freezed,Object? impersonatedBy = freezed,}) {
+  return _then(_self.copyWith(
+expiresAt: null == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,ipAddress: freezed == ipAddress ? _self.ipAddress : ipAddress // ignore: cast_nullable_to_non_nullable
+as String?,userAgent: freezed == userAgent ? _self.userAgent : userAgent // ignore: cast_nullable_to_non_nullable
+as String?,impersonatedBy: freezed == impersonatedBy ? _self.impersonatedBy : impersonatedBy // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Session].
+extension SessionPatterns on Session {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Session value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Session value)  $default,){
+final _that = this;
+switch (_that) {
+case _Session():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Session value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTime expiresAt,  String token,  DateTime updatedAt,  String userId,  DateTime? createdAt, @JsonKey(includeIfNull: false)  String? id, @JsonKey(includeIfNull: false)  String? ipAddress, @JsonKey(includeIfNull: false)  String? userAgent, @JsonKey(includeIfNull: false)  String? impersonatedBy)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that.expiresAt,_that.token,_that.updatedAt,_that.userId,_that.createdAt,_that.id,_that.ipAddress,_that.userAgent,_that.impersonatedBy);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTime expiresAt,  String token,  DateTime updatedAt,  String userId,  DateTime? createdAt, @JsonKey(includeIfNull: false)  String? id, @JsonKey(includeIfNull: false)  String? ipAddress, @JsonKey(includeIfNull: false)  String? userAgent, @JsonKey(includeIfNull: false)  String? impersonatedBy)  $default,) {final _that = this;
+switch (_that) {
+case _Session():
+return $default(_that.expiresAt,_that.token,_that.updatedAt,_that.userId,_that.createdAt,_that.id,_that.ipAddress,_that.userAgent,_that.impersonatedBy);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTime expiresAt,  String token,  DateTime updatedAt,  String userId,  DateTime? createdAt, @JsonKey(includeIfNull: false)  String? id, @JsonKey(includeIfNull: false)  String? ipAddress, @JsonKey(includeIfNull: false)  String? userAgent, @JsonKey(includeIfNull: false)  String? impersonatedBy)?  $default,) {final _that = this;
+switch (_that) {
+case _Session() when $default != null:
+return $default(_that.expiresAt,_that.token,_that.updatedAt,_that.userId,_that.createdAt,_that.id,_that.ipAddress,_that.userAgent,_that.impersonatedBy);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _Session implements Session {
+  const _Session({required this.expiresAt, required this.token, required this.updatedAt, required this.userId, this.createdAt, @JsonKey(includeIfNull: false) this.id, @JsonKey(includeIfNull: false) this.ipAddress, @JsonKey(includeIfNull: false) this.userAgent, @JsonKey(includeIfNull: false) this.impersonatedBy});
+  factory _Session.fromJson(Map<String, dynamic> json) => _$SessionFromJson(json);
+
+@override final  DateTime expiresAt;
+@override final  String token;
+@override final  DateTime updatedAt;
+@override final  String userId;
+@override final  DateTime? createdAt;
+@override@JsonKey(includeIfNull: false) final  String? id;
+@override@JsonKey(includeIfNull: false) final  String? ipAddress;
+@override@JsonKey(includeIfNull: false) final  String? userAgent;
+@override@JsonKey(includeIfNull: false) final  String? impersonatedBy;
+
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionCopyWith<_Session> get copyWith => __$SessionCopyWithImpl<_Session>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SessionToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Session&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.token, token) || other.token == token)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.id, id) || other.id == id)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.impersonatedBy, impersonatedBy) || other.impersonatedBy == impersonatedBy));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,expiresAt,token,updatedAt,userId,createdAt,id,ipAddress,userAgent,impersonatedBy);
+
+@override
+String toString() {
+  return 'Session(expiresAt: $expiresAt, token: $token, updatedAt: $updatedAt, userId: $userId, createdAt: $createdAt, id: $id, ipAddress: $ipAddress, userAgent: $userAgent, impersonatedBy: $impersonatedBy)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SessionCopyWith<$Res> implements $SessionCopyWith<$Res> {
+  factory _$SessionCopyWith(_Session value, $Res Function(_Session) _then) = __$SessionCopyWithImpl;
+@override @useResult
+$Res call({
+ DateTime expiresAt, String token, DateTime updatedAt, String userId, DateTime? createdAt,@JsonKey(includeIfNull: false) String? id,@JsonKey(includeIfNull: false) String? ipAddress,@JsonKey(includeIfNull: false) String? userAgent,@JsonKey(includeIfNull: false) String? impersonatedBy
+});
+
+
+
+
+}
+/// @nodoc
+class __$SessionCopyWithImpl<$Res>
+    implements _$SessionCopyWith<$Res> {
+  __$SessionCopyWithImpl(this._self, this._then);
+
+  final _Session _self;
+  final $Res Function(_Session) _then;
+
+/// Create a copy of Session
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? expiresAt = null,Object? token = null,Object? updatedAt = null,Object? userId = null,Object? createdAt = freezed,Object? id = freezed,Object? ipAddress = freezed,Object? userAgent = freezed,Object? impersonatedBy = freezed,}) {
+  return _then(_Session(
+expiresAt: null == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,ipAddress: freezed == ipAddress ? _self.ipAddress : ipAddress // ignore: cast_nullable_to_non_nullable
+as String?,userAgent: freezed == userAgent ? _self.userAgent : userAgent // ignore: cast_nullable_to_non_nullable
+as String?,impersonatedBy: freezed == impersonatedBy ? _self.impersonatedBy : impersonatedBy // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/session.g.dart
+++ b/packages/better_auth_api_client/lib/models/session.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'session.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Session _$SessionFromJson(Map<String, dynamic> json) => $checkedCreate(
+  '_Session',
+  json,
+  ($checkedConvert) {
+    final val = _Session(
+      expiresAt: $checkedConvert(
+        'expires_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      token: $checkedConvert('token', (v) => v as String),
+      updatedAt: $checkedConvert(
+        'updated_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      userId: $checkedConvert('user_id', (v) => v as String),
+      createdAt: $checkedConvert(
+        'created_at',
+        (v) => v == null ? null : DateTime.parse(v as String),
+      ),
+      id: $checkedConvert('id', (v) => v as String?),
+      ipAddress: $checkedConvert('ip_address', (v) => v as String?),
+      userAgent: $checkedConvert('user_agent', (v) => v as String?),
+      impersonatedBy: $checkedConvert('impersonated_by', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'expiresAt': 'expires_at',
+    'updatedAt': 'updated_at',
+    'userId': 'user_id',
+    'createdAt': 'created_at',
+    'ipAddress': 'ip_address',
+    'userAgent': 'user_agent',
+    'impersonatedBy': 'impersonated_by',
+  },
+);
+
+Map<String, dynamic> _$SessionToJson(_Session instance) => <String, dynamic>{
+  'expires_at': instance.expiresAt.toIso8601String(),
+  'token': instance.token,
+  'updated_at': instance.updatedAt.toIso8601String(),
+  'user_id': instance.userId,
+  'created_at': instance.createdAt?.toIso8601String(),
+  'id': ?instance.id,
+  'ip_address': ?instance.ipAddress,
+  'user_agent': ?instance.userAgent,
+  'impersonated_by': ?instance.impersonatedBy,
+};

--- a/packages/better_auth_api_client/lib/models/sign_in_email_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/sign_in_email_request_body.dart
@@ -1,0 +1,30 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'sign_in_email_request_body.freezed.dart';
+part 'sign_in_email_request_body.g.dart';
+
+@Freezed()
+abstract class SignInEmailRequestBody with _$SignInEmailRequestBody {
+  const factory SignInEmailRequestBody({
+    /// Email of the user
+    required String email,
+
+    /// Password of the user
+    required String password,
+
+    /// If this is false, the session will not be remembered. Default is `true`.
+    @JsonKey(includeIfNull: true)
+    @Default(true)
+    bool? rememberMe,
+
+    /// Callback URL to use as a redirect for email verification
+    @JsonKey(includeIfNull: false,name: 'callbackURL')
+    String? callbackUrl,
+  }) = _SignInEmailRequestBody;
+  
+  factory SignInEmailRequestBody.fromJson(Map<String, Object?> json) => _$SignInEmailRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/sign_in_email_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/sign_in_email_request_body.freezed.dart
@@ -1,0 +1,294 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sign_in_email_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SignInEmailRequestBody {
+
+/// Email of the user
+ String get email;/// Password of the user
+ String get password;/// If this is false, the session will not be remembered. Default is `true`.
+@JsonKey(includeIfNull: true) bool? get rememberMe;/// Callback URL to use as a redirect for email verification
+@JsonKey(includeIfNull: false, name: 'callbackURL') String? get callbackUrl;
+/// Create a copy of SignInEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SignInEmailRequestBodyCopyWith<SignInEmailRequestBody> get copyWith => _$SignInEmailRequestBodyCopyWithImpl<SignInEmailRequestBody>(this as SignInEmailRequestBody, _$identity);
+
+  /// Serializes this SignInEmailRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SignInEmailRequestBody&&(identical(other.email, email) || other.email == email)&&(identical(other.password, password) || other.password == password)&&(identical(other.rememberMe, rememberMe) || other.rememberMe == rememberMe)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,password,rememberMe,callbackUrl);
+
+@override
+String toString() {
+  return 'SignInEmailRequestBody(email: $email, password: $password, rememberMe: $rememberMe, callbackUrl: $callbackUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SignInEmailRequestBodyCopyWith<$Res>  {
+  factory $SignInEmailRequestBodyCopyWith(SignInEmailRequestBody value, $Res Function(SignInEmailRequestBody) _then) = _$SignInEmailRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String email, String password,@JsonKey(includeIfNull: true) bool? rememberMe,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$SignInEmailRequestBodyCopyWithImpl<$Res>
+    implements $SignInEmailRequestBodyCopyWith<$Res> {
+  _$SignInEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final SignInEmailRequestBody _self;
+  final $Res Function(SignInEmailRequestBody) _then;
+
+/// Create a copy of SignInEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? email = null,Object? password = null,Object? rememberMe = freezed,Object? callbackUrl = freezed,}) {
+  return _then(_self.copyWith(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,rememberMe: freezed == rememberMe ? _self.rememberMe : rememberMe // ignore: cast_nullable_to_non_nullable
+as bool?,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SignInEmailRequestBody].
+extension SignInEmailRequestBodyPatterns on SignInEmailRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SignInEmailRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SignInEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SignInEmailRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _SignInEmailRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SignInEmailRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SignInEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String email,  String password, @JsonKey(includeIfNull: true)  bool? rememberMe, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SignInEmailRequestBody() when $default != null:
+return $default(_that.email,_that.password,_that.rememberMe,_that.callbackUrl);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String email,  String password, @JsonKey(includeIfNull: true)  bool? rememberMe, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)  $default,) {final _that = this;
+switch (_that) {
+case _SignInEmailRequestBody():
+return $default(_that.email,_that.password,_that.rememberMe,_that.callbackUrl);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String email,  String password, @JsonKey(includeIfNull: true)  bool? rememberMe, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl)?  $default,) {final _that = this;
+switch (_that) {
+case _SignInEmailRequestBody() when $default != null:
+return $default(_that.email,_that.password,_that.rememberMe,_that.callbackUrl);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SignInEmailRequestBody implements SignInEmailRequestBody {
+  const _SignInEmailRequestBody({required this.email, required this.password, @JsonKey(includeIfNull: true) this.rememberMe = true, @JsonKey(includeIfNull: false, name: 'callbackURL') this.callbackUrl});
+  factory _SignInEmailRequestBody.fromJson(Map<String, dynamic> json) => _$SignInEmailRequestBodyFromJson(json);
+
+/// Email of the user
+@override final  String email;
+/// Password of the user
+@override final  String password;
+/// If this is false, the session will not be remembered. Default is `true`.
+@override@JsonKey(includeIfNull: true) final  bool? rememberMe;
+/// Callback URL to use as a redirect for email verification
+@override@JsonKey(includeIfNull: false, name: 'callbackURL') final  String? callbackUrl;
+
+/// Create a copy of SignInEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SignInEmailRequestBodyCopyWith<_SignInEmailRequestBody> get copyWith => __$SignInEmailRequestBodyCopyWithImpl<_SignInEmailRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SignInEmailRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SignInEmailRequestBody&&(identical(other.email, email) || other.email == email)&&(identical(other.password, password) || other.password == password)&&(identical(other.rememberMe, rememberMe) || other.rememberMe == rememberMe)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,email,password,rememberMe,callbackUrl);
+
+@override
+String toString() {
+  return 'SignInEmailRequestBody(email: $email, password: $password, rememberMe: $rememberMe, callbackUrl: $callbackUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SignInEmailRequestBodyCopyWith<$Res> implements $SignInEmailRequestBodyCopyWith<$Res> {
+  factory _$SignInEmailRequestBodyCopyWith(_SignInEmailRequestBody value, $Res Function(_SignInEmailRequestBody) _then) = __$SignInEmailRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String email, String password,@JsonKey(includeIfNull: true) bool? rememberMe,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl
+});
+
+
+
+
+}
+/// @nodoc
+class __$SignInEmailRequestBodyCopyWithImpl<$Res>
+    implements _$SignInEmailRequestBodyCopyWith<$Res> {
+  __$SignInEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _SignInEmailRequestBody _self;
+  final $Res Function(_SignInEmailRequestBody) _then;
+
+/// Create a copy of SignInEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? email = null,Object? password = null,Object? rememberMe = freezed,Object? callbackUrl = freezed,}) {
+  return _then(_SignInEmailRequestBody(
+email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,rememberMe: freezed == rememberMe ? _self.rememberMe : rememberMe // ignore: cast_nullable_to_non_nullable
+as bool?,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/sign_in_email_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/sign_in_email_request_body.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'sign_in_email_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SignInEmailRequestBody _$SignInEmailRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_SignInEmailRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _SignInEmailRequestBody(
+      email: $checkedConvert('email', (v) => v as String),
+      password: $checkedConvert('password', (v) => v as String),
+      rememberMe: $checkedConvert('remember_me', (v) => v as bool? ?? true),
+      callbackUrl: $checkedConvert('callbackURL', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'rememberMe': 'remember_me',
+    'callbackUrl': 'callbackURL',
+  },
+);
+
+Map<String, dynamic> _$SignInEmailRequestBodyToJson(
+  _SignInEmailRequestBody instance,
+) => <String, dynamic>{
+  'email': instance.email,
+  'password': instance.password,
+  'remember_me': instance.rememberMe,
+  'callbackURL': ?instance.callbackUrl,
+};

--- a/packages/better_auth_api_client/lib/models/sign_in_social_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/sign_in_social_request_body.dart
@@ -1,0 +1,49 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'id_token.dart';
+
+part 'sign_in_social_request_body.freezed.dart';
+part 'sign_in_social_request_body.g.dart';
+
+@Freezed()
+abstract class SignInSocialRequestBody with _$SignInSocialRequestBody {
+  const factory SignInSocialRequestBody({
+    required String provider,
+
+    /// Callback URL to redirect to after the user has signed in
+    @JsonKey(includeIfNull: false,name: 'callbackURL')
+    String? callbackUrl,
+    @JsonKey(includeIfNull: false,name: 'newUserCallbackURL')
+    String? newUserCallbackUrl,
+
+    /// Callback URL to redirect to if an error happens
+    @JsonKey(includeIfNull: false,name: 'errorCallbackURL')
+    String? errorCallbackUrl,
+
+    /// Disable automatic redirection to the provider. Useful for handling the redirection yourself
+    @JsonKey(includeIfNull: false)
+    bool? disableRedirect,
+    @JsonKey(includeIfNull: false)
+    IdToken? idToken,
+
+    /// Array of scopes to request from the provider. This will override the default scopes passed.
+    @JsonKey(includeIfNull: false)
+    List<dynamic>? scopes,
+
+    /// Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider
+    @JsonKey(includeIfNull: false)
+    bool? requestSignUp,
+
+    /// The login hint to use for the authorization code request
+    @JsonKey(includeIfNull: false)
+    String? loginHint,
+    @JsonKey(includeIfNull: false)
+    String? additionalData,
+  }) = _SignInSocialRequestBody;
+  
+  factory SignInSocialRequestBody.fromJson(Map<String, Object?> json) => _$SignInSocialRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/sign_in_social_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/sign_in_social_request_body.freezed.dart
@@ -1,0 +1,349 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sign_in_social_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SignInSocialRequestBody {
+
+ String get provider;/// Callback URL to redirect to after the user has signed in
+@JsonKey(includeIfNull: false, name: 'callbackURL') String? get callbackUrl;@JsonKey(includeIfNull: false, name: 'newUserCallbackURL') String? get newUserCallbackUrl;/// Callback URL to redirect to if an error happens
+@JsonKey(includeIfNull: false, name: 'errorCallbackURL') String? get errorCallbackUrl;/// Disable automatic redirection to the provider. Useful for handling the redirection yourself
+@JsonKey(includeIfNull: false) bool? get disableRedirect;@JsonKey(includeIfNull: false) IdToken? get idToken;/// Array of scopes to request from the provider. This will override the default scopes passed.
+@JsonKey(includeIfNull: false) List<dynamic>? get scopes;/// Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider
+@JsonKey(includeIfNull: false) bool? get requestSignUp;/// The login hint to use for the authorization code request
+@JsonKey(includeIfNull: false) String? get loginHint;@JsonKey(includeIfNull: false) String? get additionalData;
+/// Create a copy of SignInSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SignInSocialRequestBodyCopyWith<SignInSocialRequestBody> get copyWith => _$SignInSocialRequestBodyCopyWithImpl<SignInSocialRequestBody>(this as SignInSocialRequestBody, _$identity);
+
+  /// Serializes this SignInSocialRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SignInSocialRequestBody&&(identical(other.provider, provider) || other.provider == provider)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.newUserCallbackUrl, newUserCallbackUrl) || other.newUserCallbackUrl == newUserCallbackUrl)&&(identical(other.errorCallbackUrl, errorCallbackUrl) || other.errorCallbackUrl == errorCallbackUrl)&&(identical(other.disableRedirect, disableRedirect) || other.disableRedirect == disableRedirect)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&const DeepCollectionEquality().equals(other.scopes, scopes)&&(identical(other.requestSignUp, requestSignUp) || other.requestSignUp == requestSignUp)&&(identical(other.loginHint, loginHint) || other.loginHint == loginHint)&&(identical(other.additionalData, additionalData) || other.additionalData == additionalData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,provider,callbackUrl,newUserCallbackUrl,errorCallbackUrl,disableRedirect,idToken,const DeepCollectionEquality().hash(scopes),requestSignUp,loginHint,additionalData);
+
+@override
+String toString() {
+  return 'SignInSocialRequestBody(provider: $provider, callbackUrl: $callbackUrl, newUserCallbackUrl: $newUserCallbackUrl, errorCallbackUrl: $errorCallbackUrl, disableRedirect: $disableRedirect, idToken: $idToken, scopes: $scopes, requestSignUp: $requestSignUp, loginHint: $loginHint, additionalData: $additionalData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SignInSocialRequestBodyCopyWith<$Res>  {
+  factory $SignInSocialRequestBodyCopyWith(SignInSocialRequestBody value, $Res Function(SignInSocialRequestBody) _then) = _$SignInSocialRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String provider,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl,@JsonKey(includeIfNull: false, name: 'newUserCallbackURL') String? newUserCallbackUrl,@JsonKey(includeIfNull: false, name: 'errorCallbackURL') String? errorCallbackUrl,@JsonKey(includeIfNull: false) bool? disableRedirect,@JsonKey(includeIfNull: false) IdToken? idToken,@JsonKey(includeIfNull: false) List<dynamic>? scopes,@JsonKey(includeIfNull: false) bool? requestSignUp,@JsonKey(includeIfNull: false) String? loginHint,@JsonKey(includeIfNull: false) String? additionalData
+});
+
+
+$IdTokenCopyWith<$Res>? get idToken;
+
+}
+/// @nodoc
+class _$SignInSocialRequestBodyCopyWithImpl<$Res>
+    implements $SignInSocialRequestBodyCopyWith<$Res> {
+  _$SignInSocialRequestBodyCopyWithImpl(this._self, this._then);
+
+  final SignInSocialRequestBody _self;
+  final $Res Function(SignInSocialRequestBody) _then;
+
+/// Create a copy of SignInSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? provider = null,Object? callbackUrl = freezed,Object? newUserCallbackUrl = freezed,Object? errorCallbackUrl = freezed,Object? disableRedirect = freezed,Object? idToken = freezed,Object? scopes = freezed,Object? requestSignUp = freezed,Object? loginHint = freezed,Object? additionalData = freezed,}) {
+  return _then(_self.copyWith(
+provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,newUserCallbackUrl: freezed == newUserCallbackUrl ? _self.newUserCallbackUrl : newUserCallbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,errorCallbackUrl: freezed == errorCallbackUrl ? _self.errorCallbackUrl : errorCallbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,disableRedirect: freezed == disableRedirect ? _self.disableRedirect : disableRedirect // ignore: cast_nullable_to_non_nullable
+as bool?,idToken: freezed == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as IdToken?,scopes: freezed == scopes ? _self.scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,requestSignUp: freezed == requestSignUp ? _self.requestSignUp : requestSignUp // ignore: cast_nullable_to_non_nullable
+as bool?,loginHint: freezed == loginHint ? _self.loginHint : loginHint // ignore: cast_nullable_to_non_nullable
+as String?,additionalData: freezed == additionalData ? _self.additionalData : additionalData // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of SignInSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$IdTokenCopyWith<$Res>? get idToken {
+    if (_self.idToken == null) {
+    return null;
+  }
+
+  return $IdTokenCopyWith<$Res>(_self.idToken!, (value) {
+    return _then(_self.copyWith(idToken: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [SignInSocialRequestBody].
+extension SignInSocialRequestBodyPatterns on SignInSocialRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SignInSocialRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SignInSocialRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SignInSocialRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _SignInSocialRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SignInSocialRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SignInSocialRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String provider, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false, name: 'newUserCallbackURL')  String? newUserCallbackUrl, @JsonKey(includeIfNull: false, name: 'errorCallbackURL')  String? errorCallbackUrl, @JsonKey(includeIfNull: false)  bool? disableRedirect, @JsonKey(includeIfNull: false)  IdToken? idToken, @JsonKey(includeIfNull: false)  List<dynamic>? scopes, @JsonKey(includeIfNull: false)  bool? requestSignUp, @JsonKey(includeIfNull: false)  String? loginHint, @JsonKey(includeIfNull: false)  String? additionalData)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SignInSocialRequestBody() when $default != null:
+return $default(_that.provider,_that.callbackUrl,_that.newUserCallbackUrl,_that.errorCallbackUrl,_that.disableRedirect,_that.idToken,_that.scopes,_that.requestSignUp,_that.loginHint,_that.additionalData);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String provider, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false, name: 'newUserCallbackURL')  String? newUserCallbackUrl, @JsonKey(includeIfNull: false, name: 'errorCallbackURL')  String? errorCallbackUrl, @JsonKey(includeIfNull: false)  bool? disableRedirect, @JsonKey(includeIfNull: false)  IdToken? idToken, @JsonKey(includeIfNull: false)  List<dynamic>? scopes, @JsonKey(includeIfNull: false)  bool? requestSignUp, @JsonKey(includeIfNull: false)  String? loginHint, @JsonKey(includeIfNull: false)  String? additionalData)  $default,) {final _that = this;
+switch (_that) {
+case _SignInSocialRequestBody():
+return $default(_that.provider,_that.callbackUrl,_that.newUserCallbackUrl,_that.errorCallbackUrl,_that.disableRedirect,_that.idToken,_that.scopes,_that.requestSignUp,_that.loginHint,_that.additionalData);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String provider, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false, name: 'newUserCallbackURL')  String? newUserCallbackUrl, @JsonKey(includeIfNull: false, name: 'errorCallbackURL')  String? errorCallbackUrl, @JsonKey(includeIfNull: false)  bool? disableRedirect, @JsonKey(includeIfNull: false)  IdToken? idToken, @JsonKey(includeIfNull: false)  List<dynamic>? scopes, @JsonKey(includeIfNull: false)  bool? requestSignUp, @JsonKey(includeIfNull: false)  String? loginHint, @JsonKey(includeIfNull: false)  String? additionalData)?  $default,) {final _that = this;
+switch (_that) {
+case _SignInSocialRequestBody() when $default != null:
+return $default(_that.provider,_that.callbackUrl,_that.newUserCallbackUrl,_that.errorCallbackUrl,_that.disableRedirect,_that.idToken,_that.scopes,_that.requestSignUp,_that.loginHint,_that.additionalData);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SignInSocialRequestBody implements SignInSocialRequestBody {
+  const _SignInSocialRequestBody({required this.provider, @JsonKey(includeIfNull: false, name: 'callbackURL') this.callbackUrl, @JsonKey(includeIfNull: false, name: 'newUserCallbackURL') this.newUserCallbackUrl, @JsonKey(includeIfNull: false, name: 'errorCallbackURL') this.errorCallbackUrl, @JsonKey(includeIfNull: false) this.disableRedirect, @JsonKey(includeIfNull: false) this.idToken, @JsonKey(includeIfNull: false) final  List<dynamic>? scopes, @JsonKey(includeIfNull: false) this.requestSignUp, @JsonKey(includeIfNull: false) this.loginHint, @JsonKey(includeIfNull: false) this.additionalData}): _scopes = scopes;
+  factory _SignInSocialRequestBody.fromJson(Map<String, dynamic> json) => _$SignInSocialRequestBodyFromJson(json);
+
+@override final  String provider;
+/// Callback URL to redirect to after the user has signed in
+@override@JsonKey(includeIfNull: false, name: 'callbackURL') final  String? callbackUrl;
+@override@JsonKey(includeIfNull: false, name: 'newUserCallbackURL') final  String? newUserCallbackUrl;
+/// Callback URL to redirect to if an error happens
+@override@JsonKey(includeIfNull: false, name: 'errorCallbackURL') final  String? errorCallbackUrl;
+/// Disable automatic redirection to the provider. Useful for handling the redirection yourself
+@override@JsonKey(includeIfNull: false) final  bool? disableRedirect;
+@override@JsonKey(includeIfNull: false) final  IdToken? idToken;
+/// Array of scopes to request from the provider. This will override the default scopes passed.
+ final  List<dynamic>? _scopes;
+/// Array of scopes to request from the provider. This will override the default scopes passed.
+@override@JsonKey(includeIfNull: false) List<dynamic>? get scopes {
+  final value = _scopes;
+  if (value == null) return null;
+  if (_scopes is EqualUnmodifiableListView) return _scopes;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+/// Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider
+@override@JsonKey(includeIfNull: false) final  bool? requestSignUp;
+/// The login hint to use for the authorization code request
+@override@JsonKey(includeIfNull: false) final  String? loginHint;
+@override@JsonKey(includeIfNull: false) final  String? additionalData;
+
+/// Create a copy of SignInSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SignInSocialRequestBodyCopyWith<_SignInSocialRequestBody> get copyWith => __$SignInSocialRequestBodyCopyWithImpl<_SignInSocialRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SignInSocialRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SignInSocialRequestBody&&(identical(other.provider, provider) || other.provider == provider)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.newUserCallbackUrl, newUserCallbackUrl) || other.newUserCallbackUrl == newUserCallbackUrl)&&(identical(other.errorCallbackUrl, errorCallbackUrl) || other.errorCallbackUrl == errorCallbackUrl)&&(identical(other.disableRedirect, disableRedirect) || other.disableRedirect == disableRedirect)&&(identical(other.idToken, idToken) || other.idToken == idToken)&&const DeepCollectionEquality().equals(other._scopes, _scopes)&&(identical(other.requestSignUp, requestSignUp) || other.requestSignUp == requestSignUp)&&(identical(other.loginHint, loginHint) || other.loginHint == loginHint)&&(identical(other.additionalData, additionalData) || other.additionalData == additionalData));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,provider,callbackUrl,newUserCallbackUrl,errorCallbackUrl,disableRedirect,idToken,const DeepCollectionEquality().hash(_scopes),requestSignUp,loginHint,additionalData);
+
+@override
+String toString() {
+  return 'SignInSocialRequestBody(provider: $provider, callbackUrl: $callbackUrl, newUserCallbackUrl: $newUserCallbackUrl, errorCallbackUrl: $errorCallbackUrl, disableRedirect: $disableRedirect, idToken: $idToken, scopes: $scopes, requestSignUp: $requestSignUp, loginHint: $loginHint, additionalData: $additionalData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SignInSocialRequestBodyCopyWith<$Res> implements $SignInSocialRequestBodyCopyWith<$Res> {
+  factory _$SignInSocialRequestBodyCopyWith(_SignInSocialRequestBody value, $Res Function(_SignInSocialRequestBody) _then) = __$SignInSocialRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String provider,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl,@JsonKey(includeIfNull: false, name: 'newUserCallbackURL') String? newUserCallbackUrl,@JsonKey(includeIfNull: false, name: 'errorCallbackURL') String? errorCallbackUrl,@JsonKey(includeIfNull: false) bool? disableRedirect,@JsonKey(includeIfNull: false) IdToken? idToken,@JsonKey(includeIfNull: false) List<dynamic>? scopes,@JsonKey(includeIfNull: false) bool? requestSignUp,@JsonKey(includeIfNull: false) String? loginHint,@JsonKey(includeIfNull: false) String? additionalData
+});
+
+
+@override $IdTokenCopyWith<$Res>? get idToken;
+
+}
+/// @nodoc
+class __$SignInSocialRequestBodyCopyWithImpl<$Res>
+    implements _$SignInSocialRequestBodyCopyWith<$Res> {
+  __$SignInSocialRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _SignInSocialRequestBody _self;
+  final $Res Function(_SignInSocialRequestBody) _then;
+
+/// Create a copy of SignInSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? provider = null,Object? callbackUrl = freezed,Object? newUserCallbackUrl = freezed,Object? errorCallbackUrl = freezed,Object? disableRedirect = freezed,Object? idToken = freezed,Object? scopes = freezed,Object? requestSignUp = freezed,Object? loginHint = freezed,Object? additionalData = freezed,}) {
+  return _then(_SignInSocialRequestBody(
+provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
+as String,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,newUserCallbackUrl: freezed == newUserCallbackUrl ? _self.newUserCallbackUrl : newUserCallbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,errorCallbackUrl: freezed == errorCallbackUrl ? _self.errorCallbackUrl : errorCallbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,disableRedirect: freezed == disableRedirect ? _self.disableRedirect : disableRedirect // ignore: cast_nullable_to_non_nullable
+as bool?,idToken: freezed == idToken ? _self.idToken : idToken // ignore: cast_nullable_to_non_nullable
+as IdToken?,scopes: freezed == scopes ? _self._scopes : scopes // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,requestSignUp: freezed == requestSignUp ? _self.requestSignUp : requestSignUp // ignore: cast_nullable_to_non_nullable
+as bool?,loginHint: freezed == loginHint ? _self.loginHint : loginHint // ignore: cast_nullable_to_non_nullable
+as String?,additionalData: freezed == additionalData ? _self.additionalData : additionalData // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of SignInSocialRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$IdTokenCopyWith<$Res>? get idToken {
+    if (_self.idToken == null) {
+    return null;
+  }
+
+  return $IdTokenCopyWith<$Res>(_self.idToken!, (value) {
+    return _then(_self.copyWith(idToken: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/sign_in_social_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/sign_in_social_request_body.g.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'sign_in_social_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SignInSocialRequestBody _$SignInSocialRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_SignInSocialRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _SignInSocialRequestBody(
+      provider: $checkedConvert('provider', (v) => v as String),
+      callbackUrl: $checkedConvert('callbackURL', (v) => v as String?),
+      newUserCallbackUrl: $checkedConvert(
+        'newUserCallbackURL',
+        (v) => v as String?,
+      ),
+      errorCallbackUrl: $checkedConvert(
+        'errorCallbackURL',
+        (v) => v as String?,
+      ),
+      disableRedirect: $checkedConvert('disable_redirect', (v) => v as bool?),
+      idToken: $checkedConvert(
+        'id_token',
+        (v) => v == null ? null : IdToken.fromJson(v as Map<String, dynamic>),
+      ),
+      scopes: $checkedConvert('scopes', (v) => v as List<dynamic>?),
+      requestSignUp: $checkedConvert('request_sign_up', (v) => v as bool?),
+      loginHint: $checkedConvert('login_hint', (v) => v as String?),
+      additionalData: $checkedConvert('additional_data', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'callbackUrl': 'callbackURL',
+    'newUserCallbackUrl': 'newUserCallbackURL',
+    'errorCallbackUrl': 'errorCallbackURL',
+    'disableRedirect': 'disable_redirect',
+    'idToken': 'id_token',
+    'requestSignUp': 'request_sign_up',
+    'loginHint': 'login_hint',
+    'additionalData': 'additional_data',
+  },
+);
+
+Map<String, dynamic> _$SignInSocialRequestBodyToJson(
+  _SignInSocialRequestBody instance,
+) => <String, dynamic>{
+  'provider': instance.provider,
+  'callbackURL': ?instance.callbackUrl,
+  'newUserCallbackURL': ?instance.newUserCallbackUrl,
+  'errorCallbackURL': ?instance.errorCallbackUrl,
+  'disable_redirect': ?instance.disableRedirect,
+  'id_token': ?instance.idToken,
+  'scopes': ?instance.scopes,
+  'request_sign_up': ?instance.requestSignUp,
+  'login_hint': ?instance.loginHint,
+  'additional_data': ?instance.additionalData,
+};

--- a/packages/better_auth_api_client/lib/models/sign_up_email_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/sign_up_email_request_body.dart
@@ -1,0 +1,36 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'sign_up_email_request_body.freezed.dart';
+part 'sign_up_email_request_body.g.dart';
+
+@Freezed()
+abstract class SignUpEmailRequestBody with _$SignUpEmailRequestBody {
+  const factory SignUpEmailRequestBody({
+    /// The name of the user
+    required String name,
+
+    /// The email of the user
+    required String email,
+
+    /// The password of the user
+    required String password,
+
+    /// The profile image URL of the user
+    @JsonKey(includeIfNull: false)
+    String? image,
+
+    /// The URL to use for email verification callback
+    @JsonKey(includeIfNull: false,name: 'callbackURL')
+    String? callbackUrl,
+
+    /// If this is false, the session will not be remembered. Default is `true`.
+    @JsonKey(includeIfNull: false)
+    bool? rememberMe,
+  }) = _SignUpEmailRequestBody;
+  
+  factory SignUpEmailRequestBody.fromJson(Map<String, Object?> json) => _$SignUpEmailRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/sign_up_email_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/sign_up_email_request_body.freezed.dart
@@ -1,0 +1,304 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sign_up_email_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SignUpEmailRequestBody {
+
+/// The name of the user
+ String get name;/// The email of the user
+ String get email;/// The password of the user
+ String get password;/// The profile image URL of the user
+@JsonKey(includeIfNull: false) String? get image;/// The URL to use for email verification callback
+@JsonKey(includeIfNull: false, name: 'callbackURL') String? get callbackUrl;/// If this is false, the session will not be remembered. Default is `true`.
+@JsonKey(includeIfNull: false) bool? get rememberMe;
+/// Create a copy of SignUpEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SignUpEmailRequestBodyCopyWith<SignUpEmailRequestBody> get copyWith => _$SignUpEmailRequestBodyCopyWithImpl<SignUpEmailRequestBody>(this as SignUpEmailRequestBody, _$identity);
+
+  /// Serializes this SignUpEmailRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SignUpEmailRequestBody&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.password, password) || other.password == password)&&(identical(other.image, image) || other.image == image)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.rememberMe, rememberMe) || other.rememberMe == rememberMe));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,email,password,image,callbackUrl,rememberMe);
+
+@override
+String toString() {
+  return 'SignUpEmailRequestBody(name: $name, email: $email, password: $password, image: $image, callbackUrl: $callbackUrl, rememberMe: $rememberMe)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SignUpEmailRequestBodyCopyWith<$Res>  {
+  factory $SignUpEmailRequestBodyCopyWith(SignUpEmailRequestBody value, $Res Function(SignUpEmailRequestBody) _then) = _$SignUpEmailRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String name, String email, String password,@JsonKey(includeIfNull: false) String? image,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl,@JsonKey(includeIfNull: false) bool? rememberMe
+});
+
+
+
+
+}
+/// @nodoc
+class _$SignUpEmailRequestBodyCopyWithImpl<$Res>
+    implements $SignUpEmailRequestBodyCopyWith<$Res> {
+  _$SignUpEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final SignUpEmailRequestBody _self;
+  final $Res Function(SignUpEmailRequestBody) _then;
+
+/// Create a copy of SignUpEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? email = null,Object? password = null,Object? image = freezed,Object? callbackUrl = freezed,Object? rememberMe = freezed,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,rememberMe: freezed == rememberMe ? _self.rememberMe : rememberMe // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SignUpEmailRequestBody].
+extension SignUpEmailRequestBodyPatterns on SignUpEmailRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SignUpEmailRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SignUpEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SignUpEmailRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _SignUpEmailRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SignUpEmailRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SignUpEmailRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String email,  String password, @JsonKey(includeIfNull: false)  String? image, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false)  bool? rememberMe)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SignUpEmailRequestBody() when $default != null:
+return $default(_that.name,_that.email,_that.password,_that.image,_that.callbackUrl,_that.rememberMe);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String email,  String password, @JsonKey(includeIfNull: false)  String? image, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false)  bool? rememberMe)  $default,) {final _that = this;
+switch (_that) {
+case _SignUpEmailRequestBody():
+return $default(_that.name,_that.email,_that.password,_that.image,_that.callbackUrl,_that.rememberMe);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String email,  String password, @JsonKey(includeIfNull: false)  String? image, @JsonKey(includeIfNull: false, name: 'callbackURL')  String? callbackUrl, @JsonKey(includeIfNull: false)  bool? rememberMe)?  $default,) {final _that = this;
+switch (_that) {
+case _SignUpEmailRequestBody() when $default != null:
+return $default(_that.name,_that.email,_that.password,_that.image,_that.callbackUrl,_that.rememberMe);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SignUpEmailRequestBody implements SignUpEmailRequestBody {
+  const _SignUpEmailRequestBody({required this.name, required this.email, required this.password, @JsonKey(includeIfNull: false) this.image, @JsonKey(includeIfNull: false, name: 'callbackURL') this.callbackUrl, @JsonKey(includeIfNull: false) this.rememberMe});
+  factory _SignUpEmailRequestBody.fromJson(Map<String, dynamic> json) => _$SignUpEmailRequestBodyFromJson(json);
+
+/// The name of the user
+@override final  String name;
+/// The email of the user
+@override final  String email;
+/// The password of the user
+@override final  String password;
+/// The profile image URL of the user
+@override@JsonKey(includeIfNull: false) final  String? image;
+/// The URL to use for email verification callback
+@override@JsonKey(includeIfNull: false, name: 'callbackURL') final  String? callbackUrl;
+/// If this is false, the session will not be remembered. Default is `true`.
+@override@JsonKey(includeIfNull: false) final  bool? rememberMe;
+
+/// Create a copy of SignUpEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SignUpEmailRequestBodyCopyWith<_SignUpEmailRequestBody> get copyWith => __$SignUpEmailRequestBodyCopyWithImpl<_SignUpEmailRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SignUpEmailRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SignUpEmailRequestBody&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.password, password) || other.password == password)&&(identical(other.image, image) || other.image == image)&&(identical(other.callbackUrl, callbackUrl) || other.callbackUrl == callbackUrl)&&(identical(other.rememberMe, rememberMe) || other.rememberMe == rememberMe));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,email,password,image,callbackUrl,rememberMe);
+
+@override
+String toString() {
+  return 'SignUpEmailRequestBody(name: $name, email: $email, password: $password, image: $image, callbackUrl: $callbackUrl, rememberMe: $rememberMe)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SignUpEmailRequestBodyCopyWith<$Res> implements $SignUpEmailRequestBodyCopyWith<$Res> {
+  factory _$SignUpEmailRequestBodyCopyWith(_SignUpEmailRequestBody value, $Res Function(_SignUpEmailRequestBody) _then) = __$SignUpEmailRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String name, String email, String password,@JsonKey(includeIfNull: false) String? image,@JsonKey(includeIfNull: false, name: 'callbackURL') String? callbackUrl,@JsonKey(includeIfNull: false) bool? rememberMe
+});
+
+
+
+
+}
+/// @nodoc
+class __$SignUpEmailRequestBodyCopyWithImpl<$Res>
+    implements _$SignUpEmailRequestBodyCopyWith<$Res> {
+  __$SignUpEmailRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _SignUpEmailRequestBody _self;
+  final $Res Function(_SignUpEmailRequestBody) _then;
+
+/// Create a copy of SignUpEmailRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? email = null,Object? password = null,Object? image = freezed,Object? callbackUrl = freezed,Object? rememberMe = freezed,}) {
+  return _then(_SignUpEmailRequestBody(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,callbackUrl: freezed == callbackUrl ? _self.callbackUrl : callbackUrl // ignore: cast_nullable_to_non_nullable
+as String?,rememberMe: freezed == rememberMe ? _self.rememberMe : rememberMe // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/sign_up_email_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/sign_up_email_request_body.g.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'sign_up_email_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SignUpEmailRequestBody _$SignUpEmailRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_SignUpEmailRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _SignUpEmailRequestBody(
+      name: $checkedConvert('name', (v) => v as String),
+      email: $checkedConvert('email', (v) => v as String),
+      password: $checkedConvert('password', (v) => v as String),
+      image: $checkedConvert('image', (v) => v as String?),
+      callbackUrl: $checkedConvert('callbackURL', (v) => v as String?),
+      rememberMe: $checkedConvert('remember_me', (v) => v as bool?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'callbackUrl': 'callbackURL',
+    'rememberMe': 'remember_me',
+  },
+);
+
+Map<String, dynamic> _$SignUpEmailRequestBodyToJson(
+  _SignUpEmailRequestBody instance,
+) => <String, dynamic>{
+  'name': instance.name,
+  'email': instance.email,
+  'password': instance.password,
+  'image': ?instance.image,
+  'callbackURL': ?instance.callbackUrl,
+  'remember_me': ?instance.rememberMe,
+};

--- a/packages/better_auth_api_client/lib/models/unlink_account_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/unlink_account_request_body.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'unlink_account_request_body.freezed.dart';
+part 'unlink_account_request_body.g.dart';
+
+@Freezed()
+abstract class UnlinkAccountRequestBody with _$UnlinkAccountRequestBody {
+  const factory UnlinkAccountRequestBody({
+    required String providerId,
+    @JsonKey(includeIfNull: false)
+    String? accountId,
+  }) = _UnlinkAccountRequestBody;
+  
+  factory UnlinkAccountRequestBody.fromJson(Map<String, Object?> json) => _$UnlinkAccountRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/unlink_account_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/unlink_account_request_body.freezed.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'unlink_account_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$UnlinkAccountRequestBody {
+
+ String get providerId;@JsonKey(includeIfNull: false) String? get accountId;
+/// Create a copy of UnlinkAccountRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UnlinkAccountRequestBodyCopyWith<UnlinkAccountRequestBody> get copyWith => _$UnlinkAccountRequestBodyCopyWithImpl<UnlinkAccountRequestBody>(this as UnlinkAccountRequestBody, _$identity);
+
+  /// Serializes this UnlinkAccountRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UnlinkAccountRequestBody&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.accountId, accountId) || other.accountId == accountId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,providerId,accountId);
+
+@override
+String toString() {
+  return 'UnlinkAccountRequestBody(providerId: $providerId, accountId: $accountId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UnlinkAccountRequestBodyCopyWith<$Res>  {
+  factory $UnlinkAccountRequestBodyCopyWith(UnlinkAccountRequestBody value, $Res Function(UnlinkAccountRequestBody) _then) = _$UnlinkAccountRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String providerId,@JsonKey(includeIfNull: false) String? accountId
+});
+
+
+
+
+}
+/// @nodoc
+class _$UnlinkAccountRequestBodyCopyWithImpl<$Res>
+    implements $UnlinkAccountRequestBodyCopyWith<$Res> {
+  _$UnlinkAccountRequestBodyCopyWithImpl(this._self, this._then);
+
+  final UnlinkAccountRequestBody _self;
+  final $Res Function(UnlinkAccountRequestBody) _then;
+
+/// Create a copy of UnlinkAccountRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? providerId = null,Object? accountId = freezed,}) {
+  return _then(_self.copyWith(
+providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [UnlinkAccountRequestBody].
+extension UnlinkAccountRequestBodyPatterns on UnlinkAccountRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UnlinkAccountRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UnlinkAccountRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UnlinkAccountRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _UnlinkAccountRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UnlinkAccountRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UnlinkAccountRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UnlinkAccountRequestBody() when $default != null:
+return $default(_that.providerId,_that.accountId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId)  $default,) {final _that = this;
+switch (_that) {
+case _UnlinkAccountRequestBody():
+return $default(_that.providerId,_that.accountId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String providerId, @JsonKey(includeIfNull: false)  String? accountId)?  $default,) {final _that = this;
+switch (_that) {
+case _UnlinkAccountRequestBody() when $default != null:
+return $default(_that.providerId,_that.accountId);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _UnlinkAccountRequestBody implements UnlinkAccountRequestBody {
+  const _UnlinkAccountRequestBody({required this.providerId, @JsonKey(includeIfNull: false) this.accountId});
+  factory _UnlinkAccountRequestBody.fromJson(Map<String, dynamic> json) => _$UnlinkAccountRequestBodyFromJson(json);
+
+@override final  String providerId;
+@override@JsonKey(includeIfNull: false) final  String? accountId;
+
+/// Create a copy of UnlinkAccountRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UnlinkAccountRequestBodyCopyWith<_UnlinkAccountRequestBody> get copyWith => __$UnlinkAccountRequestBodyCopyWithImpl<_UnlinkAccountRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UnlinkAccountRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UnlinkAccountRequestBody&&(identical(other.providerId, providerId) || other.providerId == providerId)&&(identical(other.accountId, accountId) || other.accountId == accountId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,providerId,accountId);
+
+@override
+String toString() {
+  return 'UnlinkAccountRequestBody(providerId: $providerId, accountId: $accountId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UnlinkAccountRequestBodyCopyWith<$Res> implements $UnlinkAccountRequestBodyCopyWith<$Res> {
+  factory _$UnlinkAccountRequestBodyCopyWith(_UnlinkAccountRequestBody value, $Res Function(_UnlinkAccountRequestBody) _then) = __$UnlinkAccountRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String providerId,@JsonKey(includeIfNull: false) String? accountId
+});
+
+
+
+
+}
+/// @nodoc
+class __$UnlinkAccountRequestBodyCopyWithImpl<$Res>
+    implements _$UnlinkAccountRequestBodyCopyWith<$Res> {
+  __$UnlinkAccountRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _UnlinkAccountRequestBody _self;
+  final $Res Function(_UnlinkAccountRequestBody) _then;
+
+/// Create a copy of UnlinkAccountRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? providerId = null,Object? accountId = freezed,}) {
+  return _then(_UnlinkAccountRequestBody(
+providerId: null == providerId ? _self.providerId : providerId // ignore: cast_nullable_to_non_nullable
+as String,accountId: freezed == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/unlink_account_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/unlink_account_request_body.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'unlink_account_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_UnlinkAccountRequestBody _$UnlinkAccountRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_UnlinkAccountRequestBody',
+  json,
+  ($checkedConvert) {
+    final val = _UnlinkAccountRequestBody(
+      providerId: $checkedConvert('provider_id', (v) => v as String),
+      accountId: $checkedConvert('account_id', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'providerId': 'provider_id', 'accountId': 'account_id'},
+);
+
+Map<String, dynamic> _$UnlinkAccountRequestBodyToJson(
+  _UnlinkAccountRequestBody instance,
+) => <String, dynamic>{
+  'provider_id': instance.providerId,
+  'account_id': ?instance.accountId,
+};

--- a/packages/better_auth_api_client/lib/models/update_user_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/update_user_request_body.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'update_user_request_body.freezed.dart';
+part 'update_user_request_body.g.dart';
+
+@Freezed()
+abstract class UpdateUserRequestBody with _$UpdateUserRequestBody {
+  const factory UpdateUserRequestBody({
+    /// The name of the user
+    required String name,
+
+    /// The image of the user
+    @JsonKey(includeIfNull: false)
+    String? image,
+  }) = _UpdateUserRequestBody;
+  
+  factory UpdateUserRequestBody.fromJson(Map<String, Object?> json) => _$UpdateUserRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/update_user_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/update_user_request_body.freezed.dart
@@ -1,0 +1,284 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'update_user_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$UpdateUserRequestBody {
+
+/// The name of the user
+ String get name;/// The image of the user
+@JsonKey(includeIfNull: false) String? get image;
+/// Create a copy of UpdateUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UpdateUserRequestBodyCopyWith<UpdateUserRequestBody> get copyWith => _$UpdateUserRequestBodyCopyWithImpl<UpdateUserRequestBody>(this as UpdateUserRequestBody, _$identity);
+
+  /// Serializes this UpdateUserRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UpdateUserRequestBody&&(identical(other.name, name) || other.name == name)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,image);
+
+@override
+String toString() {
+  return 'UpdateUserRequestBody(name: $name, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UpdateUserRequestBodyCopyWith<$Res>  {
+  factory $UpdateUserRequestBodyCopyWith(UpdateUserRequestBody value, $Res Function(UpdateUserRequestBody) _then) = _$UpdateUserRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String name,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class _$UpdateUserRequestBodyCopyWithImpl<$Res>
+    implements $UpdateUserRequestBodyCopyWith<$Res> {
+  _$UpdateUserRequestBodyCopyWithImpl(this._self, this._then);
+
+  final UpdateUserRequestBody _self;
+  final $Res Function(UpdateUserRequestBody) _then;
+
+/// Create a copy of UpdateUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? image = freezed,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [UpdateUserRequestBody].
+extension UpdateUserRequestBodyPatterns on UpdateUserRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UpdateUserRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UpdateUserRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UpdateUserRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _UpdateUserRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UpdateUserRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UpdateUserRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name, @JsonKey(includeIfNull: false)  String? image)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UpdateUserRequestBody() when $default != null:
+return $default(_that.name,_that.image);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name, @JsonKey(includeIfNull: false)  String? image)  $default,) {final _that = this;
+switch (_that) {
+case _UpdateUserRequestBody():
+return $default(_that.name,_that.image);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name, @JsonKey(includeIfNull: false)  String? image)?  $default,) {final _that = this;
+switch (_that) {
+case _UpdateUserRequestBody() when $default != null:
+return $default(_that.name,_that.image);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _UpdateUserRequestBody implements UpdateUserRequestBody {
+  const _UpdateUserRequestBody({required this.name, @JsonKey(includeIfNull: false) this.image});
+  factory _UpdateUserRequestBody.fromJson(Map<String, dynamic> json) => _$UpdateUserRequestBodyFromJson(json);
+
+/// The name of the user
+@override final  String name;
+/// The image of the user
+@override@JsonKey(includeIfNull: false) final  String? image;
+
+/// Create a copy of UpdateUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UpdateUserRequestBodyCopyWith<_UpdateUserRequestBody> get copyWith => __$UpdateUserRequestBodyCopyWithImpl<_UpdateUserRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UpdateUserRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UpdateUserRequestBody&&(identical(other.name, name) || other.name == name)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,image);
+
+@override
+String toString() {
+  return 'UpdateUserRequestBody(name: $name, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UpdateUserRequestBodyCopyWith<$Res> implements $UpdateUserRequestBodyCopyWith<$Res> {
+  factory _$UpdateUserRequestBodyCopyWith(_UpdateUserRequestBody value, $Res Function(_UpdateUserRequestBody) _then) = __$UpdateUserRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String name,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class __$UpdateUserRequestBodyCopyWithImpl<$Res>
+    implements _$UpdateUserRequestBodyCopyWith<$Res> {
+  __$UpdateUserRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _UpdateUserRequestBody _self;
+  final $Res Function(_UpdateUserRequestBody) _then;
+
+/// Create a copy of UpdateUserRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? image = freezed,}) {
+  return _then(_UpdateUserRequestBody(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/update_user_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/update_user_request_body.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'update_user_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_UpdateUserRequestBody _$UpdateUserRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_UpdateUserRequestBody', json, ($checkedConvert) {
+  final val = _UpdateUserRequestBody(
+    name: $checkedConvert('name', (v) => v as String),
+    image: $checkedConvert('image', (v) => v as String?),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$UpdateUserRequestBodyToJson(
+  _UpdateUserRequestBody instance,
+) => <String, dynamic>{'name': instance.name, 'image': ?instance.image};

--- a/packages/better_auth_api_client/lib/models/user.dart
+++ b/packages/better_auth_api_client/lib/models/user.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'name.dart';
+
+part 'user.freezed.dart';
+part 'user.g.dart';
+
+@Freezed()
+abstract class User with _$User {
+  const factory User({
+    @JsonKey(includeIfNull: true)
+    required Name? name,
+    @JsonKey(includeIfNull: true)
+    required String? email,
+  }) = _User;
+  
+  factory User.fromJson(Map<String, Object?> json) => _$UserFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/user.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/user.freezed.dart
@@ -1,0 +1,304 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$User {
+
+@JsonKey(includeIfNull: true) Name? get name;@JsonKey(includeIfNull: true) String? get email;
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserCopyWith<User> get copyWith => _$UserCopyWithImpl<User>(this as User, _$identity);
+
+  /// Serializes this User to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is User&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,email);
+
+@override
+String toString() {
+  return 'User(name: $name, email: $email)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UserCopyWith<$Res>  {
+  factory $UserCopyWith(User value, $Res Function(User) _then) = _$UserCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(includeIfNull: true) Name? name,@JsonKey(includeIfNull: true) String? email
+});
+
+
+$NameCopyWith<$Res>? get name;
+
+}
+/// @nodoc
+class _$UserCopyWithImpl<$Res>
+    implements $UserCopyWith<$Res> {
+  _$UserCopyWithImpl(this._self, this._then);
+
+  final User _self;
+  final $Res Function(User) _then;
+
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = freezed,Object? email = freezed,}) {
+  return _then(_self.copyWith(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as Name?,email: freezed == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$NameCopyWith<$Res>? get name {
+    if (_self.name == null) {
+    return null;
+  }
+
+  return $NameCopyWith<$Res>(_self.name!, (value) {
+    return _then(_self.copyWith(name: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [User].
+extension UserPatterns on User {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _User value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _User value)  $default,){
+final _that = this;
+switch (_that) {
+case _User():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _User value)?  $default,){
+final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: true)  Name? name, @JsonKey(includeIfNull: true)  String? email)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that.name,_that.email);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: true)  Name? name, @JsonKey(includeIfNull: true)  String? email)  $default,) {final _that = this;
+switch (_that) {
+case _User():
+return $default(_that.name,_that.email);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: true)  Name? name, @JsonKey(includeIfNull: true)  String? email)?  $default,) {final _that = this;
+switch (_that) {
+case _User() when $default != null:
+return $default(_that.name,_that.email);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _User implements User {
+  const _User({@JsonKey(includeIfNull: true) required this.name, @JsonKey(includeIfNull: true) required this.email});
+  factory _User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+
+@override@JsonKey(includeIfNull: true) final  Name? name;
+@override@JsonKey(includeIfNull: true) final  String? email;
+
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserCopyWith<_User> get copyWith => __$UserCopyWithImpl<_User>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UserToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,email);
+
+@override
+String toString() {
+  return 'User(name: $name, email: $email)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
+  factory _$UserCopyWith(_User value, $Res Function(_User) _then) = __$UserCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(includeIfNull: true) Name? name,@JsonKey(includeIfNull: true) String? email
+});
+
+
+@override $NameCopyWith<$Res>? get name;
+
+}
+/// @nodoc
+class __$UserCopyWithImpl<$Res>
+    implements _$UserCopyWith<$Res> {
+  __$UserCopyWithImpl(this._self, this._then);
+
+  final _User _self;
+  final $Res Function(_User) _then;
+
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = freezed,Object? email = freezed,}) {
+  return _then(_User(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as Name?,email: freezed == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+/// Create a copy of User
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$NameCopyWith<$Res>? get name {
+    if (_self.name == null) {
+    return null;
+  }
+
+  return $NameCopyWith<$Res>(_self.name!, (value) {
+    return _then(_self.copyWith(name: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/user.g.dart
+++ b/packages/better_auth_api_client/lib/models/user.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'user.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_User _$UserFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('_User', json, ($checkedConvert) {
+      final val = _User(
+        name: $checkedConvert(
+          'name',
+          (v) => v == null ? null : Name.fromJson(v as Map<String, dynamic>),
+        ),
+        email: $checkedConvert('email', (v) => v as String?),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$UserToJson(_User instance) => <String, dynamic>{
+  'name': instance.name,
+  'email': instance.email,
+};

--- a/packages/better_auth_api_client/lib/models/user2.dart
+++ b/packages/better_auth_api_client/lib/models/user2.dart
@@ -1,0 +1,37 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user2.freezed.dart';
+part 'user2.g.dart';
+
+@Freezed()
+abstract class User2 with _$User2 {
+  const factory User2({
+    /// The unique identifier of the user
+    required String id,
+
+    /// The email address of the user
+    required String email,
+
+    /// The name of the user
+    required String name,
+
+    /// Whether the email has been verified
+    required bool emailVerified,
+
+    /// When the user was created
+    required DateTime createdAt,
+
+    /// When the user was last updated
+    required DateTime updatedAt,
+
+    /// The profile image URL of the user
+    @JsonKey(includeIfNull: false)
+    String? image,
+  }) = _User2;
+  
+  factory User2.fromJson(Map<String, Object?> json) => _$User2FromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/user2.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/user2.freezed.dart
@@ -1,0 +1,309 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user2.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$User2 {
+
+/// The unique identifier of the user
+ String get id;/// The email address of the user
+ String get email;/// The name of the user
+ String get name;/// Whether the email has been verified
+ bool get emailVerified;/// When the user was created
+ DateTime get createdAt;/// When the user was last updated
+ DateTime get updatedAt;/// The profile image URL of the user
+@JsonKey(includeIfNull: false) String? get image;
+/// Create a copy of User2
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$User2CopyWith<User2> get copyWith => _$User2CopyWithImpl<User2>(this as User2, _$identity);
+
+  /// Serializes this User2 to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is User2&&(identical(other.id, id) || other.id == id)&&(identical(other.email, email) || other.email == email)&&(identical(other.name, name) || other.name == name)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,email,name,emailVerified,createdAt,updatedAt,image);
+
+@override
+String toString() {
+  return 'User2(id: $id, email: $email, name: $name, emailVerified: $emailVerified, createdAt: $createdAt, updatedAt: $updatedAt, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $User2CopyWith<$Res>  {
+  factory $User2CopyWith(User2 value, $Res Function(User2) _then) = _$User2CopyWithImpl;
+@useResult
+$Res call({
+ String id, String email, String name, bool emailVerified, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class _$User2CopyWithImpl<$Res>
+    implements $User2CopyWith<$Res> {
+  _$User2CopyWithImpl(this._self, this._then);
+
+  final User2 _self;
+  final $Res Function(User2) _then;
+
+/// Create a copy of User2
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? email = null,Object? name = null,Object? emailVerified = null,Object? createdAt = null,Object? updatedAt = null,Object? image = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,emailVerified: null == emailVerified ? _self.emailVerified : emailVerified // ignore: cast_nullable_to_non_nullable
+as bool,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [User2].
+extension User2Patterns on User2 {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _User2 value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _User2() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _User2 value)  $default,){
+final _that = this;
+switch (_that) {
+case _User2():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _User2 value)?  $default,){
+final _that = this;
+switch (_that) {
+case _User2() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String email,  String name,  bool emailVerified,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: false)  String? image)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _User2() when $default != null:
+return $default(_that.id,_that.email,_that.name,_that.emailVerified,_that.createdAt,_that.updatedAt,_that.image);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String email,  String name,  bool emailVerified,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: false)  String? image)  $default,) {final _that = this;
+switch (_that) {
+case _User2():
+return $default(_that.id,_that.email,_that.name,_that.emailVerified,_that.createdAt,_that.updatedAt,_that.image);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String email,  String name,  bool emailVerified,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: false)  String? image)?  $default,) {final _that = this;
+switch (_that) {
+case _User2() when $default != null:
+return $default(_that.id,_that.email,_that.name,_that.emailVerified,_that.createdAt,_that.updatedAt,_that.image);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _User2 implements User2 {
+  const _User2({required this.id, required this.email, required this.name, required this.emailVerified, required this.createdAt, required this.updatedAt, @JsonKey(includeIfNull: false) this.image});
+  factory _User2.fromJson(Map<String, dynamic> json) => _$User2FromJson(json);
+
+/// The unique identifier of the user
+@override final  String id;
+/// The email address of the user
+@override final  String email;
+/// The name of the user
+@override final  String name;
+/// Whether the email has been verified
+@override final  bool emailVerified;
+/// When the user was created
+@override final  DateTime createdAt;
+/// When the user was last updated
+@override final  DateTime updatedAt;
+/// The profile image URL of the user
+@override@JsonKey(includeIfNull: false) final  String? image;
+
+/// Create a copy of User2
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$User2CopyWith<_User2> get copyWith => __$User2CopyWithImpl<_User2>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$User2ToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User2&&(identical(other.id, id) || other.id == id)&&(identical(other.email, email) || other.email == email)&&(identical(other.name, name) || other.name == name)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,email,name,emailVerified,createdAt,updatedAt,image);
+
+@override
+String toString() {
+  return 'User2(id: $id, email: $email, name: $name, emailVerified: $emailVerified, createdAt: $createdAt, updatedAt: $updatedAt, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$User2CopyWith<$Res> implements $User2CopyWith<$Res> {
+  factory _$User2CopyWith(_User2 value, $Res Function(_User2) _then) = __$User2CopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String email, String name, bool emailVerified, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class __$User2CopyWithImpl<$Res>
+    implements _$User2CopyWith<$Res> {
+  __$User2CopyWithImpl(this._self, this._then);
+
+  final _User2 _self;
+  final $Res Function(_User2) _then;
+
+/// Create a copy of User2
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? email = null,Object? name = null,Object? emailVerified = null,Object? createdAt = null,Object? updatedAt = null,Object? image = freezed,}) {
+  return _then(_User2(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,emailVerified: null == emailVerified ? _self.emailVerified : emailVerified // ignore: cast_nullable_to_non_nullable
+as bool,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/user2.g.dart
+++ b/packages/better_auth_api_client/lib/models/user2.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'user2.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_User2 _$User2FromJson(Map<String, dynamic> json) => $checkedCreate(
+  '_User2',
+  json,
+  ($checkedConvert) {
+    final val = _User2(
+      id: $checkedConvert('id', (v) => v as String),
+      email: $checkedConvert('email', (v) => v as String),
+      name: $checkedConvert('name', (v) => v as String),
+      emailVerified: $checkedConvert('email_verified', (v) => v as bool),
+      createdAt: $checkedConvert(
+        'created_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      updatedAt: $checkedConvert(
+        'updated_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      image: $checkedConvert('image', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'emailVerified': 'email_verified',
+    'createdAt': 'created_at',
+    'updatedAt': 'updated_at',
+  },
+);
+
+Map<String, dynamic> _$User2ToJson(_User2 instance) => <String, dynamic>{
+  'id': instance.id,
+  'email': instance.email,
+  'name': instance.name,
+  'email_verified': instance.emailVerified,
+  'created_at': instance.createdAt.toIso8601String(),
+  'updated_at': instance.updatedAt.toIso8601String(),
+  'image': ?instance.image,
+};

--- a/packages/better_auth_api_client/lib/models/user3.dart
+++ b/packages/better_auth_api_client/lib/models/user3.dart
@@ -1,0 +1,37 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user3.freezed.dart';
+part 'user3.g.dart';
+
+@Freezed()
+abstract class User3 with _$User3 {
+  const factory User3({
+    /// The unique identifier of the user
+    required String id,
+
+    /// The email address of the user
+    required String email,
+
+    /// The name of the user
+    required String name,
+
+    /// Whether the email has been verified
+    required bool emailVerified,
+
+    /// When the user was created
+    required DateTime createdAt,
+
+    /// When the user was last updated
+    required DateTime updatedAt,
+
+    /// The profile image URL of the user
+    @JsonKey(includeIfNull: false)
+    String? image,
+  }) = _User3;
+  
+  factory User3.fromJson(Map<String, Object?> json) => _$User3FromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/user3.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/user3.freezed.dart
@@ -1,0 +1,309 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user3.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$User3 {
+
+/// The unique identifier of the user
+ String get id;/// The email address of the user
+ String get email;/// The name of the user
+ String get name;/// Whether the email has been verified
+ bool get emailVerified;/// When the user was created
+ DateTime get createdAt;/// When the user was last updated
+ DateTime get updatedAt;/// The profile image URL of the user
+@JsonKey(includeIfNull: false) String? get image;
+/// Create a copy of User3
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$User3CopyWith<User3> get copyWith => _$User3CopyWithImpl<User3>(this as User3, _$identity);
+
+  /// Serializes this User3 to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is User3&&(identical(other.id, id) || other.id == id)&&(identical(other.email, email) || other.email == email)&&(identical(other.name, name) || other.name == name)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,email,name,emailVerified,createdAt,updatedAt,image);
+
+@override
+String toString() {
+  return 'User3(id: $id, email: $email, name: $name, emailVerified: $emailVerified, createdAt: $createdAt, updatedAt: $updatedAt, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $User3CopyWith<$Res>  {
+  factory $User3CopyWith(User3 value, $Res Function(User3) _then) = _$User3CopyWithImpl;
+@useResult
+$Res call({
+ String id, String email, String name, bool emailVerified, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class _$User3CopyWithImpl<$Res>
+    implements $User3CopyWith<$Res> {
+  _$User3CopyWithImpl(this._self, this._then);
+
+  final User3 _self;
+  final $Res Function(User3) _then;
+
+/// Create a copy of User3
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? email = null,Object? name = null,Object? emailVerified = null,Object? createdAt = null,Object? updatedAt = null,Object? image = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,emailVerified: null == emailVerified ? _self.emailVerified : emailVerified // ignore: cast_nullable_to_non_nullable
+as bool,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [User3].
+extension User3Patterns on User3 {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _User3 value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _User3() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _User3 value)  $default,){
+final _that = this;
+switch (_that) {
+case _User3():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _User3 value)?  $default,){
+final _that = this;
+switch (_that) {
+case _User3() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String email,  String name,  bool emailVerified,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: false)  String? image)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _User3() when $default != null:
+return $default(_that.id,_that.email,_that.name,_that.emailVerified,_that.createdAt,_that.updatedAt,_that.image);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String email,  String name,  bool emailVerified,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: false)  String? image)  $default,) {final _that = this;
+switch (_that) {
+case _User3():
+return $default(_that.id,_that.email,_that.name,_that.emailVerified,_that.createdAt,_that.updatedAt,_that.image);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String email,  String name,  bool emailVerified,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: false)  String? image)?  $default,) {final _that = this;
+switch (_that) {
+case _User3() when $default != null:
+return $default(_that.id,_that.email,_that.name,_that.emailVerified,_that.createdAt,_that.updatedAt,_that.image);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _User3 implements User3 {
+  const _User3({required this.id, required this.email, required this.name, required this.emailVerified, required this.createdAt, required this.updatedAt, @JsonKey(includeIfNull: false) this.image});
+  factory _User3.fromJson(Map<String, dynamic> json) => _$User3FromJson(json);
+
+/// The unique identifier of the user
+@override final  String id;
+/// The email address of the user
+@override final  String email;
+/// The name of the user
+@override final  String name;
+/// Whether the email has been verified
+@override final  bool emailVerified;
+/// When the user was created
+@override final  DateTime createdAt;
+/// When the user was last updated
+@override final  DateTime updatedAt;
+/// The profile image URL of the user
+@override@JsonKey(includeIfNull: false) final  String? image;
+
+/// Create a copy of User3
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$User3CopyWith<_User3> get copyWith => __$User3CopyWithImpl<_User3>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$User3ToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User3&&(identical(other.id, id) || other.id == id)&&(identical(other.email, email) || other.email == email)&&(identical(other.name, name) || other.name == name)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,email,name,emailVerified,createdAt,updatedAt,image);
+
+@override
+String toString() {
+  return 'User3(id: $id, email: $email, name: $name, emailVerified: $emailVerified, createdAt: $createdAt, updatedAt: $updatedAt, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$User3CopyWith<$Res> implements $User3CopyWith<$Res> {
+  factory _$User3CopyWith(_User3 value, $Res Function(_User3) _then) = __$User3CopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String email, String name, bool emailVerified, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class __$User3CopyWithImpl<$Res>
+    implements _$User3CopyWith<$Res> {
+  __$User3CopyWithImpl(this._self, this._then);
+
+  final _User3 _self;
+  final $Res Function(_User3) _then;
+
+/// Create a copy of User3
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? email = null,Object? name = null,Object? emailVerified = null,Object? createdAt = null,Object? updatedAt = null,Object? image = freezed,}) {
+  return _then(_User3(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,email: null == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,emailVerified: null == emailVerified ? _self.emailVerified : emailVerified // ignore: cast_nullable_to_non_nullable
+as bool,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/user3.g.dart
+++ b/packages/better_auth_api_client/lib/models/user3.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'user3.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_User3 _$User3FromJson(Map<String, dynamic> json) => $checkedCreate(
+  '_User3',
+  json,
+  ($checkedConvert) {
+    final val = _User3(
+      id: $checkedConvert('id', (v) => v as String),
+      email: $checkedConvert('email', (v) => v as String),
+      name: $checkedConvert('name', (v) => v as String),
+      emailVerified: $checkedConvert('email_verified', (v) => v as bool),
+      createdAt: $checkedConvert(
+        'created_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      updatedAt: $checkedConvert(
+        'updated_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      image: $checkedConvert('image', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'emailVerified': 'email_verified',
+    'createdAt': 'created_at',
+    'updatedAt': 'updated_at',
+  },
+);
+
+Map<String, dynamic> _$User3ToJson(_User3 instance) => <String, dynamic>{
+  'id': instance.id,
+  'email': instance.email,
+  'name': instance.name,
+  'email_verified': instance.emailVerified,
+  'created_at': instance.createdAt.toIso8601String(),
+  'updated_at': instance.updatedAt.toIso8601String(),
+  'image': ?instance.image,
+};

--- a/packages/better_auth_api_client/lib/models/user4.dart
+++ b/packages/better_auth_api_client/lib/models/user4.dart
@@ -1,0 +1,24 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user4.freezed.dart';
+part 'user4.g.dart';
+
+@Freezed()
+abstract class User4 with _$User4 {
+  const factory User4({
+    required String id,
+    required bool emailVerified,
+    @JsonKey(includeIfNull: false)
+    String? name,
+    @JsonKey(includeIfNull: false)
+    String? email,
+    @JsonKey(includeIfNull: false)
+    String? image,
+  }) = _User4;
+  
+  factory User4.fromJson(Map<String, Object?> json) => _$User4FromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/user4.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/user4.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user4.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$User4 {
+
+ String get id; bool get emailVerified;@JsonKey(includeIfNull: false) String? get name;@JsonKey(includeIfNull: false) String? get email;@JsonKey(includeIfNull: false) String? get image;
+/// Create a copy of User4
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$User4CopyWith<User4> get copyWith => _$User4CopyWithImpl<User4>(this as User4, _$identity);
+
+  /// Serializes this User4 to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is User4&&(identical(other.id, id) || other.id == id)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,emailVerified,name,email,image);
+
+@override
+String toString() {
+  return 'User4(id: $id, emailVerified: $emailVerified, name: $name, email: $email, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $User4CopyWith<$Res>  {
+  factory $User4CopyWith(User4 value, $Res Function(User4) _then) = _$User4CopyWithImpl;
+@useResult
+$Res call({
+ String id, bool emailVerified,@JsonKey(includeIfNull: false) String? name,@JsonKey(includeIfNull: false) String? email,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class _$User4CopyWithImpl<$Res>
+    implements $User4CopyWith<$Res> {
+  _$User4CopyWithImpl(this._self, this._then);
+
+  final User4 _self;
+  final $Res Function(User4) _then;
+
+/// Create a copy of User4
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? emailVerified = null,Object? name = freezed,Object? email = freezed,Object? image = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,emailVerified: null == emailVerified ? _self.emailVerified : emailVerified // ignore: cast_nullable_to_non_nullable
+as bool,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,email: freezed == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String?,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [User4].
+extension User4Patterns on User4 {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _User4 value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _User4() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _User4 value)  $default,){
+final _that = this;
+switch (_that) {
+case _User4():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _User4 value)?  $default,){
+final _that = this;
+switch (_that) {
+case _User4() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  bool emailVerified, @JsonKey(includeIfNull: false)  String? name, @JsonKey(includeIfNull: false)  String? email, @JsonKey(includeIfNull: false)  String? image)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _User4() when $default != null:
+return $default(_that.id,_that.emailVerified,_that.name,_that.email,_that.image);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  bool emailVerified, @JsonKey(includeIfNull: false)  String? name, @JsonKey(includeIfNull: false)  String? email, @JsonKey(includeIfNull: false)  String? image)  $default,) {final _that = this;
+switch (_that) {
+case _User4():
+return $default(_that.id,_that.emailVerified,_that.name,_that.email,_that.image);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  bool emailVerified, @JsonKey(includeIfNull: false)  String? name, @JsonKey(includeIfNull: false)  String? email, @JsonKey(includeIfNull: false)  String? image)?  $default,) {final _that = this;
+switch (_that) {
+case _User4() when $default != null:
+return $default(_that.id,_that.emailVerified,_that.name,_that.email,_that.image);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _User4 implements User4 {
+  const _User4({required this.id, required this.emailVerified, @JsonKey(includeIfNull: false) this.name, @JsonKey(includeIfNull: false) this.email, @JsonKey(includeIfNull: false) this.image});
+  factory _User4.fromJson(Map<String, dynamic> json) => _$User4FromJson(json);
+
+@override final  String id;
+@override final  bool emailVerified;
+@override@JsonKey(includeIfNull: false) final  String? name;
+@override@JsonKey(includeIfNull: false) final  String? email;
+@override@JsonKey(includeIfNull: false) final  String? image;
+
+/// Create a copy of User4
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$User4CopyWith<_User4> get copyWith => __$User4CopyWithImpl<_User4>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$User4ToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _User4&&(identical(other.id, id) || other.id == id)&&(identical(other.emailVerified, emailVerified) || other.emailVerified == emailVerified)&&(identical(other.name, name) || other.name == name)&&(identical(other.email, email) || other.email == email)&&(identical(other.image, image) || other.image == image));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,emailVerified,name,email,image);
+
+@override
+String toString() {
+  return 'User4(id: $id, emailVerified: $emailVerified, name: $name, email: $email, image: $image)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$User4CopyWith<$Res> implements $User4CopyWith<$Res> {
+  factory _$User4CopyWith(_User4 value, $Res Function(_User4) _then) = __$User4CopyWithImpl;
+@override @useResult
+$Res call({
+ String id, bool emailVerified,@JsonKey(includeIfNull: false) String? name,@JsonKey(includeIfNull: false) String? email,@JsonKey(includeIfNull: false) String? image
+});
+
+
+
+
+}
+/// @nodoc
+class __$User4CopyWithImpl<$Res>
+    implements _$User4CopyWith<$Res> {
+  __$User4CopyWithImpl(this._self, this._then);
+
+  final _User4 _self;
+  final $Res Function(_User4) _then;
+
+/// Create a copy of User4
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? emailVerified = null,Object? name = freezed,Object? email = freezed,Object? image = freezed,}) {
+  return _then(_User4(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,emailVerified: null == emailVerified ? _self.emailVerified : emailVerified // ignore: cast_nullable_to_non_nullable
+as bool,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,email: freezed == email ? _self.email : email // ignore: cast_nullable_to_non_nullable
+as String?,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/user4.g.dart
+++ b/packages/better_auth_api_client/lib/models/user4.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'user4.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_User4 _$User4FromJson(Map<String, dynamic> json) =>
+    $checkedCreate('_User4', json, ($checkedConvert) {
+      final val = _User4(
+        id: $checkedConvert('id', (v) => v as String),
+        emailVerified: $checkedConvert('email_verified', (v) => v as bool),
+        name: $checkedConvert('name', (v) => v as String?),
+        email: $checkedConvert('email', (v) => v as String?),
+        image: $checkedConvert('image', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {'emailVerified': 'email_verified'});
+
+Map<String, dynamic> _$User4ToJson(_User4 instance) => <String, dynamic>{
+  'id': instance.id,
+  'email_verified': instance.emailVerified,
+  'name': ?instance.name,
+  'email': ?instance.email,
+  'image': ?instance.image,
+};

--- a/packages/better_auth_api_client/lib/models/verify_password_request_body.dart
+++ b/packages/better_auth_api_client/lib/models/verify_password_request_body.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'verify_password_request_body.freezed.dart';
+part 'verify_password_request_body.g.dart';
+
+@Freezed()
+abstract class VerifyPasswordRequestBody with _$VerifyPasswordRequestBody {
+  const factory VerifyPasswordRequestBody({
+    /// The password to verify
+    required String password,
+  }) = _VerifyPasswordRequestBody;
+  
+  factory VerifyPasswordRequestBody.fromJson(Map<String, Object?> json) => _$VerifyPasswordRequestBodyFromJson(json);
+}

--- a/packages/better_auth_api_client/lib/models/verify_password_request_body.freezed.dart
+++ b/packages/better_auth_api_client/lib/models/verify_password_request_body.freezed.dart
@@ -1,0 +1,279 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'verify_password_request_body.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$VerifyPasswordRequestBody {
+
+/// The password to verify
+ String get password;
+/// Create a copy of VerifyPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VerifyPasswordRequestBodyCopyWith<VerifyPasswordRequestBody> get copyWith => _$VerifyPasswordRequestBodyCopyWithImpl<VerifyPasswordRequestBody>(this as VerifyPasswordRequestBody, _$identity);
+
+  /// Serializes this VerifyPasswordRequestBody to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VerifyPasswordRequestBody&&(identical(other.password, password) || other.password == password));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,password);
+
+@override
+String toString() {
+  return 'VerifyPasswordRequestBody(password: $password)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VerifyPasswordRequestBodyCopyWith<$Res>  {
+  factory $VerifyPasswordRequestBodyCopyWith(VerifyPasswordRequestBody value, $Res Function(VerifyPasswordRequestBody) _then) = _$VerifyPasswordRequestBodyCopyWithImpl;
+@useResult
+$Res call({
+ String password
+});
+
+
+
+
+}
+/// @nodoc
+class _$VerifyPasswordRequestBodyCopyWithImpl<$Res>
+    implements $VerifyPasswordRequestBodyCopyWith<$Res> {
+  _$VerifyPasswordRequestBodyCopyWithImpl(this._self, this._then);
+
+  final VerifyPasswordRequestBody _self;
+  final $Res Function(VerifyPasswordRequestBody) _then;
+
+/// Create a copy of VerifyPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? password = null,}) {
+  return _then(_self.copyWith(
+password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [VerifyPasswordRequestBody].
+extension VerifyPasswordRequestBodyPatterns on VerifyPasswordRequestBody {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VerifyPasswordRequestBody value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VerifyPasswordRequestBody() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VerifyPasswordRequestBody value)  $default,){
+final _that = this;
+switch (_that) {
+case _VerifyPasswordRequestBody():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VerifyPasswordRequestBody value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VerifyPasswordRequestBody() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String password)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VerifyPasswordRequestBody() when $default != null:
+return $default(_that.password);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String password)  $default,) {final _that = this;
+switch (_that) {
+case _VerifyPasswordRequestBody():
+return $default(_that.password);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String password)?  $default,) {final _that = this;
+switch (_that) {
+case _VerifyPasswordRequestBody() when $default != null:
+return $default(_that.password);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _VerifyPasswordRequestBody implements VerifyPasswordRequestBody {
+  const _VerifyPasswordRequestBody({required this.password});
+  factory _VerifyPasswordRequestBody.fromJson(Map<String, dynamic> json) => _$VerifyPasswordRequestBodyFromJson(json);
+
+/// The password to verify
+@override final  String password;
+
+/// Create a copy of VerifyPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VerifyPasswordRequestBodyCopyWith<_VerifyPasswordRequestBody> get copyWith => __$VerifyPasswordRequestBodyCopyWithImpl<_VerifyPasswordRequestBody>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VerifyPasswordRequestBodyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VerifyPasswordRequestBody&&(identical(other.password, password) || other.password == password));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,password);
+
+@override
+String toString() {
+  return 'VerifyPasswordRequestBody(password: $password)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VerifyPasswordRequestBodyCopyWith<$Res> implements $VerifyPasswordRequestBodyCopyWith<$Res> {
+  factory _$VerifyPasswordRequestBodyCopyWith(_VerifyPasswordRequestBody value, $Res Function(_VerifyPasswordRequestBody) _then) = __$VerifyPasswordRequestBodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String password
+});
+
+
+
+
+}
+/// @nodoc
+class __$VerifyPasswordRequestBodyCopyWithImpl<$Res>
+    implements _$VerifyPasswordRequestBodyCopyWith<$Res> {
+  __$VerifyPasswordRequestBodyCopyWithImpl(this._self, this._then);
+
+  final _VerifyPasswordRequestBody _self;
+  final $Res Function(_VerifyPasswordRequestBody) _then;
+
+/// Create a copy of VerifyPasswordRequestBody
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? password = null,}) {
+  return _then(_VerifyPasswordRequestBody(
+password: null == password ? _self.password : password // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/better_auth_api_client/lib/models/verify_password_request_body.g.dart
+++ b/packages/better_auth_api_client/lib/models/verify_password_request_body.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'verify_password_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_VerifyPasswordRequestBody _$VerifyPasswordRequestBodyFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_VerifyPasswordRequestBody', json, ($checkedConvert) {
+  final val = _VerifyPasswordRequestBody(
+    password: $checkedConvert('password', (v) => v as String),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$VerifyPasswordRequestBodyToJson(
+  _VerifyPasswordRequestBody instance,
+) => <String, dynamic>{'password': instance.password};

--- a/packages/better_auth_api_client/openapi/openapi.json
+++ b/packages/better_auth_api_client/openapi/openapi.json
@@ -1,0 +1,23706 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Better Auth",
+    "description": "API Reference for your Better Auth Instance",
+    "version": "1.1.0"
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "emailVerified": {
+            "type": "boolean",
+            "default": false,
+            "readOnly": true
+          },
+          "image": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "default": "Generated at runtime"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "default": "Generated at runtime"
+          },
+          "isAnonymous": {
+            "type": "boolean",
+            "default": false,
+            "readOnly": true
+          },
+          "role": {
+            "type": "string",
+            "readOnly": true
+          },
+          "banned": {
+            "type": "boolean",
+            "default": false,
+            "readOnly": true
+          },
+          "banReason": {
+            "type": "string",
+            "readOnly": true
+          },
+          "banExpires": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "Session": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "token": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "default": "Generated at runtime"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ipAddress": {
+            "type": "string"
+          },
+          "userAgent": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "impersonatedBy": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "expiresAt",
+          "token",
+          "createdAt",
+          "updatedAt",
+          "userId"
+        ]
+      },
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "accountId": {
+            "type": "string"
+          },
+          "providerId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          },
+          "idToken": {
+            "type": "string"
+          },
+          "accessTokenExpiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "refreshTokenExpiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "default": "Generated at runtime"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "accountId",
+          "providerId",
+          "userId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "Passkey": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "publicKey": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "credentialID": {
+            "type": "string"
+          },
+          "counter": {
+            "type": "number"
+          },
+          "deviceType": {
+            "type": "string"
+          },
+          "backedUp": {
+            "type": "boolean"
+          },
+          "transports": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "aaguid": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "publicKey",
+          "userId",
+          "credentialID",
+          "counter",
+          "deviceType",
+          "backedUp"
+        ]
+      },
+      "Jwks": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "publicKey": {
+            "type": "string"
+          },
+          "privateKey": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "publicKey",
+          "privateKey",
+          "createdAt"
+        ]
+      },
+      "OauthClient": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string"
+          },
+          "disabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "skipConsent": {
+            "type": "boolean"
+          },
+          "enableEndSession": {
+            "type": "boolean"
+          },
+          "subjectType": {
+            "type": "string"
+          },
+          "scopes": {
+            "type": "string[]"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "contacts": {
+            "type": "string[]"
+          },
+          "tos": {
+            "type": "string"
+          },
+          "policy": {
+            "type": "string"
+          },
+          "softwareId": {
+            "type": "string"
+          },
+          "softwareVersion": {
+            "type": "string"
+          },
+          "softwareStatement": {
+            "type": "string"
+          },
+          "redirectUris": {
+            "type": "string[]"
+          },
+          "postLogoutRedirectUris": {
+            "type": "string[]"
+          },
+          "tokenEndpointAuthMethod": {
+            "type": "string"
+          },
+          "grantTypes": {
+            "type": "string[]"
+          },
+          "responseTypes": {
+            "type": "string[]"
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          },
+          "requirePKCE": {
+            "type": "boolean"
+          },
+          "referenceId": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "json"
+          }
+        },
+        "required": [
+          "clientId",
+          "redirectUris"
+        ]
+      },
+      "OauthRefreshToken": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "sessionId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "referenceId": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "revoked": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "authTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "scopes": {
+            "type": "string[]"
+          }
+        },
+        "required": [
+          "token",
+          "clientId",
+          "userId",
+          "scopes"
+        ]
+      },
+      "OauthAccessToken": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "sessionId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "referenceId": {
+            "type": "string"
+          },
+          "refreshId": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "scopes": {
+            "type": "string[]"
+          }
+        },
+        "required": [
+          "clientId",
+          "scopes"
+        ]
+      },
+      "OauthConsent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "referenceId": {
+            "type": "string"
+          },
+          "scopes": {
+            "type": "string[]"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "clientId",
+          "scopes"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "apiKeyCookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "apiKeyCookie",
+        "description": "API Key authentication via cookie"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Bearer token authentication"
+      }
+    }
+  },
+  "security": [
+    {
+      "apiKeyCookie": [],
+      "bearerAuth": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://auth.eqmonitor.app/api/auth"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Default",
+      "description": "Default endpoints that are included with Better Auth by default. These endpoints are not part of any plugin."
+    }
+  ],
+  "paths": {
+    "/sign-in/social": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Sign in with a social provider",
+        "operationId": "socialSignIn",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callbackURL": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Callback URL to redirect to after the user has signed in"
+                  },
+                  "newUserCallbackURL": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "errorCallbackURL": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Callback URL to redirect to if an error happens"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "disableRedirect": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Disable automatic redirection to the provider. Useful for handling the redirection yourself"
+                  },
+                  "idToken": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "token": {
+                        "type": "string",
+                        "description": "ID token from the provider"
+                      },
+                      "nonce": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Nonce used to generate the token"
+                      },
+                      "accessToken": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Access token from the provider"
+                      },
+                      "refreshToken": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Refresh token from the provider"
+                      },
+                      "expiresAt": {
+                        "type": [
+                          "number",
+                          "null"
+                        ],
+                        "description": "Expiry date of the token"
+                      },
+                      "user": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "firstName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "lastName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          },
+                          "email": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "description": "The user object from the provider. Only available for some providers like Apple."
+                      }
+                    },
+                    "required": [
+                      "token"
+                    ]
+                  },
+                  "scopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "description": "Array of scopes to request from the provider. This will override the default scopes passed."
+                  },
+                  "requestSignUp": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Explicitly request sign-up. Useful when disableImplicitSignUp is true for this provider"
+                  },
+                  "loginHint": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The login hint to use for the authorization code request"
+                  },
+                  "additionalData": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "provider"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success - Returns either session details or redirect URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Session response when idToken is provided",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/User"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "redirect": {
+                      "type": "boolean",
+                      "enum": [
+                        false
+                      ]
+                    }
+                  },
+                  "required": [
+                    "redirect",
+                    "token",
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/callback/{id}": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/get-session": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Get the current session",
+        "operationId": "getSession",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "session": {
+                      "$ref": "#/components/schemas/Session"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  },
+                  "required": [
+                    "session",
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Get the current session",
+        "operationId": "getSession",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "session": {
+                      "$ref": "#/components/schemas/Session"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  },
+                  "required": [
+                    "session",
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/sign-out": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Sign out the current user",
+        "operationId": "signOut",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/sign-up/email": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Sign up a user using email and password",
+        "operationId": "signUpWithEmailAndPassword",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the user"
+                  },
+                  "email": {
+                    "type": "string",
+                    "description": "The email of the user"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "The password of the user"
+                  },
+                  "image": {
+                    "type": "string",
+                    "description": "The profile image URL of the user"
+                  },
+                  "callbackURL": {
+                    "type": "string",
+                    "description": "The URL to use for email verification callback"
+                  },
+                  "rememberMe": {
+                    "type": "boolean",
+                    "description": "If this is false, the session will not be remembered. Default is `true`."
+                  }
+                },
+                "required": [
+                  "name",
+                  "email",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Authentication token for the session"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The unique identifier of the user"
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "The email address of the user"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the user"
+                        },
+                        "image": {
+                          "type": "string",
+                          "format": "uri",
+                          "nullable": true,
+                          "description": "The profile image URL of the user"
+                        },
+                        "emailVerified": {
+                          "type": "boolean",
+                          "description": "Whether the email has been verified"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the user was created"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the user was last updated"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "email",
+                        "name",
+                        "emailVerified",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "422": {
+            "description": "Unprocessable Entity. User already exists or failed to create user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/sign-in/email": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Sign in with email and password",
+        "operationId": "signInEmail",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "Email of the user"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password of the user"
+                  },
+                  "callbackURL": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Callback URL to use as a redirect for email verification"
+                  },
+                  "rememberMe": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "If this is false, the session will not be remembered. Default is `true`.",
+                    "default": true
+                  }
+                },
+                "required": [
+                  "email",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success - Returns either session details or redirect URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Session response when idToken is provided",
+                  "properties": {
+                    "redirect": {
+                      "type": "boolean",
+                      "enum": [
+                        false
+                      ]
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "Session token"
+                    },
+                    "url": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "user": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/User"
+                    }
+                  },
+                  "required": [
+                    "redirect",
+                    "token",
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/reset-password": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Reset the password for a user",
+        "operationId": "resetPassword",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newPassword": {
+                    "type": "string",
+                    "description": "The new password to set"
+                  },
+                  "token": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The token to reset the password"
+                  }
+                },
+                "required": [
+                  "newPassword"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/verify-password": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Verify the current user's password",
+        "operationId": "verifyPassword",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string",
+                    "description": "The password to verify"
+                  }
+                },
+                "required": [
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/verify-email": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Verify the email of the user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "description": "The token to verify the email",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "callbackURL",
+            "in": "query",
+            "description": "The URL to redirect to after email verification",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/User"
+                    },
+                    "status": {
+                      "type": "boolean",
+                      "description": "Indicates if the email was verified successfully"
+                    }
+                  },
+                  "required": [
+                    "user",
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/send-verification-email": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Send a verification email to the user",
+        "operationId": "sendVerificationEmail",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "The email to send the verification email to",
+                    "example": "user@example.com"
+                  },
+                  "callbackURL": {
+                    "type": "string",
+                    "description": "The URL to use for email verification callback",
+                    "example": "https://example.com/callback",
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean",
+                      "description": "Indicates if the email was sent successfully",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Error message",
+                      "example": "Verification email isn't enabled"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/change-email": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "operationId": "changeEmail",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newEmail": {
+                    "type": "string",
+                    "description": "The new email address to set must be a valid email address"
+                  },
+                  "callbackURL": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The URL to redirect to after email verification"
+                  }
+                },
+                "required": [
+                  "newEmail"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Email change request processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/User"
+                    },
+                    "status": {
+                      "type": "boolean",
+                      "description": "Indicates if the request was successful"
+                    },
+                    "message": {
+                      "type": "string",
+                      "enum": [
+                        "Email updated",
+                        "Verification email sent"
+                      ],
+                      "description": "Status message of the email change process",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/change-password": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Change the password of the user",
+        "operationId": "changePassword",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newPassword": {
+                    "type": "string",
+                    "description": "The new password to set"
+                  },
+                  "currentPassword": {
+                    "type": "string",
+                    "description": "The current password is required"
+                  },
+                  "revokeOtherSessions": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Must be a boolean value"
+                  }
+                },
+                "required": [
+                  "newPassword",
+                  "currentPassword"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Password successfully changed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "New session token if other sessions were revoked"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The unique identifier of the user"
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "description": "The email address of the user"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The name of the user"
+                        },
+                        "image": {
+                          "type": "string",
+                          "format": "uri",
+                          "nullable": true,
+                          "description": "The profile image URL of the user"
+                        },
+                        "emailVerified": {
+                          "type": "boolean",
+                          "description": "Whether the email has been verified"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the user was created"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the user was last updated"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "email",
+                        "name",
+                        "emailVerified",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/update-session": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Update the current session",
+        "operationId": "updateSession",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/Session"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/update-user": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Update the current user",
+        "operationId": "updateUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the user"
+                  },
+                  "image": {
+                    "type": "string",
+                    "description": "The image of the user",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/delete-user": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Delete the user",
+        "operationId": "deleteUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callbackURL": {
+                    "type": "string",
+                    "description": "The callback URL to redirect to after the user is deleted"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "The user's password. Required if session is not fresh"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "The deletion verification token"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User deletion processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates if the operation was successful"
+                    },
+                    "message": {
+                      "type": "string",
+                      "enum": [
+                        "User deleted",
+                        "Verification email sent"
+                      ],
+                      "description": "Status message of the deletion process"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/request-password-reset": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Send a password reset email to the user",
+        "operationId": "requestPasswordReset",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "The email address of the user to send a password reset email to"
+                  },
+                  "redirectTo": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The URL to redirect the user to reset their password. If the token isn't valid or expired, it'll be redirected with a query parameter `?error=INVALID_TOKEN`. If the token is valid, it'll be redirected with a query parameter `?token=VALID_TOKEN"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/reset-password/{token}": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Redirects the user to the callback URL with the token",
+        "operationId": "resetPasswordCallback",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "description": "The token to reset the password",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "callbackURL",
+            "in": "query",
+            "required": true,
+            "description": "The URL to redirect the user to reset their password",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/list-sessions": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "List all active sessions for the user",
+        "operationId": "listUserSessions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Session"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/revoke-session": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Revoke a single session",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "The token to revoke"
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean",
+                      "description": "Indicates if the session was revoked successfully"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/revoke-sessions": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Revoke all sessions for the user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean",
+                      "description": "Indicates if all sessions were revoked successfully"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/revoke-other-sessions": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Revoke all other sessions for the user except the current one",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean",
+                      "description": "Indicates if all other sessions were revoked successfully"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/link-social": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Link a social account to the user",
+        "operationId": "linkSocialAccount",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callbackURL": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The URL to redirect to after the user has signed in"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "idToken": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "token": {
+                        "type": "string"
+                      },
+                      "nonce": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "accessToken": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "refreshToken": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "scopes": {
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "token"
+                    ]
+                  },
+                  "requestSignUp": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "scopes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "description": "Additional scopes to request from the provider"
+                  },
+                  "errorCallbackURL": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The URL to redirect to if there is an error during the link process"
+                  },
+                  "disableRedirect": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Disable automatic redirection to the provider. Useful for handling the redirection yourself"
+                  },
+                  "additionalData": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "provider"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "The authorization URL to redirect the user to"
+                    },
+                    "redirect": {
+                      "type": "boolean",
+                      "description": "Indicates if the user should be redirected to the authorization URL"
+                    },
+                    "status": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "redirect"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/list-accounts": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "List all accounts linked to the user",
+        "operationId": "listUserAccounts",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "providerId": {
+                        "type": "string"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "accountId": {
+                        "type": "string"
+                      },
+                      "userId": {
+                        "type": "string"
+                      },
+                      "scopes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "providerId",
+                      "createdAt",
+                      "updatedAt",
+                      "accountId",
+                      "userId",
+                      "scopes"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/delete-user/callback": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Callback to complete user deletion with verification token",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "The token to verify the deletion request"
+            }
+          },
+          {
+            "name": "callbackURL",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The URL to redirect to after deletion"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User successfully deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Indicates if the deletion was successful"
+                    },
+                    "message": {
+                      "type": "string",
+                      "enum": [
+                        "User deleted"
+                      ],
+                      "description": "Confirmation message"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/unlink-account": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Unlink an account",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "accountId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/refresh-token": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Refresh the access token using a refresh token",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string",
+                    "description": "The provider ID for the OAuth provider"
+                  },
+                  "accountId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The account ID associated with the refresh token"
+                  },
+                  "userId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The user ID associated with the account"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token refreshed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tokenType": {
+                      "type": "string"
+                    },
+                    "idToken": {
+                      "type": "string"
+                    },
+                    "accessToken": {
+                      "type": "string"
+                    },
+                    "refreshToken": {
+                      "type": "string"
+                    },
+                    "accessTokenExpiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "refreshTokenExpiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid refresh token or provider configuration"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/get-access-token": {
+      "post": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Get a valid access token, doing a refresh if needed",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string",
+                    "description": "The provider ID for the OAuth provider"
+                  },
+                  "accountId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The account ID associated with the refresh token"
+                  },
+                  "userId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The user ID associated with the account"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A Valid access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tokenType": {
+                      "type": "string"
+                    },
+                    "idToken": {
+                      "type": "string"
+                    },
+                    "accessToken": {
+                      "type": "string"
+                    },
+                    "accessTokenExpiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid refresh token or provider configuration"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/account-info": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Get the account info provided by the provider",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "emailVerified": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "emailVerified"
+                      ]
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": true
+                    }
+                  },
+                  "required": [
+                    "user",
+                    "data"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/ok": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Check if the API is working",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "API is working",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "description": "Indicates if the API is working"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/error": {
+      "get": {
+        "tags": [
+          "Default"
+        ],
+        "description": "Displays an error page",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string",
+                  "description": "The HTML content of the error page"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/sign-in/anonymous": {
+      "post": {
+        "tags": [
+          "Anonymous"
+        ],
+        "description": "Sign in anonymously",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Sign in anonymously",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    },
+                    "session": {
+                      "$ref": "#/components/schemas/Session"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/delete-anonymous-user": {
+      "post": {
+        "tags": [
+          "Anonymous"
+        ],
+        "description": "Delete an anonymous user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Anonymous user deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Anonymous user deletion is disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/passkey/generate-register-options": {
+      "get": {
+        "tags": [
+          "Passkey"
+        ],
+        "description": "Generate registration options for a new passkey",
+        "operationId": "generatePasskeyRegistrationOptions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "parameters": {
+              "query": {
+                "authenticatorAttachment": {
+                  "description": "Type of authenticator to use for registration.\n                          \"platform\" for device-specific authenticators,\n                          \"cross-platform\" for authenticators that can be used across devices.",
+                  "required": false
+                },
+                "name": {
+                  "description": "Optional custom name for the passkey.\n                          This can help identify the passkey when managing multiple credentials.",
+                  "required": false
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "challenge": {
+                      "type": "string"
+                    },
+                    "rp": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "pubKeyCredParams": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "alg": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "timeout": {
+                      "type": "number"
+                    },
+                    "excludeCredentials": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "transports": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "authenticatorSelection": {
+                      "type": "object",
+                      "properties": {
+                        "authenticatorAttachment": {
+                          "type": "string"
+                        },
+                        "requireResidentKey": {
+                          "type": "boolean"
+                        },
+                        "userVerification": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "attestation": {
+                      "type": "string"
+                    },
+                    "extensions": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/passkey/generate-authenticate-options": {
+      "get": {
+        "tags": [
+          "Passkey"
+        ],
+        "description": "Generate authentication options for a passkey",
+        "operationId": "passkeyGenerateAuthenticateOptions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "challenge": {
+                      "type": "string"
+                    },
+                    "rp": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "timeout": {
+                      "type": "number"
+                    },
+                    "allowCredentials": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "transports": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "userVerification": {
+                      "type": "string"
+                    },
+                    "authenticatorSelection": {
+                      "type": "object",
+                      "properties": {
+                        "authenticatorAttachment": {
+                          "type": "string"
+                        },
+                        "requireResidentKey": {
+                          "type": "boolean"
+                        },
+                        "userVerification": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "extensions": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/passkey/verify-registration": {
+      "post": {
+        "tags": [
+          "Passkey"
+        ],
+        "description": "Verify registration of a new passkey",
+        "operationId": "passkeyVerifyRegistration",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "response": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the passkey"
+                  }
+                },
+                "required": [
+                  "response"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Passkey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/passkey/verify-authentication": {
+      "post": {
+        "tags": [
+          "Passkey"
+        ],
+        "description": "Verify authentication of a passkey",
+        "operationId": "passkeyVerifyAuthentication",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "response": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "response"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session": {
+                      "$ref": "#/components/schemas/Session"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/passkey/list-user-passkeys": {
+      "get": {
+        "tags": [
+          "Passkey"
+        ],
+        "description": "List all passkeys for the authenticated user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Passkeys retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Passkey",
+                    "required": [
+                      "id",
+                      "userId",
+                      "publicKey",
+                      "createdAt",
+                      "updatedAt"
+                    ]
+                  },
+                  "description": "Array of passkey objects associated with the user"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/passkey/delete-passkey": {
+      "post": {
+        "tags": [
+          "Passkey"
+        ],
+        "description": "Delete a specific passkey",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The ID of the passkey to delete. Eg: \"some-passkey-id\""
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Passkey deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean",
+                      "description": "Indicates whether the deletion was successful"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/passkey/update-passkey": {
+      "post": {
+        "tags": [
+          "Passkey"
+        ],
+        "description": "Update a specific passkey's name",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The ID of the passkey which will be updated. Eg: \"passkey-id\""
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The new name which the passkey will be updated to. Eg: \"my-new-passkey-name\""
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Passkey updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "passkey": {
+                      "$ref": "#/components/schemas/Passkey"
+                    }
+                  },
+                  "required": [
+                    "passkey"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/set-role": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Set the role of a user",
+        "operationId": "setUserRole",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  },
+                  "role": {
+                    "type": "string",
+                    "description": "The role to set, this can be a string or an array of strings. Eg: `admin` or `[admin, user]`"
+                  }
+                },
+                "required": [
+                  "userId",
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User role updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/get-user": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Get an existing user",
+        "operationId": "getUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "The id of the User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/create-user": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Create a new user",
+        "operationId": "createUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "The email of the user"
+                  },
+                  "password": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the user"
+                  },
+                  "role": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "data": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "email",
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/update-user": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Update a user's details",
+        "operationId": "updateUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  },
+                  "data": {
+                    "type": "string",
+                    "description": "The user data to update"
+                  }
+                },
+                "required": [
+                  "userId",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/list-users": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "List users",
+        "operationId": "listUsers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "searchValue",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "searchField",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The field to search in, defaults to email. Can be `email` or `name`. Eg: \"name\""
+            }
+          },
+          {
+            "name": "searchOperator",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The operator to use for the search. Can be `contains`, `starts_with` or `ends_with`. Eg: \"contains\""
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The field to sort by"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The direction to sort by"
+            }
+          },
+          {
+            "name": "filterField",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The field to filter by"
+            }
+          },
+          {
+            "name": "filterValue",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "filterOperator",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The operator to use for the filter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/User"
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "limit": {
+                      "type": "number"
+                    },
+                    "offset": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "users",
+                    "total"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/list-user-sessions": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "List user sessions",
+        "operationId": "listUserSessions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of user sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Session"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/unban-user": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Unban a user",
+        "operationId": "unbanUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User unbanned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/ban-user": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Ban a user",
+        "operationId": "banUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  },
+                  "banReason": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The reason for the ban"
+                  },
+                  "banExpiresIn": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "The number of seconds until the ban expires"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User banned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/impersonate-user": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Impersonate a user",
+        "operationId": "impersonateUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Impersonation session created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "session": {
+                      "$ref": "#/components/schemas/Session"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/stop-impersonating": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/revoke-user-session": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Revoke a user session",
+        "operationId": "revokeUserSession",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionToken": {
+                    "type": "string",
+                    "description": "The session token"
+                  }
+                },
+                "required": [
+                  "sessionToken"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/revoke-user-sessions": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Revoke all user sessions",
+        "operationId": "revokeUserSessions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sessions revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/remove-user": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Delete a user and all their sessions and accounts. Cannot be undone.",
+        "operationId": "removeUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/set-user-password": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Set a user's password",
+        "operationId": "setUserPassword",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newPassword": {
+                    "type": "string",
+                    "description": "The new password"
+                  },
+                  "userId": {
+                    "type": "string",
+                    "description": "The user id"
+                  }
+                },
+                "required": [
+                  "newPassword",
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Password set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/admin/has-permission": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "description": "Check if the user has permission",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "permissions": {
+                    "type": "object",
+                    "description": "The permission to check"
+                  }
+                },
+                "required": [
+                  "permissions"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/jwks": {
+      "get": {
+        "tags": [
+          "Jwt"
+        ],
+        "description": "Get the JSON Web Key Set",
+        "operationId": "getJSONWebKeySet",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "JSON Web Key Set retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "keys": {
+                      "type": "array",
+                      "description": "Array of public JSON Web Keys",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "kid": {
+                            "type": "string",
+                            "description": "Key ID uniquely identifying the key, corresponds to the 'id' from the stored Jwk"
+                          },
+                          "kty": {
+                            "type": "string",
+                            "description": "Key type (e.g., 'RSA', 'EC', 'OKP')"
+                          },
+                          "alg": {
+                            "type": "string",
+                            "description": "Algorithm intended for use with the key (e.g., 'EdDSA', 'RS256')"
+                          },
+                          "use": {
+                            "type": "string",
+                            "description": "Intended use of the public key (e.g., 'sig' for signature)",
+                            "enum": [
+                              "sig"
+                            ],
+                            "nullable": true
+                          },
+                          "n": {
+                            "type": "string",
+                            "description": "Modulus for RSA keys (base64url-encoded)",
+                            "nullable": true
+                          },
+                          "e": {
+                            "type": "string",
+                            "description": "Exponent for RSA keys (base64url-encoded)",
+                            "nullable": true
+                          },
+                          "crv": {
+                            "type": "string",
+                            "description": "Curve name for elliptic curve keys (e.g., 'Ed25519', 'P-256')",
+                            "nullable": true
+                          },
+                          "x": {
+                            "type": "string",
+                            "description": "X coordinate for elliptic curve keys (base64url-encoded)",
+                            "nullable": true
+                          },
+                          "y": {
+                            "type": "string",
+                            "description": "Y coordinate for elliptic curve keys (base64url-encoded)",
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "kid",
+                          "kty",
+                          "alg"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "keys"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/token": {
+      "get": {
+        "tags": [
+          "Jwt"
+        ],
+        "description": "Get a JWT token",
+        "operationId": "getJSONWebToken",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/authorize": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Authorize an OAuth2 request",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "response_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "OAuth2 response type (e.g., 'code')"
+          },
+          {
+            "name": "client_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "OAuth2 client ID"
+          },
+          {
+            "name": "redirect_uri",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": "OAuth2 redirect URI"
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "OAuth2 scopes (space-separated)"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "OAuth2 state parameter"
+          },
+          {
+            "name": "code_challenge",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "PKCE code challenge"
+          },
+          {
+            "name": "code_challenge_method",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "PKCE code challenge method"
+          },
+          {
+            "name": "nonce",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "OpenID Connect nonce"
+          },
+          {
+            "name": "prompt",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "OAuth2 prompt parameter"
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to client with code or error",
+            "headers": {
+              "Location": {
+                "description": "Redirect URI with code or error",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/consent": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Handle OAuth2 consent",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "accept": {
+                    "type": "boolean",
+                    "description": "Accept or deny user consent for a set of scopes"
+                  },
+                  "scope": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "oauth_query": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "accept"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Consent processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "redirect_uri": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The URI to redirect to, either with an authorization code or an error"
+                    }
+                  },
+                  "required": [
+                    "redirect_uri"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/continue": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Continues OAuth2 authorization flow",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "selected": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "created": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "postLogin": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "oauth_query": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Consent processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "redirect_uri": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The URI to redirect to, either with an authorization code or an error"
+                    }
+                  },
+                  "required": [
+                    "redirect_uri"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/token": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Obtain an OAuth2.1 access token",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "grant_type": {
+                    "type": "string",
+                    "enum": [
+                      "authorization_code",
+                      "client_credentials",
+                      "refresh_token"
+                    ],
+                    "description": "OAuth2 grant type"
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "description": "OAuth2 client ID"
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "description": "OAuth2 client secret"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "Authorization code (for authorization_code grant)"
+                  },
+                  "code_verifier": {
+                    "type": "string",
+                    "description": "PKCE code verifier (for authorization_code grant)"
+                  },
+                  "redirect_uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Redirect URI (for authorization_code grant)"
+                  },
+                  "refresh_token": {
+                    "type": "string",
+                    "description": "Refresh token (for refresh_token grant)"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "description": "Requested token resource (ie audience) to obtain a JWT formatted access token"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "description": "Requested scopes (for client_credentials grant)"
+                  }
+                },
+                "required": [
+                  "grant_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "access_token": {
+                      "type": "string",
+                      "description": "The access token issued by the authorization server"
+                    },
+                    "token_type": {
+                      "type": "string",
+                      "description": "The type of the token issued",
+                      "enum": [
+                        "Bearer"
+                      ]
+                    },
+                    "expires_in": {
+                      "type": "number",
+                      "description": "Lifetime in seconds of the access token"
+                    },
+                    "refresh_token": {
+                      "type": "string",
+                      "description": "Refresh token, if issued"
+                    },
+                    "scope": {
+                      "type": "string",
+                      "description": "Scopes granted by the access token"
+                    },
+                    "id_token": {
+                      "type": "string",
+                      "description": "ID Token (if OpenID Connect)"
+                    }
+                  },
+                  "required": [
+                    "access_token",
+                    "token_type",
+                    "expires_in"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "error_uri": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/introspect": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Introspect an OAuth2 access or refresh token",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "client_id": {
+                    "type": "string",
+                    "description": "OAuth2 client ID"
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "description": "OAuth2 client secret"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "The token to introspect (access or refresh token)"
+                  },
+                  "token_type_hint": {
+                    "type": "string",
+                    "enum": [
+                      "access_token",
+                      "refresh_token"
+                    ],
+                    "description": "Hint about the type of the token submitted for introspection"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "description": "Introspects a token for a specific resource."
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token introspection response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "active": {
+                      "type": "boolean",
+                      "description": "Whether the token is active"
+                    },
+                    "scope": {
+                      "type": "string",
+                      "description": "Scopes associated with the token"
+                    },
+                    "client_id": {
+                      "type": "string",
+                      "description": "Client ID associated with the token"
+                    },
+                    "username": {
+                      "type": "string",
+                      "description": "Username associated with the token"
+                    },
+                    "token_type": {
+                      "type": "string",
+                      "description": "Type of the token"
+                    },
+                    "exp": {
+                      "type": "number",
+                      "description": "Expiration time of the token (seconds since epoch)"
+                    },
+                    "iat": {
+                      "type": "number",
+                      "description": "Issued at time (seconds since epoch)"
+                    },
+                    "nbf": {
+                      "type": "number",
+                      "description": "Not before time (seconds since epoch)"
+                    },
+                    "sub": {
+                      "type": "string",
+                      "description": "Subject of the token"
+                    },
+                    "aud": {
+                      "type": "string",
+                      "description": "Audience of the token"
+                    },
+                    "iss": {
+                      "type": "string",
+                      "description": "Issuer of the token"
+                    },
+                    "jti": {
+                      "type": "string",
+                      "description": "JWT ID"
+                    }
+                  },
+                  "required": [
+                    "active"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "error_uri": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/revoke": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Revoke an OAuth2 access or refresh token",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "client_id": {
+                    "type": "string",
+                    "description": "OAuth2 client ID"
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "description": "OAuth2 client secret"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "The token to revoke (access or refresh token)"
+                  },
+                  "token_type_hint": {
+                    "type": "string",
+                    "enum": [
+                      "access_token",
+                      "refresh_token"
+                    ],
+                    "description": "Hint about the type of the token submitted for revocation"
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token revoked successfully. The response body is empty.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Empty object on success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    },
+                    "error_uri": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/userinfo": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Get OpenID Connect user information (UserInfo endpoint)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Bearer access token"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User information retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sub": {
+                      "type": "string",
+                      "description": "Subject identifier (user ID)"
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email",
+                      "nullable": true,
+                      "description": "User's email address, included if 'email' scope is granted"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "User's full name, included if 'profile' scope is granted"
+                    },
+                    "picture": {
+                      "type": "string",
+                      "format": "uri",
+                      "nullable": true,
+                      "description": "User's profile picture URL, included if 'profile' scope is granted"
+                    },
+                    "given_name": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "User's given name, included if 'profile' scope is granted"
+                    },
+                    "family_name": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "User's family name, included if 'profile' scope is granted"
+                    },
+                    "email_verified": {
+                      "type": "boolean",
+                      "nullable": true,
+                      "description": "Whether the email is verified, included if 'email' scope is granted"
+                    }
+                  },
+                  "required": [
+                    "sub"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "error_description": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/end-session": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "RP-Initiated Logout endpoint. Allows clients to notify the OP that the End-User has logged out.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id_token_hint",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "client_id",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "post_logout_redirect_uri",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Logout successful. May include redirect_uri if post_logout_redirect_uri was provided.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "redirect_uri": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "URI to redirect to after logout (if post_logout_redirect_uri was provided)"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Success message"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/register": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Register an OAuth2 application",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "redirect_uris": {
+                    "type": "array"
+                  },
+                  "scope": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "client_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "client_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "logo_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contacts": {
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "tos_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "policy_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "software_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "software_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "software_statement": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "post_logout_redirect_uris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "token_endpoint_auth_method": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "default": "client_secret_basic"
+                  },
+                  "grant_types": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "default": [
+                      "authorization_code"
+                    ]
+                  },
+                  "response_types": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "default": [
+                      "code"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "subject_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "redirect_uris"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth2 application registered successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "client_id": {
+                      "type": "string",
+                      "description": "Unique identifier for the client"
+                    },
+                    "client_secret": {
+                      "type": "string",
+                      "description": "Secret key for the client"
+                    },
+                    "client_secret_expires_at": {
+                      "type": "number",
+                      "description": "Time the client secret will expire. If 0, the client secret will never expire."
+                    },
+                    "scope": {
+                      "type": "string",
+                      "description": "Space-separated scopes allowed by the client"
+                    },
+                    "user_id": {
+                      "type": "string",
+                      "description": "ID of the user who registered the client, null if registered anonymously"
+                    },
+                    "client_id_issued_at": {
+                      "type": "number",
+                      "description": "Creation timestamp of this client"
+                    },
+                    "client_name": {
+                      "type": "string",
+                      "description": "Name of the OAuth2 application"
+                    },
+                    "client_uri": {
+                      "type": "string",
+                      "description": "Name of the OAuth2 application"
+                    },
+                    "logo_uri": {
+                      "type": "string",
+                      "description": "Icon URL for the application"
+                    },
+                    "contacts": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "List representing ways to contact people responsible for this client, typically email addresses"
+                    },
+                    "tos_uri": {
+                      "type": "string",
+                      "description": "Client's terms of service uri"
+                    },
+                    "policy_uri": {
+                      "type": "string",
+                      "description": "Client's policy uri"
+                    },
+                    "software_id": {
+                      "type": "string",
+                      "description": "Unique identifier assigned by the developer to help in the dynamic registration process"
+                    },
+                    "software_version": {
+                      "type": "string",
+                      "description": "Version identifier for the software_id"
+                    },
+                    "software_statement": {
+                      "type": "string",
+                      "description": "JWT containing metadata values about the client software as claims"
+                    },
+                    "redirect_uris": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "description": "List of allowed redirect uris"
+                    },
+                    "post_logout_redirect_uris": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "description": "List of allowed logout redirect uris"
+                    },
+                    "token_endpoint_auth_method": {
+                      "type": "string",
+                      "description": "Requested authentication method for the token endpoint",
+                      "enum": [
+                        "none",
+                        "client_secret_basic",
+                        "client_secret_post"
+                      ]
+                    },
+                    "grant_types": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "authorization_code",
+                          "client_credentials",
+                          "refresh_token"
+                        ]
+                      },
+                      "description": "Requested authentication method for the token endpoint"
+                    },
+                    "response_types": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "code"
+                        ]
+                      },
+                      "description": "Requested authentication method for the token endpoint"
+                    },
+                    "public": {
+                      "type": "boolean",
+                      "description": "Whether the client is public as determined by the type"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Type of the client",
+                      "enum": [
+                        "web",
+                        "native",
+                        "user-agent-based"
+                      ]
+                    },
+                    "disabled": {
+                      "type": "boolean",
+                      "description": "Whether the client is disabled"
+                    }
+                  },
+                  "required": [
+                    "client_id"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/create-client": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Register an OAuth2 application",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "redirect_uris": {
+                    "type": "array"
+                  },
+                  "scope": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "client_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "client_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "logo_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contacts": {
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "tos_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "policy_uri": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "software_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "software_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "software_statement": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "post_logout_redirect_uris": {
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "token_endpoint_auth_method": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "default": "client_secret_basic"
+                  },
+                  "grant_types": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "default": [
+                      "authorization_code"
+                    ]
+                  },
+                  "response_types": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "default": [
+                      "code"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "redirect_uris"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth2 application registered successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "client_id": {
+                      "type": "string",
+                      "description": "Unique identifier for the client"
+                    },
+                    "client_secret": {
+                      "type": "string",
+                      "description": "Secret key for the client"
+                    },
+                    "client_secret_expires_at": {
+                      "type": "number",
+                      "description": "Time the client secret will expire. If 0, the client secret will never expire."
+                    },
+                    "scope": {
+                      "type": "string",
+                      "description": "Space-separated scopes allowed by the client"
+                    },
+                    "user_id": {
+                      "type": "string",
+                      "description": "ID of the user who registered the client, null if registered anonymously"
+                    },
+                    "client_id_issued_at": {
+                      "type": "number",
+                      "description": "Creation timestamp of this client"
+                    },
+                    "client_name": {
+                      "type": "string",
+                      "description": "Name of the OAuth2 application"
+                    },
+                    "client_uri": {
+                      "type": "string",
+                      "description": "URI of the OAuth2 application"
+                    },
+                    "logo_uri": {
+                      "type": "string",
+                      "description": "Icon URI for the application"
+                    },
+                    "contacts": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "List representing ways to contact people responsible for this client, typically email addresses"
+                    },
+                    "tos_uri": {
+                      "type": "string",
+                      "description": "Client's terms of service uri"
+                    },
+                    "policy_uri": {
+                      "type": "string",
+                      "description": "Client's policy uri"
+                    },
+                    "software_id": {
+                      "type": "string",
+                      "description": "Unique identifier assigned by the developer to help in the dynamic registration process"
+                    },
+                    "software_version": {
+                      "type": "string",
+                      "description": "Version identifier for the software_id"
+                    },
+                    "software_statement": {
+                      "type": "string",
+                      "description": "JWT containing metadata values about the client software as claims"
+                    },
+                    "redirect_uris": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "description": "List of allowed redirect uris"
+                    },
+                    "token_endpoint_auth_method": {
+                      "type": "string",
+                      "description": "Response types the client may use",
+                      "enum": [
+                        "none",
+                        "client_secret_basic",
+                        "client_secret_post"
+                      ]
+                    },
+                    "grant_types": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "authorization_code",
+                          "client_credentials",
+                          "refresh_token"
+                        ]
+                      },
+                      "description": "Requested authentication method for the token endpoint"
+                    },
+                    "response_types": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "code"
+                        ]
+                      },
+                      "description": "Requested authentication method for the token endpoint"
+                    },
+                    "public": {
+                      "type": "boolean",
+                      "description": "Whether the client is public as determined by the type"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Type of the client",
+                      "enum": [
+                        "web",
+                        "native",
+                        "user-agent-based"
+                      ]
+                    },
+                    "disabled": {
+                      "type": "boolean",
+                      "description": "Whether the client is disabled"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "nullable": true,
+                      "description": "Additional metadata for the application"
+                    }
+                  },
+                  "required": [
+                    "client_id"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/get-client": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Get OAuth2 formatted client details",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/public-client": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Gets publically available client fields",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/get-clients": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Get OAuth2 formatted client details for a user or organization",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/update-client": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Updates OAuth2 formatted client details.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "client_id": {
+                    "type": "string"
+                  },
+                  "update": {
+                    "type": "object",
+                    "properties": {
+                      "redirect_uris": {
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "scope": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "client_name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "client_uri": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "logo_uri": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "contacts": {
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "tos_uri": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "policy_uri": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "software_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "software_version": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "software_statement": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "post_logout_redirect_uris": {
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "grant_types": {
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "response_types": {
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "type": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "client_id",
+                  "update"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/client/rotate-secret": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Rotates a confidential client's secret",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "client_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "client_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/delete-client": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Deletes an oauth client",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "client_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "client_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/get-consent": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Gets details of a specific OAuth2 consent for a user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/get-consents": {
+      "get": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Gets all available OAuth2 consents for a user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/update-consent": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Updates consent granted to a client.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "update": {
+                    "type": "object",
+                    "properties": {
+                      "scopes": {
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "scopes"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "update"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/oauth2/delete-consent": {
+      "post": {
+        "tags": [
+          "Oauth-provider"
+        ],
+        "description": "Deletes consent granted to a client",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/config": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/validate": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/list-users": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/export-users": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/online-users-count": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/create-user": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "image": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "password": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "generatePassword": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "sendVerificationEmail": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "sendOrganizationInvite": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "organizationRole": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "organizationId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/delete-user": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/delete-many-users": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/list-organizations": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/export-organizations": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/members": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/invitations": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/teams": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/sso-providers": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/sso-provider/create": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "domain": {
+                    "type": "string"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  },
+                  "userId": {
+                    "type": "string"
+                  },
+                  "samlConfig": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "idpMetadata": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "metadata": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "metadataUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "entryPoint": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cert": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "entityId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "mapping": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "emailVerified": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "firstName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lastName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "extraFields": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "oidcConfig": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "clientId": {
+                        "type": "string"
+                      },
+                      "clientSecret": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "discoveryUrl": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "issuer": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "mapping": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "emailVerified": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "extraFields": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "clientId"
+                    ]
+                  }
+                },
+                "required": [
+                  "providerId",
+                  "domain",
+                  "protocol",
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/sso-provider/update": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "domain": {
+                    "type": "string"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  },
+                  "samlConfig": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "idpMetadata": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "metadata": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "metadataUrl": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      },
+                      "entryPoint": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "cert": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "entityId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "mapping": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "emailVerified": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "firstName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "lastName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "extraFields": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "oidcConfig": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "clientId": {
+                        "type": "string"
+                      },
+                      "clientSecret": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "discoveryUrl": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "issuer": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "mapping": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "emailVerified": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "extraFields": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "clientId"
+                    ]
+                  }
+                },
+                "required": [
+                  "providerId",
+                  "domain",
+                  "protocol"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/sso-provider/request-verification-token": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/sso-provider/verify-domain": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/sso-provider/delete": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/sso-provider/mark-domain-verified": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "verified": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "providerId",
+                  "verified"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{orgId}/teams/{teamId}/members": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/create": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "slug": {
+                    "type": "string"
+                  },
+                  "logo": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "defaultTeamName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "slug"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/delete": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "organizationId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "organizationId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/delete-many": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/options": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/delete-sessions": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/user": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/user-organizations": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/update-user": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "email": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "image": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "emailVerified": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/set-password": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/unlink-account": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "accountId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/list-all-sessions": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/sessions/revoke": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/sessions/revoke-all": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/sessions/revoke-many": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/impersonate-user": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "impersonation_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/update": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "logo": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "slug": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "metadata": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/create-team": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/update-team": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "teamId": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "teamId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/delete-team": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "teamId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "teamId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/add-team-member": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "teamId": {
+                    "type": "string"
+                  },
+                  "userId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "teamId",
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/remove-team-member": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "teamId": {
+                    "type": "string"
+                  },
+                  "userId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "teamId",
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/add-member": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "userId",
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/remove-member": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "memberId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "memberId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/update-member-role": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "memberId": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "memberId",
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/invite-member": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string"
+                  },
+                  "invitedBy": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email",
+                  "role",
+                  "invitedBy"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/cancel-invitation": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "invitationId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "invitationId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/resend-invitation": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "invitationId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "invitationId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/check-user-by-email": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/user-stats": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/user-graph-data": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "daily"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/user-retention-data": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "weekly"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/user-map-data": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/ban-user": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "banReason": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "banExpires": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/ban-many-users": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "banReason": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "banExpires": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/unban-user": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/send-verification-email": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callbackUrl": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "callbackUrl"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/send-many-verification-emails": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callbackUrl": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "callbackUrl"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/send-reset-password-email": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callbackUrl": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "callbackUrl"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/enable-two-factor": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/view-two-factor-totp-uri": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/view-backup-codes": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/disable-two-factor": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/generate-backup-codes": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/events/list": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/events/audit-logs": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/events/types": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/accept-invitation": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/complete-invitation": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "providerAccountId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "accessToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "refreshToken": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/check-user-exists": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/log-drains": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/log-drain/create": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "destinationType": {
+                    "type": "string"
+                  },
+                  "eventTypes": {
+                    "type": "array"
+                  },
+                  "config": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "default": true
+                  }
+                },
+                "required": [
+                  "name",
+                  "destinationType",
+                  "eventTypes",
+                  "config",
+                  "enabled"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/log-drain/update": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "logDrainId": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "destinationType": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "eventTypes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "config": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "enabled": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "logDrainId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/log-drain/delete": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "logDrainId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "logDrainId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/log-drain/test": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "destinationType": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "destinationType",
+                  "config"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{id}/directories": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/directory/create": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "ownerUserId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId",
+                  "ownerUserId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/directory/delete": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/directory/regenerate-token": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/organization/{orgId}/directory": {
+      "get": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    },
+    "/dash/execute-adapter": {
+      "post": {
+        "tags": [
+          "Dash"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Not Found. The requested resource was not found."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/better_auth_api_client/pubspec.yaml
+++ b/packages/better_auth_api_client/pubspec.yaml
@@ -1,0 +1,24 @@
+name: better_auth_api_client
+description: Better Auth API Client generated from OpenAPI specification
+version: 1.0.0
+publish_to: "none"
+
+environment:
+  sdk: ^3.10.0
+
+resolution: workspace
+
+dependencies:
+  dio: ^5.9.1
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.11.0
+  retrofit: ^4.9.2
+
+dev_dependencies:
+  altive_lints: ^2.1.0
+  build_runner: ^2.11.1
+  freezed: ^3.2.5
+  json_serializable: ^6.13.0
+  retrofit_generator: ^10.2.3
+  swagger_parser: ^1.42.0
+  test: ^1.29.0

--- a/packages/better_auth_api_client/swagger_parser.yaml
+++ b/packages/better_auth_api_client/swagger_parser.yaml
@@ -1,0 +1,31 @@
+swagger_parser:
+  schema_path: openapi/openapi.json
+  output_directory: lib
+  language: dart
+  json_serializer: freezed
+  default_content_type: "application/json"
+  extras_parameter_by_default: false
+  add_openapi_metadata: false
+  dio_options_parameter_by_default: false
+  root_client: true
+  root_client_name: ApiClient
+  export_file: true
+  put_in_folder: false
+  put_clients_in_folder: true
+  merge_clients: false
+  client_postfix: ApiClient
+  path_method_name: true
+  enums_to_json: true
+  enums_parent_prefix: true
+  unknown_enum_value: false
+  mark_files_as_generated: true
+  original_http_response: true
+  use_freezed3: true
+  use_multipart_file: true
+  generate_urls_constants: true
+  include_tags:
+    - Anonymous
+    - Default
+  include_if_null: true
+  infer_required_from_nullable: true
+  use_flutter_compute: false

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  better_auth_client:
+    dependency: transitive
+    description:
+      name: better_auth_client
+      sha256: c680f4132f3d03240ca546327f33409146bbfc663b60ce8c5f5300574192bedc
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,14 +105,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
-  better_auth_client:
-    dependency: transitive
-    description:
-      name: better_auth_client
-      sha256: c680f4132f3d03240ca546327f33409146bbfc663b60ce8c5f5300574192bedc
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.12.1"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- `better_auth_client` パッケージを追加し、Better Auth (`https://auth.eqmonitor.app`) との認証基盤を Flutter アプリに導入
- `FlutterSecureStorage` ベースの `TokenStore` を実装し、Bearer トークンを安全に永続化
- EQMonitor API 用の Dio に `BearerAuthInterceptor` を追加し、ログイン済みユーザーのリクエストに自動で `Authorization: Bearer` ヘッダを付与

## 変更内容
| ファイル | 内容 |
|---|---|
| `app/lib/core/auth/secure_storage_token_store.dart` | `TokenStore` の FlutterSecureStorage 実装 |
| `app/lib/core/auth/auth_client_provider.dart` | `BetterAuthClient` の Riverpod プロバイダ |
| `app/lib/core/auth/auth_interceptor.dart` | Dio 用 Bearer トークン Interceptor |
| `app/lib/core/provider/dio_provider.dart` | Interceptor の組み込み |
| `app/pubspec.yaml` | `better_auth_client` 依存追加 |

## バックエンド側の対応状況
- `bearer()` プラグイン: 有効済み
- `trustedOrigins`: `net.yumnumm.eqmonitor://login-callback`, `net.yumnumm.eqmonitor.dev://login-callback` 設定済み
- `sessionMiddleware`: `Authorization: Bearer` ヘッダ対応済み

## Test plan
- [ ] メール/パスワードでサインインし、セッショントークンが SecureStorage に保存されることを確認
- [ ] ログイン後の API リクエストに `Authorization: Bearer` ヘッダが付与されることを確認
- [ ] アプリ再起動後にセッションが復元されることを確認
- [ ] サインアウト後にトークンが削除され、API リクエストにヘッダが付与されないことを確認

Made with [Cursor](https://cursor.com)