### PR TITLE
feat: Firebase App Check クライアント側実装

### DIFF
--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/provider/chuck_provider.dart';
+import 'package:eqmonitor/core/provider/interceptor/app_check_interceptor.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
@@ -35,6 +36,7 @@ Dio dio(Ref ref) {
       () => ref.read(authProvider).value,
     ),
   );
+  dio.interceptors.add(AppCheckInterceptor());
   dio.interceptors.add(
     TalkerDioLogger(
       settings: TalkerDioLoggerSettings(

--- a/app/lib/core/provider/interceptor/app_check_interceptor.dart
+++ b/app/lib/core/provider/interceptor/app_check_interceptor.dart
@@ -1,0 +1,36 @@
+import 'package:dio/dio.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
+
+class AppCheckInterceptor extends Interceptor {
+  static const _headerName = 'X-EQMonitor-Device-Check';
+  static final _deviceUpsertPattern = RegExp(r'/v2/device/[^/]+$');
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final isDeviceUpsert = options.method == 'PUT' &&
+        _deviceUpsertPattern.hasMatch(options.path);
+    final String? appCheckToken;
+
+    if (isDeviceUpsert) {
+      // Replay Protection: 毎回新しいトークンを取得
+      appCheckToken = await FirebaseAppCheck.instance.getLimitedUseToken();
+    } else if (_requiresAppCheck(options)) {
+      appCheckToken = await FirebaseAppCheck.instance.getToken();
+    } else {
+      appCheckToken = null;
+    }
+
+    if (appCheckToken != null) {
+      options.headers[_headerName] = appCheckToken;
+    }
+    handler.next(options);
+  }
+
+  bool _requiresAppCheck(RequestOptions options) {
+    return options.method == 'GET' &&
+        options.path.contains('/v2/websocket/ticket');
+  }
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:eqmonitor/core/util/license/init_licenses.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/kyoshin_color_map_data_source.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_color_map.dart';
 import 'package:eqmonitor/firebase_options.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -53,6 +54,15 @@ Future<void> main() async {
   );
 
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  await FirebaseAppCheck.instance.activate(
+    providerAndroid: kDebugMode
+        ? const AndroidDebugProvider()
+        : const AndroidPlayIntegrityProvider(),
+    providerApple: kDebugMode
+        ? const AppleDebugProvider()
+        : const AppleAppAttestProvider(),
+  );
 
   talker = TalkerFlutter.init(
     settings: TalkerSettings(

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   feedback: ^3.1.0
   file_picker: ^10.1.9
   firebase_analytics: ^12.0.0
+  firebase_app_check: ^0.4.2
   firebase_app_installations: ^0.4.0
   firebase_core: ^4.0.0
   firebase_crashlytics: ^5.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: afe15ce18a287d2f89da95566e62892df339b1936bbe9b83587df45b944ee72a
+      sha256: f698de6eb8a0dd7a9a931bbfe13568e8b77e702eb2deb13dd83480c5373e7746
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.67"
+    version: "1.3.68"
   altive_lints:
     dependency: transitive
     description:
@@ -489,6 +489,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1+3"
+  firebase_app_check:
+    dependency: transitive
+    description:
+      name: firebase_app_check
+      sha256: "2a459b1ab2b280b47d14c9726a2d5107752be21a908114a2c619f120200c93cf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
+  firebase_app_check_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_app_check_platform_interface
+      sha256: "4d838f20cd536ab2babbedefdcf976bb182df63e422abfc2bb46920aaf0b8c6f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  firebase_app_check_web:
+    dependency: transitive
+    description:
+      name: firebase_app_check_web
+      sha256: "82922742f04ba38057a4693b506e27755b7e9c9e1808fbcf83cb305d940e5e75"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
   firebase_app_installations:
     dependency: transitive
     description:
@@ -517,26 +541,26 @@ packages:
     dependency: transitive
     description:
       name: firebase_core
-      sha256: f0997fee80fbb6d2c658c5b88ae87ba1f9506b5b37126db64fc2e75d8e977fbb
+      sha256: "2f988dab915efde3b3105268dbd69efce0e8570d767a218ccd914afd0c10c8cc"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.6.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: cccb4f572325dc14904c02fcc7db6323ad62ba02536833dddb5c02cac7341c64
+      sha256: "0ecda14c1bfc9ed8cac303dd0f8d04a320811b479362a9a4efb14fd331a473ce"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "856ca92bf2d75a63761286ab8e791bda3a85184c2b641764433b619647acfca6"
+      sha256: "1399ab1f0ac3b503d8a9be64a4c997fc066bbf33f701f42866e5569f26205ebe"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.1"
   firebase_crashlytics:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- `firebase_app_check` パッケージを追加し、`main.dart` で初期化 (デバッグ時は DebugProvider、本番時は PlayIntegrity / AppAttest)
- `AppCheckInterceptor` を作成し、対象エンドポイントのリクエストに `X-EQMonitor-Device-Check` ヘッダーを付与
  - `PUT /v2/device/*`: `getLimitedUseToken()` (Replay Protection 対応、使い捨てトークン)
  - `GET /v2/websocket/ticket`: `getToken()` (キャッシュ可能な標準検証)

## 残作業 (手動)
- [ ] iOS: Runner.entitlements に `com.apple.developer.devicecheck.appattest-environment` を設定
- [ ] Firebase Console で各アプリの App Check プロバイダを登録
- [ ] Google Play Console で Play Integrity API を有効化
- [ ] デバッグ用トークンの登録 (Firebase Console)

## Test plan
- [ ] デバッグビルドで App Check が DebugProvider で初期化されることを確認
- [ ] `PUT /v2/device/:deviceId` リクエストに `X-EQMonitor-Device-Check` ヘッダーが付与されることを確認
- [ ] `GET /v2/websocket/ticket` リクエストに `X-EQMonitor-Device-Check` ヘッダーが付与されることを確認
- [ ] その他のエンドポイントにはヘッダーが付与されないことを確認

Made with [Cursor](https://cursor.com)