### PR TITLE
fix: riverpod 3.x の AsyncValue ラップに対応

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -19,7 +19,7 @@ class App extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = ref.watch(themeModeProvider);
+    final theme = ref.watch(themeModeProvider).requireValue;
     final routerConfig = ref.watch(goRouterProvider);
 
     final app = BetterFeedback(

--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -23,7 +23,7 @@ Dio dio(Ref ref) {
         'user-agent':
             '${package.packageName}/${package.version}+${package.buildNumber}',
       },
-      baseUrl: ref.watch(telegramUrlProvider).restApiUrl,
+      baseUrl: ref.watch(telegramUrlProvider).requireValue.restApiUrl,
       contentType: ContentType.json.value,
       connectTimeout: const Duration(milliseconds: 5000),
       sendTimeout: const Duration(milliseconds: 5000),

--- a/app/lib/core/provider/ntp/ntp_config_provider.dart
+++ b/app/lib/core/provider/ntp/ntp_config_provider.dart
@@ -27,21 +27,21 @@ class NtpConfig extends _$NtpConfig {
   }
 
   Future<void> changeLookUpAddress(String url) async {
-    final current = state.valueOrNull ?? const NtpConfigModel();
+    final current = state.value ?? const NtpConfigModel();
     state = AsyncValue.data(current.copyWith(lookUpAddress: url));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 
   Future<void> changeTimeout(Duration timeout) async {
-    final current = state.valueOrNull ?? const NtpConfigModel();
+    final current = state.value ?? const NtpConfigModel();
     state = AsyncValue.data(current.copyWith(timeout: timeout));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 
   Future<void> changeInterval(Duration interval) async {
-    final current = state.valueOrNull ?? const NtpConfigModel();
+    final current = state.value ?? const NtpConfigModel();
     state = AsyncValue.data(current.copyWith(interval: interval));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 
   Future<void> _save(NtpConfigModel config) async {

--- a/app/lib/core/provider/ntp/ntp_provider.dart
+++ b/app/lib/core/provider/ntp/ntp_provider.dart
@@ -14,7 +14,7 @@ part 'ntp_provider.g.dart';
 class Ntp extends _$Ntp {
   @override
   NtpStateModel build() {
-    final config = ref.watch(ntpConfigProvider);
+    final config = ref.watch(ntpConfigProvider).requireValue;
     final interval = config.interval;
 
     final timer = Timer.periodic(interval, (_) async {
@@ -26,7 +26,7 @@ class Ntp extends _$Ntp {
   }
 
   Future<void> sync() async {
-    final config = ref.read(ntpConfigProvider);
+    final config = ref.read(ntpConfigProvider).requireValue;
     final int offset;
     if (kIsWeb) {
       offset = await NTP.getNtpOffset(

--- a/app/lib/core/provider/telegram_url/provider/telegram_url_provider.dart
+++ b/app/lib/core/provider/telegram_url/provider/telegram_url_provider.dart
@@ -44,14 +44,14 @@ class TelegramUrl extends _$TelegramUrl {
   }
 
   Future<void> updateRestUrl(String url) async {
-    final current = state.valueOrNull ?? _defaultTelegramUrl;
+    final current = state.value ?? _defaultTelegramUrl;
     state = AsyncValue.data(current.copyWith(restApiUrl: url));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 
   Future<void> updateWebSocketUrl(String url) async {
-    final current = state.valueOrNull ?? _defaultTelegramUrl;
+    final current = state.value ?? _defaultTelegramUrl;
     state = AsyncValue.data(current.copyWith(wsApiUrl: url));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 }

--- a/app/lib/core/provider/websocket/websocket_provider.dart
+++ b/app/lib/core/provider/websocket/websocket_provider.dart
@@ -23,7 +23,7 @@ Future<WebSocket> websocket(Ref ref) async {
     '有効期限: ${body.expiresAt.toIso8601String()}',
   );
   final ticket = body.ticket;
-  final wsApiUrl = ref.watch(telegramUrlProvider.select((v) => v.wsApiUrl));
+  final wsApiUrl = ref.watch(telegramUrlProvider.select((v) => v.requireValue.wsApiUrl));
 
   // チケットをクエリパラメータに追加
   final uri = Uri.parse(wsApiUrl).replace(

--- a/app/lib/core/theme/theme_provider.dart
+++ b/app/lib/core/theme/theme_provider.dart
@@ -23,8 +23,7 @@ class ThemeModeNotifier extends _$ThemeModeNotifier {
         ThemeMode.system;
   }
 
-  @override
-  Future<void> update(ThemeMode mode) async {
+  Future<void> setThemeMode(ThemeMode mode) async {
     state = AsyncValue.data(mode);
     final ds = ref.read(sharedPreferencesDataSourceProvider);
     await ds.setString(key: SharedPreferencesKey.themeMode, value: mode.name);

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart
@@ -45,22 +45,22 @@ class EarthquakeHistoryConfigNotifier
   }
 
   Future<void> updateListConfig(EarthquakeHistoryListConfig config) async {
-    final current = state.valueOrNull ?? _defaultEarthquakeHistoryConfig;
+    final current = state.value ?? _defaultEarthquakeHistoryConfig;
     state = AsyncValue.data(current.copyWith(list: config));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 
   Future<void> updateDetailConfig(EarthquakeHistoryDetailConfig config) async {
-    final current = state.valueOrNull ?? _defaultEarthquakeHistoryConfig;
+    final current = state.value ?? _defaultEarthquakeHistoryConfig;
     state = AsyncValue.data(current.copyWith(detail: config));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 
   Future<void> updateIntensityIcon({required bool value}) async {
-    final current = state.valueOrNull ?? _defaultEarthquakeHistoryConfig;
+    final current = state.value ?? _defaultEarthquakeHistoryConfig;
     state = AsyncValue.data(current.copyWith(
       detail: current.detail.copyWith(showIntensityIcon: value),
     ));
-    await _save(state.valueOrNull!);
+    await _save(state.value!);
   }
 }

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -103,7 +103,7 @@ class _IntensityIcons extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final config = ref.watch(
-      earthquakeHistoryConfigProvider.select((value) => value.detail),
+      earthquakeHistoryConfigProvider.select((value) => value.requireValue.detail),
     );
     final showingLpgmIntensity = config.showingLpgmIntensity;
 

--- a/app/lib/feature/home/ui/component/map/home_map_layer_modal.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_layer_modal.dart
@@ -80,7 +80,7 @@ class _KyoshinMonitorIsEnabledTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final setting = ref.watch(kyoshinMonitorSettingsProvider);
+    final setting = ref.watch(kyoshinMonitorSettingsProvider).requireValue;
 
     final subtitle = setting.useKmoni
         ? '強震モニタのリアルタイムデータを表示します \n'

--- a/app/lib/feature/home/ui/component/map/home_map_view.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_view.dart
@@ -102,10 +102,10 @@ class _MapHeader extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final useKmoni = ref.watch(
-      kyoshinMonitorSettingsProvider.select((v) => v.useKmoni),
+      kyoshinMonitorSettingsProvider.select((v) => v.requireValue.useKmoni),
     );
     final showScale = ref.watch(
-      kyoshinMonitorSettingsProvider.select((v) => v.showScale),
+      kyoshinMonitorSettingsProvider.select((v) => v.requireValue.showScale),
     );
 
     final kyoshinMonitorColumn = Column(

--- a/app/lib/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart
@@ -21,7 +21,7 @@ class KyoshinMonitorObservationLayer extends HookConsumerWidget {
     final styleController = controller.style;
     final points = ref.watch(kyoshinMonitorPointsProvider);
     final useKmoni = ref.watch(
-      kyoshinMonitorSettingsProvider.select((v) => v.useKmoni),
+      kyoshinMonitorSettingsProvider.select((v) => v.requireValue.useKmoni),
     );
 
     final eventProvider = MapLibreEventProvider.of(context);

--- a/app/lib/feature/kyoshin_monitor/data/api/kyoshin_monitor_web_api_client_provider.dart
+++ b/app/lib/feature/kyoshin_monitor/data/api/kyoshin_monitor_web_api_client_provider.dart
@@ -12,7 +12,7 @@ KyoshinMonitorWebApiClient kyoshinMonitorWebApiClient(Ref ref) =>
       ref.watch(kyoshinMonitorDioProvider),
       baseUrl: ref
           .watch(
-            kyoshinMonitorSettingsProvider.select((v) => v.api.endpoint),
+            kyoshinMonitorSettingsProvider.select((v) => v.requireValue.api.endpoint),
           )
           .url,
     );

--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
@@ -19,7 +19,7 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
     // タイマーストリームを監視
     ref.listen(kyoshinMonitorTimerStreamProvider, (_, next) async {
       if (next case AsyncData(:final value)) {
-        if (ref.read(kyoshinMonitorSettingsProvider).useKmoni) {
+        if (ref.read(kyoshinMonitorSettingsProvider).requireValue.useKmoni) {
           await _fetchAndAnalyzeImage(value);
         }
       }
@@ -33,9 +33,9 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
       if (previous == null) {
         return;
       }
-      if (previous.realtimeDataType != next.realtimeDataType ||
-          previous.realtimeLayer != next.realtimeLayer ||
-          previous.useKmoni != next.useKmoni) {
+      if (previous.requireValue.realtimeDataType != next.requireValue.realtimeDataType ||
+          previous.requireValue.realtimeLayer != next.requireValue.realtimeLayer ||
+          previous.requireValue.useKmoni != next.requireValue.useKmoni) {
         onSettingsChanged();
       }
     });
@@ -48,6 +48,7 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
     // interval + 5秒遅れている場合は遅延として扱う
     final imageFetchInterval = ref
         .read(kyoshinMonitorSettingsProvider)
+        .requireValue
         .api
         .imageFetchInterval;
     final delay = imageFetchInterval + const Duration(seconds: 5);
@@ -66,9 +67,11 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
       // 画像を取得
       final realtimeDataType = ref
           .read(kyoshinMonitorSettingsProvider)
+          .requireValue
           .realtimeDataType;
       final realtimeLayer = ref
           .read(kyoshinMonitorSettingsProvider)
+          .requireValue
           .realtimeLayer;
       final image = await dataSource.getRealtimeImageData(
         type: realtimeDataType,

--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_timer_notifier.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_timer_notifier.dart
@@ -38,7 +38,7 @@ class KyoshinMonitorTimerNotifier extends _$KyoshinMonitorTimerNotifier {
     // Resync timer
     var isResyncing = false;
     final interval = ref.watch(
-      kyoshinMonitorSettingsProvider.select((v) => v.api.imageFetchInterval),
+      kyoshinMonitorSettingsProvider.select((v) => v.requireValue.api.imageFetchInterval),
     );
     ref.listen(
       periodicTimerProvider(
@@ -125,7 +125,7 @@ class KyoshinMonitorTimerNotifier extends _$KyoshinMonitorTimerNotifier {
 Stream<void> _kyoshinMonitorDelayAdujustTiming(Ref ref) {
   final streamController = StreamController<void>();
   final delayAdjustInterval = ref.watch(
-    kyoshinMonitorSettingsProvider.select((v) => v.api.delayAdjustInterval),
+    kyoshinMonitorSettingsProvider.select((v) => v.requireValue.api.delayAdjustInterval),
   );
   ref.listen(periodicTimerProvider(delayAdjustInterval), (previous, next) {
     streamController.add(null);

--- a/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_timer_stream.dart
+++ b/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_timer_stream.dart
@@ -15,7 +15,7 @@ Stream<DateTime> kyoshinMonitorTimerStream(Ref ref) async* {
   final streamController = StreamController<DateTime>();
 
   final interval = ref.watch(
-    kyoshinMonitorSettingsProvider.select((v) => v.api.imageFetchInterval),
+    kyoshinMonitorSettingsProvider.select((v) => v.requireValue.api.imageFetchInterval),
   );
 
   ref

--- a/app/lib/feature/kyoshin_monitor/page/components/kyoshin_monitor_maintenance_card.dart
+++ b/app/lib/feature/kyoshin_monitor/page/components/kyoshin_monitor_maintenance_card.dart
@@ -12,7 +12,7 @@ class KyoshinMonitorMaintenanceCardnceCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!ref.watch(kyoshinMonitorSettingsProvider.select((v) => v.useKmoni))) {
+    if (!ref.watch(kyoshinMonitorSettingsProvider.select((v) => v.requireValue.useKmoni))) {
       return const SizedBox.shrink();
     }
     final state = ref.watch(kyoshinMonitorMaintenanceProvider);

--- a/app/lib/feature/kyoshin_monitor/page/kyoshin_monitor_settings_modal.dart
+++ b/app/lib/feature/kyoshin_monitor/page/kyoshin_monitor_settings_modal.dart
@@ -32,7 +32,7 @@ class KyoshinMonitorSettingsModal extends HookConsumerWidget {
     final backgroundColor = colorScheme.surfaceContainerLow;
 
     final isEnabled = ref.watch(
-      kyoshinMonitorSettingsProvider.select((v) => v.useKmoni),
+      kyoshinMonitorSettingsProvider.select((v) => v.requireValue.useKmoni),
     );
 
     return Scaffold(
@@ -98,12 +98,14 @@ class KyoshinMonitorSettingsModal extends HookConsumerWidget {
                     child: _RealtimeDataTypeSelector(
                       value: ref
                           .watch(kyoshinMonitorSettingsProvider)
+                          .requireValue
                           .realtimeDataType,
                       onChanged: (value) async => ref
                           .read(kyoshinMonitorSettingsProvider.notifier)
                           .save(
                             ref
                                 .read(kyoshinMonitorSettingsProvider)
+                                .requireValue
                                 .copyWith(realtimeDataType: value),
                           ),
                     ),
@@ -113,12 +115,14 @@ class KyoshinMonitorSettingsModal extends HookConsumerWidget {
                     child: _RealtimeLayerSelector(
                       value: ref
                           .watch(kyoshinMonitorSettingsProvider)
+                          .requireValue
                           .realtimeLayer,
                       onChanged: (value) async => ref
                           .read(kyoshinMonitorSettingsProvider.notifier)
                           .save(
                             ref
                                 .read(kyoshinMonitorSettingsProvider)
+                                .requireValue
                                 .copyWith(realtimeLayer: value),
                           ),
                     ),
@@ -130,12 +134,14 @@ class KyoshinMonitorSettingsModal extends HookConsumerWidget {
                     child: _MarkerTypeSelector(
                       value: ref
                           .watch(kyoshinMonitorSettingsProvider)
+                          .requireValue
                           .kmoniMarkerType,
                       onChanged: (value) async => ref
                           .read(kyoshinMonitorSettingsProvider.notifier)
                           .save(
                             ref
                                 .read(kyoshinMonitorSettingsProvider)
+                                .requireValue
                                 .copyWith(kmoniMarkerType: value),
                           ),
                     ),
@@ -153,12 +159,14 @@ class KyoshinMonitorSettingsModal extends HookConsumerWidget {
                           ),
                           value: ref
                               .watch(kyoshinMonitorSettingsProvider)
+                              .requireValue
                               .showScale,
                           onChanged: (value) async => ref
                               .read(kyoshinMonitorSettingsProvider.notifier)
                               .save(
                                 ref
                                     .read(kyoshinMonitorSettingsProvider)
+                                    .requireValue
                                     .copyWith(showScale: value),
                               ),
                         ),
@@ -180,7 +188,7 @@ class _KyoshinMonitorSwitchListTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isEnabled = ref.watch(
-      kyoshinMonitorSettingsProvider.select((v) => v.useKmoni),
+      kyoshinMonitorSettingsProvider.select((v) => v.requireValue.useKmoni),
     );
 
     return Padding(
@@ -195,6 +203,7 @@ class _KyoshinMonitorSwitchListTile extends ConsumerWidget {
               .save(
                 ref
                     .read(kyoshinMonitorSettingsProvider)
+                    .requireValue
                     .copyWith(useKmoni: value),
               ),
         ),

--- a/app/lib/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart
+++ b/app/lib/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart
@@ -14,7 +14,7 @@ class KyoshinMonitorScaleCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final realtimeDataType = ref.watch(
-      kyoshinMonitorSettingsProvider.select((v) => v.realtimeDataType),
+      kyoshinMonitorSettingsProvider.select((v) => v.requireValue.realtimeDataType),
     );
     final type = switch (realtimeDataType) {
       RealtimeDataType.shindo => KyoshinMonitorScaleType.intensity,

--- a/app/lib/feature/settings/children/config/debug/api_endpoint_selector/http_api_endpoint_selector_page.dart
+++ b/app/lib/feature/settings/children/config/debug/api_endpoint_selector/http_api_endpoint_selector_page.dart
@@ -11,7 +11,7 @@ class HttpApiEndpointSelectorPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     const defaultUrl = Env.restApiUrl;
     final developUrl = defaultUrl.replaceAll('api.', 'dev.api.');
-    final state = ref.watch(telegramUrlProvider.select((v) => v.restApiUrl));
+    final state = ref.watch(telegramUrlProvider.select((v) => v.requireValue.restApiUrl));
     return Scaffold(
       appBar: AppBar(title: const Text('API Endpoint Selector')),
       body: Column(

--- a/app/lib/feature/settings/children/config/debug/api_endpoint_selector/websocket_api_endpoint_selector_page.dart
+++ b/app/lib/feature/settings/children/config/debug/api_endpoint_selector/websocket_api_endpoint_selector_page.dart
@@ -11,7 +11,7 @@ class WebSocketApiEndpointSelectorPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     const defaultUrl = Env.wsApiUrl;
     final developUrl = defaultUrl.replaceAll('api.', 'dev.api.');
-    final state = ref.watch(telegramUrlProvider.select((v) => v.wsApiUrl));
+    final state = ref.watch(telegramUrlProvider.select((v) => v.requireValue.wsApiUrl));
     return Scaffold(
       appBar: AppBar(title: const Text('WebSocket Endpoint Selector')),
       body: Column(

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -27,7 +27,7 @@ class _DebugWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isDebugEnabled = ref.watch(debugProvider);
+    final isDebugEnabled = ref.watch(debugProvider).requireValue;
 
     final notificationToken = ref.watch(notificationTokenStreamProvider).value;
 
@@ -55,14 +55,14 @@ class _DebugWidget extends ConsumerWidget {
           ListTile(
             title: const Text('REST APIエンドポイント'),
             leading: const Icon(Icons.http),
-            subtitle: Text(ref.watch(telegramUrlProvider).restApiUrl),
+            subtitle: Text(ref.watch(telegramUrlProvider).requireValue.restApiUrl),
             onTap: () async =>
                 const HttpApiEndpointSelectorRoute().push<void>(context),
           ),
           ListTile(
             title: const Text('WebSocketエンドポイント'),
             leading: const Icon(Icons.http),
-            subtitle: Text(ref.watch(telegramUrlProvider).wsApiUrl),
+            subtitle: Text(ref.watch(telegramUrlProvider).requireValue.wsApiUrl),
             onTap: () async =>
                 const WebsocketEndpointSelectorRoute().push<void>(context),
           ),

--- a/app/lib/feature/settings/children/config/debug/kyoshin_monitor/debug_kyoshin_monitor.dart
+++ b/app/lib/feature/settings/children/config/debug/kyoshin_monitor/debug_kyoshin_monitor.dart
@@ -164,7 +164,7 @@ class _Body extends ConsumerWidget {
               Text(
                 const JsonEncoder.withIndent(
                   '  ',
-                ).convert(ref.watch(kyoshinMonitorSettingsProvider).toJson()),
+                ).convert(ref.watch(kyoshinMonitorSettingsProvider).requireValue.toJson()),
                 style: bodyTextStyle,
               ),
             ],

--- a/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
+++ b/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
@@ -34,7 +34,7 @@ class _EarthquakeHistoryListConfigWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(
-      earthquakeHistoryConfigProvider.select((value) => value.list),
+      earthquakeHistoryConfigProvider.select((value) => value.requireValue.list),
     );
     return Column(
       children: [
@@ -57,7 +57,7 @@ class _EarthquakeHistoryDetailConfigWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final state = ref.watch(
-      earthquakeHistoryConfigProvider.select((value) => value.detail),
+      earthquakeHistoryConfigProvider.select((value) => value.requireValue.detail),
     );
     final sheetBar = Container(
       margin: const EdgeInsets.symmetric(vertical: 8),
@@ -153,7 +153,7 @@ class _EarthquakeHistoryDetailConfigBody extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final showingLpgmIntensity = ref.watch(
       earthquakeHistoryConfigProvider.select(
-        (value) => value.detail.showingLpgmIntensity,
+        (value) => value.requireValue.detail.showingLpgmIntensity,
       ),
     );
     final theme = Theme.of(context);
@@ -210,6 +210,7 @@ class _EarthquakeHistoryDetailConfigBody extends HookConsumerWidget {
                     .updateDetailConfig(
                       ref
                           .watch(earthquakeHistoryConfigProvider)
+                          .requireValue
                           .detail
                           .copyWith(
                             showingLpgmIntensity: value == _IntensityMode.lpgm,
@@ -239,7 +240,7 @@ class __IntensityFillModeSegmentedControlState
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(
-      earthquakeHistoryConfigProvider.select((value) => value.detail),
+      earthquakeHistoryConfigProvider.select((value) => value.requireValue.detail),
     );
     final showCitySelector = widget.showCitySelector;
     const choices = IntensityFillMode.values;
@@ -347,7 +348,7 @@ class _IntensityStationIconModeSegmentedButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(
-      earthquakeHistoryConfigProvider.select((value) => value.detail),
+      earthquakeHistoryConfigProvider.select((value) => value.requireValue.detail),
     );
     final isShowingLpgmIntensity = state.showingLpgmIntensity;
     return SwitchListTile.adaptive(

--- a/app/lib/feature/settings/features/display_settings/ui/display_settings.dart
+++ b/app/lib/feature/settings/features/display_settings/ui/display_settings.dart
@@ -50,7 +50,7 @@ class _ThemeSelector extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(themeModeProvider);
+    final state = ref.watch(themeModeProvider).requireValue;
 
     final brightness = MediaQuery.platformBrightnessOf(context);
 
@@ -60,7 +60,7 @@ class _ThemeSelector extends ConsumerWidget {
           : Brightness.dark;
       return Expanded(
         child: GestureDetector(
-          onTap: () async => ref.read(themeModeProvider.notifier).update(mode),
+          onTap: () async => ref.read(themeModeProvider.notifier).setThemeMode(mode),
           child: Column(
             children: [
               SizedBox(
@@ -93,7 +93,7 @@ class _ThemeSelector extends ConsumerWidget {
                 groupValue: state,
                 // ignore: deprecated_member_use
                 onChanged: (value) async =>
-                    ref.read(themeModeProvider.notifier).update(mode),
+                    ref.read(themeModeProvider.notifier).setThemeMode(mode),
               ),
             ],
           ),
@@ -136,7 +136,7 @@ class _ThemeSelector extends ConsumerWidget {
             value: state == ThemeMode.system,
             onChanged: (value) async => ref
                 .read(themeModeProvider.notifier)
-                .update(
+                .setThemeMode(
                   value
                       ? ThemeMode.system
                       : PlatformDispatcher.instance.platformBrightness ==

--- a/app/lib/feature/settings/settings_screen.dart
+++ b/app/lib/feature/settings/settings_screen.dart
@@ -21,7 +21,7 @@ class SettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isDebugEnabled = ref.watch(debugProvider);
+    final isDebugEnabled = ref.watch(debugProvider).requireValue;
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 


### PR DESCRIPTION
## Summary
- riverpod 3.x / riverpod_generator 4.x で同期 Notifier の `ref.watch()` が `AsyncValue<T>` を返すようになった破壊的変更に対応
- `ref.watch(provider)` に `.requireValue` を追加（26ファイル）
- `.select((v) => v.prop)` を `.select((v) => v.requireValue.prop)` に修正
- Notifier 内の `state.valueOrNull`（削除済みAPI）を `state.value` に置換
- `ThemeModeNotifier.update` を `setThemeMode` にリネーム（基底クラスの `update` メソッドとの衝突回避）

## 変更ファイル（26ファイル）
| カテゴリ | ファイル |
|---|---|
| Core | `app.dart`, `dio_provider.dart`, `telegram_url_provider.dart`, `websocket_provider.dart`, `theme_provider.dart`, `ntp_config_provider.dart`, `ntp_provider.dart` |
| Kyoshin Monitor | `kyoshin_monitor_settings_modal.dart`, `kyoshin_monitor_notifier.dart`, `kyoshin_monitor_timer_notifier.dart`, `kyoshin_monitor_timer_stream.dart`, `kyoshin_monitor_web_api_client_provider.dart`, `kyoshin_monitor_scale_card.dart`, `kyoshin_monitor_maintenance_card.dart`, `debug_kyoshin_monitor.dart` |
| Settings | `display_settings.dart`, `debug_page.dart`, `settings_screen.dart`, `http_api_endpoint_selector_page.dart`, `websocket_api_endpoint_selector_page.dart`, `earthquake_history_config_page.dart` |
| Home | `home_map_layer_modal.dart`, `home_map_view.dart`, `kyoshin_monitor_observation_layer.dart` |
| Earthquake History | `earthquake_history_details_page.dart`, `earthquake_history_config_notifier.dart` |

## Test plan
- [ ] アプリが正常に起動すること
- [ ] 強震モニタ設定画面が正常に動作すること
- [ ] テーマ切り替えが動作すること
- [ ] デバッグ画面のAPI URL変更が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)