### PR TITLE
fix(ci): ghalint policy 013（checkout persist-credentials）

### DIFF
--- a/.github/workflows/actonlint.yaml
+++ b/.github/workflows/actonlint.yaml
@@ -23,6 +23,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies

--- a/.github/workflows/create-tag-and-release-note.yaml
+++ b/.github/workflows/create-tag-and-release-note.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
       - id: tagpr
         uses: Songmu/tagpr@84850af451fc53753c6685a3a6a2af7beef23607 # v1.18.2
         env:

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract SOPS Age Key File
         run: |
@@ -214,6 +215,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # https://github.com/maxim-lobanov/setup-xcode
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -334,6 +336,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract SOPS Age Key File
         run: |
@@ -423,6 +427,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract SOPS Age Key File
         run: |
@@ -516,6 +521,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # https://github.com/actions/download-artifact
       - name: Download AAB

--- a/.github/workflows/flutter-auto-fix.yaml
+++ b/.github/workflows/flutter-auto-fix.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Mise dependencies
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/openapi-client.yaml
+++ b/.github/workflows/openapi-client.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
       # https://github.com/jdx/mise-action

--- a/.github/workflows/plan-terraform-google-cloud.yaml
+++ b/.github/workflows/plan-terraform-google-cloud.yaml
@@ -57,6 +57,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract SOPS Age Key File
         working-directory: terraform

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Application Runtime
         uses: ./.github/actions/setup-application-runtime
@@ -73,6 +74,7 @@ jobs:
         with:
           # Fetch all history for all tags and branches
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download artifact aab
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -119,6 +121,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Application Runtime
         uses: ./.github/actions/setup-application-runtime
@@ -211,6 +214,7 @@ jobs:
         with:
           # Fetch all history for all tags and branches
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download artifact ipa
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/wc-changes.yaml
+++ b/.github/workflows/wc-changes.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # https://github.com/dorny/paths-filter
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/wc-check-dart-analyze.yaml
+++ b/.github/workflows/wc-check-dart-analyze.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Mise dependencies
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/wc-check-dart-test.yaml
+++ b/.github/workflows/wc-check-dart-test.yaml
@@ -22,6 +22,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Fetch base for diff tests
         env:

--- a/.github/workflows/wc-check-terraform-validate.yaml
+++ b/.github/workflows/wc-check-terraform-validate.yaml
@@ -24,6 +24,8 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies


### PR DESCRIPTION
## 参照
https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/013.md

## 内容
- 該当ワークフローの `actions/checkout` に `persist-credentials: false` を付与しました。

## 完了
この PR マージ後、`mise exec -- ghalint run` は成功する想定です。

Made with [Cursor](https://cursor.com)