### PR TITLE
fix: zizmor cache-poisoning を有効化 (Part 2/3)

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -128,7 +128,8 @@ jobs:
         # https://github.com/ruby/setup-ruby
         uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
         with:
-          bundler-cache: true
+          # リリース成果物を生成するワークフローではキャッシュ汚染リスクを避けるため無効化（zizmor cache-poisoning）
+          bundler-cache: false
           working-directory: app/ios
 
       - name: Install brew dependencies

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,5 @@
 # zizmor discovers this from .github/workflows/ (see https://docs.zizmor.sh/configuration/)
 # 既存ワークフロー向けの暫定無効化。段階的にルールを戻す。
 rules:
-  cache-poisoning:
-    disable: true
   excessive-permissions:
     disable: true


### PR DESCRIPTION
## 概要
Part 1 マージ後の続きとして、`cache-poisoning` ルールを有効化する（Part 2/3）。

## 変更内容
- `tag-release.yaml`: リリース成果物を出すジョブで `ruby/setup-ruby` の `bundler-cache` を無効化（[zizmor cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) の推奨）
- `zizmor.yml`: `excessive-permissions` のみ無効のまま

## 依存
- ベース: `chore/zizmor-part1-enable-template-injection`（#1118）

Made with [Cursor](https://cursor.com)