### PR TITLE
fix(ci): ghalint policy 005/006（GITHUB_TOKEN の配置）

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -21,7 +21,6 @@ permissions:
   contents: read
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   XCODE_VERSION: 26.3
   GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER: projects/179553945248/locations/global/workloadIdentityPools/github-actions-identity-pool/providers/github-actions-identity-provider
   GOOGLE_CLOUD_SERVICE_ACCOUNT: actions-eqmonitor-appdistro@eqmonitor-main.iam.gserviceaccount.com
@@ -91,6 +90,8 @@ jobs:
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           install_args: "flutter xcbeautify"
 
@@ -240,6 +241,8 @@ jobs:
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           install_args: "xcbeautify yq"
 
@@ -343,6 +346,8 @@ jobs:
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           install_args: "flutter java uv python pipx:codemagic-cli-tools"
 
@@ -430,6 +435,8 @@ jobs:
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           install_args: "firebase yq"
 
@@ -536,6 +543,8 @@ jobs:
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           install_args: "github:YumNumm/google-play-cli yq"
 


### PR DESCRIPTION
## 参照
- https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/005.md
- https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/006.md

## 内容
- `deploy-app.yaml` のワークフロー全体 `env` から `GITHUB_TOKEN` を削除しました。
- `jdx/mise-action` ステップの `env` にのみ `GITHUB_TOKEN` を渡し、ジョブ `env` には置きません（policy 006）。

## 次の PR
`fix/ghalint-010-github-app-token-permissions`

Made with [Cursor](https://cursor.com)