### PR TITLE
feat: chuck_interceptorを導入してHTTPデバッグ機能を追加

### DIFF
--- a/app/ios/Flutter/Debug.xcconfig
+++ b/app/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
 #include "Environment.xcconfig"

--- a/app/ios/Flutter/Release.xcconfig
+++ b/app/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
 #include "Environment.xcconfig"

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/app/lib/core/provider/chuck_provider.dart
+++ b/app/lib/core/provider/chuck_provider.dart
@@ -1,0 +1,10 @@
+import 'package:chuck_interceptor/chuck_interceptor.dart';
+import 'package:eqmonitor/app.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'chuck_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+Chuck chuck(Ref ref) {
+  return Chuck(navigatorKey: App.navigatorKey, showNotification: true);
+}

--- a/app/lib/core/provider/chuck_provider.dart
+++ b/app/lib/core/provider/chuck_provider.dart
@@ -6,5 +6,5 @@ part 'chuck_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 Chuck chuck(Ref ref) {
-  return Chuck(navigatorKey: App.navigatorKey, showNotification: true);
+  return Chuck(navigatorKey: App.navigatorKey);
 }

--- a/app/lib/core/provider/chuck_provider.g.dart
+++ b/app/lib/core/provider/chuck_provider.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
 
-part of 'kyoshin_monitor_dio.dart';
+part of 'chuck_provider.dart';
 
 // **************************************************************************
 // RiverpodGenerator
@@ -11,42 +11,42 @@ part of 'kyoshin_monitor_dio.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(kyoshinMonitorDio)
-final kyoshinMonitorDioProvider = KyoshinMonitorDioProvider._();
+@ProviderFor(chuck)
+final chuckProvider = ChuckProvider._();
 
-final class KyoshinMonitorDioProvider extends $FunctionalProvider<Dio, Dio, Dio>
-    with $Provider<Dio> {
-  KyoshinMonitorDioProvider._()
+final class ChuckProvider extends $FunctionalProvider<Chuck, Chuck, Chuck>
+    with $Provider<Chuck> {
+  ChuckProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'kyoshinMonitorDioProvider',
+        name: r'chuckProvider',
         isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$kyoshinMonitorDioHash();
+  String debugGetCreateSourceHash() => _$chuckHash();
 
   @$internal
   @override
-  $ProviderElement<Dio> $createElement($ProviderPointer pointer) =>
+  $ProviderElement<Chuck> $createElement($ProviderPointer pointer) =>
       $ProviderElement(pointer);
 
   @override
-  Dio create(Ref ref) {
-    return kyoshinMonitorDio(ref);
+  Chuck create(Ref ref) {
+    return chuck(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Dio value) {
+  Override overrideWithValue(Chuck value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<Dio>(value),
+      providerOverride: $SyncValueProvider<Chuck>(value),
     );
   }
 }
 
-String _$kyoshinMonitorDioHash() => r'cac5258ff19006fc7b22964c2a12cb88e6713041';
+String _$chuckHash() => r'8f65c840cd2747b8e97eef9d02275f752fd9478d';

--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/chuck_provider.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
@@ -46,5 +47,6 @@ Dio dio(Ref ref) {
       talker: talker,
     ),
   );
+  dio.interceptors.add(ref.watch(chuckProvider).dioInterceptor);
   return dio;
 }

--- a/app/lib/core/provider/dio_provider.g.dart
+++ b/app/lib/core/provider/dio_provider.g.dart
@@ -49,4 +49,4 @@ final class DioProvider extends $FunctionalProvider<Dio, Dio, Dio>
   }
 }
 
-String _$dioHash() => r'4bdd91895bec104250597b789c9e856e51ab12c8';
+String _$dioHash() => r'0413bc6ae0859b98b7e7bd48061304da4feb1aba';

--- a/app/lib/feature/auth/data/provider/auth_api_client_provider.dart
+++ b/app/lib/feature/auth/data/provider/auth_api_client_provider.dart
@@ -1,5 +1,6 @@
 import 'package:better_auth_api_client/export.dart' as auth_api;
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/chuck_provider.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/util/env.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -33,5 +34,6 @@ auth_api.ApiClient authApiClient(Ref ref) {
       talker: talker,
     ),
   );
+  dio.interceptors.add(ref.watch(chuckProvider).dioInterceptor);
   return auth_api.ApiClient(dio);
 }

--- a/app/lib/feature/auth/data/provider/auth_api_client_provider.g.dart
+++ b/app/lib/feature/auth/data/provider/auth_api_client_provider.g.dart
@@ -56,4 +56,4 @@ final class AuthApiClientProvider
   }
 }
 
-String _$authApiClientHash() => r'd74194b4eb978c695ad709d68702ba745aac1ccf';
+String _$authApiClientHash() => r'69d00a3594677fe39f18fcbc613150582a2f7df0';

--- a/app/lib/feature/kyoshin_monitor/data/api/kyoshin_monitor_dio.dart
+++ b/app/lib/feature/kyoshin_monitor/data/api/kyoshin_monitor_dio.dart
@@ -1,28 +1,33 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/chuck_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'kyoshin_monitor_dio.g.dart';
 
 @Riverpod(keepAlive: true)
-Dio kyoshinMonitorDio(Ref ref) => Dio(
-  BaseOptions(
-    connectTimeout: const Duration(seconds: 2),
-    receiveTimeout: const Duration(seconds: 2),
-    sendTimeout: const Duration(seconds: 2),
-    headers: {
-      HttpHeaders.acceptHeader:
-          'text/javascript, application/javascript, application/ecmascript, application/x-ecmascript, */*; q=0.01',
-      'Accept-Language': 'ja-JP,ja;q=0.9,en-JP;q=0.8,en;q=0.7,en-US;q=0.6',
-      HttpHeaders.cacheControlHeader: 'no-cache',
-      'Connection': 'keep-alive',
-      'DNT': '1',
-      'Pragma': 'no-cache',
-      HttpHeaders.refererHeader: 'http://www.kmoni.bosai.go.jp/',
-      HttpHeaders.userAgentHeader:
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
-      'X-Requested-With': 'XMLHttpRequest',
-    },
-  ),
-);
+Dio kyoshinMonitorDio(Ref ref) {
+  final dio = Dio(
+    BaseOptions(
+      connectTimeout: const Duration(seconds: 2),
+      receiveTimeout: const Duration(seconds: 2),
+      sendTimeout: const Duration(seconds: 2),
+      headers: {
+        HttpHeaders.acceptHeader:
+            'text/javascript, application/javascript, application/ecmascript, application/x-ecmascript, */*; q=0.01',
+        'Accept-Language': 'ja-JP,ja;q=0.9,en-JP;q=0.8,en;q=0.7,en-US;q=0.6',
+        HttpHeaders.cacheControlHeader: 'no-cache',
+        'Connection': 'keep-alive',
+        'DNT': '1',
+        'Pragma': 'no-cache',
+        HttpHeaders.refererHeader: 'http://www.kmoni.bosai.go.jp/',
+        HttpHeaders.userAgentHeader:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    ),
+  );
+  dio.interceptors.add(ref.watch(chuckProvider).dioInterceptor);
+  return dio;
+}

--- a/app/lib/feature/nied/data/provider/nied_dio_provider.dart
+++ b/app/lib/feature/nied/data/provider/nied_dio_provider.dart
@@ -1,17 +1,22 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/chuck_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'nied_dio_provider.g.dart';
 
 @Riverpod(keepAlive: true)
-Dio niedDio(Ref ref) => Dio(
-  BaseOptions(
-    connectTimeout: const Duration(seconds: 10),
-    receiveTimeout: const Duration(seconds: 10),
-    sendTimeout: const Duration(seconds: 10),
-    responseType: ResponseType.plain,
-    contentType: ContentType.html.value,
-  ),
-);
+Dio niedDio(Ref ref) {
+  final dio = Dio(
+    BaseOptions(
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+      sendTimeout: const Duration(seconds: 10),
+      responseType: ResponseType.plain,
+      contentType: ContentType.html.value,
+    ),
+  );
+  dio.interceptors.add(ref.watch(chuckProvider).dioInterceptor);
+  return dio;
+}

--- a/app/lib/feature/nied/data/provider/nied_dio_provider.g.dart
+++ b/app/lib/feature/nied/data/provider/nied_dio_provider.g.dart
@@ -49,4 +49,4 @@ final class NiedDioProvider extends $FunctionalProvider<Dio, Dio, Dio>
   }
 }
 
-String _$niedDioHash() => r'160f4cf8093bd208f840271a93fb186db1922310';
+String _$niedDioHash() => r'33d9cf59b20bc45cdbb42618661c238cf838c33b';

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:eqmonitor/core/provider/chuck_provider.dart';
 import 'package:eqmonitor/core/provider/jma_parameter/jma_parameter.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
 import 'package:eqmonitor/core/router/router.dart';
@@ -73,6 +74,11 @@ class _DebugWidget extends ConsumerWidget {
             title: const Text('ログ'),
             leading: const Icon(Icons.list),
             onTap: () async => const TalkerRoute().push<void>(context),
+          ),
+          ListTile(
+            title: const Text('HTTP Inspector (Chuck)'),
+            leading: const Icon(Icons.network_check),
+            onTap: () => ref.read(chuckProvider).showInspector(),
           ),
           ListTile(
             title: const Text('REST APIエンドポイント'),

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -83,14 +83,18 @@ class _DebugWidget extends ConsumerWidget {
           ListTile(
             title: const Text('REST APIエンドポイント'),
             leading: const Icon(Icons.http),
-            subtitle: Text(ref.watch(telegramUrlProvider).requireValue.restApiUrl),
+            subtitle: Text(
+              ref.watch(telegramUrlProvider).requireValue.restApiUrl,
+            ),
             onTap: () async =>
                 const HttpApiEndpointSelectorRoute().push<void>(context),
           ),
           ListTile(
             title: const Text('WebSocketエンドポイント'),
             leading: const Icon(Icons.http),
-            subtitle: Text(ref.watch(telegramUrlProvider).requireValue.wsApiUrl),
+            subtitle: Text(
+              ref.watch(telegramUrlProvider).requireValue.wsApiUrl,
+            ),
             onTap: () async =>
                 const WebsocketEndpointSelectorRoute().push<void>(context),
           ),
@@ -220,25 +224,25 @@ class _GoogleSignInTile extends ConsumerWidget {
           : null,
       subtitle: switch (state) {
         MutationError(:final error) => Text(
-            error.toString(),
-            style: TextStyle(color: Theme.of(context).colorScheme.error),
-          ),
+          error.toString(),
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
+        ),
         MutationSuccess() => const Text('サインイン成功'),
         _ => null,
       },
       onTap: isPending
           ? null
           : () => AuthNotifier.signInWithGoogleMutation.run(ref, (tsx) async {
-                await tsx.get(googleSignInInitProvider.future);
-                final account = await GoogleSignIn.instance.authenticate();
-                final idToken = account.authentication.idToken;
-                if (idToken == null) {
-                  throw Exception('Google idToken が取得できませんでした');
-                }
-                await tsx
-                    .get(authProvider.notifier)
-                    .signInWithGoogle(idToken: idToken);
-              }),
+              await tsx.get(googleSignInInitProvider.future);
+              final account = await GoogleSignIn.instance.authenticate();
+              final idToken = account.authentication.idToken;
+              if (idToken == null) {
+                throw Exception('Google idToken が取得できませんでした');
+              }
+              await tsx
+                  .get(authProvider.notifier)
+                  .signInWithGoogle(idToken: idToken);
+            }),
     );
   }
 }
@@ -261,18 +265,18 @@ class _SignOutTile extends ConsumerWidget {
           : null,
       subtitle: switch (state) {
         MutationError(:final error) => Text(
-            error.toString(),
-            style: TextStyle(color: Theme.of(context).colorScheme.error),
-          ),
+          error.toString(),
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
+        ),
         MutationSuccess() => const Text('サインアウト完了'),
         _ => null,
       },
       onTap: isPending
           ? null
           : () => AuthNotifier.signOutMutation.run(ref, (tsx) async {
-                await tsx.get(authProvider.notifier).signOut();
-                await GoogleSignIn.instance.signOut();
-              }),
+              await tsx.get(authProvider.notifier).signOut();
+              await GoogleSignIn.instance.signOut();
+            }),
     );
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   better_auth_api_client:
     path: ../packages/better_auth_api_client
   cached_network_image: ^3.4.1
+  chuck_interceptor: ^2.4.1
   clock: ^1.1.2
   collection: ^1.19.1
   core:

