### PR TITLE
feat: デバッグにデバイス・通知設定画面を追加

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:eqmonitor/app.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/feature/devices/ui/page/debug_device_settings_page.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_details_page.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_page.dart';
 import 'package:eqmonitor/feature/earthquake_replay/ui/earthquake_replay_page.dart';
@@ -205,6 +206,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
         TypedGoRoute<DebugKyoshinMonitorRoute>(path: 'kyoshin-monitor'),
         TypedGoRoute<DebugJmaMapRoute>(path: 'jma-map'),
         TypedGoRoute<PlaygroundRoute>(path: 'playground'),
+        TypedGoRoute<DebugDeviceSettingsRoute>(path: 'device-settings'),
         TypedGoRoute<EarthquakeReplayRoute>(path: 'earthquake-replay'),
         TypedGoRoute<NiedRoute>(
           path: 'nied',
@@ -376,6 +378,16 @@ class PlaygroundRoute extends GoRouteData with $PlaygroundRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const PlaygroundPage();
+  }
+}
+
+class DebugDeviceSettingsRoute extends GoRouteData
+    with $DebugDeviceSettingsRoute {
+  const DebugDeviceSettingsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const DebugDeviceSettingsPage();
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -336,6 +336,10 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           factory: $PlaygroundRoute._fromState,
         ),
         GoRouteData.$route(
+          path: 'device-settings',
+          factory: $DebugDeviceSettingsRoute._fromState,
+        ),
+        GoRouteData.$route(
           path: 'earthquake-replay',
           factory: $EarthquakeReplayRoute._fromState,
         ),
@@ -733,6 +737,28 @@ mixin $PlaygroundRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/settings/debug/playground');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DebugDeviceSettingsRoute on GoRouteData {
+  static DebugDeviceSettingsRoute _fromState(GoRouterState state) =>
+      const DebugDeviceSettingsRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/device-settings');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/devices/data/model/registered_device.dart
+++ b/app/lib/feature/devices/data/model/registered_device.dart
@@ -1,0 +1,52 @@
+import 'package:eqmonitor_api/export.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'registered_device.freezed.dart';
+
+@freezed
+abstract class RegisteredDevice with _$RegisteredDevice {
+  const factory RegisteredDevice({
+    required String id,
+    required RegisteredDevicePlatform platform,
+    required String userId,
+    required RegisteredDeviceLocale locale,
+    required String createdAtIso,
+    required String updatedAtIso,
+  }) = _RegisteredDevice;
+}
+
+enum RegisteredDevicePlatform {
+  ios,
+  android,
+}
+
+enum RegisteredDeviceLocale {
+  ja,
+  en,
+  zh,
+}
+
+extension RegisteredDevicePlatformDisplay on RegisteredDevicePlatform {
+  String get displayLabel => switch (this) {
+        RegisteredDevicePlatform.ios => 'iOS',
+        RegisteredDevicePlatform.android => 'Android',
+      };
+}
+
+extension RegisteredDeviceApiExtension on api.DeviceResponse {
+  RegisteredDevice get toRegisteredDevice => RegisteredDevice(
+        id: id,
+        platform: switch (type) {
+          api.DeviceResponseType.ios => RegisteredDevicePlatform.ios,
+          api.DeviceResponseType.android => RegisteredDevicePlatform.android,
+        },
+        userId: userId,
+        locale: switch (locale) {
+          api.DeviceResponseLocale.ja => RegisteredDeviceLocale.ja,
+          api.DeviceResponseLocale.en => RegisteredDeviceLocale.en,
+          api.DeviceResponseLocale.zh => RegisteredDeviceLocale.zh,
+        },
+        createdAtIso: createdAt,
+        updatedAtIso: updatedAt,
+      );
+}

