### PR TITLE
feat: スプラッシュ画面で匿名認証を実装

### DIFF
--- a/app/lib/core/auth/auth_client_provider.g.dart
+++ b/app/lib/core/auth/auth_client_provider.g.dart
@@ -11,49 +11,90 @@ part of 'auth_client_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(authClient)
-final authClientProvider = AuthClientProvider._();
+@ProviderFor(authTokenStore)
+final authTokenStoreProvider = AuthTokenStoreProvider._();
 
-final class AuthClientProvider
-    extends
-        $FunctionalProvider<
-          BetterAuthClient<User>,
-          BetterAuthClient<User>,
-          BetterAuthClient<User>
-        >
-    with $Provider<BetterAuthClient<User>> {
-  AuthClientProvider._()
+final class AuthTokenStoreProvider
+    extends $FunctionalProvider<AuthTokenStore, AuthTokenStore, AuthTokenStore>
+    with $Provider<AuthTokenStore> {
+  AuthTokenStoreProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'authClientProvider',
+        name: r'authTokenStoreProvider',
         isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$authClientHash();
+  String debugGetCreateSourceHash() => _$authTokenStoreHash();
 
   @$internal
   @override
-  $ProviderElement<BetterAuthClient<User>> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
+  $ProviderElement<AuthTokenStore> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
-  BetterAuthClient<User> create(Ref ref) {
-    return authClient(ref);
+  AuthTokenStore create(Ref ref) {
+    return authTokenStore(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(BetterAuthClient<User> value) {
+  Override overrideWithValue(AuthTokenStore value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<BetterAuthClient<User>>(value),
+      providerOverride: $SyncValueProvider<AuthTokenStore>(value),
     );
   }
 }
 
-String _$authClientHash() => r'0c25dd8c6daa1bdcdc08ccd7717dd470bf68c4f0';
+String _$authTokenStoreHash() => r'6f411afa2574f45a75c232075512a269d2aa442d';
+
+@ProviderFor(authApiClient)
+final authApiClientProvider = AuthApiClientProvider._();
+
+final class AuthApiClientProvider
+    extends
+        $FunctionalProvider<
+          auth_api.ApiClient,
+          auth_api.ApiClient,
+          auth_api.ApiClient
+        >
+    with $Provider<auth_api.ApiClient> {
+  AuthApiClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'authApiClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$authApiClientHash();
+
+  @$internal
+  @override
+  $ProviderElement<auth_api.ApiClient> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  auth_api.ApiClient create(Ref ref) {
+    return authApiClient(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(auth_api.ApiClient value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<auth_api.ApiClient>(value),
+    );
+  }
+}
+
+String _$authApiClientHash() => r'9636aa64f977ade8ec5047ef3e94920ad975bb4f';

--- a/app/lib/core/auth/auth_notifier.dart
+++ b/app/lib/core/auth/auth_notifier.dart
@@ -1,0 +1,24 @@
+import 'package:eqmonitor/core/auth/auth_client_provider.dart';
+import 'package:riverpod/experimental/mutation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auth_notifier.g.dart';
+
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+@Riverpod(keepAlive: true)
+class AuthNotifier extends _$AuthNotifier {
+  /// 匿名サインインを行う [Mutation]。
+  ///
+  /// スプラッシュ画面から呼び出し、
+  /// 既存のセッションが無い場合に Better Auth `/sign-in/anonymous` を実行する。
+  static final signInAnonymously = Mutation<void>();
+
+  @override
+  Future<String?> build() async {
+    final tokenStore = ref.watch(authTokenStoreProvider);
+    return tokenStore.getToken();
+  }
+}

--- a/app/lib/core/auth/auth_notifier.g.dart
+++ b/app/lib/core/auth/auth_notifier.g.dart
@@ -1,0 +1,73 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'auth_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+
+@ProviderFor(AuthNotifier)
+final authProvider = AuthNotifierProvider._();
+
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+final class AuthNotifierProvider
+    extends $AsyncNotifierProvider<AuthNotifier, String?> {
+  /// 認証状態(セッショントークン)を管理する Notifier。
+  ///
+  /// [build] ではストレージからトークンの有無を確認するのみ。
+  /// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+  AuthNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'authProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$authNotifierHash();
+
+  @$internal
+  @override
+  AuthNotifier create() => AuthNotifier();
+}
+
+String _$authNotifierHash() => r'e9c3f30b9dd25d8fb957ad8d4c6845ce59925133';
+
+/// 認証状態(セッショントークン)を管理する Notifier。
+///
+/// [build] ではストレージからトークンの有無を確認するのみ。
+/// 副作用(匿名認証)は [signInAnonymously] Mutation で実行する。
+
+abstract class _$AuthNotifier extends $AsyncNotifier<String?> {
+  FutureOr<String?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<String?>, String?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<String?>, String?>,
+              AsyncValue<String?>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/core/provider/dio_provider.g.dart
+++ b/app/lib/core/provider/dio_provider.g.dart
@@ -49,4 +49,4 @@ final class DioProvider extends $FunctionalProvider<Dio, Dio, Dio>
   }
 }
 
-String _$dioHash() => r'217681bb3e86b36ae21b12c5278db2f19391dc12';
+String _$dioHash() => r'7326321bb56ba3d5290153322fb9fc47f0ab5bef';

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -30,6 +30,7 @@ import 'package:eqmonitor/feature/settings/children/config/earthquake_history/ea
 import 'package:eqmonitor/feature/settings/features/display_settings/color_scheme/color_scheme_config_page.dart';
 import 'package:eqmonitor/feature/settings/features/display_settings/ui/display_settings.dart';
 import 'package:eqmonitor/feature/settings/settings_screen.dart';
+import 'package:eqmonitor/feature/splash/ui/splash_page.dart';
 import 'package:eqmonitor/feature/telegram_list/ui/telegram_list_by_event_id_page.dart';
 import 'package:eqmonitor/page/home_page.dart';
 import 'package:eqmonitor/page/talker/talker_page.dart';
@@ -47,7 +48,7 @@ part 'router.g.dart';
 GoRouter goRouter(Ref ref) => GoRouter(
   routes: $appRoutes,
   navigatorKey: App.navigatorKey,
-  initialLocation: const HomeRoute().location,
+  initialLocation: const SplashRoute().location,
   observers: [
     _NavigatorObserver(talker),
     FirebaseAnalyticsObserver(analytics: FirebaseAnalytics.instance),
@@ -59,6 +60,15 @@ class GoRouterRedirectException implements Exception {
   GoRouterRedirectException(this.message);
 
   final String message;
+}
+
+@TypedGoRoute<SplashRoute>(path: '/splash')
+class SplashRoute extends GoRouteData with $SplashRoute {
+  const SplashRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const SplashPage();
 }
 
 @TypedGoRoute<EarthquakeHistoryRoute>(path: '/earthquake-history')

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -9,6 +9,7 @@ part of 'router.dart';
 // **************************************************************************
 
 List<RouteBase> get $appRoutes => [
+  $splashRoute,
   $earthquakeHistoryRoute,
   $earthquakeSearchSelectionRoute,
   $earthquakeSearchResultRoute,
@@ -18,6 +19,29 @@ List<RouteBase> get $appRoutes => [
   $talkerRoute,
   $settingsRoute,
 ];
+
+RouteBase get $splashRoute =>
+    GoRouteData.$route(path: '/splash', factory: $SplashRoute._fromState);
+
+mixin $SplashRoute on GoRouteData {
+  static SplashRoute _fromState(GoRouterState state) => const SplashRoute();
+
+  @override
+  String get location => GoRouteData.$location('/splash');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
 
 RouteBase get $earthquakeHistoryRoute => GoRouteData.$route(
   path: '/earthquake-history',
@@ -916,4 +940,4 @@ final class GoRouterProvider
   }
 }
 
-String _$goRouterHash() => r'8a62453a9e9e24d88c219ecf204af1cc7658b177';
+String _$goRouterHash() => r'3888af6622fff60a0b0e8a0dc2c86bfa0efc4f30';

--- a/app/lib/feature/splash/ui/splash_page.dart
+++ b/app/lib/feature/splash/ui/splash_page.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/auth/auth_client_provider.dart';
+import 'package:eqmonitor/core/auth/auth_notifier.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/experimental/mutation.dart';
+
+/// アプリ起動時に認証状態を確認し、
+/// 未ログインであれば匿名認証を行うスプラッシュ画面。
+class SplashPage extends ConsumerStatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  ConsumerState<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends ConsumerState<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_checkAuth());
+  }
+
+  Future<void> _checkAuth() async {
+    final token = await ref.read(authProvider.future);
+    if (!mounted) {
+      return;
+    }
+
+    if (token != null) {
+      // 既にセッションがある → ホームへ遷移
+      const HomeRoute().go(context);
+      return;
+    }
+
+    // セッションが無い → 匿名認証を実行
+    _signInAnonymously();
+  }
+
+  void _signInAnonymously() {
+    unawaited(
+      AuthNotifier.signInAnonymously.run(ref, (tsx) async {
+        final apiClient = tsx.get(authApiClientProvider);
+        final tokenStore = tsx.get(authTokenStoreProvider);
+
+        final response = await apiClient.anonymous.postSignInAnonymous();
+        final session = response.data.session;
+        await tokenStore.saveToken(session.token);
+      }),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mutationState = ref.watch(AuthNotifier.signInAnonymously);
+
+    // 匿名認証が成功したらホームへ遷移
+    ref.listen(AuthNotifier.signInAnonymously, (prev, next) {
+      if (next is MutationSuccess) {
+        const HomeRoute().go(context);
+      }
+    });
+
+    return Scaffold(
+      body: Center(
+        child: switch (mutationState) {
+          MutationIdle() ||
+          MutationPending() ||
+          MutationSuccess() =>
+            const CircularProgressIndicator.adaptive(),
+          MutationError(:final error) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error_outline, size: 48, color: Colors.red),
+                  const SizedBox(height: 16),
+                  Text(
+                    '認証に失敗しました',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    error.toString(),
+                    style: Theme.of(context).textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton.icon(
+                    onPressed: _signInAnonymously,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('再試行'),
+                  ),
+                ],
+              ),
+            ),
+        },
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -95,6 +95,7 @@ dependencies:
   package_info_plus: ^9.0.0
   path_provider: ^2.1.5
   purchases_flutter: ^9.1.0
+  riverpod: ^3.2.1
   riverpod_annotation: ^4.0.0
   screenshot: 3.0.0
   share_plus: ^12.0.0


### PR DESCRIPTION
## Summary
- `AuthNotifier` を追加し、`build()` ではストレージからトークン確認のみ、副作用は `Mutation` で管理
- `SplashPage` を追加し、アプリ起動時に認証状態を確認 → 未ログインなら匿名サインインを実行
- GoRouter の `initialLocation` を `/splash` に変更し、認証完了後にホームへ遷移

## 変更ファイル
| ファイル | 内容 |
|---|---|
| `app/lib/core/auth/auth_notifier.dart` | `AuthNotifier` + `signInAnonymously` Mutation |
| `app/lib/feature/splash/ui/splash_page.dart` | スプラッシュ画面（認証ゲート） |
| `app/lib/core/router/router.dart` | `SplashRoute` 追加、初期ルート変更 |
| `app/pubspec.yaml` | `riverpod` を直接依存に追加（experimental Mutation API 使用） |

## フロー
```
アプリ起動 → /splash (SplashPage)
  ├─ トークンあり → / (HomeRoute)
  └─ トークンなし → Mutation: POST /sign-in/anonymous
       ├─ 成功 → トークン保存 → / (HomeRoute)
       └─ 失敗 → エラー表示 + 再試行ボタン
```

## Test plan
- [ ] 初回起動時に匿名サインインが実行され、ホーム画面に遷移すること
- [ ] アプリ再起動時に既存トークンでスプラッシュをスキップしてホームに遷移すること
- [ ] ネットワークエラー時にエラー画面と再試行ボタンが表示されること
- [ ] 再試行ボタンで匿名サインインが再実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)