### PR TITLE
fix(ci): ghalint policy 001（ジョブ permissions）

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -30,6 +30,8 @@ jobs:
   define-matrix:
     name: Define Matrix
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     timeout-minutes: 1
     outputs:
       deploy-ios: ${{ steps.define-environment-matrix.outputs.deploy-ios }}
@@ -65,6 +67,8 @@ jobs:
     needs: define-matrix
     if: ${{ needs.define-matrix.outputs.deploy-ios }}
     runs-on: macos-26
+    permissions:
+      contents: read
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-android
@@ -195,6 +199,8 @@ jobs:
     name: Deploy iOS
     needs: build-ios
     runs-on: macos-26
+    permissions:
+      contents: read
     environment:
       name: EQMonitor-iOS
     concurrency:

--- a/.github/workflows/flutter.yaml
+++ b/.github/workflows/flutter.yaml
@@ -15,17 +15,26 @@ concurrency:
 
 jobs:
   changes:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/wc-changes.yaml
 
   flutter-analyze:
     needs: changes
     if: needs.changes.outputs.flutter == 'true'
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/wc-check-dart-analyze.yaml
     secrets: inherit
 
   flutter-test:
     needs: changes
     if: needs.changes.outputs.flutter == 'true'
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/wc-check-dart-test.yaml
     secrets: inherit
 

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   build-android:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 45
     env:
       TZ: Asia/Tokyo
@@ -59,6 +62,9 @@ jobs:
   deploy-android:
     runs-on: ubuntu-24.04-arm
     needs: build-android
+    permissions:
+      contents: read
+      actions: read
     steps:
       # https://github.com/actions/checkout
       - name: Checkout
@@ -93,6 +99,9 @@ jobs:
 
   build-ios:
     runs-on: macos-26
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 60
     env:
       TZ: Asia/Tokyo
@@ -190,6 +199,9 @@ jobs:
   deploy-ios:
     runs-on: macos-26
     needs: build-ios
+    permissions:
+      contents: read
+      actions: read
     steps:
       # https://github.com/actions/checkout
       - name: Checkout


### PR DESCRIPTION
## 参照
https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/001.md

## 内容
- `deploy-app.yaml` / `flutter.yaml` / `tag-release.yaml` の該当ジョブに最小限の `permissions` を追加しました。

## 次の PR
マージ後、`fix/ghalint-004-deny-inherit-secrets` をベースにした PR を続けてください。

Made with [Cursor](https://cursor.com)