### PR TITLE
chore: hk に zizmor・pinact・shellcheck を追加

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+# zizmor discovers this from .github/workflows/ (see https://docs.zizmor.sh/configuration/)
+# 既存ワークフロー向けの暫定無効化。段階的にルールを戻す。
+rules:
+  template-injection:
+    disable: true
+  cache-poisoning:
+    disable: true
+  excessive-permissions:
+    disable: true

--- a/hk.pkl
+++ b/hk.pkl
@@ -3,6 +3,8 @@ amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.
 // Staged paths for hk util helpers (see https://hk.jdx.dev/cli/util.html )
 local utilFileGlobs = List("**/*")
 
+local workflowGlobs = List(".github/workflows/**/*.yml", ".github/workflows/**/*.yaml")
+
 local linters = new Mapping<String, Step> {
     ["util-check-merge-conflict"] {
         glob = utilFileGlobs
@@ -18,6 +20,19 @@ local linters = new Mapping<String, Step> {
     }
     ["gitleaks"] {
         check = "mise exec -- gitleaks git --staged --baseline-path .gitleaks.baseline.json"
+    }
+    ["zizmor"] {
+        glob = workflowGlobs
+        check = "mise exec -- zizmor --min-severity high {{files}}"
+    }
+    ["pinact"] {
+        glob = workflowGlobs
+        check = "mise exec -- pinact run --check {{files}}"
+    }
+    ["shellcheck"] {
+        glob = List("**/*.sh", "**/*.bash")
+        exclude = List("packages/jma_parameter_converter_internal/updater.sh")
+        check = "mise exec -- shellcheck -S error {{files}}"
     }
 }
 

--- a/utils/map_converter/shrink.sh
+++ b/utils/map_converter/shrink.sh
@@ -7,9 +7,9 @@ fi
 cp -r data/geojson data/geojson_shrinked
 
 for file in data/geojson_shrinked/*.geojson; do
-    mv $file $file.tmp
+    mv "$file" "$file.tmp"
     echo "Shrinking $file"
     # CityQuakeだけデカすぎてエラー出るので https://mapshaper.org/ からやる
-    mapshaper-xl 20gb $file.tmp -simplify dp 1% -o $file
-    rm $file.tmp
+    mapshaper-xl 20gb "$file.tmp" -simplify dp 1% -o "$file"
+    rm "$file.tmp"
 done


### PR DESCRIPTION
## 内容
- **zizmor**: `.github/workflows` 向け。`--min-severity high` に加え、現状の high 向け監査3種（`template-injection` / `cache-poisoning` / `excessive-permissions`）を [`.github/zizmor.yml`](https://docs.zizmor.sh/configuration/) で暫定無効化。段階的に戻せるようにする。
- **pinact**: `pinact run --check {{files}}`（アクションの pin 検証）。
- **shellcheck**: `**/*.sh` / `**/*.bash` のみ、`shellcheck -S error`。Fish の `packages/jma_parameter_converter_internal/updater.sh` は [SC1071](https://www.shellcheck.net/wiki/SC1071) のため hk の `exclude` で除外。
- **utils/map_converter/shrink.sh**: SC2086 回避のため変数をクォート。

## ghalint について（次 PR）
`ghalint` の `excludes` はポリシーによって `workflow_file_path` に加え `job_name` / `step_id` などが必須になり、現状の違反数に対して設定が巨大になるため、**本 PR では hk に含めていません**。ワークフロー側の整理やポリシー単位の除外設計と合わせて次 PR で対応する想定です。

## 確認
- `mise exec -- hk validate`
- `mise exec -- hk run check -n -S zizmor -a` / `-S pinact -a` / `-S shellcheck -a`

Made with [Cursor](https://cursor.com)