### PR TITLE
fix(ci): ghalint policy 012（timeout-minutes）

### DIFF
--- a/.github/workflows/create-tag-and-release-note.yaml
+++ b/.github/workflows/create-tag-and-release-note.yaml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   check:
     runs-on: ubuntu-slim
+    timeout-minutes: 30
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -62,6 +62,7 @@ jobs:
   deploy-android:
     runs-on: ubuntu-24.04-arm
     needs: build-android
+    timeout-minutes: 45
     permissions:
       contents: read
       actions: read
@@ -199,6 +200,7 @@ jobs:
   deploy-ios:
     runs-on: macos-26
     needs: build-ios
+    timeout-minutes: 60
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## 参照
https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/012.md

## 内容
- `create-tag-and-release-note.yaml` の `check` に `timeout-minutes: 30` を追加。
- `tag-release.yaml` の `deploy-android` / `deploy-ios` にタイムアウトを追加。

## 次の PR
`fix/ghalint-013-checkout-persist-credentials`

Made with [Cursor](https://cursor.com)