### PR TITLE
fix: toApiRequest getter の括弧を削除

### DIFF
--- a/app/lib/feature/notification/data/repository/push_notification_repository.dart
+++ b/app/lib/feature/notification/data/repository/push_notification_repository.dart
@@ -66,7 +66,7 @@ class PushNotificationRepository {
         final response =
             await _api.notification.postV2DeviceDeviceIdNotificationTest(
           deviceId: deviceId,
-          body: kind.toApiRequest(),
+          body: kind.toApiRequest,
         );
         return response.data.toTestNotificationDeliveryResult;
       });


### PR DESCRIPTION
## Summary
- `push_notification_repository.dart` の69行目で `toApiRequest` getter を `kind.toApiRequest()` と関数呼び出しで使用していたのを `kind.toApiRequest` に修正
- これにより `'toApiRequest' isn't a function or method and can't be invoked.` コンパイルエラーが解消されます

## 関連
- https://github.com/YumNumm/EQMonitor/actions/runs/23306850152/job/67783271970#step:12:1

## Test plan
- [ ] Android / iOS ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)