--- a/app/test/core/provider/config/theme/intensity_color/intensity_color_provider_test.dart
+++ b/app/test/core/provider/config/theme/intensity_color/intensity_color_provider_test.dart
@@ -1,7 +1,7 @@
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -15,7 +15,9 @@ void main() {
       final preferences = await SharedPreferences.getInstance();
       final container = ProviderContainer(
         overrides: [
-          sharedPreferencesProvider.overrideWithValue(preferences),
+          app_prefs.sharedPreferencesProvider.overrideWithValue(
+            app_prefs.SharedPreferencesAsync(preferences),
+          ),
         ],
       );
       addTearDown(container.dispose);
@@ -36,7 +38,9 @@ void main() {
       final preferences = await SharedPreferences.getInstance();
       final container = ProviderContainer(
         overrides: [
-          sharedPreferencesProvider.overrideWithValue(preferences),
+          app_prefs.sharedPreferencesProvider.overrideWithValue(
+            app_prefs.SharedPreferencesAsync(preferences),
+          ),
         ],
       );
       addTearDown(container.dispose);

--- a/app/test/feature/settings/features/display_settings/color_scheme/color_scheme_config_page_test.dart
+++ b/app/test/feature/settings/features/display_settings/color_scheme/color_scheme_config_page_test.dart
@@ -1,6 +1,6 @@
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
-import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
 import 'package:eqmonitor/feature/settings/features/display_settings/color_scheme/color_scheme_config_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,7 +15,9 @@ void main() {
     final preferences = await SharedPreferences.getInstance();
     final container = ProviderContainer(
       overrides: [
-        sharedPreferencesProvider.overrideWithValue(preferences),
+        app_prefs.sharedPreferencesProvider.overrideWithValue(
+          app_prefs.SharedPreferencesAsync(preferences),
+        ),
       ],
     );
     addTearDown(container.dispose);

--- a/packages/better_auth_api_client/lib/models/message.dart
+++ b/packages/better_auth_api_client/lib/models/message.dart
@@ -21,7 +21,7 @@ enum Message {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
           'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/better_auth_api_client/lib/models/message2.dart
+++ b/packages/better_auth_api_client/lib/models/message2.dart
@@ -21,7 +21,7 @@ enum Message2 {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
           'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/better_auth_api_client/lib/models/message3.dart
+++ b/packages/better_auth_api_client/lib/models/message3.dart
@@ -19,7 +19,7 @@ enum Message3 {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
           'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/api_client.dart
+++ b/packages/eqmonitor_api/lib/api_client.dart
@@ -17,11 +17,7 @@ import 'clients/web_socket_api_client.dart';
 ///
 /// EQMonitorのAPI仕様書.
 class ApiClient {
-  ApiClient(
-    Dio dio, {
-    String? baseUrl,
-  })  : _dio = dio,
-        _baseUrl = baseUrl;
+  ApiClient(Dio dio, {String? baseUrl}) : _dio = dio, _baseUrl = baseUrl;
 
   final Dio _dio;
   final String? _baseUrl;
@@ -37,19 +33,25 @@ class ApiClient {
   UserApiClient? _user;
   WebSocketApiClient? _webSocket;
 
-  DeviceApiClient get device => _device ??= DeviceApiClient(_dio, baseUrl: _baseUrl);
+  DeviceApiClient get device =>
+      _device ??= DeviceApiClient(_dio, baseUrl: _baseUrl);
 
-  NotificationApiClient get notification => _notification ??= NotificationApiClient(_dio, baseUrl: _baseUrl);
+  NotificationApiClient get notification =>
+      _notification ??= NotificationApiClient(_dio, baseUrl: _baseUrl);
 
-  EarthquakeApiClient get earthquake => _earthquake ??= EarthquakeApiClient(_dio, baseUrl: _baseUrl);
+  EarthquakeApiClient get earthquake =>
+      _earthquake ??= EarthquakeApiClient(_dio, baseUrl: _baseUrl);
 
   EewApiClient get eew => _eew ??= EewApiClient(_dio, baseUrl: _baseUrl);
 
-  TelegramApiClient get telegram => _telegram ??= TelegramApiClient(_dio, baseUrl: _baseUrl);
+  TelegramApiClient get telegram =>
+      _telegram ??= TelegramApiClient(_dio, baseUrl: _baseUrl);
 
-  TsunamiApiClient get tsunami => _tsunami ??= TsunamiApiClient(_dio, baseUrl: _baseUrl);
+  TsunamiApiClient get tsunami =>
+      _tsunami ??= TsunamiApiClient(_dio, baseUrl: _baseUrl);
 
   UserApiClient get user => _user ??= UserApiClient(_dio, baseUrl: _baseUrl);
 
-  WebSocketApiClient get webSocket => _webSocket ??= WebSocketApiClient(_dio, baseUrl: _baseUrl);
+  WebSocketApiClient get webSocket =>
+      _webSocket ??= WebSocketApiClient(_dio, baseUrl: _baseUrl);
 }

--- a/packages/eqmonitor_api/lib/clients/device_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/device_api_client.dart
@@ -99,82 +99,98 @@ abstract class DeviceApiClient {
 
   /// Live Activity updateToken一覧を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdLiveActivity)
-  Future<HttpResponse<List<LiveActivityTokenResponse>>> getV2DeviceDeviceIdLiveActivity({
-    @Path('deviceId') required String deviceId,
-  });
+  Future<HttpResponse<List<LiveActivityTokenResponse>>>
+  getV2DeviceDeviceIdLiveActivity({@Path('deviceId') required String deviceId});
 
   /// Live Activity updateTokenを更新。notification-resolverで作成されたレコードのtokenを更新する。
   @PUT(DeviceApiClientUrls.putV2DeviceDeviceIdLiveActivityLiveActivityIdToken)
-  Future<HttpResponse<LiveActivityTokenResponse>> putV2DeviceDeviceIdLiveActivityLiveActivityIdToken({
+  Future<HttpResponse<LiveActivityTokenResponse>>
+  putV2DeviceDeviceIdLiveActivityLiveActivityIdToken({
     @Path('liveActivityId') required String liveActivityId,
     @Path('deviceId') required String deviceId,
     @Body() required LiveActivityTokenRequest body,
   });
 
   /// Live Activity updateTokenを削除
-  @DELETE(DeviceApiClientUrls.deleteV2DeviceDeviceIdLiveActivityLiveActivityIdToken)
-  Future<HttpResponse<void>> deleteV2DeviceDeviceIdLiveActivityLiveActivityIdToken({
+  @DELETE(
+    DeviceApiClientUrls.deleteV2DeviceDeviceIdLiveActivityLiveActivityIdToken,
+  )
+  Future<HttpResponse<void>>
+  deleteV2DeviceDeviceIdLiveActivityLiveActivityIdToken({
     @Path('liveActivityId') required String liveActivityId,
     @Path('deviceId') required String deviceId,
   });
 
   /// 全般通知設定を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsNotification)
-  Future<HttpResponse<NotificationSettingsResponse>> getV2DeviceDeviceIdSettingsNotification({
+  Future<HttpResponse<NotificationSettingsResponse>>
+  getV2DeviceDeviceIdSettingsNotification({
     @Path('deviceId') required String deviceId,
   });
 
   /// 全般通知設定を更新
   @PATCH(DeviceApiClientUrls.patchV2DeviceDeviceIdSettingsNotification)
-  Future<HttpResponse<NotificationSettingsResponse>> patchV2DeviceDeviceIdSettingsNotification({
+  Future<HttpResponse<NotificationSettingsResponse>>
+  patchV2DeviceDeviceIdSettingsNotification({
     @Path('deviceId') required String deviceId,
     @Body() required NotificationSettingsRequest body,
   });
 
   /// 地震通知設定を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsEarthquake)
-  Future<HttpResponse<EarthquakeSettingsResponse>> getV2DeviceDeviceIdSettingsEarthquake({
+  Future<HttpResponse<EarthquakeSettingsResponse>>
+  getV2DeviceDeviceIdSettingsEarthquake({
     @Path('deviceId') required String deviceId,
   });
 
   /// 地震通知設定を更新
   @PATCH(DeviceApiClientUrls.patchV2DeviceDeviceIdSettingsEarthquake)
-  Future<HttpResponse<EarthquakeSettingsResponse>> patchV2DeviceDeviceIdSettingsEarthquake({
+  Future<HttpResponse<EarthquakeSettingsResponse>>
+  patchV2DeviceDeviceIdSettingsEarthquake({
     @Path('deviceId') required String deviceId,
     @Body() required EarthquakeSettingsRequest body,
   });
 
   /// 地震通知リージョン設定一覧を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsEarthquakeRegions)
-  Future<HttpResponse<List<RegionSettingResponse>>> getV2DeviceDeviceIdSettingsEarthquakeRegions({
+  Future<HttpResponse<List<RegionSettingResponse>>>
+  getV2DeviceDeviceIdSettingsEarthquakeRegions({
     @Path('deviceId') required String deviceId,
   });
 
   /// 地震通知リージョン設定を一括更新（全件上書き）
   @PUT(DeviceApiClientUrls.putV2DeviceDeviceIdSettingsEarthquakeRegions)
-  Future<HttpResponse<List<RegionSettingResponse>>> putV2DeviceDeviceIdSettingsEarthquakeRegions({
+  Future<HttpResponse<List<RegionSettingResponse>>>
+  putV2DeviceDeviceIdSettingsEarthquakeRegions({
     @Path('deviceId') required String deviceId,
     @Body() required List<RegionSettingRequest> body,
   });
 
   /// 特定のリージョン設定を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId)
-  Future<HttpResponse<RegionSettingResponse>> getV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId({
+  Future<HttpResponse<RegionSettingResponse>>
+  getV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId({
     @Path('regionId') required num regionId,
     @Path('deviceId') required String deviceId,
   });
 
   /// 特定のリージョン設定を更新
-  @PATCH(DeviceApiClientUrls.patchV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId)
-  Future<HttpResponse<RegionSettingResponse>> patchV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId({
+  @PATCH(
+    DeviceApiClientUrls.patchV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId,
+  )
+  Future<HttpResponse<RegionSettingResponse>>
+  patchV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId({
     @Path('regionId') required num regionId,
     @Path('deviceId') required String deviceId,
     @Body() required RegionSettingPatchRequest body,
   });
 
   /// 特定のリージョン設定を削除
-  @DELETE(DeviceApiClientUrls.deleteV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId)
-  Future<HttpResponse<void>> deleteV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId({
+  @DELETE(
+    DeviceApiClientUrls.deleteV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId,
+  )
+  Future<HttpResponse<void>>
+  deleteV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId({
     @Path('regionId') required num regionId,
     @Path('deviceId') required String deviceId,
   });
@@ -194,27 +210,31 @@ abstract class DeviceApiClient {
 
   /// EEW通知リージョン設定一覧を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsEewRegions)
-  Future<HttpResponse<List<RegionSettingResponse>>> getV2DeviceDeviceIdSettingsEewRegions({
+  Future<HttpResponse<List<RegionSettingResponse>>>
+  getV2DeviceDeviceIdSettingsEewRegions({
     @Path('deviceId') required String deviceId,
   });
 
   /// EEW通知リージョン設定を一括更新（全件上書き）
   @PUT(DeviceApiClientUrls.putV2DeviceDeviceIdSettingsEewRegions)
-  Future<HttpResponse<List<RegionSettingResponse>>> putV2DeviceDeviceIdSettingsEewRegions({
+  Future<HttpResponse<List<RegionSettingResponse>>>
+  putV2DeviceDeviceIdSettingsEewRegions({
     @Path('deviceId') required String deviceId,
     @Body() required List<RegionSettingRequest> body,
   });
 
   /// 特定のリージョン設定を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsEewRegionsRegionId)
-  Future<HttpResponse<RegionSettingResponse>> getV2DeviceDeviceIdSettingsEewRegionsRegionId({
+  Future<HttpResponse<RegionSettingResponse>>
+  getV2DeviceDeviceIdSettingsEewRegionsRegionId({
     @Path('regionId') required num regionId,
     @Path('deviceId') required String deviceId,
   });
 
   /// 特定のリージョン設定を更新
   @PATCH(DeviceApiClientUrls.patchV2DeviceDeviceIdSettingsEewRegionsRegionId)
-  Future<HttpResponse<RegionSettingResponse>> patchV2DeviceDeviceIdSettingsEewRegionsRegionId({
+  Future<HttpResponse<RegionSettingResponse>>
+  patchV2DeviceDeviceIdSettingsEewRegionsRegionId({
     @Path('regionId') required num regionId,
     @Path('deviceId') required String deviceId,
     @Body() required RegionSettingPatchRequest body,
@@ -229,89 +249,146 @@ abstract class DeviceApiClient {
 
   /// 揺れ検知通知設定一覧を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsShakeDetection)
-  Future<HttpResponse<List<ShakeDetectionSettingResponse>>> getV2DeviceDeviceIdSettingsShakeDetection({
+  Future<HttpResponse<List<ShakeDetectionSettingResponse>>>
+  getV2DeviceDeviceIdSettingsShakeDetection({
     @Path('deviceId') required String deviceId,
   });
 
   /// 揺れ検知通知設定を一括更新（全件上書き）
   @PUT(DeviceApiClientUrls.putV2DeviceDeviceIdSettingsShakeDetection)
-  Future<HttpResponse<List<ShakeDetectionSettingResponse>>> putV2DeviceDeviceIdSettingsShakeDetection({
+  Future<HttpResponse<List<ShakeDetectionSettingResponse>>>
+  putV2DeviceDeviceIdSettingsShakeDetection({
     @Path('deviceId') required String deviceId,
     @Body() required List<ShakeDetectionSettingRequest> body,
   });
 
   /// 揺れ検知サブ地域マスター一覧を取得
   @GET(DeviceApiClientUrls.getV2DeviceDeviceIdSettingsShakeDetectionSubRegions)
-  Future<HttpResponse<List<ShakeDetectionSubRegionResponse>>> getV2DeviceDeviceIdSettingsShakeDetectionSubRegions({
+  Future<HttpResponse<List<ShakeDetectionSubRegionResponse>>>
+  getV2DeviceDeviceIdSettingsShakeDetectionSubRegions({
     @Path('deviceId') required String deviceId,
   });
 }
 
-
 abstract class DeviceApiClientUrls {
-	/// /v2/device/{deviceId}
-	static const putV2DeviceDeviceId = "/v2/device/{deviceId}";
-	/// /v2/device/{deviceId}
-	static const getV2DeviceDeviceId = "/v2/device/{deviceId}";
-	/// /v2/device/{deviceId}
-	static const deleteV2DeviceDeviceId = "/v2/device/{deviceId}";
-	/// /v2/device/{deviceId}/apns
-	static const getV2DeviceDeviceIdApns = "/v2/device/{deviceId}/apns";
-	/// /v2/device/{deviceId}/apns/{type}
-	static const getV2DeviceDeviceIdApnsType = "/v2/device/{deviceId}/apns/{type}";
-	/// /v2/device/{deviceId}/apns/{type}
-	static const patchV2DeviceDeviceIdApnsType = "/v2/device/{deviceId}/apns/{type}";
-	/// /v2/device/{deviceId}/apns/{type}
-	static const deleteV2DeviceDeviceIdApnsType = "/v2/device/{deviceId}/apns/{type}";
-	/// /v2/device/{deviceId}/fcm
-	static const getV2DeviceDeviceIdFcm = "/v2/device/{deviceId}/fcm";
-	/// /v2/device/{deviceId}/fcm
-	static const patchV2DeviceDeviceIdFcm = "/v2/device/{deviceId}/fcm";
-	/// /v2/device/{deviceId}/fcm
-	static const deleteV2DeviceDeviceIdFcm = "/v2/device/{deviceId}/fcm";
-	/// /v2/device/{deviceId}/live-activity
-	static const getV2DeviceDeviceIdLiveActivity = "/v2/device/{deviceId}/live-activity";
-	/// /v2/device/{deviceId}/live-activity/{liveActivityId}/token
-	static const putV2DeviceDeviceIdLiveActivityLiveActivityIdToken = "/v2/device/{deviceId}/live-activity/{liveActivityId}/token";
-	/// /v2/device/{deviceId}/live-activity/{liveActivityId}/token
-	static const deleteV2DeviceDeviceIdLiveActivityLiveActivityIdToken = "/v2/device/{deviceId}/live-activity/{liveActivityId}/token";
-	/// /v2/device/{deviceId}/settings/notification
-	static const getV2DeviceDeviceIdSettingsNotification = "/v2/device/{deviceId}/settings/notification";
-	/// /v2/device/{deviceId}/settings/notification
-	static const patchV2DeviceDeviceIdSettingsNotification = "/v2/device/{deviceId}/settings/notification";
-	/// /v2/device/{deviceId}/settings/earthquake
-	static const getV2DeviceDeviceIdSettingsEarthquake = "/v2/device/{deviceId}/settings/earthquake";
-	/// /v2/device/{deviceId}/settings/earthquake
-	static const patchV2DeviceDeviceIdSettingsEarthquake = "/v2/device/{deviceId}/settings/earthquake";
-	/// /v2/device/{deviceId}/settings/earthquake/regions
-	static const getV2DeviceDeviceIdSettingsEarthquakeRegions = "/v2/device/{deviceId}/settings/earthquake/regions";
-	/// /v2/device/{deviceId}/settings/earthquake/regions
-	static const putV2DeviceDeviceIdSettingsEarthquakeRegions = "/v2/device/{deviceId}/settings/earthquake/regions";
-	/// /v2/device/{deviceId}/settings/earthquake/regions/{regionId}
-	static const getV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId = "/v2/device/{deviceId}/settings/earthquake/regions/{regionId}";
-	/// /v2/device/{deviceId}/settings/earthquake/regions/{regionId}
-	static const patchV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId = "/v2/device/{deviceId}/settings/earthquake/regions/{regionId}";
-	/// /v2/device/{deviceId}/settings/earthquake/regions/{regionId}
-	static const deleteV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId = "/v2/device/{deviceId}/settings/earthquake/regions/{regionId}";
-	/// /v2/device/{deviceId}/settings/eew
-	static const getV2DeviceDeviceIdSettingsEew = "/v2/device/{deviceId}/settings/eew";
-	/// /v2/device/{deviceId}/settings/eew
-	static const patchV2DeviceDeviceIdSettingsEew = "/v2/device/{deviceId}/settings/eew";
-	/// /v2/device/{deviceId}/settings/eew/regions
-	static const getV2DeviceDeviceIdSettingsEewRegions = "/v2/device/{deviceId}/settings/eew/regions";
-	/// /v2/device/{deviceId}/settings/eew/regions
-	static const putV2DeviceDeviceIdSettingsEewRegions = "/v2/device/{deviceId}/settings/eew/regions";
-	/// /v2/device/{deviceId}/settings/eew/regions/{regionId}
-	static const getV2DeviceDeviceIdSettingsEewRegionsRegionId = "/v2/device/{deviceId}/settings/eew/regions/{regionId}";
-	/// /v2/device/{deviceId}/settings/eew/regions/{regionId}
-	static const patchV2DeviceDeviceIdSettingsEewRegionsRegionId = "/v2/device/{deviceId}/settings/eew/regions/{regionId}";
-	/// /v2/device/{deviceId}/settings/eew/regions/{regionId}
-	static const deleteV2DeviceDeviceIdSettingsEewRegionsRegionId = "/v2/device/{deviceId}/settings/eew/regions/{regionId}";
-	/// /v2/device/{deviceId}/settings/shake-detection
-	static const getV2DeviceDeviceIdSettingsShakeDetection = "/v2/device/{deviceId}/settings/shake-detection";
-	/// /v2/device/{deviceId}/settings/shake-detection
-	static const putV2DeviceDeviceIdSettingsShakeDetection = "/v2/device/{deviceId}/settings/shake-detection";
-	/// /v2/device/{deviceId}/settings/shake-detection/sub-regions
-	static const getV2DeviceDeviceIdSettingsShakeDetectionSubRegions = "/v2/device/{deviceId}/settings/shake-detection/sub-regions";
-}
+  /// /v2/device/{deviceId}
+  static const putV2DeviceDeviceId = "/v2/device/{deviceId}";
 
+  /// /v2/device/{deviceId}
+  static const getV2DeviceDeviceId = "/v2/device/{deviceId}";
+
+  /// /v2/device/{deviceId}
+  static const deleteV2DeviceDeviceId = "/v2/device/{deviceId}";
+
+  /// /v2/device/{deviceId}/apns
+  static const getV2DeviceDeviceIdApns = "/v2/device/{deviceId}/apns";
+
+  /// /v2/device/{deviceId}/apns/{type}
+  static const getV2DeviceDeviceIdApnsType =
+      "/v2/device/{deviceId}/apns/{type}";
+
+  /// /v2/device/{deviceId}/apns/{type}
+  static const patchV2DeviceDeviceIdApnsType =
+      "/v2/device/{deviceId}/apns/{type}";
+
+  /// /v2/device/{deviceId}/apns/{type}
+  static const deleteV2DeviceDeviceIdApnsType =
+      "/v2/device/{deviceId}/apns/{type}";
+
+  /// /v2/device/{deviceId}/fcm
+  static const getV2DeviceDeviceIdFcm = "/v2/device/{deviceId}/fcm";
+
+  /// /v2/device/{deviceId}/fcm
+  static const patchV2DeviceDeviceIdFcm = "/v2/device/{deviceId}/fcm";
+
+  /// /v2/device/{deviceId}/fcm
+  static const deleteV2DeviceDeviceIdFcm = "/v2/device/{deviceId}/fcm";
+
+  /// /v2/device/{deviceId}/live-activity
+  static const getV2DeviceDeviceIdLiveActivity =
+      "/v2/device/{deviceId}/live-activity";
+
+  /// /v2/device/{deviceId}/live-activity/{liveActivityId}/token
+  static const putV2DeviceDeviceIdLiveActivityLiveActivityIdToken =
+      "/v2/device/{deviceId}/live-activity/{liveActivityId}/token";
+
+  /// /v2/device/{deviceId}/live-activity/{liveActivityId}/token
+  static const deleteV2DeviceDeviceIdLiveActivityLiveActivityIdToken =
+      "/v2/device/{deviceId}/live-activity/{liveActivityId}/token";
+
+  /// /v2/device/{deviceId}/settings/notification
+  static const getV2DeviceDeviceIdSettingsNotification =
+      "/v2/device/{deviceId}/settings/notification";
+
+  /// /v2/device/{deviceId}/settings/notification
+  static const patchV2DeviceDeviceIdSettingsNotification =
+      "/v2/device/{deviceId}/settings/notification";
+
+  /// /v2/device/{deviceId}/settings/earthquake
+  static const getV2DeviceDeviceIdSettingsEarthquake =
+      "/v2/device/{deviceId}/settings/earthquake";
+
+  /// /v2/device/{deviceId}/settings/earthquake
+  static const patchV2DeviceDeviceIdSettingsEarthquake =
+      "/v2/device/{deviceId}/settings/earthquake";
+
+  /// /v2/device/{deviceId}/settings/earthquake/regions
+  static const getV2DeviceDeviceIdSettingsEarthquakeRegions =
+      "/v2/device/{deviceId}/settings/earthquake/regions";
+
+  /// /v2/device/{deviceId}/settings/earthquake/regions
+  static const putV2DeviceDeviceIdSettingsEarthquakeRegions =
+      "/v2/device/{deviceId}/settings/earthquake/regions";
+
+  /// /v2/device/{deviceId}/settings/earthquake/regions/{regionId}
+  static const getV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId =
+      "/v2/device/{deviceId}/settings/earthquake/regions/{regionId}";
+
+  /// /v2/device/{deviceId}/settings/earthquake/regions/{regionId}
+  static const patchV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId =
+      "/v2/device/{deviceId}/settings/earthquake/regions/{regionId}";
+
+  /// /v2/device/{deviceId}/settings/earthquake/regions/{regionId}
+  static const deleteV2DeviceDeviceIdSettingsEarthquakeRegionsRegionId =
+      "/v2/device/{deviceId}/settings/earthquake/regions/{regionId}";
+
+  /// /v2/device/{deviceId}/settings/eew
+  static const getV2DeviceDeviceIdSettingsEew =
+      "/v2/device/{deviceId}/settings/eew";
+
+  /// /v2/device/{deviceId}/settings/eew
+  static const patchV2DeviceDeviceIdSettingsEew =
+      "/v2/device/{deviceId}/settings/eew";
+
+  /// /v2/device/{deviceId}/settings/eew/regions
+  static const getV2DeviceDeviceIdSettingsEewRegions =
+      "/v2/device/{deviceId}/settings/eew/regions";
+
+  /// /v2/device/{deviceId}/settings/eew/regions
+  static const putV2DeviceDeviceIdSettingsEewRegions =
+      "/v2/device/{deviceId}/settings/eew/regions";
+
+  /// /v2/device/{deviceId}/settings/eew/regions/{regionId}
+  static const getV2DeviceDeviceIdSettingsEewRegionsRegionId =
+      "/v2/device/{deviceId}/settings/eew/regions/{regionId}";
+
+  /// /v2/device/{deviceId}/settings/eew/regions/{regionId}
+  static const patchV2DeviceDeviceIdSettingsEewRegionsRegionId =
+      "/v2/device/{deviceId}/settings/eew/regions/{regionId}";
+
+  /// /v2/device/{deviceId}/settings/eew/regions/{regionId}
+  static const deleteV2DeviceDeviceIdSettingsEewRegionsRegionId =
+      "/v2/device/{deviceId}/settings/eew/regions/{regionId}";
+
+  /// /v2/device/{deviceId}/settings/shake-detection
+  static const getV2DeviceDeviceIdSettingsShakeDetection =
+      "/v2/device/{deviceId}/settings/shake-detection";
+
+  /// /v2/device/{deviceId}/settings/shake-detection
+  static const putV2DeviceDeviceIdSettingsShakeDetection =
+      "/v2/device/{deviceId}/settings/shake-detection";
+
+  /// /v2/device/{deviceId}/settings/shake-detection/sub-regions
+  static const getV2DeviceDeviceIdSettingsShakeDetectionSubRegions =
+      "/v2/device/{deviceId}/settings/shake-detection/sub-regions";
+}

--- a/packages/eqmonitor_api/lib/clients/earthquake_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/earthquake_api_client.dart
@@ -21,7 +21,8 @@ part 'earthquake_api_client.g.dart';
 
 @RestApi()
 abstract class EarthquakeApiClient {
-  factory EarthquakeApiClient(Dio dio, {String? baseUrl}) = _EarthquakeApiClient;
+  factory EarthquakeApiClient(Dio dio, {String? baseUrl}) =
+      _EarthquakeApiClient;
 
   /// 地震情報一覧.
   ///
@@ -78,7 +79,8 @@ abstract class EarthquakeApiClient {
   ///
   /// [originTimeLte] - ISO8601形式のタイムスタンプ (例: 2024-01-01T00:00:00Z).
   @GET(EarthquakeApiClientUrls.getV2EarthquakeIntensityRegionCode)
-  Future<HttpResponse<IntensityRegionSearchResponse>> getV2EarthquakeIntensityRegionCode({
+  Future<HttpResponse<IntensityRegionSearchResponse>>
+  getV2EarthquakeIntensityRegionCode({
     @Path('code') required String code,
     @Query('statuses') List<TelegramStatus>? statuses = const [.normal],
     @Query('sortBy') EarthquakeSortBy? sortBy = EarthquakeSortBy.eventId,
@@ -111,7 +113,8 @@ abstract class EarthquakeApiClient {
   ///
   /// [originTimeLte] - ISO8601形式のタイムスタンプ (例: 2024-01-01T00:00:00Z).
   @GET(EarthquakeApiClientUrls.getV2EarthquakeIntensityPrefectureCode)
-  Future<HttpResponse<IntensityPrefectureSearchResponse>> getV2EarthquakeIntensityPrefectureCode({
+  Future<HttpResponse<IntensityPrefectureSearchResponse>>
+  getV2EarthquakeIntensityPrefectureCode({
     @Path('code') required String code,
     @Query('statuses') List<TelegramStatus>? statuses = const [.normal],
     @Query('sortBy') EarthquakeSortBy? sortBy = EarthquakeSortBy.eventId,
@@ -144,7 +147,8 @@ abstract class EarthquakeApiClient {
   ///
   /// [originTimeLte] - ISO8601形式のタイムスタンプ (例: 2024-01-01T00:00:00Z).
   @GET(EarthquakeApiClientUrls.getV2EarthquakeIntensityCityCode)
-  Future<HttpResponse<IntensityCitySearchResponse>> getV2EarthquakeIntensityCityCode({
+  Future<HttpResponse<IntensityCitySearchResponse>>
+  getV2EarthquakeIntensityCityCode({
     @Path('code') required String code,
     @Query('statuses') List<TelegramStatus>? statuses = const [.normal],
     @Query('sortBy') EarthquakeSortBy? sortBy = EarthquakeSortBy.eventId,
@@ -177,7 +181,8 @@ abstract class EarthquakeApiClient {
   ///
   /// [originTimeLte] - ISO8601形式のタイムスタンプ (例: 2024-01-01T00:00:00Z).
   @GET(EarthquakeApiClientUrls.getV2EarthquakeIntensityStationCode)
-  Future<HttpResponse<IntensityStationSearchResponse>> getV2EarthquakeIntensityStationCode({
+  Future<HttpResponse<IntensityStationSearchResponse>>
+  getV2EarthquakeIntensityStationCode({
     @Path('code') required String code,
     @Query('statuses') List<TelegramStatus>? statuses = const [.normal],
     @Query('sortBy') EarthquakeSortBy? sortBy = EarthquakeSortBy.eventId,
@@ -228,21 +233,29 @@ abstract class EarthquakeApiClient {
   });
 }
 
-
 abstract class EarthquakeApiClientUrls {
-	/// /v2/earthquake
-	static const getV2Earthquake = "/v2/earthquake";
-	/// /v2/earthquake/{eventId}
-	static const getV2EarthquakeEventId = "/v2/earthquake/{eventId}";
-	/// /v2/earthquake/intensity/region/{code}
-	static const getV2EarthquakeIntensityRegionCode = "/v2/earthquake/intensity/region/{code}";
-	/// /v2/earthquake/intensity/prefecture/{code}
-	static const getV2EarthquakeIntensityPrefectureCode = "/v2/earthquake/intensity/prefecture/{code}";
-	/// /v2/earthquake/intensity/city/{code}
-	static const getV2EarthquakeIntensityCityCode = "/v2/earthquake/intensity/city/{code}";
-	/// /v2/earthquake/intensity/station/{code}
-	static const getV2EarthquakeIntensityStationCode = "/v2/earthquake/intensity/station/{code}";
-	/// /v2/earthquake/epicenter/{code}
-	static const getV2EarthquakeEpicenterCode = "/v2/earthquake/epicenter/{code}";
-}
+  /// /v2/earthquake
+  static const getV2Earthquake = "/v2/earthquake";
 
+  /// /v2/earthquake/{eventId}
+  static const getV2EarthquakeEventId = "/v2/earthquake/{eventId}";
+
+  /// /v2/earthquake/intensity/region/{code}
+  static const getV2EarthquakeIntensityRegionCode =
+      "/v2/earthquake/intensity/region/{code}";
+
+  /// /v2/earthquake/intensity/prefecture/{code}
+  static const getV2EarthquakeIntensityPrefectureCode =
+      "/v2/earthquake/intensity/prefecture/{code}";
+
+  /// /v2/earthquake/intensity/city/{code}
+  static const getV2EarthquakeIntensityCityCode =
+      "/v2/earthquake/intensity/city/{code}";
+
+  /// /v2/earthquake/intensity/station/{code}
+  static const getV2EarthquakeIntensityStationCode =
+      "/v2/earthquake/intensity/station/{code}";
+
+  /// /v2/earthquake/epicenter/{code}
+  static const getV2EarthquakeEpicenterCode = "/v2/earthquake/epicenter/{code}";
+}

--- a/packages/eqmonitor_api/lib/clients/eew_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/eew_api_client.dart
@@ -64,15 +64,16 @@ abstract class EewApiClient {
   });
 }
 
-
 abstract class EewApiClientUrls {
-	/// /v2/eew
-	static const getV2Eew = "/v2/eew";
-	/// /v2/eew/latest
-	static const getV2EewLatest = "/v2/eew/latest";
-	/// /v2/eew/{eventId}
-	static const getV2EewEventId = "/v2/eew/{eventId}";
-	/// /v2/eew/{eventId}/{serialNo}
-	static const getV2EewEventIdSerialNo = "/v2/eew/{eventId}/{serialNo}";
-}
+  /// /v2/eew
+  static const getV2Eew = "/v2/eew";
 
+  /// /v2/eew/latest
+  static const getV2EewLatest = "/v2/eew/latest";
+
+  /// /v2/eew/{eventId}
+  static const getV2EewEventId = "/v2/eew/{eventId}";
+
+  /// /v2/eew/{eventId}/{serialNo}
+  static const getV2EewEventIdSerialNo = "/v2/eew/{eventId}/{serialNo}";
+}

--- a/packages/eqmonitor_api/lib/clients/notification_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/notification_api_client.dart
@@ -15,11 +15,13 @@ part 'notification_api_client.g.dart';
 
 @RestApi()
 abstract class NotificationApiClient {
-  factory NotificationApiClient(Dio dio, {String? baseUrl}) = _NotificationApiClient;
+  factory NotificationApiClient(Dio dio, {String? baseUrl}) =
+      _NotificationApiClient;
 
   /// デバイスの通知履歴を取得
   @GET(NotificationApiClientUrls.getV2DeviceDeviceIdNotificationHistory)
-  Future<HttpResponse<NotificationHistoryResponse>> getV2DeviceDeviceIdNotificationHistory({
+  Future<HttpResponse<NotificationHistoryResponse>>
+  getV2DeviceDeviceIdNotificationHistory({
     @Path('deviceId') required String deviceId,
     @Query('cursor') String? cursor,
     @Query('limit') int? limit = 100,
@@ -27,34 +29,45 @@ abstract class NotificationApiClient {
 
   /// 配信サマリー一覧（admin）
   @GET(NotificationApiClientUrls.getV2DeviceDeviceIdNotificationDispatches)
-  Future<HttpResponse<DispatchSummaryListResponse>> getV2DeviceDeviceIdNotificationDispatches({
+  Future<HttpResponse<DispatchSummaryListResponse>>
+  getV2DeviceDeviceIdNotificationDispatches({
     @Path('deviceId') required String deviceId,
   });
 
   /// 配信サマリー詳細（admin）
-  @GET(NotificationApiClientUrls.getV2DeviceDeviceIdNotificationDispatchesCorrelationKey)
-  Future<HttpResponse<DispatchSummaryDetailResponse>> getV2DeviceDeviceIdNotificationDispatchesCorrelationKey({
+  @GET(
+    NotificationApiClientUrls
+        .getV2DeviceDeviceIdNotificationDispatchesCorrelationKey,
+  )
+  Future<HttpResponse<DispatchSummaryDetailResponse>>
+  getV2DeviceDeviceIdNotificationDispatchesCorrelationKey({
     @Path('deviceId') required String deviceId,
     @Path('correlationKey') required String correlationKey,
   });
 
   /// テスト通知を送信
   @POST(NotificationApiClientUrls.postV2DeviceDeviceIdNotificationTest)
-  Future<HttpResponse<TestNotificationResponse>> postV2DeviceDeviceIdNotificationTest({
+  Future<HttpResponse<TestNotificationResponse>>
+  postV2DeviceDeviceIdNotificationTest({
     @Path('deviceId') required String deviceId,
     @Body() required TestNotificationRequest body,
   });
 }
 
-
 abstract class NotificationApiClientUrls {
-	/// /v2/device/{deviceId}/notification/history
-	static const getV2DeviceDeviceIdNotificationHistory = "/v2/device/{deviceId}/notification/history";
-	/// /v2/device/{deviceId}/notification/dispatches
-	static const getV2DeviceDeviceIdNotificationDispatches = "/v2/device/{deviceId}/notification/dispatches";
-	/// /v2/device/{deviceId}/notification/dispatches/{correlationKey}
-	static const getV2DeviceDeviceIdNotificationDispatchesCorrelationKey = "/v2/device/{deviceId}/notification/dispatches/{correlationKey}";
-	/// /v2/device/{deviceId}/notification/test
-	static const postV2DeviceDeviceIdNotificationTest = "/v2/device/{deviceId}/notification/test";
-}
+  /// /v2/device/{deviceId}/notification/history
+  static const getV2DeviceDeviceIdNotificationHistory =
+      "/v2/device/{deviceId}/notification/history";
 
+  /// /v2/device/{deviceId}/notification/dispatches
+  static const getV2DeviceDeviceIdNotificationDispatches =
+      "/v2/device/{deviceId}/notification/dispatches";
+
+  /// /v2/device/{deviceId}/notification/dispatches/{correlationKey}
+  static const getV2DeviceDeviceIdNotificationDispatchesCorrelationKey =
+      "/v2/device/{deviceId}/notification/dispatches/{correlationKey}";
+
+  /// /v2/device/{deviceId}/notification/test
+  static const postV2DeviceDeviceIdNotificationTest =
+      "/v2/device/{deviceId}/notification/test";
+}

--- a/packages/eqmonitor_api/lib/clients/telegram_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/telegram_api_client.dart
@@ -54,15 +54,16 @@ abstract class TelegramApiClient {
   });
 }
 
-
 abstract class TelegramApiClientUrls {
-	/// /v2/telegram
-	static const getV2Telegram = "/v2/telegram";
-	/// /v2/telegram/type/{type}
-	static const getV2TelegramTypeType = "/v2/telegram/type/{type}";
-	/// /v2/telegram/eventId/{eventId}
-	static const getV2TelegramEventIdEventId = "/v2/telegram/eventId/{eventId}";
-	/// /v2/telegram/{id}
-	static const getV2TelegramId = "/v2/telegram/{id}";
-}
+  /// /v2/telegram
+  static const getV2Telegram = "/v2/telegram";
 
+  /// /v2/telegram/type/{type}
+  static const getV2TelegramTypeType = "/v2/telegram/type/{type}";
+
+  /// /v2/telegram/eventId/{eventId}
+  static const getV2TelegramEventIdEventId = "/v2/telegram/eventId/{eventId}";
+
+  /// /v2/telegram/{id}
+  static const getV2TelegramId = "/v2/telegram/{id}";
+}

--- a/packages/eqmonitor_api/lib/clients/tsunami_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/tsunami_api_client.dart
@@ -56,15 +56,17 @@ abstract class TsunamiApiClient {
   });
 }
 
-
 abstract class TsunamiApiClientUrls {
-	/// /v2/tsunami
-	static const getV2Tsunami = "/v2/tsunami";
-	/// /v2/tsunami/by-event-id/{eventId}
-	static const getV2TsunamiByEventIdEventId = "/v2/tsunami/by-event-id/{eventId}";
-	/// /v2/tsunami/active
-	static const getV2TsunamiActive = "/v2/tsunami/active";
-	/// /v2/tsunami/{tsunamiId}
-	static const getV2TsunamiTsunamiId = "/v2/tsunami/{tsunamiId}";
-}
+  /// /v2/tsunami
+  static const getV2Tsunami = "/v2/tsunami";
 
+  /// /v2/tsunami/by-event-id/{eventId}
+  static const getV2TsunamiByEventIdEventId =
+      "/v2/tsunami/by-event-id/{eventId}";
+
+  /// /v2/tsunami/active
+  static const getV2TsunamiActive = "/v2/tsunami/active";
+
+  /// /v2/tsunami/{tsunamiId}
+  static const getV2TsunamiTsunamiId = "/v2/tsunami/{tsunamiId}";
+}

--- a/packages/eqmonitor_api/lib/clients/user_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/user_api_client.dart
@@ -42,19 +42,22 @@ abstract class UserApiClient {
   });
 }
 
-
 abstract class UserApiClientUrls {
-	/// /v2/user/me
-	static const getV2UserMe = "/v2/user/me";
-	/// /v2/user/me
-	static const patchV2UserMe = "/v2/user/me";
-	/// /v2/user/me
-	static const deleteV2UserMe = "/v2/user/me";
-	/// /v2/user/me/devices
-	static const getV2UserMeDevices = "/v2/user/me/devices";
-	/// /v2/user/me/sessions
-	static const getV2UserMeSessions = "/v2/user/me/sessions";
-	/// /v2/user/me/sessions/{token}
-	static const deleteV2UserMeSessionsToken = "/v2/user/me/sessions/{token}";
-}
+  /// /v2/user/me
+  static const getV2UserMe = "/v2/user/me";
 
+  /// /v2/user/me
+  static const patchV2UserMe = "/v2/user/me";
+
+  /// /v2/user/me
+  static const deleteV2UserMe = "/v2/user/me";
+
+  /// /v2/user/me/devices
+  static const getV2UserMeDevices = "/v2/user/me/devices";
+
+  /// /v2/user/me/sessions
+  static const getV2UserMeSessions = "/v2/user/me/sessions";
+
+  /// /v2/user/me/sessions/{token}
+  static const deleteV2UserMeSessionsToken = "/v2/user/me/sessions/{token}";
+}

--- a/packages/eqmonitor_api/lib/clients/web_socket_api_client.dart
+++ b/packages/eqmonitor_api/lib/clients/web_socket_api_client.dart
@@ -18,9 +18,7 @@ abstract class WebSocketApiClient {
   Future<HttpResponse<WebsocketTicketResponse>> getV2WebsocketTicket();
 }
 
-
 abstract class WebSocketApiClientUrls {
-	/// /v2/websocket/ticket
-	static const getV2WebsocketTicket = "/v2/websocket/ticket";
+  /// /v2/websocket/ticket
+  static const getV2WebsocketTicket = "/v2/websocket/ticket";
 }
-

--- a/packages/eqmonitor_api/lib/export.dart
+++ b/packages/eqmonitor_api/lib/export.dart
@@ -142,4 +142,3 @@ export 'models/user_device_response_type.dart';
 export 'models/user_device_response_locale.dart';
 // Root client
 export 'api_client.dart';
-

--- a/packages/eqmonitor_api/lib/models/apns_environment.dart
+++ b/packages/eqmonitor_api/lib/models/apns_environment.dart
@@ -18,10 +18,12 @@ enum ApnsEnvironment {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/apns_token_request.dart
+++ b/packages/eqmonitor_api/lib/models/apns_token_request.dart
@@ -13,9 +13,9 @@ part 'apns_token_request.g.dart';
 abstract class ApnsTokenRequest with _$ApnsTokenRequest {
   const factory ApnsTokenRequest({
     required String token,
-    @JsonKey(includeIfNull: false)
-    ApnsEnvironment? environment,
+    @JsonKey(includeIfNull: false) ApnsEnvironment? environment,
   }) = _ApnsTokenRequest;
-  
-  factory ApnsTokenRequest.fromJson(Map<String, Object?> json) => _$ApnsTokenRequestFromJson(json);
+
+  factory ApnsTokenRequest.fromJson(Map<String, Object?> json) =>
+      _$ApnsTokenRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/apns_token_response.dart
+++ b/packages/eqmonitor_api/lib/models/apns_token_response.dart
@@ -17,6 +17,7 @@ abstract class ApnsTokenResponse with _$ApnsTokenResponse {
     required String token,
     required ApnsTokenResponseEnvironment environment,
   }) = _ApnsTokenResponse;
-  
-  factory ApnsTokenResponse.fromJson(Map<String, Object?> json) => _$ApnsTokenResponseFromJson(json);
+
+  factory ApnsTokenResponse.fromJson(Map<String, Object?> json) =>
+      _$ApnsTokenResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/apns_token_response_environment.dart
+++ b/packages/eqmonitor_api/lib/models/apns_token_response_environment.dart
@@ -17,10 +17,12 @@ enum ApnsTokenResponseEnvironment {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/apns_token_type.dart
+++ b/packages/eqmonitor_api/lib/models/apns_token_type.dart
@@ -18,10 +18,12 @@ enum ApnsTokenType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/bad_request_response.dart
+++ b/packages/eqmonitor_api/lib/models/bad_request_response.dart
@@ -12,9 +12,9 @@ abstract class BadRequestResponse with _$BadRequestResponse {
   const factory BadRequestResponse({
     required dynamic code,
     required dynamic message,
-    @JsonKey(includeIfNull: false)
-    String? reason,
+    @JsonKey(includeIfNull: false) String? reason,
   }) = _BadRequestResponse;
-  
-  factory BadRequestResponse.fromJson(Map<String, Object?> json) => _$BadRequestResponseFromJson(json);
+
+  factory BadRequestResponse.fromJson(Map<String, Object?> json) =>
+      _$BadRequestResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/code_name.dart
+++ b/packages/eqmonitor_api/lib/models/code_name.dart
@@ -10,10 +10,9 @@ part 'code_name.g.dart';
 /// コードと名前のペア
 @Freezed()
 abstract class CodeName with _$CodeName {
-  const factory CodeName({
-    required String code,
-    required String name,
-  }) = _CodeName;
-  
-  factory CodeName.fromJson(Map<String, Object?> json) => _$CodeNameFromJson(json);
+  const factory CodeName({required String code, required String name}) =
+      _CodeName;
+
+  factory CodeName.fromJson(Map<String, Object?> json) =>
+      _$CodeNameFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/coordinate.dart
+++ b/packages/eqmonitor_api/lib/models/coordinate.dart
@@ -16,17 +16,15 @@ abstract class Coordinate with _$Coordinate {
     required CoordinateType type,
 
     /// 緯度(typeがLAT_LNGのときのみ出現する)
-    @JsonKey(includeIfNull: false)
-    num? latitude,
+    @JsonKey(includeIfNull: false) num? latitude,
 
     /// 経度(typeがLAT_LNGのときのみ出現する)
-    @JsonKey(includeIfNull: false)
-    num? longitude,
+    @JsonKey(includeIfNull: false) num? longitude,
 
     /// 不明の場合のみ出現する
-    @JsonKey(includeIfNull: false)
-    String? condition,
+    @JsonKey(includeIfNull: false) String? condition,
   }) = _Coordinate;
-  
-  factory Coordinate.fromJson(Map<String, Object?> json) => _$CoordinateFromJson(json);
+
+  factory Coordinate.fromJson(Map<String, Object?> json) =>
+      _$CoordinateFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/coordinate_type.dart
+++ b/packages/eqmonitor_api/lib/models/coordinate_type.dart
@@ -18,10 +18,12 @@ enum CoordinateType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/depth.dart
+++ b/packages/eqmonitor_api/lib/models/depth.dart
@@ -16,9 +16,8 @@ abstract class Depth with _$Depth {
     required DepthType type,
 
     /// typeがNORMALのときのみ出現する
-    @JsonKey(includeIfNull: false)
-    num? value,
+    @JsonKey(includeIfNull: false) num? value,
   }) = _Depth;
-  
+
   factory Depth.fromJson(Map<String, Object?> json) => _$DepthFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/depth_type.dart
+++ b/packages/eqmonitor_api/lib/models/depth_type.dart
@@ -22,10 +22,12 @@ enum DepthType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/device_response.dart
+++ b/packages/eqmonitor_api/lib/models/device_response.dart
@@ -15,14 +15,12 @@ abstract class DeviceResponse with _$DeviceResponse {
   const factory DeviceResponse({
     required String id,
     required DeviceResponseType type,
-    @JsonKey(name: 'user_id')
-    required String userId,
+    @JsonKey(name: 'user_id') required String userId,
     required DeviceResponseLocale locale,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
-    @JsonKey(name: 'updated_at')
-    required String updatedAt,
+    @JsonKey(name: 'created_at') required String createdAt,
+    @JsonKey(name: 'updated_at') required String updatedAt,
   }) = _DeviceResponse;
-  
-  factory DeviceResponse.fromJson(Map<String, Object?> json) => _$DeviceResponseFromJson(json);
+
+  factory DeviceResponse.fromJson(Map<String, Object?> json) =>
+      _$DeviceResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/device_response_locale.dart
+++ b/packages/eqmonitor_api/lib/models/device_response_locale.dart
@@ -19,10 +19,12 @@ enum DeviceResponseLocale {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/device_response_type.dart
+++ b/packages/eqmonitor_api/lib/models/device_response_type.dart
@@ -17,10 +17,12 @@ enum DeviceResponseType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/dispatch_summary_detail_response.dart
+++ b/packages/eqmonitor_api/lib/models/dispatch_summary_detail_response.dart
@@ -10,10 +10,11 @@ part 'dispatch_summary_detail_response.freezed.dart';
 part 'dispatch_summary_detail_response.g.dart';
 
 @Freezed()
-abstract class DispatchSummaryDetailResponse with _$DispatchSummaryDetailResponse {
-  const factory DispatchSummaryDetailResponse({
-    required Item item,
-  }) = _DispatchSummaryDetailResponse;
-  
-  factory DispatchSummaryDetailResponse.fromJson(Map<String, Object?> json) => _$DispatchSummaryDetailResponseFromJson(json);
+abstract class DispatchSummaryDetailResponse
+    with _$DispatchSummaryDetailResponse {
+  const factory DispatchSummaryDetailResponse({required Item item}) =
+      _DispatchSummaryDetailResponse;
+
+  factory DispatchSummaryDetailResponse.fromJson(Map<String, Object?> json) =>
+      _$DispatchSummaryDetailResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/dispatch_summary_list_response.dart
+++ b/packages/eqmonitor_api/lib/models/dispatch_summary_list_response.dart
@@ -11,9 +11,9 @@ part 'dispatch_summary_list_response.g.dart';
 
 @Freezed()
 abstract class DispatchSummaryListResponse with _$DispatchSummaryListResponse {
-  const factory DispatchSummaryListResponse({
-    required List<Items> items,
-  }) = _DispatchSummaryListResponse;
-  
-  factory DispatchSummaryListResponse.fromJson(Map<String, Object?> json) => _$DispatchSummaryListResponseFromJson(json);
+  const factory DispatchSummaryListResponse({required List<Items> items}) =
+      _DispatchSummaryListResponse;
+
+  factory DispatchSummaryListResponse.fromJson(Map<String, Object?> json) =>
+      _$DispatchSummaryListResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/earthquake.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake.dart
@@ -18,26 +18,22 @@ part 'earthquake.g.dart';
 abstract class Earthquake with _$Earthquake {
   const factory Earthquake({
     /// yyyyMMddHHmmss形式のイベントID
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required TelegramStatus status,
     @JsonKey(name: 'origin_time_precision')
     required OriginTimePrecision originTimePrecision,
     required EarthquakeDatasource datasource,
     required List<Telegrams> telegrams,
-    @JsonKey(includeIfNull: false,name: 'origin_time')
-    DateTime? originTime,
-    @JsonKey(includeIfNull: false,name: 'arrival_time')
-    DateTime? arrivalTime,
-    @JsonKey(includeIfNull: false)
-    Hypocenter? hypocenter,
-    @JsonKey(includeIfNull: false)
-    Intensity? intensity,
+    @JsonKey(includeIfNull: false, name: 'origin_time') DateTime? originTime,
+    @JsonKey(includeIfNull: false, name: 'arrival_time') DateTime? arrivalTime,
+    @JsonKey(includeIfNull: false) Hypocenter? hypocenter,
+    @JsonKey(includeIfNull: false) Intensity? intensity,
 
     /// 推計震度PMTilesのフルURL
-    @JsonKey(includeIfNull: false,name: 'estimated_intensity_tile')
+    @JsonKey(includeIfNull: false, name: 'estimated_intensity_tile')
     String? estimatedIntensityTile,
   }) = _Earthquake;
-  
-  factory Earthquake.fromJson(Map<String, Object?> json) => _$EarthquakeFromJson(json);
+
+  factory Earthquake.fromJson(Map<String, Object?> json) =>
+      _$EarthquakeFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/earthquake_datasource.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake_datasource.dart
@@ -18,10 +18,12 @@ enum EarthquakeDatasource {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/earthquake_detail_response.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake_detail_response.dart
@@ -11,9 +11,9 @@ part 'earthquake_detail_response.g.dart';
 
 @Freezed()
 abstract class EarthquakeDetailResponse with _$EarthquakeDetailResponse {
-  const factory EarthquakeDetailResponse({
-    required Earthquake earthquake,
-  }) = _EarthquakeDetailResponse;
-  
-  factory EarthquakeDetailResponse.fromJson(Map<String, Object?> json) => _$EarthquakeDetailResponseFromJson(json);
+  const factory EarthquakeDetailResponse({required Earthquake earthquake}) =
+      _EarthquakeDetailResponse;
+
+  factory EarthquakeDetailResponse.fromJson(Map<String, Object?> json) =>
+      _$EarthquakeDetailResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/earthquake_list_response.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake_list_response.dart
@@ -15,13 +15,12 @@ abstract class EarthquakeListResponse with _$EarthquakeListResponse {
     required List<EarthquakePartial> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _EarthquakeListResponse;
-  
-  factory EarthquakeListResponse.fromJson(Map<String, Object?> json) => _$EarthquakeListResponseFromJson(json);
+
+  factory EarthquakeListResponse.fromJson(Map<String, Object?> json) =>
+      _$EarthquakeListResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/earthquake_partial.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake_partial.dart
@@ -17,25 +17,21 @@ part 'earthquake_partial.g.dart';
 abstract class EarthquakePartial with _$EarthquakePartial {
   const factory EarthquakePartial({
     /// yyyyMMddHHmmss形式のイベントID
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required TelegramStatus status,
     @JsonKey(name: 'origin_time_precision')
     required OriginTimePrecision originTimePrecision,
     required EarthquakeDatasource datasource,
-    @JsonKey(includeIfNull: false,name: 'origin_time')
-    DateTime? originTime,
-    @JsonKey(includeIfNull: false,name: 'arrival_time')
-    DateTime? arrivalTime,
-    @JsonKey(includeIfNull: false)
-    Hypocenter? hypocenter,
+    @JsonKey(includeIfNull: false, name: 'origin_time') DateTime? originTime,
+    @JsonKey(includeIfNull: false, name: 'arrival_time') DateTime? arrivalTime,
+    @JsonKey(includeIfNull: false) Hypocenter? hypocenter,
 
     /// 推計震度PMTilesのフルURL
-    @JsonKey(includeIfNull: false,name: 'estimated_intensity_tile')
+    @JsonKey(includeIfNull: false, name: 'estimated_intensity_tile')
     String? estimatedIntensityTile,
-    @JsonKey(includeIfNull: false)
-    Intensity? intensity,
+    @JsonKey(includeIfNull: false) Intensity? intensity,
   }) = _EarthquakePartial;
-  
-  factory EarthquakePartial.fromJson(Map<String, Object?> json) => _$EarthquakePartialFromJson(json);
+
+  factory EarthquakePartial.fromJson(Map<String, Object?> json) =>
+      _$EarthquakePartialFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/earthquake_settings_request.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake_settings_request.dart
@@ -12,13 +12,13 @@ part 'earthquake_settings_request.g.dart';
 @Freezed()
 abstract class EarthquakeSettingsRequest with _$EarthquakeSettingsRequest {
   const factory EarthquakeSettingsRequest({
-    @JsonKey(includeIfNull: false)
-    bool? enabled,
-    @JsonKey(includeIfNull: false,name: 'notification_tiers')
+    @JsonKey(includeIfNull: false) bool? enabled,
+    @JsonKey(includeIfNull: false, name: 'notification_tiers')
     List<NotificationTiers2>? notificationTiers,
-    @JsonKey(includeIfNull: false,name: 'estimated_intensity_enabled')
+    @JsonKey(includeIfNull: false, name: 'estimated_intensity_enabled')
     bool? estimatedIntensityEnabled,
   }) = _EarthquakeSettingsRequest;
-  
-  factory EarthquakeSettingsRequest.fromJson(Map<String, Object?> json) => _$EarthquakeSettingsRequestFromJson(json);
+
+  factory EarthquakeSettingsRequest.fromJson(Map<String, Object?> json) =>
+      _$EarthquakeSettingsRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/earthquake_settings_response.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake_settings_response.dart
@@ -18,6 +18,7 @@ abstract class EarthquakeSettingsResponse with _$EarthquakeSettingsResponse {
     @JsonKey(name: 'estimated_intensity_enabled')
     required bool estimatedIntensityEnabled,
   }) = _EarthquakeSettingsResponse;
-  
-  factory EarthquakeSettingsResponse.fromJson(Map<String, Object?> json) => _$EarthquakeSettingsResponseFromJson(json);
+
+  factory EarthquakeSettingsResponse.fromJson(Map<String, Object?> json) =>
+      _$EarthquakeSettingsResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/earthquake_sort_by.dart
+++ b/packages/eqmonitor_api/lib/models/earthquake_sort_by.dart
@@ -26,10 +26,12 @@ enum EarthquakeSortBy {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/eew_accuracy.dart
+++ b/packages/eqmonitor_api/lib/models/eew_accuracy.dart
@@ -20,13 +20,13 @@ abstract class EewAccuracy with _$EewAccuracy {
     required num depth,
 
     /// マグニチュードの精度値
-    @JsonKey(name: 'magnitude_calculation')
-    required num magnitudeCalculation,
+    @JsonKey(name: 'magnitude_calculation') required num magnitudeCalculation,
 
     /// マグニチュード計算使用観測点数
     @JsonKey(name: 'number_of_magnitude_calculation')
     required num numberOfMagnitudeCalculation,
   }) = _EewAccuracy;
-  
-  factory EewAccuracy.fromJson(Map<String, Object?> json) => _$EewAccuracyFromJson(json);
+
+  factory EewAccuracy.fromJson(Map<String, Object?> json) =>
+      _$EewAccuracyFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_array_response.dart
+++ b/packages/eqmonitor_api/lib/models/eew_array_response.dart
@@ -11,9 +11,9 @@ part 'eew_array_response.g.dart';
 
 @Freezed()
 abstract class EewArrayResponse with _$EewArrayResponse {
-  const factory EewArrayResponse({
-    required List<EewItemWithRelations> items,
-  }) = _EewArrayResponse;
-  
-  factory EewArrayResponse.fromJson(Map<String, Object?> json) => _$EewArrayResponseFromJson(json);
+  const factory EewArrayResponse({required List<EewItemWithRelations> items}) =
+      _EewArrayResponse;
+
+  factory EewArrayResponse.fromJson(Map<String, Object?> json) =>
+      _$EewArrayResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_hypocenter.dart
+++ b/packages/eqmonitor_api/lib/models/eew_hypocenter.dart
@@ -16,15 +16,13 @@ abstract class EewHypocenter with _$EewHypocenter {
   const factory EewHypocenter({
     required CodeName value,
     required Coordinate coordinates,
-    @JsonKey(includeIfNull: true)
-    required num? magnitude,
+    @JsonKey(includeIfNull: true) required num? magnitude,
 
     /// 震源の深さ `0`: `ごく浅い`, `700`: `700km以上`, `null`: `不明`
-    @JsonKey(includeIfNull: true)
-    required num? depth,
-    @JsonKey(includeIfNull: false)
-    CodeName? detailed,
+    @JsonKey(includeIfNull: true) required num? depth,
+    @JsonKey(includeIfNull: false) CodeName? detailed,
   }) = _EewHypocenter;
-  
-  factory EewHypocenter.fromJson(Map<String, Object?> json) => _$EewHypocenterFromJson(json);
+
+  factory EewHypocenter.fromJson(Map<String, Object?> json) =>
+      _$EewHypocenterFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_intensity.dart
+++ b/packages/eqmonitor_api/lib/models/eew_intensity.dart
@@ -16,11 +16,12 @@ part 'eew_intensity.g.dart';
 abstract class EewIntensity with _$EewIntensity {
   const factory EewIntensity({
     required List<EewIntensityItem> regions,
-    @JsonKey(includeIfNull: false,name: 'max_intensity')
+    @JsonKey(includeIfNull: false, name: 'max_intensity')
     EewIntensityValue? maxIntensity,
-    @JsonKey(includeIfNull: false,name: 'max_lpgm_intensity')
+    @JsonKey(includeIfNull: false, name: 'max_lpgm_intensity')
     EewIntensityLpgmValue? maxLpgmIntensity,
   }) = _EewIntensity;
-  
-  factory EewIntensity.fromJson(Map<String, Object?> json) => _$EewIntensityFromJson(json);
+
+  factory EewIntensity.fromJson(Map<String, Object?> json) =>
+      _$EewIntensityFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_intensity_item.dart
+++ b/packages/eqmonitor_api/lib/models/eew_intensity_item.dart
@@ -15,18 +15,16 @@ part 'eew_intensity_item.g.dart';
 abstract class EewIntensityItem with _$EewIntensityItem {
   const factory EewIntensityItem({
     required CodeName value,
-    @JsonKey(name: 'is_plum')
-    required bool isPlum,
-    @JsonKey(name: 'is_warning')
-    required bool isWarning,
+    @JsonKey(name: 'is_plum') required bool isPlum,
+    @JsonKey(name: 'is_warning') required bool isWarning,
     required EewIntensityValue intensity,
-    @JsonKey(includeIfNull: false,name: 'lpgm_intensity')
+    @JsonKey(includeIfNull: false, name: 'lpgm_intensity')
     EewIntensityLpgmValue? lpgmIntensity,
 
     /// 到達予想時刻。undefinedの場合は、すでに到達済みと推定されます。
-    @JsonKey(includeIfNull: false,name: 'arrival_time')
-    DateTime? arrivalTime,
+    @JsonKey(includeIfNull: false, name: 'arrival_time') DateTime? arrivalTime,
   }) = _EewIntensityItem;
-  
-  factory EewIntensityItem.fromJson(Map<String, Object?> json) => _$EewIntensityItemFromJson(json);
+
+  factory EewIntensityItem.fromJson(Map<String, Object?> json) =>
+      _$EewIntensityItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_intensity_lpgm_value.dart
+++ b/packages/eqmonitor_api/lib/models/eew_intensity_lpgm_value.dart
@@ -14,9 +14,9 @@ part 'eew_intensity_lpgm_value.g.dart';
 abstract class EewIntensityLpgmValue with _$EewIntensityLpgmValue {
   const factory EewIntensityLpgmValue({
     required JmaLpgmIntensity value,
-    @JsonKey(name: 'is_over')
-    required bool isOver,
+    @JsonKey(name: 'is_over') required bool isOver,
   }) = _EewIntensityLpgmValue;
-  
-  factory EewIntensityLpgmValue.fromJson(Map<String, Object?> json) => _$EewIntensityLpgmValueFromJson(json);
+
+  factory EewIntensityLpgmValue.fromJson(Map<String, Object?> json) =>
+      _$EewIntensityLpgmValueFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_intensity_value.dart
+++ b/packages/eqmonitor_api/lib/models/eew_intensity_value.dart
@@ -14,9 +14,9 @@ part 'eew_intensity_value.g.dart';
 abstract class EewIntensityValue with _$EewIntensityValue {
   const factory EewIntensityValue({
     required JmaIntensity value,
-    @JsonKey(name: 'is_over')
-    required bool isOver,
+    @JsonKey(name: 'is_over') required bool isOver,
   }) = _EewIntensityValue;
-  
-  factory EewIntensityValue.fromJson(Map<String, Object?> json) => _$EewIntensityValueFromJson(json);
+
+  factory EewIntensityValue.fromJson(Map<String, Object?> json) =>
+      _$EewIntensityValueFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_item_with_relations.dart
+++ b/packages/eqmonitor_api/lib/models/eew_item_with_relations.dart
@@ -19,41 +19,30 @@ part 'eew_item_with_relations.g.dart';
 abstract class EewItemWithRelations with _$EewItemWithRelations {
   const factory EewItemWithRelations({
     /// yyyyMMddHHmmss形式のイベントID
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required TelegramType type,
     required TelegramStatus status,
-    @JsonKey(name: 'info_type')
-    required EewItemWithRelationsInfoType infoType,
-    @JsonKey(name: 'serial_no')
-    required num serialNo,
-    @JsonKey(includeIfNull: true)
-    required String? headline,
-    @JsonKey(name: 'is_canceled')
-    required bool isCanceled,
-    @JsonKey(includeIfNull: true,name: 'is_warning')
-    required bool? isWarning,
-    @JsonKey(name: 'is_last_info')
-    required bool isLastInfo,
-    @JsonKey(includeIfNull: true,name: 'origin_time')
+    @JsonKey(name: 'info_type') required EewItemWithRelationsInfoType infoType,
+    @JsonKey(name: 'serial_no') required num serialNo,
+    @JsonKey(includeIfNull: true) required String? headline,
+    @JsonKey(name: 'is_canceled') required bool isCanceled,
+    @JsonKey(includeIfNull: true, name: 'is_warning') required bool? isWarning,
+    @JsonKey(name: 'is_last_info') required bool isLastInfo,
+    @JsonKey(includeIfNull: true, name: 'origin_time')
     required DateTime? originTime,
-    @JsonKey(includeIfNull: true,name: 'arrival_time')
+    @JsonKey(includeIfNull: true, name: 'arrival_time')
     required DateTime? arrivalTime,
-    @JsonKey(includeIfNull: true)
-    required EewAccuracy? accuracy,
-    @JsonKey(name: 'is_plum')
-    required bool isPlum,
-    @JsonKey(includeIfNull: true,name: 'editorial_office')
+    @JsonKey(includeIfNull: true) required EewAccuracy? accuracy,
+    @JsonKey(name: 'is_plum') required bool isPlum,
+    @JsonKey(includeIfNull: true, name: 'editorial_office')
     required String? editorialOffice,
-    @JsonKey(name: 'report_time')
-    required DateTime reportTime,
-    @JsonKey(includeIfNull: false)
-    EewHypocenter? hypocenter,
-    @JsonKey(includeIfNull: false,name: 'forecast_intensity')
+    @JsonKey(name: 'report_time') required DateTime reportTime,
+    @JsonKey(includeIfNull: false) EewHypocenter? hypocenter,
+    @JsonKey(includeIfNull: false, name: 'forecast_intensity')
     EewIntensity? forecastIntensity,
-    @JsonKey(includeIfNull: false)
-    EewWarning? warning,
+    @JsonKey(includeIfNull: false) EewWarning? warning,
   }) = _EewItemWithRelations;
-  
-  factory EewItemWithRelations.fromJson(Map<String, Object?> json) => _$EewItemWithRelationsFromJson(json);
+
+  factory EewItemWithRelations.fromJson(Map<String, Object?> json) =>
+      _$EewItemWithRelationsFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_item_with_relations_info_type.dart
+++ b/packages/eqmonitor_api/lib/models/eew_item_with_relations_info_type.dart
@@ -21,10 +21,12 @@ enum EewItemWithRelationsInfoType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/eew_latest_response.dart
+++ b/packages/eqmonitor_api/lib/models/eew_latest_response.dart
@@ -11,9 +11,9 @@ part 'eew_latest_response.g.dart';
 
 @Freezed()
 abstract class EewLatestResponse with _$EewLatestResponse {
-  const factory EewLatestResponse({
-    required List<EewItemWithRelations> items,
-  }) = _EewLatestResponse;
-  
-  factory EewLatestResponse.fromJson(Map<String, Object?> json) => _$EewLatestResponseFromJson(json);
+  const factory EewLatestResponse({required List<EewItemWithRelations> items}) =
+      _EewLatestResponse;
+
+  factory EewLatestResponse.fromJson(Map<String, Object?> json) =>
+      _$EewLatestResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_list_response.dart
+++ b/packages/eqmonitor_api/lib/models/eew_list_response.dart
@@ -15,13 +15,12 @@ abstract class EewListResponse with _$EewListResponse {
     required List<EewItemWithRelations> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _EewListResponse;
-  
-  factory EewListResponse.fromJson(Map<String, Object?> json) => _$EewListResponseFromJson(json);
+
+  factory EewListResponse.fromJson(Map<String, Object?> json) =>
+      _$EewListResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_settings_request.dart
+++ b/packages/eqmonitor_api/lib/models/eew_settings_request.dart
@@ -12,13 +12,13 @@ part 'eew_settings_request.g.dart';
 @Freezed()
 abstract class EewSettingsRequest with _$EewSettingsRequest {
   const factory EewSettingsRequest({
-    @JsonKey(includeIfNull: false)
-    bool? enabled,
-    @JsonKey(includeIfNull: false,name: 'notification_tiers')
+    @JsonKey(includeIfNull: false) bool? enabled,
+    @JsonKey(includeIfNull: false, name: 'notification_tiers')
     List<NotificationTiers4>? notificationTiers,
-    @JsonKey(includeIfNull: false,name: 'start_live_activity')
+    @JsonKey(includeIfNull: false, name: 'start_live_activity')
     bool? startLiveActivity,
   }) = _EewSettingsRequest;
-  
-  factory EewSettingsRequest.fromJson(Map<String, Object?> json) => _$EewSettingsRequestFromJson(json);
+
+  factory EewSettingsRequest.fromJson(Map<String, Object?> json) =>
+      _$EewSettingsRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_settings_response.dart
+++ b/packages/eqmonitor_api/lib/models/eew_settings_response.dart
@@ -15,9 +15,9 @@ abstract class EewSettingsResponse with _$EewSettingsResponse {
     required bool enabled,
     @JsonKey(name: 'notification_tiers')
     required List<NotificationTiers3> notificationTiers,
-    @JsonKey(name: 'start_live_activity')
-    required bool startLiveActivity,
+    @JsonKey(name: 'start_live_activity') required bool startLiveActivity,
   }) = _EewSettingsResponse;
-  
-  factory EewSettingsResponse.fromJson(Map<String, Object?> json) => _$EewSettingsResponseFromJson(json);
+
+  factory EewSettingsResponse.fromJson(Map<String, Object?> json) =>
+      _$EewSettingsResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_warning.dart
+++ b/packages/eqmonitor_api/lib/models/eew_warning.dart
@@ -16,6 +16,7 @@ abstract class EewWarning with _$EewWarning {
     required List<EewWarningZoneItem> prefectures,
     required List<EewWarningZoneItem> regions,
   }) = _EewWarning;
-  
-  factory EewWarning.fromJson(Map<String, Object?> json) => _$EewWarningFromJson(json);
+
+  factory EewWarning.fromJson(Map<String, Object?> json) =>
+      _$EewWarningFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/eew_warning_zone_item.dart
+++ b/packages/eqmonitor_api/lib/models/eew_warning_zone_item.dart
@@ -15,9 +15,9 @@ abstract class EewWarningZoneItem with _$EewWarningZoneItem {
     required CodeName value,
 
     /// 前回の情報において、警報だったかどうか
-    @JsonKey(name: 'had_warning')
-    required bool hadWarning,
+    @JsonKey(name: 'had_warning') required bool hadWarning,
   }) = _EewWarningZoneItem;
-  
-  factory EewWarningZoneItem.fromJson(Map<String, Object?> json) => _$EewWarningZoneItemFromJson(json);
+
+  factory EewWarningZoneItem.fromJson(Map<String, Object?> json) =>
+      _$EewWarningZoneItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/epicenter_info.dart
+++ b/packages/eqmonitor_api/lib/models/epicenter_info.dart
@@ -9,10 +9,9 @@ part 'epicenter_info.g.dart';
 
 @Freezed()
 abstract class EpicenterInfo with _$EpicenterInfo {
-  const factory EpicenterInfo({
-    required num code,
-    required String name,
-  }) = _EpicenterInfo;
-  
-  factory EpicenterInfo.fromJson(Map<String, Object?> json) => _$EpicenterInfoFromJson(json);
+  const factory EpicenterInfo({required num code, required String name}) =
+      _EpicenterInfo;
+
+  factory EpicenterInfo.fromJson(Map<String, Object?> json) =>
+      _$EpicenterInfoFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/epicenter_search_item.dart
+++ b/packages/eqmonitor_api/lib/models/epicenter_search_item.dart
@@ -13,11 +13,11 @@ part 'epicenter_search_item.g.dart';
 @Freezed()
 abstract class EpicenterSearchItem with _$EpicenterSearchItem {
   const factory EpicenterSearchItem({
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required EpicenterInfo epicenter,
     required EarthquakePartial earthquake,
   }) = _EpicenterSearchItem;
-  
-  factory EpicenterSearchItem.fromJson(Map<String, Object?> json) => _$EpicenterSearchItemFromJson(json);
+
+  factory EpicenterSearchItem.fromJson(Map<String, Object?> json) =>
+      _$EpicenterSearchItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/epicenter_search_response.dart
+++ b/packages/eqmonitor_api/lib/models/epicenter_search_response.dart
@@ -15,13 +15,12 @@ abstract class EpicenterSearchResponse with _$EpicenterSearchResponse {
     required List<EpicenterSearchItem> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _EpicenterSearchResponse;
-  
-  factory EpicenterSearchResponse.fromJson(Map<String, Object?> json) => _$EpicenterSearchResponseFromJson(json);
+
+  factory EpicenterSearchResponse.fromJson(Map<String, Object?> json) =>
+      _$EpicenterSearchResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/fcm_token_request.dart
+++ b/packages/eqmonitor_api/lib/models/fcm_token_request.dart
@@ -9,9 +9,8 @@ part 'fcm_token_request.g.dart';
 
 @Freezed()
 abstract class FcmTokenRequest with _$FcmTokenRequest {
-  const factory FcmTokenRequest({
-    required String token,
-  }) = _FcmTokenRequest;
-  
-  factory FcmTokenRequest.fromJson(Map<String, Object?> json) => _$FcmTokenRequestFromJson(json);
+  const factory FcmTokenRequest({required String token}) = _FcmTokenRequest;
+
+  factory FcmTokenRequest.fromJson(Map<String, Object?> json) =>
+      _$FcmTokenRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/fcm_token_response.dart
+++ b/packages/eqmonitor_api/lib/models/fcm_token_response.dart
@@ -9,9 +9,8 @@ part 'fcm_token_response.g.dart';
 
 @Freezed()
 abstract class FcmTokenResponse with _$FcmTokenResponse {
-  const factory FcmTokenResponse({
-    required String token,
-  }) = _FcmTokenResponse;
-  
-  factory FcmTokenResponse.fromJson(Map<String, Object?> json) => _$FcmTokenResponseFromJson(json);
+  const factory FcmTokenResponse({required String token}) = _FcmTokenResponse;
+
+  factory FcmTokenResponse.fromJson(Map<String, Object?> json) =>
+      _$FcmTokenResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/forbidden_response.dart
+++ b/packages/eqmonitor_api/lib/models/forbidden_response.dart
@@ -13,6 +13,7 @@ abstract class ForbiddenResponse with _$ForbiddenResponse {
     required dynamic code,
     required String message,
   }) = _ForbiddenResponse;
-  
-  factory ForbiddenResponse.fromJson(Map<String, Object?> json) => _$ForbiddenResponseFromJson(json);
+
+  factory ForbiddenResponse.fromJson(Map<String, Object?> json) =>
+      _$ForbiddenResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/hypocenter.dart
+++ b/packages/eqmonitor_api/lib/models/hypocenter.dart
@@ -21,11 +21,10 @@ abstract class Hypocenter with _$Hypocenter {
     required Coordinate coordinates,
     required Magnitude magnitude,
     required Depth depth,
-    @JsonKey(includeIfNull: false)
-    CodeName? detailed,
-    @JsonKey(includeIfNull: false)
-    HypocenterAuxiliary? auxiliary,
+    @JsonKey(includeIfNull: false) CodeName? detailed,
+    @JsonKey(includeIfNull: false) HypocenterAuxiliary? auxiliary,
   }) = _Hypocenter;
-  
-  factory Hypocenter.fromJson(Map<String, Object?> json) => _$HypocenterFromJson(json);
+
+  factory Hypocenter.fromJson(Map<String, Object?> json) =>
+      _$HypocenterFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/hypocenter_auxiliary.dart
+++ b/packages/eqmonitor_api/lib/models/hypocenter_auxiliary.dart
@@ -14,9 +14,9 @@ abstract class HypocenterAuxiliary with _$HypocenterAuxiliary {
     required String code,
     required String name,
     required String direction,
-    @JsonKey(name: 'distance_km')
-    required num distanceKm,
+    @JsonKey(name: 'distance_km') required num distanceKm,
   }) = _HypocenterAuxiliary;
-  
-  factory HypocenterAuxiliary.fromJson(Map<String, Object?> json) => _$HypocenterAuxiliaryFromJson(json);
+
+  factory HypocenterAuxiliary.fromJson(Map<String, Object?> json) =>
+      _$HypocenterAuxiliaryFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/info_type.dart
+++ b/packages/eqmonitor_api/lib/models/info_type.dart
@@ -21,10 +21,12 @@ enum InfoType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/intensity.dart
+++ b/packages/eqmonitor_api/lib/models/intensity.dart
@@ -14,13 +14,13 @@ part 'intensity.g.dart';
 @Freezed()
 abstract class Intensity with _$Intensity {
   const factory Intensity({
-    @JsonKey(name: 'max_intensity')
-    required JmaIntensity maxIntensity,
+    @JsonKey(name: 'max_intensity') required JmaIntensity maxIntensity,
     required List<IntensityItem> prefectures,
     required List<IntensityItem> regions,
-    @JsonKey(includeIfNull: false,name: 'max_lpgm_intensity')
+    @JsonKey(includeIfNull: false, name: 'max_lpgm_intensity')
     JmaLpgmIntensity? maxLpgmIntensity,
   }) = _Intensity;
-  
-  factory Intensity.fromJson(Map<String, Object?> json) => _$IntensityFromJson(json);
+
+  factory Intensity.fromJson(Map<String, Object?> json) =>
+      _$IntensityFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_city_search_item.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_city_search_item.dart
@@ -13,11 +13,11 @@ part 'intensity_city_search_item.g.dart';
 @Freezed()
 abstract class IntensityCitySearchItem with _$IntensityCitySearchItem {
   const factory IntensityCitySearchItem({
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required IntensityRegionInfo city,
     required EarthquakePartial earthquake,
   }) = _IntensityCitySearchItem;
-  
-  factory IntensityCitySearchItem.fromJson(Map<String, Object?> json) => _$IntensityCitySearchItemFromJson(json);
+
+  factory IntensityCitySearchItem.fromJson(Map<String, Object?> json) =>
+      _$IntensityCitySearchItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_city_search_response.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_city_search_response.dart
@@ -15,13 +15,12 @@ abstract class IntensityCitySearchResponse with _$IntensityCitySearchResponse {
     required List<IntensityCitySearchItem> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _IntensityCitySearchResponse;
-  
-  factory IntensityCitySearchResponse.fromJson(Map<String, Object?> json) => _$IntensityCitySearchResponseFromJson(json);
+
+  factory IntensityCitySearchResponse.fromJson(Map<String, Object?> json) =>
+      _$IntensityCitySearchResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_item.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_item.dart
@@ -15,11 +15,12 @@ part 'intensity_item.g.dart';
 abstract class IntensityItem with _$IntensityItem {
   const factory IntensityItem({
     required CodeName value,
-    @JsonKey(includeIfNull: false,name: 'max_intensity')
+    @JsonKey(includeIfNull: false, name: 'max_intensity')
     JmaIntensity? maxIntensity,
-    @JsonKey(includeIfNull: false,name: 'max_lpgm_intensity')
+    @JsonKey(includeIfNull: false, name: 'max_lpgm_intensity')
     JmaLpgmIntensity? maxLpgmIntensity,
   }) = _IntensityItem;
-  
-  factory IntensityItem.fromJson(Map<String, Object?> json) => _$IntensityItemFromJson(json);
+
+  factory IntensityItem.fromJson(Map<String, Object?> json) =>
+      _$IntensityItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_prefecture_search_item.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_prefecture_search_item.dart
@@ -11,13 +11,14 @@ part 'intensity_prefecture_search_item.freezed.dart';
 part 'intensity_prefecture_search_item.g.dart';
 
 @Freezed()
-abstract class IntensityPrefectureSearchItem with _$IntensityPrefectureSearchItem {
+abstract class IntensityPrefectureSearchItem
+    with _$IntensityPrefectureSearchItem {
   const factory IntensityPrefectureSearchItem({
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required IntensityRegionInfo prefecture,
     required EarthquakePartial earthquake,
   }) = _IntensityPrefectureSearchItem;
-  
-  factory IntensityPrefectureSearchItem.fromJson(Map<String, Object?> json) => _$IntensityPrefectureSearchItemFromJson(json);
+
+  factory IntensityPrefectureSearchItem.fromJson(Map<String, Object?> json) =>
+      _$IntensityPrefectureSearchItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_prefecture_search_response.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_prefecture_search_response.dart
@@ -10,18 +10,19 @@ part 'intensity_prefecture_search_response.freezed.dart';
 part 'intensity_prefecture_search_response.g.dart';
 
 @Freezed()
-abstract class IntensityPrefectureSearchResponse with _$IntensityPrefectureSearchResponse {
+abstract class IntensityPrefectureSearchResponse
+    with _$IntensityPrefectureSearchResponse {
   const factory IntensityPrefectureSearchResponse({
     required List<IntensityPrefectureSearchItem> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _IntensityPrefectureSearchResponse;
-  
-  factory IntensityPrefectureSearchResponse.fromJson(Map<String, Object?> json) => _$IntensityPrefectureSearchResponseFromJson(json);
+
+  factory IntensityPrefectureSearchResponse.fromJson(
+    Map<String, Object?> json,
+  ) => _$IntensityPrefectureSearchResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_region_info.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_region_info.dart
@@ -15,11 +15,11 @@ abstract class IntensityRegionInfo with _$IntensityRegionInfo {
   const factory IntensityRegionInfo({
     required String code,
     required String name,
-    @JsonKey(includeIfNull: true)
-    required JmaIntensity? intensity,
-    @JsonKey(includeIfNull: true,name: 'lpgm_intensity')
+    @JsonKey(includeIfNull: true) required JmaIntensity? intensity,
+    @JsonKey(includeIfNull: true, name: 'lpgm_intensity')
     required JmaLpgmIntensity? lpgmIntensity,
   }) = _IntensityRegionInfo;
-  
-  factory IntensityRegionInfo.fromJson(Map<String, Object?> json) => _$IntensityRegionInfoFromJson(json);
+
+  factory IntensityRegionInfo.fromJson(Map<String, Object?> json) =>
+      _$IntensityRegionInfoFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_region_search_item.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_region_search_item.dart
@@ -13,11 +13,11 @@ part 'intensity_region_search_item.g.dart';
 @Freezed()
 abstract class IntensityRegionSearchItem with _$IntensityRegionSearchItem {
   const factory IntensityRegionSearchItem({
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required IntensityRegionInfo region,
     required EarthquakePartial earthquake,
   }) = _IntensityRegionSearchItem;
-  
-  factory IntensityRegionSearchItem.fromJson(Map<String, Object?> json) => _$IntensityRegionSearchItemFromJson(json);
+
+  factory IntensityRegionSearchItem.fromJson(Map<String, Object?> json) =>
+      _$IntensityRegionSearchItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_region_search_response.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_region_search_response.dart
@@ -10,18 +10,18 @@ part 'intensity_region_search_response.freezed.dart';
 part 'intensity_region_search_response.g.dart';
 
 @Freezed()
-abstract class IntensityRegionSearchResponse with _$IntensityRegionSearchResponse {
+abstract class IntensityRegionSearchResponse
+    with _$IntensityRegionSearchResponse {
   const factory IntensityRegionSearchResponse({
     required List<IntensityRegionSearchItem> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _IntensityRegionSearchResponse;
-  
-  factory IntensityRegionSearchResponse.fromJson(Map<String, Object?> json) => _$IntensityRegionSearchResponseFromJson(json);
+
+  factory IntensityRegionSearchResponse.fromJson(Map<String, Object?> json) =>
+      _$IntensityRegionSearchResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_station_info.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_station_info.dart
@@ -16,15 +16,14 @@ abstract class IntensityStationInfo with _$IntensityStationInfo {
   const factory IntensityStationInfo({
     required String code,
     required String name,
-    @JsonKey(includeIfNull: true)
-    required JmaIntensity? intensity,
-    @JsonKey(includeIfNull: true,name: 'lpgm_intensity')
+    @JsonKey(includeIfNull: true) required JmaIntensity? intensity,
+    @JsonKey(includeIfNull: true, name: 'lpgm_intensity')
     required JmaLpgmIntensity? lpgmIntensity,
-    @JsonKey(includeIfNull: true)
-    required num? sva,
-    @JsonKey(includeIfNull: true,name: 'pre_periods')
+    @JsonKey(includeIfNull: true) required num? sva,
+    @JsonKey(includeIfNull: true, name: 'pre_periods')
     required List<PrePeriods2>? prePeriods,
   }) = _IntensityStationInfo;
-  
-  factory IntensityStationInfo.fromJson(Map<String, Object?> json) => _$IntensityStationInfoFromJson(json);
+
+  factory IntensityStationInfo.fromJson(Map<String, Object?> json) =>
+      _$IntensityStationInfoFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_station_item.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_station_item.dart
@@ -22,11 +22,12 @@ abstract class IntensityStationItem with _$IntensityStationItem {
 
     /// 1秒～7秒の範囲で1秒毎の周期帯における長周期地震動階級と絶対応答スペクトル
     required List<PrePeriods> prePeriods,
-    @JsonKey(includeIfNull: false,name: 'max_intensity')
+    @JsonKey(includeIfNull: false, name: 'max_intensity')
     JmaIntensity? maxIntensity,
-    @JsonKey(includeIfNull: false,name: 'max_lpgm_intensity')
+    @JsonKey(includeIfNull: false, name: 'max_lpgm_intensity')
     JmaLpgmIntensity? maxLpgmIntensity,
   }) = _IntensityStationItem;
-  
-  factory IntensityStationItem.fromJson(Map<String, Object?> json) => _$IntensityStationItemFromJson(json);
+
+  factory IntensityStationItem.fromJson(Map<String, Object?> json) =>
+      _$IntensityStationItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_station_search_item.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_station_search_item.dart
@@ -13,11 +13,11 @@ part 'intensity_station_search_item.g.dart';
 @Freezed()
 abstract class IntensityStationSearchItem with _$IntensityStationSearchItem {
   const factory IntensityStationSearchItem({
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required IntensityStationInfo station,
     required EarthquakePartial earthquake,
   }) = _IntensityStationSearchItem;
-  
-  factory IntensityStationSearchItem.fromJson(Map<String, Object?> json) => _$IntensityStationSearchItemFromJson(json);
+
+  factory IntensityStationSearchItem.fromJson(Map<String, Object?> json) =>
+      _$IntensityStationSearchItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/intensity_station_search_response.dart
+++ b/packages/eqmonitor_api/lib/models/intensity_station_search_response.dart
@@ -10,18 +10,18 @@ part 'intensity_station_search_response.freezed.dart';
 part 'intensity_station_search_response.g.dart';
 
 @Freezed()
-abstract class IntensityStationSearchResponse with _$IntensityStationSearchResponse {
+abstract class IntensityStationSearchResponse
+    with _$IntensityStationSearchResponse {
   const factory IntensityStationSearchResponse({
     required List<IntensityStationSearchItem> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _IntensityStationSearchResponse;
-  
-  factory IntensityStationSearchResponse.fromJson(Map<String, Object?> json) => _$IntensityStationSearchResponseFromJson(json);
+
+  factory IntensityStationSearchResponse.fromJson(Map<String, Object?> json) =>
+      _$IntensityStationSearchResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/internal_server_error_response.dart
+++ b/packages/eqmonitor_api/lib/models/internal_server_error_response.dart
@@ -12,9 +12,9 @@ abstract class InternalServerErrorResponse with _$InternalServerErrorResponse {
   const factory InternalServerErrorResponse({
     required dynamic code,
     required dynamic message,
-    @JsonKey(includeIfNull: false)
-    String? reason,
+    @JsonKey(includeIfNull: false) String? reason,
   }) = _InternalServerErrorResponse;
-  
-  factory InternalServerErrorResponse.fromJson(Map<String, Object?> json) => _$InternalServerErrorResponseFromJson(json);
+
+  factory InternalServerErrorResponse.fromJson(Map<String, Object?> json) =>
+      _$InternalServerErrorResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/interruption_level.dart
+++ b/packages/eqmonitor_api/lib/models/interruption_level.dart
@@ -21,10 +21,12 @@ enum InterruptionLevel {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/is_canceled.dart
+++ b/packages/eqmonitor_api/lib/models/is_canceled.dart
@@ -9,6 +9,7 @@ enum IsCanceled {
   /// The name has been replaced because it contains a keyword. Original name: `true`.
   @JsonValue('true')
   valueTrue('true'),
+
   /// The name has been replaced because it contains a keyword. Original name: `false`.
   @JsonValue('false')
   valueFalse('false');
@@ -19,10 +20,12 @@ enum IsCanceled {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/item.dart
+++ b/packages/eqmonitor_api/lib/models/item.dart
@@ -25,11 +25,9 @@ abstract class Item with _$Item {
     required num failedApns,
     required String createdAt,
     required String updatedAt,
-    @JsonKey(includeIfNull: false)
-    String? headline,
-    @JsonKey(includeIfNull: false)
-    num? resolverDelayMs,
+    @JsonKey(includeIfNull: false) String? headline,
+    @JsonKey(includeIfNull: false) num? resolverDelayMs,
   }) = _Item;
-  
+
   factory Item.fromJson(Map<String, Object?> json) => _$ItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/items.dart
+++ b/packages/eqmonitor_api/lib/models/items.dart
@@ -25,11 +25,9 @@ abstract class Items with _$Items {
     required num failedApns,
     required String createdAt,
     required String updatedAt,
-    @JsonKey(includeIfNull: false)
-    String? headline,
-    @JsonKey(includeIfNull: false)
-    num? resolverDelayMs,
+    @JsonKey(includeIfNull: false) String? headline,
+    @JsonKey(includeIfNull: false) num? resolverDelayMs,
   }) = _Items;
-  
+
   factory Items.fromJson(Map<String, Object?> json) => _$ItemsFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/items2.dart
+++ b/packages/eqmonitor_api/lib/models/items2.dart
@@ -15,37 +15,24 @@ part 'items2.g.dart';
 abstract class Items2 with _$Items2 {
   const factory Items2({
     required String id,
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required TelegramType type,
     required String title,
     required TelegramStatus status,
-    @JsonKey(name: 'info_type')
-    required InfoType infoType,
-    @JsonKey(name: 'editorial_office')
-    required String editorialOffice,
-    @JsonKey(name: 'publishing_office')
-    required List<String> publishingOffice,
-    @JsonKey(name: 'press_at')
-    required DateTime pressAt,
-    @JsonKey(name: 'report_at')
-    required DateTime reportAt,
-    @JsonKey(name: 'info_kind')
-    required String infoKind,
-    @JsonKey(name: 'info_kind_version')
-    required String infoKindVersion,
+    @JsonKey(name: 'info_type') required InfoType infoType,
+    @JsonKey(name: 'editorial_office') required String editorialOffice,
+    @JsonKey(name: 'publishing_office') required List<String> publishingOffice,
+    @JsonKey(name: 'press_at') required DateTime pressAt,
+    @JsonKey(name: 'report_at') required DateTime reportAt,
+    @JsonKey(name: 'info_kind') required String infoKind,
+    @JsonKey(name: 'info_kind_version') required String infoKindVersion,
     required String hash,
-    @JsonKey(name: 'created_at')
-    required DateTime createdAt,
-    @JsonKey(includeIfNull: false,name: 'serial_no')
-    num? serialNo,
-    @JsonKey(includeIfNull: false,name: 'target_at')
-    DateTime? targetAt,
-    @JsonKey(includeIfNull: false,name: 'revoke_at')
-    DateTime? revokeAt,
-    @JsonKey(includeIfNull: false)
-    String? headline,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+    @JsonKey(includeIfNull: false, name: 'serial_no') num? serialNo,
+    @JsonKey(includeIfNull: false, name: 'target_at') DateTime? targetAt,
+    @JsonKey(includeIfNull: false, name: 'revoke_at') DateTime? revokeAt,
+    @JsonKey(includeIfNull: false) String? headline,
   }) = _Items2;
-  
+
   factory Items2.fromJson(Map<String, Object?> json) => _$Items2FromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/models/jma_intensity.dart
@@ -36,10 +36,12 @@ enum JmaIntensity {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/jma_lpgm_intensity.dart
+++ b/packages/eqmonitor_api/lib/models/jma_lpgm_intensity.dart
@@ -24,10 +24,12 @@ enum JmaLpgmIntensity {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/live_activity_start_trigger.dart
+++ b/packages/eqmonitor_api/lib/models/live_activity_start_trigger.dart
@@ -18,10 +18,12 @@ enum LiveActivityStartTrigger {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/live_activity_token_request.dart
+++ b/packages/eqmonitor_api/lib/models/live_activity_token_request.dart
@@ -9,9 +9,9 @@ part 'live_activity_token_request.g.dart';
 
 @Freezed()
 abstract class LiveActivityTokenRequest with _$LiveActivityTokenRequest {
-  const factory LiveActivityTokenRequest({
-    required String token,
-  }) = _LiveActivityTokenRequest;
-  
-  factory LiveActivityTokenRequest.fromJson(Map<String, Object?> json) => _$LiveActivityTokenRequestFromJson(json);
+  const factory LiveActivityTokenRequest({required String token}) =
+      _LiveActivityTokenRequest;
+
+  factory LiveActivityTokenRequest.fromJson(Map<String, Object?> json) =>
+      _$LiveActivityTokenRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/live_activity_token_response.dart
+++ b/packages/eqmonitor_api/lib/models/live_activity_token_response.dart
@@ -12,15 +12,13 @@ part 'live_activity_token_response.g.dart';
 @Freezed()
 abstract class LiveActivityTokenResponse with _$LiveActivityTokenResponse {
   const factory LiveActivityTokenResponse({
-    @JsonKey(name: 'live_activity_id')
-    required String liveActivityId,
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'live_activity_id') required String liveActivityId,
+    @JsonKey(name: 'event_id') required String eventId,
     @JsonKey(name: 'start_trigger')
     required LiveActivityStartTrigger startTrigger,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
+    @JsonKey(name: 'created_at') required String createdAt,
   }) = _LiveActivityTokenResponse;
-  
-  factory LiveActivityTokenResponse.fromJson(Map<String, Object?> json) => _$LiveActivityTokenResponseFromJson(json);
+
+  factory LiveActivityTokenResponse.fromJson(Map<String, Object?> json) =>
+      _$LiveActivityTokenResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/magnitude.dart
+++ b/packages/eqmonitor_api/lib/models/magnitude.dart
@@ -16,9 +16,9 @@ abstract class Magnitude with _$Magnitude {
     required MagnitudeType type,
 
     /// typeがNORMALのときのみ出現する
-    @JsonKey(includeIfNull: false)
-    num? value,
+    @JsonKey(includeIfNull: false) num? value,
   }) = _Magnitude;
-  
-  factory Magnitude.fromJson(Map<String, Object?> json) => _$MagnitudeFromJson(json);
+
+  factory Magnitude.fromJson(Map<String, Object?> json) =>
+      _$MagnitudeFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/magnitude_type.dart
+++ b/packages/eqmonitor_api/lib/models/magnitude_type.dart
@@ -19,10 +19,12 @@ enum MagnitudeType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/min_jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/models/min_jma_intensity.dart
@@ -35,10 +35,12 @@ enum MinJmaIntensity {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/not_found_response.dart
+++ b/packages/eqmonitor_api/lib/models/not_found_response.dart
@@ -13,6 +13,7 @@ abstract class NotFoundResponse with _$NotFoundResponse {
     required dynamic code,
     required dynamic message,
   }) = _NotFoundResponse;
-  
-  factory NotFoundResponse.fromJson(Map<String, Object?> json) => _$NotFoundResponseFromJson(json);
+
+  factory NotFoundResponse.fromJson(Map<String, Object?> json) =>
+      _$NotFoundResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_history_response.dart
+++ b/packages/eqmonitor_api/lib/models/notification_history_response.dart
@@ -13,9 +13,9 @@ part 'notification_history_response.g.dart';
 abstract class NotificationHistoryResponse with _$NotificationHistoryResponse {
   const factory NotificationHistoryResponse({
     required List<NotificationLogItem> items,
-    @JsonKey(includeIfNull: false,name: 'next_cursor')
-    String? nextCursor,
+    @JsonKey(includeIfNull: false, name: 'next_cursor') String? nextCursor,
   }) = _NotificationHistoryResponse;
-  
-  factory NotificationHistoryResponse.fromJson(Map<String, Object?> json) => _$NotificationHistoryResponseFromJson(json);
+
+  factory NotificationHistoryResponse.fromJson(Map<String, Object?> json) =>
+      _$NotificationHistoryResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_log_item.dart
+++ b/packages/eqmonitor_api/lib/models/notification_log_item.dart
@@ -13,35 +13,26 @@ part 'notification_log_item.g.dart';
 @Freezed()
 abstract class NotificationLogItem with _$NotificationLogItem {
   const factory NotificationLogItem({
-    @JsonKey(name: 'stream_id')
-    required String streamId,
-    @JsonKey(name: 'device_id')
-    required String deviceId,
+    @JsonKey(name: 'stream_id') required String streamId,
+    @JsonKey(name: 'device_id') required String deviceId,
     required NotificationLogItemFramework framework,
     required NotificationLogItemResult result,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
-    @JsonKey(includeIfNull: false,name: 'error_code')
-    String? errorCode,
-    @JsonKey(includeIfNull: false,name: 'error_message')
-    String? errorMessage,
-    @JsonKey(includeIfNull: false,name: 'event_id')
-    String? eventId,
-    @JsonKey(includeIfNull: false)
-    String? title,
-    @JsonKey(includeIfNull: false)
-    String? body,
-    @JsonKey(includeIfNull: false,name: 'android_priority')
+    @JsonKey(name: 'created_at') required String createdAt,
+    @JsonKey(includeIfNull: false, name: 'error_code') String? errorCode,
+    @JsonKey(includeIfNull: false, name: 'error_message') String? errorMessage,
+    @JsonKey(includeIfNull: false, name: 'event_id') String? eventId,
+    @JsonKey(includeIfNull: false) String? title,
+    @JsonKey(includeIfNull: false) String? body,
+    @JsonKey(includeIfNull: false, name: 'android_priority')
     String? androidPriority,
-    @JsonKey(includeIfNull: false,name: 'android_notification_priority')
+    @JsonKey(includeIfNull: false, name: 'android_notification_priority')
     String? androidNotificationPriority,
-    @JsonKey(includeIfNull: false,name: 'channel_id')
-    String? channelId,
-    @JsonKey(includeIfNull: false,name: 'apns_priority')
-    String? apnsPriority,
-    @JsonKey(includeIfNull: false,name: 'interruption_level')
+    @JsonKey(includeIfNull: false, name: 'channel_id') String? channelId,
+    @JsonKey(includeIfNull: false, name: 'apns_priority') String? apnsPriority,
+    @JsonKey(includeIfNull: false, name: 'interruption_level')
     String? interruptionLevel,
   }) = _NotificationLogItem;
-  
-  factory NotificationLogItem.fromJson(Map<String, Object?> json) => _$NotificationLogItemFromJson(json);
+
+  factory NotificationLogItem.fromJson(Map<String, Object?> json) =>
+      _$NotificationLogItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_log_item_framework.dart
+++ b/packages/eqmonitor_api/lib/models/notification_log_item_framework.dart
@@ -17,10 +17,12 @@ enum NotificationLogItemFramework {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/notification_log_item_result.dart
+++ b/packages/eqmonitor_api/lib/models/notification_log_item_result.dart
@@ -17,10 +17,12 @@ enum NotificationLogItemResult {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/notification_settings_request.dart
+++ b/packages/eqmonitor_api/lib/models/notification_settings_request.dart
@@ -10,11 +10,12 @@ part 'notification_settings_request.g.dart';
 @Freezed()
 abstract class NotificationSettingsRequest with _$NotificationSettingsRequest {
   const factory NotificationSettingsRequest({
-    @JsonKey(includeIfNull: false,name: 'tsunami_enabled')
+    @JsonKey(includeIfNull: false, name: 'tsunami_enabled')
     bool? tsunamiEnabled,
-    @JsonKey(includeIfNull: false,name: 'training_enabled')
+    @JsonKey(includeIfNull: false, name: 'training_enabled')
     bool? trainingEnabled,
   }) = _NotificationSettingsRequest;
-  
-  factory NotificationSettingsRequest.fromJson(Map<String, Object?> json) => _$NotificationSettingsRequestFromJson(json);
+
+  factory NotificationSettingsRequest.fromJson(Map<String, Object?> json) =>
+      _$NotificationSettingsRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_settings_response.dart
+++ b/packages/eqmonitor_api/lib/models/notification_settings_response.dart
@@ -8,13 +8,13 @@ part 'notification_settings_response.freezed.dart';
 part 'notification_settings_response.g.dart';
 
 @Freezed()
-abstract class NotificationSettingsResponse with _$NotificationSettingsResponse {
+abstract class NotificationSettingsResponse
+    with _$NotificationSettingsResponse {
   const factory NotificationSettingsResponse({
-    @JsonKey(name: 'tsunami_enabled')
-    required bool tsunamiEnabled,
-    @JsonKey(name: 'training_enabled')
-    required bool trainingEnabled,
+    @JsonKey(name: 'tsunami_enabled') required bool tsunamiEnabled,
+    @JsonKey(name: 'training_enabled') required bool trainingEnabled,
   }) = _NotificationSettingsResponse;
-  
-  factory NotificationSettingsResponse.fromJson(Map<String, Object?> json) => _$NotificationSettingsResponseFromJson(json);
+
+  factory NotificationSettingsResponse.fromJson(Map<String, Object?> json) =>
+      _$NotificationSettingsResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_tiers.dart
+++ b/packages/eqmonitor_api/lib/models/notification_tiers.dart
@@ -19,6 +19,7 @@ abstract class NotificationTiers with _$NotificationTiers {
     @JsonKey(name: 'interruption_level')
     required InterruptionLevel interruptionLevel,
   }) = _NotificationTiers;
-  
-  factory NotificationTiers.fromJson(Map<String, Object?> json) => _$NotificationTiersFromJson(json);
+
+  factory NotificationTiers.fromJson(Map<String, Object?> json) =>
+      _$NotificationTiersFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_tiers2.dart
+++ b/packages/eqmonitor_api/lib/models/notification_tiers2.dart
@@ -19,6 +19,7 @@ abstract class NotificationTiers2 with _$NotificationTiers2 {
     @JsonKey(name: 'interruption_level')
     required InterruptionLevel interruptionLevel,
   }) = _NotificationTiers2;
-  
-  factory NotificationTiers2.fromJson(Map<String, Object?> json) => _$NotificationTiers2FromJson(json);
+
+  factory NotificationTiers2.fromJson(Map<String, Object?> json) =>
+      _$NotificationTiers2FromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_tiers3.dart
+++ b/packages/eqmonitor_api/lib/models/notification_tiers3.dart
@@ -19,6 +19,7 @@ abstract class NotificationTiers3 with _$NotificationTiers3 {
     @JsonKey(name: 'interruption_level')
     required InterruptionLevel interruptionLevel,
   }) = _NotificationTiers3;
-  
-  factory NotificationTiers3.fromJson(Map<String, Object?> json) => _$NotificationTiers3FromJson(json);
+
+  factory NotificationTiers3.fromJson(Map<String, Object?> json) =>
+      _$NotificationTiers3FromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/notification_tiers4.dart
+++ b/packages/eqmonitor_api/lib/models/notification_tiers4.dart
@@ -19,6 +19,7 @@ abstract class NotificationTiers4 with _$NotificationTiers4 {
     @JsonKey(name: 'interruption_level')
     required InterruptionLevel interruptionLevel,
   }) = _NotificationTiers4;
-  
-  factory NotificationTiers4.fromJson(Map<String, Object?> json) => _$NotificationTiers4FromJson(json);
+
+  factory NotificationTiers4.fromJson(Map<String, Object?> json) =>
+      _$NotificationTiers4FromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/origin_time_precision.dart
+++ b/packages/eqmonitor_api/lib/models/origin_time_precision.dart
@@ -26,10 +26,12 @@ enum OriginTimePrecision {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/pre_periods.dart
+++ b/packages/eqmonitor_api/lib/models/pre_periods.dart
@@ -13,10 +13,10 @@ part 'pre_periods.g.dart';
 abstract class PrePeriods with _$PrePeriods {
   const factory PrePeriods({
     required num band,
-    @JsonKey(name: 'lpgm_intensity')
-    required JmaLpgmIntensity lpgmIntensity,
+    @JsonKey(name: 'lpgm_intensity') required JmaLpgmIntensity lpgmIntensity,
     required num sva,
   }) = _PrePeriods;
-  
-  factory PrePeriods.fromJson(Map<String, Object?> json) => _$PrePeriodsFromJson(json);
+
+  factory PrePeriods.fromJson(Map<String, Object?> json) =>
+      _$PrePeriodsFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/pre_periods2.dart
+++ b/packages/eqmonitor_api/lib/models/pre_periods2.dart
@@ -11,10 +11,10 @@ part 'pre_periods2.g.dart';
 abstract class PrePeriods2 with _$PrePeriods2 {
   const factory PrePeriods2({
     required num band,
-    @JsonKey(name: 'lpgm_intensity')
-    required String lpgmIntensity,
+    @JsonKey(name: 'lpgm_intensity') required String lpgmIntensity,
     required num sva,
   }) = _PrePeriods2;
-  
-  factory PrePeriods2.fromJson(Map<String, Object?> json) => _$PrePeriods2FromJson(json);
+
+  factory PrePeriods2.fromJson(Map<String, Object?> json) =>
+      _$PrePeriods2FromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/region_setting_patch_request.dart
+++ b/packages/eqmonitor_api/lib/models/region_setting_patch_request.dart
@@ -12,13 +12,13 @@ part 'region_setting_patch_request.g.dart';
 @Freezed()
 abstract class RegionSettingPatchRequest with _$RegionSettingPatchRequest {
   const factory RegionSettingPatchRequest({
-    @JsonKey(includeIfNull: false,name: 'region_name')
-    String? regionName,
-    @JsonKey(includeIfNull: false,name: 'is_current_location')
+    @JsonKey(includeIfNull: false, name: 'region_name') String? regionName,
+    @JsonKey(includeIfNull: false, name: 'is_current_location')
     bool? isCurrentLocation,
-    @JsonKey(includeIfNull: false,name: 'min_jma_intensity')
+    @JsonKey(includeIfNull: false, name: 'min_jma_intensity')
     JmaIntensity? minJmaIntensity,
   }) = _RegionSettingPatchRequest;
-  
-  factory RegionSettingPatchRequest.fromJson(Map<String, Object?> json) => _$RegionSettingPatchRequestFromJson(json);
+
+  factory RegionSettingPatchRequest.fromJson(Map<String, Object?> json) =>
+      _$RegionSettingPatchRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/region_setting_request.dart
+++ b/packages/eqmonitor_api/lib/models/region_setting_request.dart
@@ -12,15 +12,12 @@ part 'region_setting_request.g.dart';
 @Freezed()
 abstract class RegionSettingRequest with _$RegionSettingRequest {
   const factory RegionSettingRequest({
-    @JsonKey(name: 'region_id')
-    required num regionId,
-    @JsonKey(name: 'is_current_location')
-    required bool isCurrentLocation,
-    @JsonKey(name: 'min_jma_intensity')
-    required JmaIntensity minJmaIntensity,
-    @JsonKey(includeIfNull: false,name: 'region_name')
-    String? regionName,
+    @JsonKey(name: 'region_id') required num regionId,
+    @JsonKey(name: 'is_current_location') required bool isCurrentLocation,
+    @JsonKey(name: 'min_jma_intensity') required JmaIntensity minJmaIntensity,
+    @JsonKey(includeIfNull: false, name: 'region_name') String? regionName,
   }) = _RegionSettingRequest;
-  
-  factory RegionSettingRequest.fromJson(Map<String, Object?> json) => _$RegionSettingRequestFromJson(json);
+
+  factory RegionSettingRequest.fromJson(Map<String, Object?> json) =>
+      _$RegionSettingRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/region_setting_response.dart
+++ b/packages/eqmonitor_api/lib/models/region_setting_response.dart
@@ -12,19 +12,15 @@ part 'region_setting_response.g.dart';
 @Freezed()
 abstract class RegionSettingResponse with _$RegionSettingResponse {
   const factory RegionSettingResponse({
-    @JsonKey(name: 'region_id')
-    required num regionId,
-    @JsonKey(includeIfNull: true,name: 'region_name')
+    @JsonKey(name: 'region_id') required num regionId,
+    @JsonKey(includeIfNull: true, name: 'region_name')
     required String? regionName,
-    @JsonKey(name: 'is_current_location')
-    required bool isCurrentLocation,
-    @JsonKey(name: 'min_jma_intensity')
-    required JmaIntensity minJmaIntensity,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
-    @JsonKey(name: 'updated_at')
-    required String updatedAt,
+    @JsonKey(name: 'is_current_location') required bool isCurrentLocation,
+    @JsonKey(name: 'min_jma_intensity') required JmaIntensity minJmaIntensity,
+    @JsonKey(name: 'created_at') required String createdAt,
+    @JsonKey(name: 'updated_at') required String updatedAt,
   }) = _RegionSettingResponse;
-  
-  factory RegionSettingResponse.fromJson(Map<String, Object?> json) => _$RegionSettingResponseFromJson(json);
+
+  factory RegionSettingResponse.fromJson(Map<String, Object?> json) =>
+      _$RegionSettingResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/service_unavailable_response.dart
+++ b/packages/eqmonitor_api/lib/models/service_unavailable_response.dart
@@ -13,6 +13,7 @@ abstract class ServiceUnavailableResponse with _$ServiceUnavailableResponse {
     required dynamic code,
     required String message,
   }) = _ServiceUnavailableResponse;
-  
-  factory ServiceUnavailableResponse.fromJson(Map<String, Object?> json) => _$ServiceUnavailableResponseFromJson(json);
+
+  factory ServiceUnavailableResponse.fromJson(Map<String, Object?> json) =>
+      _$ServiceUnavailableResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/session_response.dart
+++ b/packages/eqmonitor_api/lib/models/session_response.dart
@@ -12,17 +12,15 @@ abstract class SessionResponse with _$SessionResponse {
   const factory SessionResponse({
     required String id,
     required String token,
-    @JsonKey(name: 'expires_at')
-    required String expiresAt,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
-    @JsonKey(name: 'updated_at')
-    required String updatedAt,
-    @JsonKey(includeIfNull: true,name: 'ip_address')
+    @JsonKey(name: 'expires_at') required String expiresAt,
+    @JsonKey(name: 'created_at') required String createdAt,
+    @JsonKey(name: 'updated_at') required String updatedAt,
+    @JsonKey(includeIfNull: true, name: 'ip_address')
     required String? ipAddress,
-    @JsonKey(includeIfNull: true,name: 'user_agent')
+    @JsonKey(includeIfNull: true, name: 'user_agent')
     required String? userAgent,
   }) = _SessionResponse;
-  
-  factory SessionResponse.fromJson(Map<String, Object?> json) => _$SessionResponseFromJson(json);
+
+  factory SessionResponse.fromJson(Map<String, Object?> json) =>
+      _$SessionResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/shake_detection_level.dart
+++ b/packages/eqmonitor_api/lib/models/shake_detection_level.dart
@@ -24,10 +24,12 @@ enum ShakeDetectionLevel {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/shake_detection_setting_request.dart
+++ b/packages/eqmonitor_api/lib/models/shake_detection_setting_request.dart
@@ -10,15 +10,15 @@ part 'shake_detection_setting_request.freezed.dart';
 part 'shake_detection_setting_request.g.dart';
 
 @Freezed()
-abstract class ShakeDetectionSettingRequest with _$ShakeDetectionSettingRequest {
+abstract class ShakeDetectionSettingRequest
+    with _$ShakeDetectionSettingRequest {
   const factory ShakeDetectionSettingRequest({
-    @JsonKey(includeIfNull: true,name: 'sub_region_id')
+    @JsonKey(includeIfNull: true, name: 'sub_region_id')
     required String? subRegionId,
-    @JsonKey(name: 'min_level')
-    required ShakeDetectionLevel minLevel,
-    @JsonKey(name: 'is_current_location')
-    required bool isCurrentLocation,
+    @JsonKey(name: 'min_level') required ShakeDetectionLevel minLevel,
+    @JsonKey(name: 'is_current_location') required bool isCurrentLocation,
   }) = _ShakeDetectionSettingRequest;
-  
-  factory ShakeDetectionSettingRequest.fromJson(Map<String, Object?> json) => _$ShakeDetectionSettingRequestFromJson(json);
+
+  factory ShakeDetectionSettingRequest.fromJson(Map<String, Object?> json) =>
+      _$ShakeDetectionSettingRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/shake_detection_setting_response.dart
+++ b/packages/eqmonitor_api/lib/models/shake_detection_setting_response.dart
@@ -10,20 +10,18 @@ part 'shake_detection_setting_response.freezed.dart';
 part 'shake_detection_setting_response.g.dart';
 
 @Freezed()
-abstract class ShakeDetectionSettingResponse with _$ShakeDetectionSettingResponse {
+abstract class ShakeDetectionSettingResponse
+    with _$ShakeDetectionSettingResponse {
   const factory ShakeDetectionSettingResponse({
     required String id,
-    @JsonKey(includeIfNull: true,name: 'sub_region_id')
+    @JsonKey(includeIfNull: true, name: 'sub_region_id')
     required String? subRegionId,
-    @JsonKey(name: 'min_level')
-    required ShakeDetectionLevel minLevel,
-    @JsonKey(name: 'is_current_location')
-    required bool isCurrentLocation,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
-    @JsonKey(name: 'updated_at')
-    required String updatedAt,
+    @JsonKey(name: 'min_level') required ShakeDetectionLevel minLevel,
+    @JsonKey(name: 'is_current_location') required bool isCurrentLocation,
+    @JsonKey(name: 'created_at') required String createdAt,
+    @JsonKey(name: 'updated_at') required String updatedAt,
   }) = _ShakeDetectionSettingResponse;
-  
-  factory ShakeDetectionSettingResponse.fromJson(Map<String, Object?> json) => _$ShakeDetectionSettingResponseFromJson(json);
+
+  factory ShakeDetectionSettingResponse.fromJson(Map<String, Object?> json) =>
+      _$ShakeDetectionSettingResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/shake_detection_sub_region_response.dart
+++ b/packages/eqmonitor_api/lib/models/shake_detection_sub_region_response.dart
@@ -8,12 +8,14 @@ part 'shake_detection_sub_region_response.freezed.dart';
 part 'shake_detection_sub_region_response.g.dart';
 
 @Freezed()
-abstract class ShakeDetectionSubRegionResponse with _$ShakeDetectionSubRegionResponse {
+abstract class ShakeDetectionSubRegionResponse
+    with _$ShakeDetectionSubRegionResponse {
   const factory ShakeDetectionSubRegionResponse({
     required String id,
     required String code,
     required String name,
   }) = _ShakeDetectionSubRegionResponse;
-  
-  factory ShakeDetectionSubRegionResponse.fromJson(Map<String, Object?> json) => _$ShakeDetectionSubRegionResponseFromJson(json);
+
+  factory ShakeDetectionSubRegionResponse.fromJson(Map<String, Object?> json) =>
+      _$ShakeDetectionSubRegionResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/sort_order.dart
+++ b/packages/eqmonitor_api/lib/models/sort_order.dart
@@ -18,10 +18,12 @@ enum SortOrder {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/telegram.dart
+++ b/packages/eqmonitor_api/lib/models/telegram.dart
@@ -15,39 +15,26 @@ part 'telegram.g.dart';
 abstract class Telegram with _$Telegram {
   const factory Telegram({
     required String id,
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required TelegramType type,
     required String title,
     required TelegramStatus status,
-    @JsonKey(name: 'info_type')
-    required TelegramInfoType infoType,
-    @JsonKey(name: 'editorial_office')
-    required String editorialOffice,
-    @JsonKey(name: 'publishing_office')
-    required List<String> publishingOffice,
-    @JsonKey(name: 'press_at')
-    required DateTime pressAt,
-    @JsonKey(name: 'report_at')
-    required DateTime reportAt,
-    @JsonKey(name: 'info_kind')
-    required String infoKind,
-    @JsonKey(name: 'info_kind_version')
-    required String infoKindVersion,
+    @JsonKey(name: 'info_type') required TelegramInfoType infoType,
+    @JsonKey(name: 'editorial_office') required String editorialOffice,
+    @JsonKey(name: 'publishing_office') required List<String> publishingOffice,
+    @JsonKey(name: 'press_at') required DateTime pressAt,
+    @JsonKey(name: 'report_at') required DateTime reportAt,
+    @JsonKey(name: 'info_kind') required String infoKind,
+    @JsonKey(name: 'info_kind_version') required String infoKindVersion,
     required String hash,
-    @JsonKey(name: 'created_at')
-    required DateTime createdAt,
-    @JsonKey(includeIfNull: false,name: 'serial_no')
-    num? serialNo,
-    @JsonKey(includeIfNull: false,name: 'target_at')
-    DateTime? targetAt,
-    @JsonKey(includeIfNull: false,name: 'revoke_at')
-    DateTime? revokeAt,
-    @JsonKey(includeIfNull: false)
-    String? headline,
-    @JsonKey(includeIfNull: false)
-    dynamic body,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+    @JsonKey(includeIfNull: false, name: 'serial_no') num? serialNo,
+    @JsonKey(includeIfNull: false, name: 'target_at') DateTime? targetAt,
+    @JsonKey(includeIfNull: false, name: 'revoke_at') DateTime? revokeAt,
+    @JsonKey(includeIfNull: false) String? headline,
+    @JsonKey(includeIfNull: false) dynamic body,
   }) = _Telegram;
-  
-  factory Telegram.fromJson(Map<String, Object?> json) => _$TelegramFromJson(json);
+
+  factory Telegram.fromJson(Map<String, Object?> json) =>
+      _$TelegramFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/telegram_comments.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_comments.dart
@@ -10,21 +10,16 @@ part 'telegram_comments.g.dart';
 @Freezed()
 abstract class TelegramComments with _$TelegramComments {
   const factory TelegramComments({
-    @JsonKey(includeIfNull: false)
-    String? text,
-    @JsonKey(includeIfNull: false)
-    String? free,
-    @JsonKey(includeIfNull: false)
-    String? warning,
-    @JsonKey(includeIfNull: false)
-    String? forecast,
+    @JsonKey(includeIfNull: false) String? text,
+    @JsonKey(includeIfNull: false) String? free,
+    @JsonKey(includeIfNull: false) String? warning,
+    @JsonKey(includeIfNull: false) String? forecast,
 
     /// 固定付加文, var
-    @JsonKey(includeIfNull: false)
-    String? additional,
-    @JsonKey(includeIfNull: false)
-    String? uri,
+    @JsonKey(includeIfNull: false) String? additional,
+    @JsonKey(includeIfNull: false) String? uri,
   }) = _TelegramComments;
-  
-  factory TelegramComments.fromJson(Map<String, Object?> json) => _$TelegramCommentsFromJson(json);
+
+  factory TelegramComments.fromJson(Map<String, Object?> json) =>
+      _$TelegramCommentsFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/telegram_detail.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_detail.dart
@@ -15,38 +15,26 @@ part 'telegram_detail.g.dart';
 abstract class TelegramDetail with _$TelegramDetail {
   const factory TelegramDetail({
     required String id,
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required TelegramType type,
     required String title,
     required TelegramStatus status,
-    @JsonKey(name: 'info_type')
-    required TelegramDetailInfoType infoType,
-    @JsonKey(name: 'editorial_office')
-    required String editorialOffice,
-    @JsonKey(name: 'publishing_office')
-    required List<String> publishingOffice,
-    @JsonKey(name: 'press_at')
-    required DateTime pressAt,
-    @JsonKey(name: 'report_at')
-    required DateTime reportAt,
-    @JsonKey(name: 'info_kind')
-    required String infoKind,
-    @JsonKey(name: 'info_kind_version')
-    required String infoKindVersion,
+    @JsonKey(name: 'info_type') required TelegramDetailInfoType infoType,
+    @JsonKey(name: 'editorial_office') required String editorialOffice,
+    @JsonKey(name: 'publishing_office') required List<String> publishingOffice,
+    @JsonKey(name: 'press_at') required DateTime pressAt,
+    @JsonKey(name: 'report_at') required DateTime reportAt,
+    @JsonKey(name: 'info_kind') required String infoKind,
+    @JsonKey(name: 'info_kind_version') required String infoKindVersion,
     required String hash,
-    @JsonKey(name: 'created_at')
-    required DateTime createdAt,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
     required dynamic body,
-    @JsonKey(includeIfNull: false,name: 'serial_no')
-    num? serialNo,
-    @JsonKey(includeIfNull: false,name: 'target_at')
-    DateTime? targetAt,
-    @JsonKey(includeIfNull: false,name: 'revoke_at')
-    DateTime? revokeAt,
-    @JsonKey(includeIfNull: false)
-    String? headline,
+    @JsonKey(includeIfNull: false, name: 'serial_no') num? serialNo,
+    @JsonKey(includeIfNull: false, name: 'target_at') DateTime? targetAt,
+    @JsonKey(includeIfNull: false, name: 'revoke_at') DateTime? revokeAt,
+    @JsonKey(includeIfNull: false) String? headline,
   }) = _TelegramDetail;
-  
-  factory TelegramDetail.fromJson(Map<String, Object?> json) => _$TelegramDetailFromJson(json);
+
+  factory TelegramDetail.fromJson(Map<String, Object?> json) =>
+      _$TelegramDetailFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/telegram_detail_info_type.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_detail_info_type.dart
@@ -21,10 +21,12 @@ enum TelegramDetailInfoType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/telegram_detail_response.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_detail_response.dart
@@ -14,9 +14,9 @@ part 'telegram_detail_response.g.dart';
 abstract class TelegramDetailResponse with _$TelegramDetailResponse {
   const factory TelegramDetailResponse({
     required TelegramDetail telegram,
-    @JsonKey(includeIfNull: true)
-    required TelegramComments? comments,
+    @JsonKey(includeIfNull: true) required TelegramComments? comments,
   }) = _TelegramDetailResponse;
-  
-  factory TelegramDetailResponse.fromJson(Map<String, Object?> json) => _$TelegramDetailResponseFromJson(json);
+
+  factory TelegramDetailResponse.fromJson(Map<String, Object?> json) =>
+      _$TelegramDetailResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/telegram_info_type.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_info_type.dart
@@ -21,10 +21,12 @@ enum TelegramInfoType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/telegram_list_response.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_list_response.dart
@@ -15,13 +15,12 @@ abstract class TelegramListResponse with _$TelegramListResponse {
     required List<Items2> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _TelegramListResponse;
-  
-  factory TelegramListResponse.fromJson(Map<String, Object?> json) => _$TelegramListResponseFromJson(json);
+
+  factory TelegramListResponse.fromJson(Map<String, Object?> json) =>
+      _$TelegramListResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/telegram_status.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_status.dart
@@ -20,10 +20,12 @@ enum TelegramStatus {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/telegram_type.dart
+++ b/packages/eqmonitor_api/lib/models/telegram_type.dart
@@ -52,10 +52,12 @@ enum TelegramType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/telegrams.dart
+++ b/packages/eqmonitor_api/lib/models/telegrams.dart
@@ -14,9 +14,9 @@ part 'telegrams.g.dart';
 abstract class Telegrams with _$Telegrams {
   const factory Telegrams({
     required Telegram telegram,
-    @JsonKey(includeIfNull: true)
-    required TelegramComments? comments,
+    @JsonKey(includeIfNull: true) required TelegramComments? comments,
   }) = _Telegrams;
-  
-  factory Telegrams.fromJson(Map<String, Object?> json) => _$TelegramsFromJson(json);
+
+  factory Telegrams.fromJson(Map<String, Object?> json) =>
+      _$TelegramsFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/test_notification_request.dart
+++ b/packages/eqmonitor_api/lib/models/test_notification_request.dart
@@ -14,6 +14,7 @@ abstract class TestNotificationRequest with _$TestNotificationRequest {
   const factory TestNotificationRequest({
     required TestNotificationRequestType type,
   }) = _TestNotificationRequest;
-  
-  factory TestNotificationRequest.fromJson(Map<String, Object?> json) => _$TestNotificationRequestFromJson(json);
+
+  factory TestNotificationRequest.fromJson(Map<String, Object?> json) =>
+      _$TestNotificationRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/test_notification_request_type.dart
+++ b/packages/eqmonitor_api/lib/models/test_notification_request_type.dart
@@ -19,10 +19,12 @@ enum TestNotificationRequestType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/test_notification_response.dart
+++ b/packages/eqmonitor_api/lib/models/test_notification_response.dart
@@ -15,6 +15,7 @@ abstract class TestNotificationResponse with _$TestNotificationResponse {
     required String message,
     required TestNotificationResponseFramework framework,
   }) = _TestNotificationResponse;
-  
-  factory TestNotificationResponse.fromJson(Map<String, Object?> json) => _$TestNotificationResponseFromJson(json);
+
+  factory TestNotificationResponse.fromJson(Map<String, Object?> json) =>
+      _$TestNotificationResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/test_notification_response_framework.dart
+++ b/packages/eqmonitor_api/lib/models/test_notification_response_framework.dart
@@ -17,10 +17,12 @@ enum TestNotificationResponseFramework {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/tsunami_detail.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_detail.dart
@@ -13,10 +13,10 @@ part 'tsunami_detail.g.dart';
 abstract class TsunamiDetail with _$TsunamiDetail {
   const factory TsunamiDetail({
     required String id,
-    @JsonKey(name: 'event_ids')
-    required List<String> eventIds,
+    @JsonKey(name: 'event_ids') required List<String> eventIds,
     required List<TsunamiTelegramHeaderOnlyItem> telegrams,
   }) = _TsunamiDetail;
-  
-  factory TsunamiDetail.fromJson(Map<String, Object?> json) => _$TsunamiDetailFromJson(json);
+
+  factory TsunamiDetail.fromJson(Map<String, Object?> json) =>
+      _$TsunamiDetailFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/tsunami_detail_response.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_detail_response.dart
@@ -11,9 +11,9 @@ part 'tsunami_detail_response.g.dart';
 
 @Freezed()
 abstract class TsunamiDetailResponse with _$TsunamiDetailResponse {
-  const factory TsunamiDetailResponse({
-    required TsunamiDetail tsunami,
-  }) = _TsunamiDetailResponse;
-  
-  factory TsunamiDetailResponse.fromJson(Map<String, Object?> json) => _$TsunamiDetailResponseFromJson(json);
+  const factory TsunamiDetailResponse({required TsunamiDetail tsunami}) =
+      _TsunamiDetailResponse;
+
+  factory TsunamiDetailResponse.fromJson(Map<String, Object?> json) =>
+      _$TsunamiDetailResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/tsunami_list_item.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_list_item.dart
@@ -11,9 +11,9 @@ part 'tsunami_list_item.g.dart';
 abstract class TsunamiListItem with _$TsunamiListItem {
   const factory TsunamiListItem({
     required String id,
-    @JsonKey(name: 'event_ids')
-    required List<String> eventIds,
+    @JsonKey(name: 'event_ids') required List<String> eventIds,
   }) = _TsunamiListItem;
-  
-  factory TsunamiListItem.fromJson(Map<String, Object?> json) => _$TsunamiListItemFromJson(json);
+
+  factory TsunamiListItem.fromJson(Map<String, Object?> json) =>
+      _$TsunamiListItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/tsunami_list_response.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_list_response.dart
@@ -15,13 +15,12 @@ abstract class TsunamiListResponse with _$TsunamiListResponse {
     required List<TsunamiListItem> items,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_token')
-    String? nextToken,
+    @JsonKey(includeIfNull: false, name: 'next_token') String? nextToken,
 
     /// カーソル情報（base64エンコード）
-    @JsonKey(includeIfNull: false,name: 'next_pooling')
-    String? nextPooling,
+    @JsonKey(includeIfNull: false, name: 'next_pooling') String? nextPooling,
   }) = _TsunamiListResponse;
-  
-  factory TsunamiListResponse.fromJson(Map<String, Object?> json) => _$TsunamiListResponseFromJson(json);
+
+  factory TsunamiListResponse.fromJson(Map<String, Object?> json) =>
+      _$TsunamiListResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/tsunami_telegram_header.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_telegram_header.dart
@@ -15,36 +15,24 @@ part 'tsunami_telegram_header.g.dart';
 abstract class TsunamiTelegramHeader with _$TsunamiTelegramHeader {
   const factory TsunamiTelegramHeader({
     required String hash,
-    @JsonKey(name: 'event_id')
-    required String eventId,
+    @JsonKey(name: 'event_id') required String eventId,
     required TsunamiTelegramHeaderType type,
     required String title,
     required TsunamiTelegramHeaderStatus status,
-    @JsonKey(name: 'info_type')
-    required TsunamiTelegramHeaderInfoType infoType,
-    @JsonKey(name: 'editorial_office')
-    required String editorialOffice,
-    @JsonKey(name: 'publishing_office')
-    required List<String> publishingOffice,
-    @JsonKey(name: 'press_at')
-    required DateTime pressAt,
-    @JsonKey(name: 'report_at')
-    required DateTime reportAt,
-    @JsonKey(name: 'info_kind')
-    required String infoKind,
-    @JsonKey(name: 'info_kind_version')
-    required String infoKindVersion,
-    @JsonKey(name: 'created_at')
-    required DateTime createdAt,
-    @JsonKey(includeIfNull: false,name: 'serial_no')
-    num? serialNo,
-    @JsonKey(includeIfNull: false,name: 'target_at')
-    DateTime? targetAt,
-    @JsonKey(includeIfNull: false,name: 'revoke_at')
-    DateTime? revokeAt,
-    @JsonKey(includeIfNull: false)
-    String? headline,
+    @JsonKey(name: 'info_type') required TsunamiTelegramHeaderInfoType infoType,
+    @JsonKey(name: 'editorial_office') required String editorialOffice,
+    @JsonKey(name: 'publishing_office') required List<String> publishingOffice,
+    @JsonKey(name: 'press_at') required DateTime pressAt,
+    @JsonKey(name: 'report_at') required DateTime reportAt,
+    @JsonKey(name: 'info_kind') required String infoKind,
+    @JsonKey(name: 'info_kind_version') required String infoKindVersion,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+    @JsonKey(includeIfNull: false, name: 'serial_no') num? serialNo,
+    @JsonKey(includeIfNull: false, name: 'target_at') DateTime? targetAt,
+    @JsonKey(includeIfNull: false, name: 'revoke_at') DateTime? revokeAt,
+    @JsonKey(includeIfNull: false) String? headline,
   }) = _TsunamiTelegramHeader;
-  
-  factory TsunamiTelegramHeader.fromJson(Map<String, Object?> json) => _$TsunamiTelegramHeaderFromJson(json);
+
+  factory TsunamiTelegramHeader.fromJson(Map<String, Object?> json) =>
+      _$TsunamiTelegramHeaderFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/tsunami_telegram_header_info_type.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_telegram_header_info_type.dart
@@ -21,10 +21,12 @@ enum TsunamiTelegramHeaderInfoType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/tsunami_telegram_header_only_item.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_telegram_header_only_item.dart
@@ -10,10 +10,12 @@ part 'tsunami_telegram_header_only_item.freezed.dart';
 part 'tsunami_telegram_header_only_item.g.dart';
 
 @Freezed()
-abstract class TsunamiTelegramHeaderOnlyItem with _$TsunamiTelegramHeaderOnlyItem {
+abstract class TsunamiTelegramHeaderOnlyItem
+    with _$TsunamiTelegramHeaderOnlyItem {
   const factory TsunamiTelegramHeaderOnlyItem({
     required TsunamiTelegramHeader telegram,
   }) = _TsunamiTelegramHeaderOnlyItem;
-  
-  factory TsunamiTelegramHeaderOnlyItem.fromJson(Map<String, Object?> json) => _$TsunamiTelegramHeaderOnlyItemFromJson(json);
+
+  factory TsunamiTelegramHeaderOnlyItem.fromJson(Map<String, Object?> json) =>
+      _$TsunamiTelegramHeaderOnlyItemFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/tsunami_telegram_header_status.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_telegram_header_status.dart
@@ -19,10 +19,12 @@ enum TsunamiTelegramHeaderStatus {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/tsunami_telegram_header_type.dart
+++ b/packages/eqmonitor_api/lib/models/tsunami_telegram_header_type.dart
@@ -19,10 +19,12 @@ enum TsunamiTelegramHeaderType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/unauthorized_response.dart
+++ b/packages/eqmonitor_api/lib/models/unauthorized_response.dart
@@ -13,6 +13,7 @@ abstract class UnauthorizedResponse with _$UnauthorizedResponse {
     required dynamic code,
     required String message,
   }) = _UnauthorizedResponse;
-  
-  factory UnauthorizedResponse.fromJson(Map<String, Object?> json) => _$UnauthorizedResponseFromJson(json);
+
+  factory UnauthorizedResponse.fromJson(Map<String, Object?> json) =>
+      _$UnauthorizedResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/user_device_response.dart
+++ b/packages/eqmonitor_api/lib/models/user_device_response.dart
@@ -16,11 +16,10 @@ abstract class UserDeviceResponse with _$UserDeviceResponse {
     required String id,
     required UserDeviceResponseType type,
     required UserDeviceResponseLocale locale,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
-    @JsonKey(name: 'updated_at')
-    required String updatedAt,
+    @JsonKey(name: 'created_at') required String createdAt,
+    @JsonKey(name: 'updated_at') required String updatedAt,
   }) = _UserDeviceResponse;
-  
-  factory UserDeviceResponse.fromJson(Map<String, Object?> json) => _$UserDeviceResponseFromJson(json);
+
+  factory UserDeviceResponse.fromJson(Map<String, Object?> json) =>
+      _$UserDeviceResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/user_device_response_locale.dart
+++ b/packages/eqmonitor_api/lib/models/user_device_response_locale.dart
@@ -19,10 +19,12 @@ enum UserDeviceResponseLocale {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/user_device_response_type.dart
+++ b/packages/eqmonitor_api/lib/models/user_device_response_type.dart
@@ -17,10 +17,12 @@ enum UserDeviceResponseType {
   String toJson() {
     final value = json;
     if (value == null) {
-      throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+      throw StateError(
+        'Cannot convert enum value with null JSON representation to String. '
+        'This usually happens for \$unknown or @JsonValue(null) entries.',
+      );
     }
-    return value as String;
+    return value;
   }
 
   @override

--- a/packages/eqmonitor_api/lib/models/user_response.dart
+++ b/packages/eqmonitor_api/lib/models/user_response.dart
@@ -13,17 +13,14 @@ abstract class UserResponse with _$UserResponse {
     required String id,
     required String name,
     required String email,
-    @JsonKey(includeIfNull: true)
-    required String? image,
-    @JsonKey(includeIfNull: true)
-    required String? role,
-    @JsonKey(includeIfNull: true,name: 'is_anonymous')
+    @JsonKey(includeIfNull: true) required String? image,
+    @JsonKey(includeIfNull: true) required String? role,
+    @JsonKey(includeIfNull: true, name: 'is_anonymous')
     required bool? isAnonymous,
-    @JsonKey(includeIfNull: true)
-    required bool? banned,
-    @JsonKey(name: 'created_at')
-    required String createdAt,
+    @JsonKey(includeIfNull: true) required bool? banned,
+    @JsonKey(name: 'created_at') required String createdAt,
   }) = _UserResponse;
-  
-  factory UserResponse.fromJson(Map<String, Object?> json) => _$UserResponseFromJson(json);
+
+  factory UserResponse.fromJson(Map<String, Object?> json) =>
+      _$UserResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/models/websocket_ticket_response.dart
+++ b/packages/eqmonitor_api/lib/models/websocket_ticket_response.dart
@@ -11,9 +11,9 @@ part 'websocket_ticket_response.g.dart';
 abstract class WebsocketTicketResponse with _$WebsocketTicketResponse {
   const factory WebsocketTicketResponse({
     required String ticket,
-    @JsonKey(name: 'expires_at')
-    required DateTime expiresAt,
+    @JsonKey(name: 'expires_at') required DateTime expiresAt,
   }) = _WebsocketTicketResponse;
-  
-  factory WebsocketTicketResponse.fromJson(Map<String, Object?> json) => _$WebsocketTicketResponseFromJson(json);
+
+  factory WebsocketTicketResponse.fromJson(Map<String, Object?> json) =>
+      _$WebsocketTicketResponseFromJson(json);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  chuck_interceptor:
+    dependency: transitive
+    description:
+      name: chuck_interceptor
+      sha256: "40558f7eeb7a420668e72e0cca2ddc4029cab27379760497127b129217f6bd08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   cli_config:
     dependency: transitive
     description:
@@ -1582,6 +1590,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: transitive
+    description:
+      name: permission_handler
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ environment:
   flutter: ^3.41.0
 workspace:
   - app
+  # ignore: path_does_not_exist
   - packages/*
 dependencies:
   melos: ^7.4.0


### PR DESCRIPTION
## Summary

- `chuck_interceptor` パッケージを導入し、HTTP通信のデバッグを可能にする
- すべての Dio インスタンス（dioProvider / authApiClient / kyoshinMonitorDio / niedDio）に Chuck インターセプターを追加
- デバッグページに「HTTP Inspector (Chuck)」ボタンを追加

## Changes

### New Files
- `app/lib/core/provider/chuck_provider.dart` — `Chuck` インスタンスを Riverpod で管理する provider

### Modified Files
- `app/lib/core/provider/dio_provider.dart` — Chuck interceptor 追加
- `app/lib/feature/auth/data/provider/auth_api_client_provider.dart` — Chuck interceptor 追加
- `app/lib/feature/kyoshin_monitor/data/api/kyoshin_monitor_dio.dart` — Chuck interceptor 追加
- `app/lib/feature/nied/data/provider/nied_dio_provider.dart` — Chuck interceptor 追加
- `app/lib/feature/settings/children/config/debug/debug_page.dart` — HTTP Inspector ボタン追加

## Test plan

- [ ] デバッグページ → 「HTTP Inspector (Chuck)」をタップして Chuck 画面が開くことを確認
- [ ] 各種 API リクエストが Chuck に記録されることを確認（REST API / Auth / 強震モニタ / NIED）
- [ ] 通知トレイに Chuck のノーティフィケーションが表示されることを確認

Made with [Cursor](https://cursor.com)