### PR TITLE
fix: zizmor template-injection を有効化 (Part 1/3)

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -117,13 +117,15 @@ jobs:
 
       - name: Configure iOS
         working-directory: app
+        env:
+          COMMIT_INFORMATION: ${{ github.ref_name }}-${{ github.sha }}
         run: |
           flutter build ios --config-only \
             --no-codesign \
             --no-pub \
             --build-number=${{ github.run_number }} \
             --dart-define-from-file=../environment/.env.prod \
-            --dart-define COMMIT_INFORMATION=${{ github.ref_name }}-${{ github.sha }}
+            --dart-define COMMIT_INFORMATION=$COMMIT_INFORMATION
 
       - name: Extract App Store Connect API Key
         run: |

--- a/.github/workflows/openapi-client.yaml
+++ b/.github/workflows/openapi-client.yaml
@@ -85,8 +85,9 @@ jobs:
 
       - name: Determine base branch
         id: determine-base-branch
+        env:
+          BASE_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.repository.default_branch }}
         run: |
-          BASE_BRANCH="${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.repository.default_branch }}"
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
           echo "base_branch=$BASE_BRANCH"
 

--- a/.github/workflows/wc-check-dart-test.yaml
+++ b/.github/workflows/wc-check-dart-test.yaml
@@ -21,11 +21,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Fetch base for diff tests
+        env:
+          PR_BASE_REF: ${{ github.base_ref }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1
+            git fetch origin "$PR_BASE_REF" --depth=1
           elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            git fetch origin "${{ github.event.merge_group.base_sha }}" --depth=1
+            git fetch origin "$MERGE_GROUP_BASE_SHA" --depth=1
           fi
 
       # https://github.com/jdx/mise-action

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,6 @@
 # zizmor discovers this from .github/workflows/ (see https://docs.zizmor.sh/configuration/)
 # 既存ワークフロー向けの暫定無効化。段階的にルールを戻す。
 rules:
-  template-injection:
-    disable: true
   cache-poisoning:
     disable: true
   excessive-permissions:


### PR DESCRIPTION
## 概要
`.github/zizmor.yml` の `template-injection` 無効化を外し、該当するワークフローを修正する（Part 1/3）。

## 変更内容
- `wc-check-dart-test` / `deploy-app` / `openapi-client`: シェル内の `${{ }}` 展開を `env` 経由に変更
- `zizmor.yml`: `cache-poisoning` と `excessive-permissions` は引き続き無効のまま

## 次のステップ
マージ後に Part 2 (`chore/zizmor-part2-enable-cache-poisoning` → 本ブランチまたは `develop` にリベース) を続けてください。

Made with [Cursor](https://cursor.com)