### PR TITLE
fix: Auth API Dioクライアントの307リダイレクトエラーを修正

### DIFF
--- a/app/lib/feature/auth/data/provider/auth_api_client_provider.dart
+++ b/app/lib/feature/auth/data/provider/auth_api_client_provider.dart
@@ -13,6 +13,9 @@ auth_api.ApiClient authApiClient(Ref ref) {
       baseUrl: Env.betterAuthUrl,
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 10),
+      followRedirects: true,
+      maxRedirects: 5,
+      validateStatus: (status) => status != null && status < 400,
     ),
   );
   return auth_api.ApiClient(dio);


### PR DESCRIPTION
## Summary
- 認証時（Google Sign-In / 匿名認証）にサーバーが307 Temporary Redirectを返した際に `DioException [bad response]` が発生していた問題を修正
- Auth API用のDioクライアントに `followRedirects`, `maxRedirects`, `validateStatus` を明示的に設定し、3xxレスポンスをエラーとして扱わないようにした

## Test plan
- [ ] Google Sign-Inで認証が正常に完了すること
- [ ] 匿名認証で認証が正常に完了すること
- [ ] デバッグページからの認証フローでエラーが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)