### PR TITLE
fix: zizmor excessive-permissions を有効化 (Part 3/3)

### DIFF
--- a/.github/workflows/plan-terraform-google-cloud.yaml
+++ b/.github/workflows/plan-terraform-google-cloud.yaml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  pull-requests: write
 
 concurrency:
   group: terraform-gcp-prod-${{ github.ref }}
@@ -24,11 +22,16 @@ env:
 
 jobs:
   changes:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/wc-changes.yaml
 
   validate:
     needs: changes
     if: needs.changes.outputs.terraform == 'true'
+    permissions:
+      contents: read
     uses: ./.github/workflows/wc-check-terraform-validate.yaml
     secrets: inherit
     with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,2 @@
 # zizmor discovers this from .github/workflows/ (see https://docs.zizmor.sh/configuration/)
-# 既存ワークフロー向けの暫定無効化。段階的にルールを戻す。
-rules:
-  excessive-permissions:
-    disable: true
+rules: {}


### PR DESCRIPTION
## 概要
`excessive-permissions` ルールを有効化し、`.github/zizmor.yml` のルール無効化をすべて解消する（Part 3/3）。

## 変更内容
- `plan-terraform-google-cloud.yaml`: ワークフロー先頭の `id-token: write` / `pull-requests: write` をやめ、`contents: read` のみに。必要な権限は `changes` / `validate` / `plan` ジョブに明示
- `zizmor.yml`: `rules: {}`（デフォルトルールすべて有効）

## 依存
- ベース: `chore/zizmor-part2-enable-cache-poisoning`

Made with [Cursor](https://cursor.com)