### PR TITLE
fix: Auth APIの307リダイレクト処理を修正しTalkerDioLoggerを追加

### DIFF
--- a/app/lib/feature/auth/data/provider/auth_api_client_provider.dart
+++ b/app/lib/feature/auth/data/provider/auth_api_client_provider.dart
@@ -1,7 +1,11 @@
 import 'package:better_auth_api_client/export.dart' as auth_api;
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/util/env.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:talker_dio_logger/talker_dio_logger_interceptor.dart';
+import 'package:talker_dio_logger/talker_dio_logger_settings.dart';
+import 'package:talker_flutter/talker_flutter.dart';
 
 part 'auth_api_client_provider.g.dart';
 
@@ -13,9 +17,54 @@ auth_api.ApiClient authApiClient(Ref ref) {
       baseUrl: Env.betterAuthUrl,
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 10),
-      followRedirects: true,
-      maxRedirects: 5,
-      validateStatus: (status) => status != null && status < 400,
+      // POSTリクエストの307/308リダイレクトはDioが正しく処理できないため、
+      // インターセプターで手動処理する
+      followRedirects: false,
+    ),
+  );
+  // 307/308リダイレクトをPOSTでも正しく処理するインターセプター
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onError: (error, handler) {
+        final response = error.response;
+        if (response != null &&
+            (response.statusCode == 307 || response.statusCode == 308)) {
+          final redirectUrl = response.headers.value('location');
+          if (redirectUrl != null) {
+            final options = error.requestOptions;
+            options.path = redirectUrl;
+            dio.fetch<dynamic>(options).then(
+              handler.resolve,
+              onError: (Object e) {
+                if (e is DioException) {
+                  handler.reject(e);
+                } else {
+                  handler.reject(
+                    DioException(
+                      requestOptions: options,
+                      error: e,
+                    ),
+                  );
+                }
+              },
+            );
+            return;
+          }
+        }
+        handler.next(error);
+      },
+    ),
+  );
+  dio.interceptors.add(
+    TalkerDioLogger(
+      settings: TalkerDioLoggerSettings(
+        errorPen: AnsiPen()..red(),
+        requestPen: AnsiPen()..yellow(),
+        responsePen: AnsiPen()..green(),
+        printResponseData: false,
+        printErrorMessage: false,
+      ),
+      talker: talker,
     ),
   );
   return auth_api.ApiClient(dio);


### PR DESCRIPTION
## Summary
- Auth API (Better Auth) への POST リクエスト時に 307 Temporary Redirect が返された際の処理を修正
  - 前回の `validateStatus` による修正では、307 レスポンスのボディが `null` のため Retrofit 生成コードの `_result.data!` で `Null check operator used on a null value` エラーが発生していた
  - `followRedirects: false` に設定し、`onError` インターセプターで 307/308 リダイレクトを検知してリクエストを再送信するように修正
- Auth API 用の Dio クライアントに `TalkerDioLogger` を追加し、リクエスト/レスポンスのログを確認できるようにした

## Test plan
- [ ] Google Sign-In で認証が正常に完了すること
- [ ] 匿名認証で認証が正常に完了すること
- [ ] Talker ログに Auth API のリクエスト/レスポンスが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)