### PR TITLE
fix(ci): ghalint policy 004（secrets: inherit の排除）

### DIFF
--- a/.github/workflows/flutter.yaml
+++ b/.github/workflows/flutter.yaml
@@ -27,7 +27,8 @@ jobs:
       contents: read
       checks: write
     uses: ./.github/workflows/wc-check-dart-analyze.yaml
-    secrets: inherit
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   flutter-test:
     needs: changes
@@ -36,7 +37,8 @@ jobs:
       contents: read
       checks: write
     uses: ./.github/workflows/wc-check-dart-test.yaml
-    secrets: inherit
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   status-check:
     name: Flutter Status Check

--- a/.github/workflows/plan-terraform-google-cloud.yaml
+++ b/.github/workflows/plan-terraform-google-cloud.yaml
@@ -33,7 +33,8 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/wc-check-terraform-validate.yaml
-    secrets: inherit
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
       target: googlecloud/environments/production
 

--- a/.github/workflows/wc-check-dart-analyze.yaml
+++ b/.github/workflows/wc-check-dart-analyze.yaml
@@ -2,6 +2,9 @@ name: Dart Analyze
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/wc-check-dart-test.yaml
+++ b/.github/workflows/wc-check-dart-test.yaml
@@ -2,6 +2,9 @@ name: Dart Test
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/wc-check-terraform-validate.yaml
+++ b/.github/workflows/wc-check-terraform-validate.yaml
@@ -2,6 +2,9 @@ name: Terraform Validate
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
     inputs:
       target:
         description: "Target directory relative to terraform/"


### PR DESCRIPTION
## 参照
https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/004.md

## 内容
- 呼び出し側で `secrets: inherit` をやめ、`GITHUB_TOKEN` のみ明示渡しにしました。
- 再利用ワークフローに `workflow_call.secrets.GITHUB_TOKEN` を宣言しました。

## 前提
#1121 のマージ後、ベースを `develop` に差し替えるか、そのまま上からマージしてください。

## 次の PR
`fix/ghalint-005-workflow-env-secrets`

Made with [Cursor](https://cursor.com)