--- a/app/lib/feature/devices/data/model/registered_device.freezed.dart
+++ b/app/lib/feature/devices/data/model/registered_device.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'registered_device.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$RegisteredDevice {
+
+ String get id; RegisteredDevicePlatform get platform; String get userId; RegisteredDeviceLocale get locale; String get createdAtIso; String get updatedAtIso;
+/// Create a copy of RegisteredDevice
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RegisteredDeviceCopyWith<RegisteredDevice> get copyWith => _$RegisteredDeviceCopyWithImpl<RegisteredDevice>(this as RegisteredDevice, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegisteredDevice&&(identical(other.id, id) || other.id == id)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.createdAtIso, createdAtIso) || other.createdAtIso == createdAtIso)&&(identical(other.updatedAtIso, updatedAtIso) || other.updatedAtIso == updatedAtIso));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id,platform,userId,locale,createdAtIso,updatedAtIso);
+
+@override
+String toString() {
+  return 'RegisteredDevice(id: $id, platform: $platform, userId: $userId, locale: $locale, createdAtIso: $createdAtIso, updatedAtIso: $updatedAtIso)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RegisteredDeviceCopyWith<$Res>  {
+  factory $RegisteredDeviceCopyWith(RegisteredDevice value, $Res Function(RegisteredDevice) _then) = _$RegisteredDeviceCopyWithImpl;
+@useResult
+$Res call({
+ String id, RegisteredDevicePlatform platform, String userId, RegisteredDeviceLocale locale, String createdAtIso, String updatedAtIso
+});
+
+
+
+
+}
+/// @nodoc
+class _$RegisteredDeviceCopyWithImpl<$Res>
+    implements $RegisteredDeviceCopyWith<$Res> {
+  _$RegisteredDeviceCopyWithImpl(this._self, this._then);
+
+  final RegisteredDevice _self;
+  final $Res Function(RegisteredDevice) _then;
+
+/// Create a copy of RegisteredDevice
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? platform = null,Object? userId = null,Object? locale = null,Object? createdAtIso = null,Object? updatedAtIso = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as RegisteredDevicePlatform,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as RegisteredDeviceLocale,createdAtIso: null == createdAtIso ? _self.createdAtIso : createdAtIso // ignore: cast_nullable_to_non_nullable
+as String,updatedAtIso: null == updatedAtIso ? _self.updatedAtIso : updatedAtIso // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RegisteredDevice].
+extension RegisteredDevicePatterns on RegisteredDevice {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RegisteredDevice value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RegisteredDevice() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RegisteredDevice value)  $default,){
+final _that = this;
+switch (_that) {
+case _RegisteredDevice():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RegisteredDevice value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RegisteredDevice() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  RegisteredDevicePlatform platform,  String userId,  RegisteredDeviceLocale locale,  String createdAtIso,  String updatedAtIso)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RegisteredDevice() when $default != null:
+return $default(_that.id,_that.platform,_that.userId,_that.locale,_that.createdAtIso,_that.updatedAtIso);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  RegisteredDevicePlatform platform,  String userId,  RegisteredDeviceLocale locale,  String createdAtIso,  String updatedAtIso)  $default,) {final _that = this;
+switch (_that) {
+case _RegisteredDevice():
+return $default(_that.id,_that.platform,_that.userId,_that.locale,_that.createdAtIso,_that.updatedAtIso);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  RegisteredDevicePlatform platform,  String userId,  RegisteredDeviceLocale locale,  String createdAtIso,  String updatedAtIso)?  $default,) {final _that = this;
+switch (_that) {
+case _RegisteredDevice() when $default != null:
+return $default(_that.id,_that.platform,_that.userId,_that.locale,_that.createdAtIso,_that.updatedAtIso);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _RegisteredDevice implements RegisteredDevice {
+  const _RegisteredDevice({required this.id, required this.platform, required this.userId, required this.locale, required this.createdAtIso, required this.updatedAtIso});
+  
+
+@override final  String id;
+@override final  RegisteredDevicePlatform platform;
+@override final  String userId;
+@override final  RegisteredDeviceLocale locale;
+@override final  String createdAtIso;
+@override final  String updatedAtIso;
+
+/// Create a copy of RegisteredDevice
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RegisteredDeviceCopyWith<_RegisteredDevice> get copyWith => __$RegisteredDeviceCopyWithImpl<_RegisteredDevice>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegisteredDevice&&(identical(other.id, id) || other.id == id)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.createdAtIso, createdAtIso) || other.createdAtIso == createdAtIso)&&(identical(other.updatedAtIso, updatedAtIso) || other.updatedAtIso == updatedAtIso));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id,platform,userId,locale,createdAtIso,updatedAtIso);
+
+@override
+String toString() {
+  return 'RegisteredDevice(id: $id, platform: $platform, userId: $userId, locale: $locale, createdAtIso: $createdAtIso, updatedAtIso: $updatedAtIso)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RegisteredDeviceCopyWith<$Res> implements $RegisteredDeviceCopyWith<$Res> {
+  factory _$RegisteredDeviceCopyWith(_RegisteredDevice value, $Res Function(_RegisteredDevice) _then) = __$RegisteredDeviceCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, RegisteredDevicePlatform platform, String userId, RegisteredDeviceLocale locale, String createdAtIso, String updatedAtIso
+});
+
+
+
+
+}
+/// @nodoc
+class __$RegisteredDeviceCopyWithImpl<$Res>
+    implements _$RegisteredDeviceCopyWith<$Res> {
+  __$RegisteredDeviceCopyWithImpl(this._self, this._then);
+
+  final _RegisteredDevice _self;
+  final $Res Function(_RegisteredDevice) _then;
+
+/// Create a copy of RegisteredDevice
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? platform = null,Object? userId = null,Object? locale = null,Object? createdAtIso = null,Object? updatedAtIso = null,}) {
+  return _then(_RegisteredDevice(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as RegisteredDevicePlatform,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as RegisteredDeviceLocale,createdAtIso: null == createdAtIso ? _self.createdAtIso : createdAtIso // ignore: cast_nullable_to_non_nullable
+as String,updatedAtIso: null == updatedAtIso ? _self.updatedAtIso : updatedAtIso // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/devices/data/provider/debug_device_settings_providers.dart
+++ b/app/lib/feature/devices/data/provider/debug_device_settings_providers.dart
@@ -1,0 +1,84 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/core/provider/device_id.dart';
+import 'package:eqmonitor/feature/auth/data/notifier/auth_notifier.dart';
+import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
+import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
+import 'package:eqmonitor/feature/notification/data/model/general_notification_settings.dart';
+import 'package:eqmonitor/feature/notification/data/model/push_notification_log.dart';
+import 'package:eqmonitor/feature/notification/data/repository/push_notification_repository.dart';
+import 'package:eqmonitor/feature/settings/features/notification/data/model/notification_token.dart';
+import 'package:eqmonitor/feature/settings/features/notification/data/provider/notification_token_stream.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_device_settings_providers.g.dart';
+
+typedef DebugDeviceSessionSnapshot = ({
+  String deviceId,
+  RegisteredDevice device,
+  GeneralNotificationSettings notificationSettings,
+});
+
+@riverpod
+Future<DebugDeviceSessionSnapshot?> debugDeviceSession(Ref ref) async {
+  final authToken = ref.watch(authProvider).value;
+  if (authToken == null) {
+    return null;
+  }
+
+  ref.watch(notificationTokenStreamProvider);
+  final deviceId = await ref.watch(deviceIdProvider.future);
+  final deviceRepo = ref.watch(deviceRepositoryProvider);
+  final notifRepo = ref.watch(pushNotificationRepositoryProvider);
+
+  final deviceResult = await deviceRepo.fetchOrRegister(deviceId);
+  final device = switch (deviceResult) {
+    Success(:final value) => value,
+    Failure(:final exception) => throw exception,
+  };
+
+  final tokenAsync = ref.watch(notificationTokenStreamProvider);
+  final notificationToken =
+      tokenAsync.value ?? const NotificationToken();
+
+  final syncResult = await deviceRepo.syncPushTokens(
+    deviceId: deviceId,
+    token: notificationToken,
+  );
+  switch (syncResult) {
+    case Failure(:final exception):
+      throw exception;
+    case Success():
+      break;
+  }
+
+  final settingsResult = await notifRepo.getNotificationSettings(deviceId);
+  final notificationSettings = switch (settingsResult) {
+    Success(:final value) => value,
+    Failure(:final exception) => throw exception,
+  };
+
+  return (
+    deviceId: deviceId,
+    device: device,
+    notificationSettings: notificationSettings,
+  );
+}
+
+@riverpod
+Future<List<PushNotificationLogEntry>> debugNotificationHistory(
+  Ref ref,
+) async {
+  final session = await ref.watch(debugDeviceSessionProvider.future);
+  if (session == null) {
+    return [];
+  }
+  final repo = ref.watch(pushNotificationRepositoryProvider);
+  final result = await repo.getNotificationHistory(
+    deviceId: session.deviceId,
+    limit: 50,
+  );
+  return switch (result) {
+    Success(:final value) => value.items,
+    Failure(:final exception) => throw exception,
+  };
+}

--- a/app/lib/feature/devices/data/provider/debug_device_settings_providers.g.dart
+++ b/app/lib/feature/devices/data/provider/debug_device_settings_providers.g.dart
@@ -1,0 +1,96 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_device_settings_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugDeviceSession)
+final debugDeviceSessionProvider = DebugDeviceSessionProvider._();
+
+final class DebugDeviceSessionProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<DebugDeviceSessionSnapshot?>,
+          DebugDeviceSessionSnapshot?,
+          FutureOr<DebugDeviceSessionSnapshot?>
+        >
+    with
+        $FutureModifier<DebugDeviceSessionSnapshot?>,
+        $FutureProvider<DebugDeviceSessionSnapshot?> {
+  DebugDeviceSessionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugDeviceSessionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugDeviceSessionHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<DebugDeviceSessionSnapshot?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<DebugDeviceSessionSnapshot?> create(Ref ref) {
+    return debugDeviceSession(ref);
+  }
+}
+
+String _$debugDeviceSessionHash() =>
+    r'84003edc96aac7899fe79a42020ef58805dff22d';
+
+@ProviderFor(debugNotificationHistory)
+final debugNotificationHistoryProvider = DebugNotificationHistoryProvider._();
+
+final class DebugNotificationHistoryProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<PushNotificationLogEntry>>,
+          List<PushNotificationLogEntry>,
+          FutureOr<List<PushNotificationLogEntry>>
+        >
+    with
+        $FutureModifier<List<PushNotificationLogEntry>>,
+        $FutureProvider<List<PushNotificationLogEntry>> {
+  DebugNotificationHistoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugNotificationHistoryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugNotificationHistoryHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<PushNotificationLogEntry>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<PushNotificationLogEntry>> create(Ref ref) {
+    return debugNotificationHistory(ref);
+  }
+}
+
+String _$debugNotificationHistoryHash() =>
+    r'386d4b980d6a175b46d72fed292ef8838364d250';

--- a/app/lib/feature/devices/data/repository/device_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.dart
@@ -1,0 +1,120 @@
+import 'dart:io' show Platform;
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
+import 'package:eqmonitor/feature/settings/features/notification/data/model/notification_token.dart';
+import 'package:eqmonitor_api/export.dart' as api;
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'device_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+DeviceRepository deviceRepository(Ref ref) =>
+    DeviceRepository(ref.watch(apiClientProvider));
+
+class DeviceRepository {
+  DeviceRepository(this._api);
+
+  final api.ApiClient _api;
+
+  Future<Result<RegisteredDevice, Exception>> getDevice(String deviceId) =>
+      Result.capture(() async {
+        final response = await _api.device.getV2DeviceDeviceId(
+          deviceId: deviceId,
+        );
+        return response.data.toRegisteredDevice;
+      });
+
+  Future<Result<RegisteredDevice, Exception>> registerDevice(
+    String deviceId,
+  ) =>
+      Result.capture(() async {
+        final response = await _api.device.putV2DeviceDeviceId(
+          deviceId: deviceId,
+        );
+        return response.data.toRegisteredDevice;
+      });
+
+  Future<Result<RegisteredDevice, Exception>> fetchOrRegister(
+    String deviceId,
+  ) async {
+    final getResult = await getDevice(deviceId);
+    switch (getResult) {
+      case Success(:final value):
+        return Success(value);
+      case Failure(:final exception, :final stackTrace):
+        if (_isNotFound(exception)) {
+          return registerDevice(deviceId);
+        }
+        return Failure(exception, stackTrace);
+    }
+  }
+
+  Future<Result<void, Exception>> syncPushTokens({
+    required String deviceId,
+    required NotificationToken token,
+  }) async {
+    final fcm = token.fcmToken;
+    if (fcm != null && fcm.isNotEmpty) {
+      final r = await Result.capture(() async {
+        await _api.device.patchV2DeviceDeviceIdFcm(
+          deviceId: deviceId,
+          body: api.FcmTokenRequest(token: fcm),
+        );
+      });
+      if (r is Failure<void, Exception>) {
+        return r;
+      }
+    }
+
+    if (kIsWeb || !(Platform.isIOS || Platform.isMacOS)) {
+      return const Success(null);
+    }
+
+    final apns = token.apnsToken;
+    if (apns != null && apns.isNotEmpty) {
+      final r = await Result.capture(() async {
+        await _api.device.patchV2DeviceDeviceIdApnsType(
+          type: api.ApnsTokenType.notification,
+          deviceId: deviceId,
+          body: api.ApnsTokenRequest(
+            token: apns,
+            environment: kDebugMode
+                ? api.ApnsEnvironment.development
+                : api.ApnsEnvironment.production,
+          ),
+        );
+      });
+      if (r is Failure<void, Exception>) {
+        return r;
+      }
+    }
+
+    final pushToStart = token.apnsPushToStartToken;
+    if (pushToStart != null && pushToStart.isNotEmpty) {
+      final r = await Result.capture(() async {
+        await _api.device.patchV2DeviceDeviceIdApnsType(
+          type: api.ApnsTokenType.liveActivityStart,
+          deviceId: deviceId,
+          body: api.ApnsTokenRequest(
+            token: pushToStart,
+            environment: kDebugMode
+                ? api.ApnsEnvironment.development
+                : api.ApnsEnvironment.production,
+          ),
+        );
+      });
+      if (r is Failure<void, Exception>) {
+        return r;
+      }
+    }
+
+    return const Success(null);
+  }
+}
+
+bool _isNotFound(Exception e) =>
+    e is DioException && e.response?.statusCode == 404;

--- a/app/lib/feature/devices/data/repository/device_repository.g.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'device_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(deviceRepository)
+final deviceRepositoryProvider = DeviceRepositoryProvider._();
+
+final class DeviceRepositoryProvider
+    extends
+        $FunctionalProvider<
+          DeviceRepository,
+          DeviceRepository,
+          DeviceRepository
+        >
+    with $Provider<DeviceRepository> {
+  DeviceRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deviceRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deviceRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<DeviceRepository> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  DeviceRepository create(Ref ref) {
+    return deviceRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DeviceRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DeviceRepository>(value),
+    );
+  }
+}
+
+String _$deviceRepositoryHash() => r'e4059dd27d0ff4680e3786595f8ee281c79cbce5';

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -1,0 +1,611 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/auth/data/notifier/auth_notifier.dart';
+import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
+import 'package:eqmonitor/feature/devices/data/provider/debug_device_settings_providers.dart';
+import 'package:eqmonitor/feature/notification/data/model/general_notification_settings.dart';
+import 'package:eqmonitor/feature/notification/data/model/push_notification_log.dart';
+import 'package:eqmonitor/feature/notification/data/model/test_notification_delivery.dart';
+import 'package:eqmonitor/feature/notification/data/repository/push_notification_repository.dart';
+import 'package:eqmonitor/feature/settings/features/notification/data/provider/notification_token_stream.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DebugDeviceSettingsPage extends HookConsumerWidget {
+  const DebugDeviceSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sessionAsync = ref.watch(debugDeviceSessionProvider);
+    final historyAsync = ref.watch(debugNotificationHistoryProvider);
+
+    Future<void> onRefresh() async {
+      ref.invalidate(debugDeviceSessionProvider);
+      ref.invalidate(debugNotificationHistoryProvider);
+      await ref.read(debugDeviceSessionProvider.future);
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('デバイス・通知'),
+      ),
+      body: RefreshIndicator(
+        onRefresh: onRefresh,
+        child: CustomScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          slivers: [
+            switch (sessionAsync) {
+              AsyncData(:final value) => value == null
+                  ? const SliverFillRemaining(
+                      child: _UnauthenticatedMessage(),
+                    )
+                  : _DeviceSettingsSliverList(
+                      snapshot: value,
+                      historyAsync: historyAsync,
+                    ),
+              AsyncError(:final error, :final stackTrace) => SliverFillRemaining(
+                  child: _LoadErrorBody(
+                    message: error.toString(),
+                    stackTrace: stackTrace,
+                    onRetry: onRefresh,
+                  ),
+                ),
+              _ => const SliverFillRemaining(
+                  child: Center(child: CircularProgressIndicator.adaptive()),
+                ),
+            },
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UnauthenticatedMessage extends StatelessWidget {
+  const _UnauthenticatedMessage();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.lock_outline, size: 48, color: scheme.primary),
+            const SizedBox(height: 16),
+            Text(
+              'デバイス登録と通知設定にはログインが必要です',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'デバッグページの Google サインインから認証してください',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LoadErrorBody extends StatelessWidget {
+  const _LoadErrorBody({
+    required this.message,
+    required this.stackTrace,
+    required this.onRetry,
+  });
+
+  final String message;
+  final StackTrace stackTrace;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.error_outline, size: 48, color: scheme.error),
+          const SizedBox(height: 16),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: scheme.onSurface),
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: () async => onRetry(),
+            icon: const Icon(Icons.refresh),
+            label: const Text('再試行'),
+          ),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: () async {
+              await Clipboard.setData(
+                ClipboardData(text: '$message\n\n$stackTrace'),
+              );
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('エラーをクリップボードにコピーしました')),
+                );
+              }
+            },
+            child: const Text('詳細をコピー'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeviceSettingsSliverList extends ConsumerWidget {
+  const _DeviceSettingsSliverList({
+    required this.snapshot,
+    required this.historyAsync,
+  });
+
+  final DebugDeviceSessionSnapshot snapshot;
+  final AsyncValue<List<PushNotificationLogEntry>> historyAsync;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokenAsync = ref.watch(notificationTokenStreamProvider);
+    final token = tokenAsync.value;
+
+    return SliverList.list(
+      children: [
+        const SizedBox(height: 8),
+        _SectionCard(
+          title: 'デバイス',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _KeyValueRow(label: 'Device ID', value: snapshot.deviceId),
+              const Divider(height: 24),
+              _KeyValueRow(
+                label: 'サーバー上の ID',
+                value: snapshot.device.id,
+              ),
+              _KeyValueRow(
+                label: 'ユーザー',
+                value: snapshot.device.userId,
+              ),
+              _KeyValueRow(
+                label: '種別',
+                value: snapshot.device.platform.displayLabel,
+              ),
+            ],
+          ),
+        ),
+        _SectionCard(
+          title: 'ローカルのプッシュトークン',
+          subtitle: '表示されているトークンはサーバーへ同期済みです（画面表示時）',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _TokenChip(
+                label: 'FCM',
+                isPresent: _hasNonEmptyText(token?.fcmToken),
+              ),
+              const SizedBox(height: 8),
+              _TokenChip(
+                label: 'APNs（通知）',
+                isPresent: _hasNonEmptyText(token?.apnsToken),
+              ),
+              const SizedBox(height: 8),
+              _TokenChip(
+                label: 'Push to Start',
+                isPresent: _hasNonEmptyText(token?.apnsPushToStartToken),
+              ),
+            ],
+          ),
+        ),
+        _NotificationSettingsSection(snapshot: snapshot),
+        _TestNotificationSection(deviceId: snapshot.deviceId),
+        _HistorySection(historyAsync: historyAsync),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+}
+
+class _NotificationSettingsSection extends HookConsumerWidget {
+  const _NotificationSettingsSection({required this.snapshot});
+
+  final DebugDeviceSessionSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isBusy = useState(false);
+    final tsunami = useState(snapshot.notificationSettings.tsunamiEnabled);
+    final training = useState(snapshot.notificationSettings.trainingEnabled);
+
+    Future<void> submit() async {
+      if (isBusy.value) {
+        return;
+      }
+      isBusy.value = true;
+      final messenger = ScaffoldMessenger.of(context);
+      final repo = ref.read(pushNotificationRepositoryProvider);
+      final result = await repo.patchNotificationSettings(
+        deviceId: snapshot.deviceId,
+        settings: GeneralNotificationSettings(
+          tsunamiEnabled: tsunami.value,
+          trainingEnabled: training.value,
+        ),
+      );
+      isBusy.value = false;
+      if (!context.mounted) {
+        return;
+      }
+      switch (result) {
+        case Success():
+          ref.invalidate(debugDeviceSessionProvider);
+          messenger.showSnackBar(
+            const SnackBar(content: Text('通知設定を更新しました')),
+          );
+        case Failure(:final exception):
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text('更新に失敗しました: $exception'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+      }
+    }
+
+    return _SectionCard(
+      title: '全般通知設定',
+      child: Column(
+        children: [
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('津波情報の通知'),
+            subtitle: const Text('training / 訓練報とは別の津波関連通知'),
+            value: tsunami.value,
+            onChanged: isBusy.value
+                ? null
+                : (v) {
+                    tsunami.value = v;
+                  },
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('訓練報・試験報の通知'),
+            value: training.value,
+            onChanged: isBusy.value
+                ? null
+                : (v) {
+                    training.value = v;
+                  },
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: FilledButton(
+              onPressed: isBusy.value
+                  ? null
+                  : () async {
+                      await submit();
+                    },
+              child: isBusy.value
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator.adaptive(
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Text('設定をサーバーに反映'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TestNotificationSection extends HookConsumerWidget {
+  const _TestNotificationSection({required this.deviceId});
+
+  final String deviceId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pendingKind = useState<TestNotificationKind?>(null);
+
+    Future<void> send(TestNotificationKind kind) async {
+      if (ref.read(authProvider).value == null) {
+        return;
+      }
+      pendingKind.value = kind;
+      final messenger = ScaffoldMessenger.of(context);
+      final repo = ref.read(pushNotificationRepositoryProvider);
+      final result = await repo.sendTestNotification(
+        deviceId: deviceId,
+        kind: kind,
+      );
+      pendingKind.value = null;
+      if (!context.mounted) {
+        return;
+      }
+      switch (result) {
+        case Success(:final value):
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text(
+                '送信しました（${value.framework.displayLabel}）: ${value.message}',
+              ),
+            ),
+          );
+        case Failure(:final exception):
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text('送信に失敗: $exception'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+      }
+    }
+
+    return _SectionCard(
+      title: 'テスト通知',
+      subtitle: 'サイレント・通常・クリティカルをサーバー経由で送信します',
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          TestNotificationKind.silent,
+          TestNotificationKind.normal,
+          TestNotificationKind.critical,
+        ].map((kind) {
+          final isPending = pendingKind.value == kind;
+          return FilledButton.tonal(
+            onPressed: pendingKind.value != null && !isPending
+                ? null
+                : () async {
+                    await send(kind);
+                  },
+            child: isPending
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                  )
+                : Text(kind.displayLabel),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+class _HistorySection extends ConsumerWidget {
+  const _HistorySection({required this.historyAsync});
+
+  final AsyncValue<List<PushNotificationLogEntry>> historyAsync;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return _SectionCard(
+      title: '通知履歴',
+      trailing: IconButton(
+        tooltip: '更新',
+        onPressed: () {
+          ref.invalidate(debugNotificationHistoryProvider);
+        },
+        icon: const Icon(Icons.refresh),
+      ),
+      child: switch (historyAsync) {
+        AsyncData(:final value) when value.isEmpty => Text(
+            '履歴はまだありません',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+        AsyncData(:final value) => ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: value.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final item = value[index];
+              return _NotificationHistoryTile(item: item);
+            },
+          ),
+        AsyncError(:final error) => Text(
+            '履歴の取得に失敗: $error',
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        _ => const Center(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: CircularProgressIndicator.adaptive(),
+            ),
+          ),
+      },
+    );
+  }
+}
+
+class _NotificationHistoryTile extends StatelessWidget {
+  const _NotificationHistoryTile({required this.item});
+
+  final PushNotificationLogEntry item;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final ok = item.result == PushNotificationDeliveryResult.ok;
+    final resultColor = ok ? scheme.primary : scheme.error;
+    final subtitle = [
+      item.framework.displayLabel,
+      item.result.displayLabel,
+      if (item.title != null) item.title,
+      if (item.body != null) item.body,
+      if (item.errorMessage != null) item.errorMessage,
+    ].join(' · ');
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(
+        _formatCreatedAt(item.createdAtIso),
+        style: Theme.of(context).textTheme.titleSmall,
+      ),
+      subtitle: Text(
+        subtitle,
+        maxLines: 4,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Icon(
+        ok ? Icons.check_circle_outline : Icons.error_outline,
+        color: resultColor,
+      ),
+    );
+  }
+
+  String _formatCreatedAt(String raw) {
+    final parsed = DateTime.tryParse(raw);
+    if (parsed == null) {
+      return raw;
+    }
+    final local = parsed.toLocal();
+    return '${local.year}/${local.month.toString().padLeft(2, '0')}/${local.day.toString().padLeft(2, '0')} '
+        '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({
+    required this.title,
+    required this.child,
+    this.subtitle,
+    this.trailing,
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget child;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Card(
+        elevation: 0,
+        color: scheme.surfaceContainerHighest.withValues(alpha: 0.65),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        if (subtitle != null) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            subtitle!,
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: scheme.onSurfaceVariant),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  ?trailing,
+                ],
+              ),
+              const SizedBox(height: 12),
+              child,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _KeyValueRow extends StatelessWidget {
+  const _KeyValueRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          Expanded(
+            child: SelectableText(
+              value,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TokenChip extends StatelessWidget {
+  const _TokenChip({required this.label, required this.isPresent});
+
+  final String label;
+  final bool isPresent;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Row(
+      children: [
+        Icon(
+          isPresent ? Icons.check_circle : Icons.radio_button_unchecked,
+          size: 20,
+          color: isPresent ? scheme.primary : scheme.outline,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            isPresent ? '$label: 取得済み' : '$label: 未取得',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+bool _hasNonEmptyText(String? value) => value != null && value.isNotEmpty;

--- a/app/lib/feature/notification/data/model/general_notification_settings.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor_api/export.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'general_notification_settings.freezed.dart';
+
+@freezed
+abstract class GeneralNotificationSettings with _$GeneralNotificationSettings {
+  const factory GeneralNotificationSettings({
+    required bool tsunamiEnabled,
+    required bool trainingEnabled,
+  }) = _GeneralNotificationSettings;
+}
+
+extension GeneralNotificationSettingsApiExtension
+    on api.NotificationSettingsResponse {
+  GeneralNotificationSettings get toGeneralNotificationSettings =>
+      GeneralNotificationSettings(
+        tsunamiEnabled: tsunamiEnabled,
+        trainingEnabled: trainingEnabled,
+      );
+}

--- a/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
@@ -1,0 +1,274 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'general_notification_settings.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$GeneralNotificationSettings {
+
+ bool get tsunamiEnabled; bool get trainingEnabled;
+/// Create a copy of GeneralNotificationSettings
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GeneralNotificationSettingsCopyWith<GeneralNotificationSettings> get copyWith => _$GeneralNotificationSettingsCopyWithImpl<GeneralNotificationSettings>(this as GeneralNotificationSettings, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled);
+
+@override
+String toString() {
+  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GeneralNotificationSettingsCopyWith<$Res>  {
+  factory $GeneralNotificationSettingsCopyWith(GeneralNotificationSettings value, $Res Function(GeneralNotificationSettings) _then) = _$GeneralNotificationSettingsCopyWithImpl;
+@useResult
+$Res call({
+ bool tsunamiEnabled, bool trainingEnabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$GeneralNotificationSettingsCopyWithImpl<$Res>
+    implements $GeneralNotificationSettingsCopyWith<$Res> {
+  _$GeneralNotificationSettingsCopyWithImpl(this._self, this._then);
+
+  final GeneralNotificationSettings _self;
+  final $Res Function(GeneralNotificationSettings) _then;
+
+/// Create a copy of GeneralNotificationSettings
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,}) {
+  return _then(_self.copyWith(
+tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GeneralNotificationSettings].
+extension GeneralNotificationSettingsPatterns on GeneralNotificationSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GeneralNotificationSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GeneralNotificationSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GeneralNotificationSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _GeneralNotificationSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GeneralNotificationSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GeneralNotificationSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GeneralNotificationSettings() when $default != null:
+return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled)  $default,) {final _that = this;
+switch (_that) {
+case _GeneralNotificationSettings():
+return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool tsunamiEnabled,  bool trainingEnabled)?  $default,) {final _that = this;
+switch (_that) {
+case _GeneralNotificationSettings() when $default != null:
+return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _GeneralNotificationSettings implements GeneralNotificationSettings {
+  const _GeneralNotificationSettings({required this.tsunamiEnabled, required this.trainingEnabled});
+  
+
+@override final  bool tsunamiEnabled;
+@override final  bool trainingEnabled;
+
+/// Create a copy of GeneralNotificationSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GeneralNotificationSettingsCopyWith<_GeneralNotificationSettings> get copyWith => __$GeneralNotificationSettingsCopyWithImpl<_GeneralNotificationSettings>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled);
+
+@override
+String toString() {
+  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GeneralNotificationSettingsCopyWith<$Res> implements $GeneralNotificationSettingsCopyWith<$Res> {
+  factory _$GeneralNotificationSettingsCopyWith(_GeneralNotificationSettings value, $Res Function(_GeneralNotificationSettings) _then) = __$GeneralNotificationSettingsCopyWithImpl;
+@override @useResult
+$Res call({
+ bool tsunamiEnabled, bool trainingEnabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$GeneralNotificationSettingsCopyWithImpl<$Res>
+    implements _$GeneralNotificationSettingsCopyWith<$Res> {
+  __$GeneralNotificationSettingsCopyWithImpl(this._self, this._then);
+
+  final _GeneralNotificationSettings _self;
+  final $Res Function(_GeneralNotificationSettings) _then;
+
+/// Create a copy of GeneralNotificationSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,}) {
+  return _then(_GeneralNotificationSettings(
+tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/notification/data/model/push_notification_log.dart
+++ b/app/lib/feature/notification/data/model/push_notification_log.dart
@@ -1,0 +1,95 @@
+import 'package:eqmonitor_api/export.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'push_notification_log.freezed.dart';
+
+@freezed
+abstract class PushNotificationHistory with _$PushNotificationHistory {
+  const factory PushNotificationHistory({
+    required List<PushNotificationLogEntry> items,
+    String? nextCursor,
+  }) = _PushNotificationHistory;
+}
+
+@freezed
+abstract class PushNotificationLogEntry with _$PushNotificationLogEntry {
+  const factory PushNotificationLogEntry({
+    required String streamId,
+    required String deviceId,
+    required PushNotificationDeliveryFramework framework,
+    required PushNotificationDeliveryResult result,
+    required String createdAtIso,
+    String? errorCode,
+    String? errorMessage,
+    String? eventId,
+    String? title,
+    String? body,
+    String? androidPriority,
+    String? androidNotificationPriority,
+    String? channelId,
+    String? apnsPriority,
+    String? interruptionLevel,
+  }) = _PushNotificationLogEntry;
+}
+
+enum PushNotificationDeliveryFramework {
+  fcm,
+  apns,
+}
+
+enum PushNotificationDeliveryResult {
+  ok,
+  ng,
+}
+
+extension PushNotificationDeliveryFrameworkDisplay
+    on PushNotificationDeliveryFramework {
+  String get displayLabel => switch (this) {
+    .fcm => 'FCM',
+    .apns => 'APNs',
+  };
+}
+
+extension PushNotificationDeliveryResultDisplay
+    on PushNotificationDeliveryResult {
+  String get displayLabel => switch (this) {
+    .ok => 'OK',
+    .ng => 'NG',
+  };
+}
+
+extension NotificationHistoryResponseApiExtension
+    on api.NotificationHistoryResponse {
+  PushNotificationHistory get toPushNotificationHistory =>
+      PushNotificationHistory(
+        items: items.map((e) => e.toPushNotificationLogEntry).toList(),
+        nextCursor: nextCursor,
+      );
+}
+
+extension NotificationLogItemApiExtension on api.NotificationLogItem {
+  PushNotificationLogEntry get toPushNotificationLogEntry =>
+      PushNotificationLogEntry(
+        streamId: streamId,
+        deviceId: deviceId,
+        framework: switch (framework) {
+          .fcm => .fcm,
+          .apns => .apns,
+        },
+        result: switch (result) {
+          .ok => .ok,
+          .ng => .ng,
+        },
+        createdAtIso: createdAt,
+        errorCode: errorCode,
+        errorMessage: errorMessage,
+        eventId: eventId,
+        title: title,
+        body: body,
+        androidPriority: androidPriority,
+        androidNotificationPriority: androidNotificationPriority,
+        channelId: channelId,
+        apnsPriority: apnsPriority,
+        interruptionLevel: interruptionLevel,
+      );
+}

--- a/app/lib/feature/notification/data/model/push_notification_log.freezed.dart
+++ b/app/lib/feature/notification/data/model/push_notification_log.freezed.dart
@@ -1,0 +1,579 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'push_notification_log.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$PushNotificationHistory {
+
+ List<PushNotificationLogEntry> get items; String? get nextCursor;
+/// Create a copy of PushNotificationHistory
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PushNotificationHistoryCopyWith<PushNotificationHistory> get copyWith => _$PushNotificationHistoryCopyWithImpl<PushNotificationHistory>(this as PushNotificationHistory, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PushNotificationHistory&&const DeepCollectionEquality().equals(other.items, items)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(items),nextCursor);
+
+@override
+String toString() {
+  return 'PushNotificationHistory(items: $items, nextCursor: $nextCursor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PushNotificationHistoryCopyWith<$Res>  {
+  factory $PushNotificationHistoryCopyWith(PushNotificationHistory value, $Res Function(PushNotificationHistory) _then) = _$PushNotificationHistoryCopyWithImpl;
+@useResult
+$Res call({
+ List<PushNotificationLogEntry> items, String? nextCursor
+});
+
+
+
+
+}
+/// @nodoc
+class _$PushNotificationHistoryCopyWithImpl<$Res>
+    implements $PushNotificationHistoryCopyWith<$Res> {
+  _$PushNotificationHistoryCopyWithImpl(this._self, this._then);
+
+  final PushNotificationHistory _self;
+  final $Res Function(PushNotificationHistory) _then;
+
+/// Create a copy of PushNotificationHistory
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? items = null,Object? nextCursor = freezed,}) {
+  return _then(_self.copyWith(
+items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+as List<PushNotificationLogEntry>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PushNotificationHistory].
+extension PushNotificationHistoryPatterns on PushNotificationHistory {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PushNotificationHistory value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PushNotificationHistory() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PushNotificationHistory value)  $default,){
+final _that = this;
+switch (_that) {
+case _PushNotificationHistory():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PushNotificationHistory value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PushNotificationHistory() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<PushNotificationLogEntry> items,  String? nextCursor)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PushNotificationHistory() when $default != null:
+return $default(_that.items,_that.nextCursor);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<PushNotificationLogEntry> items,  String? nextCursor)  $default,) {final _that = this;
+switch (_that) {
+case _PushNotificationHistory():
+return $default(_that.items,_that.nextCursor);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<PushNotificationLogEntry> items,  String? nextCursor)?  $default,) {final _that = this;
+switch (_that) {
+case _PushNotificationHistory() when $default != null:
+return $default(_that.items,_that.nextCursor);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _PushNotificationHistory implements PushNotificationHistory {
+  const _PushNotificationHistory({required final  List<PushNotificationLogEntry> items, this.nextCursor}): _items = items;
+  
+
+ final  List<PushNotificationLogEntry> _items;
+@override List<PushNotificationLogEntry> get items {
+  if (_items is EqualUnmodifiableListView) return _items;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_items);
+}
+
+@override final  String? nextCursor;
+
+/// Create a copy of PushNotificationHistory
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PushNotificationHistoryCopyWith<_PushNotificationHistory> get copyWith => __$PushNotificationHistoryCopyWithImpl<_PushNotificationHistory>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PushNotificationHistory&&const DeepCollectionEquality().equals(other._items, _items)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_items),nextCursor);
+
+@override
+String toString() {
+  return 'PushNotificationHistory(items: $items, nextCursor: $nextCursor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PushNotificationHistoryCopyWith<$Res> implements $PushNotificationHistoryCopyWith<$Res> {
+  factory _$PushNotificationHistoryCopyWith(_PushNotificationHistory value, $Res Function(_PushNotificationHistory) _then) = __$PushNotificationHistoryCopyWithImpl;
+@override @useResult
+$Res call({
+ List<PushNotificationLogEntry> items, String? nextCursor
+});
+
+
+
+
+}
+/// @nodoc
+class __$PushNotificationHistoryCopyWithImpl<$Res>
+    implements _$PushNotificationHistoryCopyWith<$Res> {
+  __$PushNotificationHistoryCopyWithImpl(this._self, this._then);
+
+  final _PushNotificationHistory _self;
+  final $Res Function(_PushNotificationHistory) _then;
+
+/// Create a copy of PushNotificationHistory
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? items = null,Object? nextCursor = freezed,}) {
+  return _then(_PushNotificationHistory(
+items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
+as List<PushNotificationLogEntry>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$PushNotificationLogEntry {
+
+ String get streamId; String get deviceId; PushNotificationDeliveryFramework get framework; PushNotificationDeliveryResult get result; String get createdAtIso; String? get errorCode; String? get errorMessage; String? get eventId; String? get title; String? get body; String? get androidPriority; String? get androidNotificationPriority; String? get channelId; String? get apnsPriority; String? get interruptionLevel;
+/// Create a copy of PushNotificationLogEntry
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PushNotificationLogEntryCopyWith<PushNotificationLogEntry> get copyWith => _$PushNotificationLogEntryCopyWithImpl<PushNotificationLogEntry>(this as PushNotificationLogEntry, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PushNotificationLogEntry&&(identical(other.streamId, streamId) || other.streamId == streamId)&&(identical(other.deviceId, deviceId) || other.deviceId == deviceId)&&(identical(other.framework, framework) || other.framework == framework)&&(identical(other.result, result) || other.result == result)&&(identical(other.createdAtIso, createdAtIso) || other.createdAtIso == createdAtIso)&&(identical(other.errorCode, errorCode) || other.errorCode == errorCode)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.androidPriority, androidPriority) || other.androidPriority == androidPriority)&&(identical(other.androidNotificationPriority, androidNotificationPriority) || other.androidNotificationPriority == androidNotificationPriority)&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.apnsPriority, apnsPriority) || other.apnsPriority == apnsPriority)&&(identical(other.interruptionLevel, interruptionLevel) || other.interruptionLevel == interruptionLevel));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,streamId,deviceId,framework,result,createdAtIso,errorCode,errorMessage,eventId,title,body,androidPriority,androidNotificationPriority,channelId,apnsPriority,interruptionLevel);
+
+@override
+String toString() {
+  return 'PushNotificationLogEntry(streamId: $streamId, deviceId: $deviceId, framework: $framework, result: $result, createdAtIso: $createdAtIso, errorCode: $errorCode, errorMessage: $errorMessage, eventId: $eventId, title: $title, body: $body, androidPriority: $androidPriority, androidNotificationPriority: $androidNotificationPriority, channelId: $channelId, apnsPriority: $apnsPriority, interruptionLevel: $interruptionLevel)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PushNotificationLogEntryCopyWith<$Res>  {
+  factory $PushNotificationLogEntryCopyWith(PushNotificationLogEntry value, $Res Function(PushNotificationLogEntry) _then) = _$PushNotificationLogEntryCopyWithImpl;
+@useResult
+$Res call({
+ String streamId, String deviceId, PushNotificationDeliveryFramework framework, PushNotificationDeliveryResult result, String createdAtIso, String? errorCode, String? errorMessage, String? eventId, String? title, String? body, String? androidPriority, String? androidNotificationPriority, String? channelId, String? apnsPriority, String? interruptionLevel
+});
+
+
+
+
+}
+/// @nodoc
+class _$PushNotificationLogEntryCopyWithImpl<$Res>
+    implements $PushNotificationLogEntryCopyWith<$Res> {
+  _$PushNotificationLogEntryCopyWithImpl(this._self, this._then);
+
+  final PushNotificationLogEntry _self;
+  final $Res Function(PushNotificationLogEntry) _then;
+
+/// Create a copy of PushNotificationLogEntry
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? streamId = null,Object? deviceId = null,Object? framework = null,Object? result = null,Object? createdAtIso = null,Object? errorCode = freezed,Object? errorMessage = freezed,Object? eventId = freezed,Object? title = freezed,Object? body = freezed,Object? androidPriority = freezed,Object? androidNotificationPriority = freezed,Object? channelId = freezed,Object? apnsPriority = freezed,Object? interruptionLevel = freezed,}) {
+  return _then(_self.copyWith(
+streamId: null == streamId ? _self.streamId : streamId // ignore: cast_nullable_to_non_nullable
+as String,deviceId: null == deviceId ? _self.deviceId : deviceId // ignore: cast_nullable_to_non_nullable
+as String,framework: null == framework ? _self.framework : framework // ignore: cast_nullable_to_non_nullable
+as PushNotificationDeliveryFramework,result: null == result ? _self.result : result // ignore: cast_nullable_to_non_nullable
+as PushNotificationDeliveryResult,createdAtIso: null == createdAtIso ? _self.createdAtIso : createdAtIso // ignore: cast_nullable_to_non_nullable
+as String,errorCode: freezed == errorCode ? _self.errorCode : errorCode // ignore: cast_nullable_to_non_nullable
+as String?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,eventId: freezed == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String?,androidPriority: freezed == androidPriority ? _self.androidPriority : androidPriority // ignore: cast_nullable_to_non_nullable
+as String?,androidNotificationPriority: freezed == androidNotificationPriority ? _self.androidNotificationPriority : androidNotificationPriority // ignore: cast_nullable_to_non_nullable
+as String?,channelId: freezed == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String?,apnsPriority: freezed == apnsPriority ? _self.apnsPriority : apnsPriority // ignore: cast_nullable_to_non_nullable
+as String?,interruptionLevel: freezed == interruptionLevel ? _self.interruptionLevel : interruptionLevel // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PushNotificationLogEntry].
+extension PushNotificationLogEntryPatterns on PushNotificationLogEntry {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PushNotificationLogEntry value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PushNotificationLogEntry() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PushNotificationLogEntry value)  $default,){
+final _that = this;
+switch (_that) {
+case _PushNotificationLogEntry():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PushNotificationLogEntry value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PushNotificationLogEntry() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String streamId,  String deviceId,  PushNotificationDeliveryFramework framework,  PushNotificationDeliveryResult result,  String createdAtIso,  String? errorCode,  String? errorMessage,  String? eventId,  String? title,  String? body,  String? androidPriority,  String? androidNotificationPriority,  String? channelId,  String? apnsPriority,  String? interruptionLevel)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PushNotificationLogEntry() when $default != null:
+return $default(_that.streamId,_that.deviceId,_that.framework,_that.result,_that.createdAtIso,_that.errorCode,_that.errorMessage,_that.eventId,_that.title,_that.body,_that.androidPriority,_that.androidNotificationPriority,_that.channelId,_that.apnsPriority,_that.interruptionLevel);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String streamId,  String deviceId,  PushNotificationDeliveryFramework framework,  PushNotificationDeliveryResult result,  String createdAtIso,  String? errorCode,  String? errorMessage,  String? eventId,  String? title,  String? body,  String? androidPriority,  String? androidNotificationPriority,  String? channelId,  String? apnsPriority,  String? interruptionLevel)  $default,) {final _that = this;
+switch (_that) {
+case _PushNotificationLogEntry():
+return $default(_that.streamId,_that.deviceId,_that.framework,_that.result,_that.createdAtIso,_that.errorCode,_that.errorMessage,_that.eventId,_that.title,_that.body,_that.androidPriority,_that.androidNotificationPriority,_that.channelId,_that.apnsPriority,_that.interruptionLevel);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String streamId,  String deviceId,  PushNotificationDeliveryFramework framework,  PushNotificationDeliveryResult result,  String createdAtIso,  String? errorCode,  String? errorMessage,  String? eventId,  String? title,  String? body,  String? androidPriority,  String? androidNotificationPriority,  String? channelId,  String? apnsPriority,  String? interruptionLevel)?  $default,) {final _that = this;
+switch (_that) {
+case _PushNotificationLogEntry() when $default != null:
+return $default(_that.streamId,_that.deviceId,_that.framework,_that.result,_that.createdAtIso,_that.errorCode,_that.errorMessage,_that.eventId,_that.title,_that.body,_that.androidPriority,_that.androidNotificationPriority,_that.channelId,_that.apnsPriority,_that.interruptionLevel);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _PushNotificationLogEntry implements PushNotificationLogEntry {
+  const _PushNotificationLogEntry({required this.streamId, required this.deviceId, required this.framework, required this.result, required this.createdAtIso, this.errorCode, this.errorMessage, this.eventId, this.title, this.body, this.androidPriority, this.androidNotificationPriority, this.channelId, this.apnsPriority, this.interruptionLevel});
+  
+
+@override final  String streamId;
+@override final  String deviceId;
+@override final  PushNotificationDeliveryFramework framework;
+@override final  PushNotificationDeliveryResult result;
+@override final  String createdAtIso;
+@override final  String? errorCode;
+@override final  String? errorMessage;
+@override final  String? eventId;
+@override final  String? title;
+@override final  String? body;
+@override final  String? androidPriority;
+@override final  String? androidNotificationPriority;
+@override final  String? channelId;
+@override final  String? apnsPriority;
+@override final  String? interruptionLevel;
+
+/// Create a copy of PushNotificationLogEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PushNotificationLogEntryCopyWith<_PushNotificationLogEntry> get copyWith => __$PushNotificationLogEntryCopyWithImpl<_PushNotificationLogEntry>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PushNotificationLogEntry&&(identical(other.streamId, streamId) || other.streamId == streamId)&&(identical(other.deviceId, deviceId) || other.deviceId == deviceId)&&(identical(other.framework, framework) || other.framework == framework)&&(identical(other.result, result) || other.result == result)&&(identical(other.createdAtIso, createdAtIso) || other.createdAtIso == createdAtIso)&&(identical(other.errorCode, errorCode) || other.errorCode == errorCode)&&(identical(other.errorMessage, errorMessage) || other.errorMessage == errorMessage)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.title, title) || other.title == title)&&(identical(other.body, body) || other.body == body)&&(identical(other.androidPriority, androidPriority) || other.androidPriority == androidPriority)&&(identical(other.androidNotificationPriority, androidNotificationPriority) || other.androidNotificationPriority == androidNotificationPriority)&&(identical(other.channelId, channelId) || other.channelId == channelId)&&(identical(other.apnsPriority, apnsPriority) || other.apnsPriority == apnsPriority)&&(identical(other.interruptionLevel, interruptionLevel) || other.interruptionLevel == interruptionLevel));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,streamId,deviceId,framework,result,createdAtIso,errorCode,errorMessage,eventId,title,body,androidPriority,androidNotificationPriority,channelId,apnsPriority,interruptionLevel);
+
+@override
+String toString() {
+  return 'PushNotificationLogEntry(streamId: $streamId, deviceId: $deviceId, framework: $framework, result: $result, createdAtIso: $createdAtIso, errorCode: $errorCode, errorMessage: $errorMessage, eventId: $eventId, title: $title, body: $body, androidPriority: $androidPriority, androidNotificationPriority: $androidNotificationPriority, channelId: $channelId, apnsPriority: $apnsPriority, interruptionLevel: $interruptionLevel)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PushNotificationLogEntryCopyWith<$Res> implements $PushNotificationLogEntryCopyWith<$Res> {
+  factory _$PushNotificationLogEntryCopyWith(_PushNotificationLogEntry value, $Res Function(_PushNotificationLogEntry) _then) = __$PushNotificationLogEntryCopyWithImpl;
+@override @useResult
+$Res call({
+ String streamId, String deviceId, PushNotificationDeliveryFramework framework, PushNotificationDeliveryResult result, String createdAtIso, String? errorCode, String? errorMessage, String? eventId, String? title, String? body, String? androidPriority, String? androidNotificationPriority, String? channelId, String? apnsPriority, String? interruptionLevel
+});
+
+
+
+
+}
+/// @nodoc
+class __$PushNotificationLogEntryCopyWithImpl<$Res>
+    implements _$PushNotificationLogEntryCopyWith<$Res> {
+  __$PushNotificationLogEntryCopyWithImpl(this._self, this._then);
+
+  final _PushNotificationLogEntry _self;
+  final $Res Function(_PushNotificationLogEntry) _then;
+
+/// Create a copy of PushNotificationLogEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? streamId = null,Object? deviceId = null,Object? framework = null,Object? result = null,Object? createdAtIso = null,Object? errorCode = freezed,Object? errorMessage = freezed,Object? eventId = freezed,Object? title = freezed,Object? body = freezed,Object? androidPriority = freezed,Object? androidNotificationPriority = freezed,Object? channelId = freezed,Object? apnsPriority = freezed,Object? interruptionLevel = freezed,}) {
+  return _then(_PushNotificationLogEntry(
+streamId: null == streamId ? _self.streamId : streamId // ignore: cast_nullable_to_non_nullable
+as String,deviceId: null == deviceId ? _self.deviceId : deviceId // ignore: cast_nullable_to_non_nullable
+as String,framework: null == framework ? _self.framework : framework // ignore: cast_nullable_to_non_nullable
+as PushNotificationDeliveryFramework,result: null == result ? _self.result : result // ignore: cast_nullable_to_non_nullable
+as PushNotificationDeliveryResult,createdAtIso: null == createdAtIso ? _self.createdAtIso : createdAtIso // ignore: cast_nullable_to_non_nullable
+as String,errorCode: freezed == errorCode ? _self.errorCode : errorCode // ignore: cast_nullable_to_non_nullable
+as String?,errorMessage: freezed == errorMessage ? _self.errorMessage : errorMessage // ignore: cast_nullable_to_non_nullable
+as String?,eventId: freezed == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String?,androidPriority: freezed == androidPriority ? _self.androidPriority : androidPriority // ignore: cast_nullable_to_non_nullable
+as String?,androidNotificationPriority: freezed == androidNotificationPriority ? _self.androidNotificationPriority : androidNotificationPriority // ignore: cast_nullable_to_non_nullable
+as String?,channelId: freezed == channelId ? _self.channelId : channelId // ignore: cast_nullable_to_non_nullable
+as String?,apnsPriority: freezed == apnsPriority ? _self.apnsPriority : apnsPriority // ignore: cast_nullable_to_non_nullable
+as String?,interruptionLevel: freezed == interruptionLevel ? _self.interruptionLevel : interruptionLevel // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/notification/data/model/test_notification_delivery.dart
+++ b/app/lib/feature/notification/data/model/test_notification_delivery.dart
@@ -1,0 +1,61 @@
+import 'package:eqmonitor_api/export.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'test_notification_delivery.freezed.dart';
+
+enum TestNotificationKind {
+  silent,
+  normal,
+  critical,
+}
+
+@freezed
+abstract class TestNotificationDeliveryResult
+    with _$TestNotificationDeliveryResult {
+  const factory TestNotificationDeliveryResult({
+    required String message,
+    required TestNotificationFramework framework,
+  }) = _TestNotificationDeliveryResult;
+}
+
+enum TestNotificationFramework {
+  fcm,
+  apns,
+}
+
+extension TestNotificationFrameworkDisplay on TestNotificationFramework {
+  String get displayLabel => switch (this) {
+    .fcm => 'FCM',
+    .apns => 'APNs',
+  };
+}
+
+extension TestNotificationKindDisplay on TestNotificationKind {
+  String get displayLabel => switch (this) {
+    .silent => 'Silent',
+    .normal => 'Normal',
+    .critical => 'Critical',
+  };
+}
+
+extension TestNotificationDeliveryResultApiExtension
+    on api.TestNotificationResponse {
+  TestNotificationDeliveryResult get toTestNotificationDeliveryResult =>
+      TestNotificationDeliveryResult(
+        message: message,
+        framework: switch (framework) {
+          .fcm => .fcm,
+          .apns => .apns,
+        },
+      );
+}
+
+extension TestNotificationKindApiExtension on TestNotificationKind {
+  api.TestNotificationRequest get toApiRequest => api.TestNotificationRequest(
+    type: switch (this) {
+      .silent => .silent,
+      .normal => .normal,
+      .critical => .critical,
+    },
+  );
+}

--- a/app/lib/feature/notification/data/model/test_notification_delivery.freezed.dart
+++ b/app/lib/feature/notification/data/model/test_notification_delivery.freezed.dart
@@ -1,0 +1,274 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'test_notification_delivery.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$TestNotificationDeliveryResult {
+
+ String get message; TestNotificationFramework get framework;
+/// Create a copy of TestNotificationDeliveryResult
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TestNotificationDeliveryResultCopyWith<TestNotificationDeliveryResult> get copyWith => _$TestNotificationDeliveryResultCopyWithImpl<TestNotificationDeliveryResult>(this as TestNotificationDeliveryResult, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TestNotificationDeliveryResult&&(identical(other.message, message) || other.message == message)&&(identical(other.framework, framework) || other.framework == framework));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message,framework);
+
+@override
+String toString() {
+  return 'TestNotificationDeliveryResult(message: $message, framework: $framework)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TestNotificationDeliveryResultCopyWith<$Res>  {
+  factory $TestNotificationDeliveryResultCopyWith(TestNotificationDeliveryResult value, $Res Function(TestNotificationDeliveryResult) _then) = _$TestNotificationDeliveryResultCopyWithImpl;
+@useResult
+$Res call({
+ String message, TestNotificationFramework framework
+});
+
+
+
+
+}
+/// @nodoc
+class _$TestNotificationDeliveryResultCopyWithImpl<$Res>
+    implements $TestNotificationDeliveryResultCopyWith<$Res> {
+  _$TestNotificationDeliveryResultCopyWithImpl(this._self, this._then);
+
+  final TestNotificationDeliveryResult _self;
+  final $Res Function(TestNotificationDeliveryResult) _then;
+
+/// Create a copy of TestNotificationDeliveryResult
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? message = null,Object? framework = null,}) {
+  return _then(_self.copyWith(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,framework: null == framework ? _self.framework : framework // ignore: cast_nullable_to_non_nullable
+as TestNotificationFramework,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TestNotificationDeliveryResult].
+extension TestNotificationDeliveryResultPatterns on TestNotificationDeliveryResult {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TestNotificationDeliveryResult value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TestNotificationDeliveryResult() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TestNotificationDeliveryResult value)  $default,){
+final _that = this;
+switch (_that) {
+case _TestNotificationDeliveryResult():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TestNotificationDeliveryResult value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TestNotificationDeliveryResult() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String message,  TestNotificationFramework framework)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TestNotificationDeliveryResult() when $default != null:
+return $default(_that.message,_that.framework);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String message,  TestNotificationFramework framework)  $default,) {final _that = this;
+switch (_that) {
+case _TestNotificationDeliveryResult():
+return $default(_that.message,_that.framework);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String message,  TestNotificationFramework framework)?  $default,) {final _that = this;
+switch (_that) {
+case _TestNotificationDeliveryResult() when $default != null:
+return $default(_that.message,_that.framework);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _TestNotificationDeliveryResult implements TestNotificationDeliveryResult {
+  const _TestNotificationDeliveryResult({required this.message, required this.framework});
+  
+
+@override final  String message;
+@override final  TestNotificationFramework framework;
+
+/// Create a copy of TestNotificationDeliveryResult
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TestNotificationDeliveryResultCopyWith<_TestNotificationDeliveryResult> get copyWith => __$TestNotificationDeliveryResultCopyWithImpl<_TestNotificationDeliveryResult>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TestNotificationDeliveryResult&&(identical(other.message, message) || other.message == message)&&(identical(other.framework, framework) || other.framework == framework));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message,framework);
+
+@override
+String toString() {
+  return 'TestNotificationDeliveryResult(message: $message, framework: $framework)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TestNotificationDeliveryResultCopyWith<$Res> implements $TestNotificationDeliveryResultCopyWith<$Res> {
+  factory _$TestNotificationDeliveryResultCopyWith(_TestNotificationDeliveryResult value, $Res Function(_TestNotificationDeliveryResult) _then) = __$TestNotificationDeliveryResultCopyWithImpl;
+@override @useResult
+$Res call({
+ String message, TestNotificationFramework framework
+});
+
+
+
+
+}
+/// @nodoc
+class __$TestNotificationDeliveryResultCopyWithImpl<$Res>
+    implements _$TestNotificationDeliveryResultCopyWith<$Res> {
+  __$TestNotificationDeliveryResultCopyWithImpl(this._self, this._then);
+
+  final _TestNotificationDeliveryResult _self;
+  final $Res Function(_TestNotificationDeliveryResult) _then;
+
+/// Create a copy of TestNotificationDeliveryResult
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? message = null,Object? framework = null,}) {
+  return _then(_TestNotificationDeliveryResult(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,framework: null == framework ? _self.framework : framework // ignore: cast_nullable_to_non_nullable
+as TestNotificationFramework,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/notification/data/repository/push_notification_repository.dart
+++ b/app/lib/feature/notification/data/repository/push_notification_repository.dart
@@ -1,0 +1,73 @@
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/notification/data/model/general_notification_settings.dart';
+import 'package:eqmonitor/feature/notification/data/model/push_notification_log.dart';
+import 'package:eqmonitor/feature/notification/data/model/test_notification_delivery.dart';
+import 'package:eqmonitor_api/export.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'push_notification_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+PushNotificationRepository pushNotificationRepository(Ref ref) =>
+    PushNotificationRepository(ref.watch(apiClientProvider));
+
+class PushNotificationRepository {
+  PushNotificationRepository(this._api);
+
+  final api.ApiClient _api;
+
+  Future<Result<GeneralNotificationSettings, Exception>>
+      getNotificationSettings(String deviceId) =>
+          Result.capture(() async {
+            final response =
+                await _api.device.getV2DeviceDeviceIdSettingsNotification(
+              deviceId: deviceId,
+            );
+            return response.data.toGeneralNotificationSettings;
+          });
+
+  Future<Result<GeneralNotificationSettings, Exception>>
+      patchNotificationSettings({
+    required String deviceId,
+    required GeneralNotificationSettings settings,
+  }) =>
+          Result.capture(() async {
+            final response =
+                await _api.device.patchV2DeviceDeviceIdSettingsNotification(
+              deviceId: deviceId,
+              body: api.NotificationSettingsRequest(
+                tsunamiEnabled: settings.tsunamiEnabled,
+                trainingEnabled: settings.trainingEnabled,
+              ),
+            );
+            return response.data.toGeneralNotificationSettings;
+          });
+
+  Future<Result<PushNotificationHistory, Exception>> getNotificationHistory({
+    required String deviceId,
+    int? limit,
+  }) =>
+      Result.capture(() async {
+        final response =
+            await _api.notification.getV2DeviceDeviceIdNotificationHistory(
+          deviceId: deviceId,
+          limit: limit,
+        );
+        return response.data.toPushNotificationHistory;
+      });
+
+  Future<Result<TestNotificationDeliveryResult, Exception>>
+      sendTestNotification({
+    required String deviceId,
+    required TestNotificationKind kind,
+  }) =>
+      Result.capture(() async {
+        final response =
+            await _api.notification.postV2DeviceDeviceIdNotificationTest(
+          deviceId: deviceId,
+          body: kind.toApiRequest(),
+        );
+        return response.data.toTestNotificationDeliveryResult;
+      });
+}

--- a/app/lib/feature/notification/data/repository/push_notification_repository.g.dart
+++ b/app/lib/feature/notification/data/repository/push_notification_repository.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'push_notification_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(pushNotificationRepository)
+final pushNotificationRepositoryProvider =
+    PushNotificationRepositoryProvider._();
+
+final class PushNotificationRepositoryProvider
+    extends
+        $FunctionalProvider<
+          PushNotificationRepository,
+          PushNotificationRepository,
+          PushNotificationRepository
+        >
+    with $Provider<PushNotificationRepository> {
+  PushNotificationRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'pushNotificationRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$pushNotificationRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<PushNotificationRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  PushNotificationRepository create(Ref ref) {
+    return pushNotificationRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PushNotificationRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PushNotificationRepository>(value),
+    );
+  }
+}
+
+String _$pushNotificationRepositoryHash() =>
+    r'5efdd26888ce50cf9d38c56972f38196ad82860a';

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -125,6 +125,14 @@ class _DebugWidget extends ConsumerWidget {
               ),
             ),
           ),
+          ListTile(
+            title: const Text('デバイス・通知'),
+            subtitle: const Text('登録・トークン同期・設定・テスト通知・履歴'),
+            leading: const Icon(Icons.phonelink_setup),
+            onTap: () async => const DebugDeviceSettingsRoute().push<void>(
+              context,
+            ),
+          ),
           const Divider(),
           const ListTile(
             title: Text('認証情報'),
@@ -267,7 +275,7 @@ class _SignOutTile extends ConsumerWidget {
           : () => AuthNotifier.signOut.run(ref, (tsx) async {
                 final apiClient = tsx.get(authApiClientProvider);
                 final notifier = tsx.get(authProvider.notifier);
-                await apiClient.auth.postSignOut(body: null);
+                await apiClient.auth.postSignOut();
                 await GoogleSignIn.instance.signOut();
                 await notifier.clearToken();
               }),


### PR DESCRIPTION
## 概要
- デバッグメニューから「デバイス・通知」画面へ遷移（`/settings/debug/device-settings`）
- ログイン時: デバイス未取得なら登録、FCM/APNs/Push to Start トークン同期、全般通知設定の更新、テスト通知、通知履歴表示
- `devices` / `notification` feature にリポジトリとアプリ用モデル（API 型は extension で変換）

## その他
- `dart analyze` クリーン
- `postSignOut(body: null)` の冗長引数を削除