### PR TITLE
地震履歴詳細画面の地図（MapLibre・推計震度・震源）を実装

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_estimated_intensity_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_estimated_intensity_layer.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+
+import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
+
+/// 地震履歴詳細の推計震度（PMTiles ラスタ）レイヤー
+class EarthquakeHistoryDetailsEstimatedIntensityLayer
+    extends HookConsumerWidget {
+  const EarthquakeHistoryDetailsEstimatedIntensityLayer({
+    required this.tileUrl,
+    super.key,
+  });
+
+  final String tileUrl;
+
+  static const _sourceId = 'earthquake-history-estimated-intensity';
+  static const _layerId = 'earthquake-history-estimated-intensity-raster';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final styleController = MapController.maybeOf(context)?.style;
+
+    useEffect(
+      () {
+        if (styleController == null) {
+          return null;
+        }
+
+        unawaited(() async {
+          await styleController.addSource(
+            RasterSource(
+              id: _sourceId,
+              tiles: [tileUrl],
+              tileSize: 512,
+              minZoom: 0,
+              maxZoom: 14,
+            ),
+          );
+
+          await styleController.addLayer(
+            const RasterStyleLayer(
+              id: _layerId,
+              sourceId: _sourceId,
+              paint: {
+                'raster-opacity': 0.75,
+              },
+            ),
+            belowLayerId: BaseLayer.countriesFill.name,
+          );
+        }());
+
+        return () async {
+          await styleController.removeLayer(_layerId);
+          await styleController.removeSource(_sourceId);
+        };
+      },
+      [styleController],
+    );
+
+    return const SizedBox.shrink();
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_camera_controller.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_camera_controller.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity_map_focus.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_map_focus_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_map_camera.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+
+/// 各地の震度でマップフォーカスが選ばれたときにカメラを移動する
+class EarthquakeHistoryDetailsMapCameraController extends ConsumerWidget {
+  const EarthquakeHistoryDetailsMapCameraController({
+    required this.eventId,
+    required this.earthquake,
+    super.key,
+  });
+
+  final String eventId;
+  final Earthquake earthquake;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<EarthquakeIntensityMapFocus?>(
+      earthquakeHistoryMapFocusProvider(eventId),
+      (previous, next) {
+        if (next == null) {
+          return;
+        }
+        final mapController = MapController.maybeOf(context);
+        if (mapController == null) {
+          return;
+        }
+        final target =
+            geographicForEarthquakeIntensityFocus(earthquake, next) ??
+                initialGeographicForEarthquake(earthquake);
+        unawaited(
+          mapController.animateCamera(
+            center: target,
+            zoom: kEarthquakeHistoryMapFocusZoom,
+            nativeDuration: const Duration(milliseconds: 600),
+          ),
+        );
+      },
+    );
+
+    return const SizedBox.shrink();
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -1,23 +1,34 @@
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_details_estimated_intensity_layer.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_details_map_camera_controller.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_hypocenter_layer.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_map_camera.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
+import 'package:eqmonitor/feature/map/ui/maplibre_event_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
 
 class EarthquakeHistoryDetailsMapView extends HookConsumerWidget {
-  const EarthquakeHistoryDetailsMapView({required this.earthquake, super.key});
+  const EarthquakeHistoryDetailsMapView({
+    required this.earthquake,
+    required this.eventId,
+    super.key,
+  });
 
   final Earthquake earthquake;
+  final String eventId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final mapConfiguration = ref.watch(mapConfigurationProvider);
 
     return switch (mapConfiguration) {
-      AsyncData(:final value) when value.styleString != null => LayoutBuilder(
-        builder: (context, constraints) {
-          return const Placeholder();
-        },
+      AsyncData(:final value) when value.styleString != null => _MapContent(
+        styleString: value.styleString!,
+        earthquake: earthquake,
+        eventId: eventId,
       ),
       AsyncError(:final error) => Center(child: ErrorCard(error: error)),
       _ => const Center(child: CircularProgressIndicator.adaptive()),
@@ -25,25 +36,43 @@ class EarthquakeHistoryDetailsMapView extends HookConsumerWidget {
   }
 }
 
-// class _MapHeader extends ConsumerWidget {
-//   const _MapHeader({required this.initialPosition});
+class _MapContent extends HookConsumerWidget {
+  const _MapContent({
+    required this.styleString,
+    required this.earthquake,
+    required this.eventId,
+  });
 
-//   final MapCameraPosition initialPosition;
+  final String styleString;
+  final Earthquake earthquake;
+  final String eventId;
 
-//   @override
-//   Widget build(BuildContext context, WidgetRef ref) {
-//     return Row(
-//       mainAxisAlignment: MainAxisAlignment.spaceBetween,
-//       crossAxisAlignment: CrossAxisAlignment.start,
-//       children: [
-//         const SizedBox.shrink(),
-//         const Column(),
-//         EarthquakeHistoryControllerCard(
-//           onLayerButtonTap: () async =>
-//               EarthquakeHistoryDetailsMapLayerModal.show(context),
-//           onLocationButtonTap: () async => throw UnimplementedError(),
-//         ),
-//       ],
-//     );
-//   }
-// }
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final center = initialGeographicForEarthquake(earthquake);
+    final zoom = initialZoomForEarthquake(earthquake);
+    final mapOptions = MapOptions(
+      initCenter: center,
+      initZoom: zoom,
+      initStyle: styleString,
+    );
+
+    final tileUrl = earthquake.estimatedIntensityTileUrl;
+
+    return MapLibreEventProvider(
+      child: MapLibreMap(
+        options: mapOptions,
+        onEvent: (event) => MapLibreEventProvider.of(context).emit(event),
+        children: [
+          if (tileUrl != null)
+            EarthquakeHistoryDetailsEstimatedIntensityLayer(tileUrl: tileUrl),
+          EarthquakeHistoryHypocenterLayer(earthquake: earthquake),
+          EarthquakeHistoryDetailsMapCameraController(
+            eventId: eventId,
+            earthquake: earthquake,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_hypocenter_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_hypocenter_layer.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:eqmonitor/core/gen/assets.gen.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+
+/// 地震履歴詳細の震源マーカー
+class EarthquakeHistoryHypocenterLayer extends HookConsumerWidget {
+  const EarthquakeHistoryHypocenterLayer({required this.earthquake, super.key});
+
+  final Earthquake earthquake;
+
+  static const _sourceId = 'earthquake-history-hypocenter';
+  static const _layerId = 'earthquake-history-hypocenter-symbol';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final styleController = MapController.maybeOf(context)?.style;
+    final isInitialized = useRef(false);
+
+    useEffect(
+      () {
+        if (styleController == null) {
+          return null;
+        }
+
+        unawaited(() async {
+          await styleController.addImageFromAssets(
+            id: 'earthquake-history-hypocenter-icon',
+            asset: Assets.images.map.normalHypocenter.path,
+          );
+
+          await styleController.addSource(
+            GeoJsonSource(
+              id: _sourceId,
+              data: jsonEncode({
+                'type': 'FeatureCollection',
+                'features': <Map<String, dynamic>>[],
+              }),
+            ),
+          );
+
+          await styleController.addLayer(
+            SymbolStyleLayer(
+              id: _layerId,
+              sourceId: _sourceId,
+              layout: {
+                'icon-allow-overlap': true,
+                'icon-ignore-placement': true,
+                'icon-image': 'earthquake-history-hypocenter-icon',
+                'icon-size': [
+                  'interpolate',
+                  ['linear'],
+                  ['zoom'],
+                  3,
+                  0.3,
+                  20,
+                  2,
+                ],
+              },
+            ),
+          );
+          isInitialized.value = true;
+        }());
+
+        return () async {
+          await styleController.removeLayer(_layerId);
+          await styleController.removeSource(_sourceId);
+        };
+      },
+      [styleController],
+    );
+
+    useEffect(
+      () {
+        if (styleController == null || !isInitialized.value) {
+          return null;
+        }
+
+        unawaited(
+          () async {
+            final hyp = earthquake.hypocenter;
+            if (hyp == null) {
+              await _clear(styleController);
+              return;
+            }
+            final coords = hyp.coordinates;
+            if (coords is! CoordinateLatLng) {
+              await _clear(styleController);
+              return;
+            }
+
+            try {
+              await styleController.updateGeoJsonSource(
+                id: _sourceId,
+                data: jsonEncode({
+                  'type': 'FeatureCollection',
+                  'features': [
+                    {
+                      'type': 'Feature',
+                      'geometry': {
+                        'type': 'Point',
+                        'coordinates': [coords.longitude, coords.latitude],
+                      },
+                      'properties': <String, dynamic>{},
+                    },
+                  ],
+                }),
+              );
+            } on Exception catch (e) {
+              talker.log(e);
+            }
+          }(),
+        );
+
+        return null;
+      },
+      [styleController, earthquake],
+    );
+
+    return const SizedBox.shrink();
+  }
+
+  Future<void> _clear(StyleController styleController) async {
+    try {
+      await styleController.updateGeoJsonSource(
+        id: _sourceId,
+        data: jsonEncode({
+          'type': 'FeatureCollection',
+          'features': <Map<String, dynamic>>[],
+        }),
+      );
+    } on Exception catch (e) {
+      talker.log(e);
+    }
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_map_camera.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_map_camera.dart
@@ -1,0 +1,104 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity_map_focus.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
+import 'package:maplibre/maplibre.dart';
+
+/// 地震履歴詳細マップの初期表示位置（震源が取れない場合のフォールバック）
+const Geographic kEarthquakeHistoryMapDefaultCenter = Geographic(
+  lon: 138,
+  lat: 36.5,
+);
+
+const double kEarthquakeHistoryMapDefaultZoom = 5;
+const double kEarthquakeHistoryMapHypocenterZoom = 6.5;
+const double kEarthquakeHistoryMapFocusZoom = 8;
+
+/// 震源があればその位置、なければ日本付近の既定位置
+Geographic initialGeographicForEarthquake(Earthquake earthquake) {
+  final hyp = earthquake.hypocenter;
+  if (hyp == null) {
+    return kEarthquakeHistoryMapDefaultCenter;
+  }
+  return switch (hyp.coordinates) {
+    CoordinateLatLng(latitude: final lat, longitude: final lng) =>
+      Geographic(lon: lng, lat: lat),
+    _ => kEarthquakeHistoryMapDefaultCenter,
+  };
+}
+
+double initialZoomForEarthquake(Earthquake earthquake) =>
+    earthquake.hypocenter == null
+    ? kEarthquakeHistoryMapDefaultZoom
+    : kEarthquakeHistoryMapHypocenterZoom;
+
+/// 各地の震度ツリーで選択されたコードに対応する代表座標（観測点の緯度経度を優先）
+Geographic? geographicForEarthquakeIntensityFocus(
+  Earthquake earthquake,
+  EarthquakeIntensityMapFocus focus,
+) {
+  final intensity = earthquake.intensity;
+  if (intensity == null) {
+    return null;
+  }
+
+  for (final regions in intensity.intensityTree.values) {
+    for (final regionNode in regions) {
+      final region = regionNode.region.region;
+      switch (focus.kind) {
+        case EarthquakeIntensityMapFocusKind.prefectureRegion:
+          if (region.code == focus.code) {
+            return _representativeGeographicForRegion(regionNode);
+          }
+        case EarthquakeIntensityMapFocusKind.city:
+          for (final city in regionNode.cities) {
+            if (city.city.code == focus.code) {
+              return _representativeGeographicForCity(city);
+            }
+          }
+        case EarthquakeIntensityMapFocusKind.station:
+          for (final city in regionNode.cities) {
+            for (final stationNode in city.stations) {
+              final station = stationNode.station;
+              if (station.code == focus.code) {
+                if (station.hasLatitude() && station.hasLongitude()) {
+                  return Geographic(lon: station.longitude, lat: station.latitude);
+                }
+                return null;
+              }
+            }
+          }
+      }
+    }
+  }
+  return null;
+}
+
+Geographic? _representativeGeographicForRegion(RegionIntensityNode regionNode) {
+  for (final city in regionNode.cities) {
+    final g = _representativeGeographicForCity(city);
+    if (g != null) {
+      return g;
+    }
+  }
+  Geographic? fallback;
+  for (final city in regionNode.cities) {
+    for (final stationNode in city.stations) {
+      final station = stationNode.station;
+      if (station.hasLatitude() && station.hasLongitude()) {
+        fallback ??= Geographic(lon: station.longitude, lat: station.latitude);
+      }
+    }
+  }
+  return fallback;
+}
+
+Geographic? _representativeGeographicForCity(CityIntensityNode cityNode) {
+  for (final stationNode in cityNode.stations) {
+    final station = stationNode.station;
+    if (station.hasLatitude() && station.hasLongitude()) {
+      return Geographic(lon: station.longitude, lat: station.latitude);
+    }
+  }
+  return null;
+}

--- a/app/lib/feature/earthquake_history/ui/components/region_intensity.dart
+++ b/app/lib/feature/earthquake_history/ui/components/region_intensity.dart
@@ -6,19 +6,27 @@ import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity_map_focus.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_map_focus_notifier.dart';
 import 'package:eqmonitor/feature/home/ui/component/sheet/sheet_header.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sheet/route.dart';
 
-class RegionIntensityWidget extends StatelessWidget {
-  const RegionIntensityWidget({required this.item, super.key});
+class RegionIntensityWidget extends ConsumerWidget {
+  const RegionIntensityWidget({
+    required this.item,
+    this.eventId,
+    super.key,
+  });
 
   final Earthquake item;
+  final String? eventId;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final intensity = item.intensity;
@@ -69,6 +77,8 @@ class RegionIntensityWidget extends StatelessWidget {
                 ),
                 onTap: () async => _RegionModalBottomSheet.show(
                   context: context,
+                  ref: ref,
+                  eventId: eventId,
                   intensity: jmaIntensity,
                   regions: entry.value,
                 ),
@@ -126,23 +136,31 @@ List<TreeSliverNode<_RegionIntensityTreeContent>> _buildRegionDetailTree(
 
 class _RegionModalBottomSheet extends StatelessWidget {
   const _RegionModalBottomSheet({
+    required this.ref,
+    required this.eventId,
     required this.intensity,
     required this.regions,
   });
 
   static Future<void> show({
     required BuildContext context,
+    required WidgetRef ref,
+    String? eventId,
     required JmaIntensity intensity,
     required List<RegionIntensityNode> regions,
   }) => Navigator.of(context).push(
     SheetRoute(
       builder: (context) => _RegionModalBottomSheet(
+        ref: ref,
+        eventId: eventId,
         intensity: intensity,
         regions: regions,
       ),
     ),
   );
 
+  final WidgetRef ref;
+  final String? eventId;
   final JmaIntensity intensity;
   final List<RegionIntensityNode> regions;
 
@@ -164,6 +182,7 @@ class _RegionModalBottomSheet extends StatelessWidget {
             treeNodeBuilder: (context, node, toggleAnimationStyle) =>
                 _regionDetailTreeNodeBuilder(
                   context,
+                  ref,
                   colorScheme,
                   node,
                   toggleAnimationStyle,
@@ -184,6 +203,7 @@ class _RegionModalBottomSheet extends StatelessWidget {
 
   Widget _regionDetailTreeNodeBuilder(
     BuildContext context,
+    WidgetRef ref,
     ColorScheme colorScheme,
     TreeSliverNode<Object?> node,
     AnimationStyle toggleAnimationStyle,
@@ -201,6 +221,7 @@ class _RegionModalBottomSheet extends StatelessWidget {
         child: switch (content) {
           final _TreeRegion c => _regionRow(
             context,
+            ref,
             node,
             duration,
             curve,
@@ -208,6 +229,7 @@ class _RegionModalBottomSheet extends StatelessWidget {
           ),
           final _TreeCity c => _cityRow(
             context,
+            ref,
             node,
             duration,
             curve,
@@ -215,6 +237,8 @@ class _RegionModalBottomSheet extends StatelessWidget {
             c.node,
           ),
           final _TreeStation c => _stationRow(
+            context,
+            ref,
             colorScheme,
             c.node,
           ),
@@ -225,6 +249,7 @@ class _RegionModalBottomSheet extends StatelessWidget {
 
   Widget _regionRow(
     BuildContext context,
+    WidgetRef ref,
     TreeSliverNode<Object?> node,
     Duration duration,
     Curve curve,
@@ -247,6 +272,15 @@ class _RegionModalBottomSheet extends StatelessWidget {
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ),
+        if (eventId != null)
+          _mapFocusButton(
+            context,
+            ref,
+            EarthquakeIntensityMapFocus(
+              kind: EarthquakeIntensityMapFocusKind.prefectureRegion,
+              code: region.region.region.code,
+            ),
+          ),
         if (node.children.isNotEmpty)
           _expandIcon(context, node, duration, curve),
       ],
@@ -255,6 +289,7 @@ class _RegionModalBottomSheet extends StatelessWidget {
 
   Widget _cityRow(
     BuildContext context,
+    WidgetRef ref,
     TreeSliverNode<Object?> node,
     Duration duration,
     Curve curve,
@@ -279,6 +314,15 @@ class _RegionModalBottomSheet extends StatelessWidget {
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ),
+        if (eventId != null)
+          _mapFocusButton(
+            context,
+            ref,
+            EarthquakeIntensityMapFocus(
+              kind: EarthquakeIntensityMapFocusKind.city,
+              code: city.city.code,
+            ),
+          ),
         if (node.children.isNotEmpty)
           _expandIcon(context, node, duration, curve),
       ],
@@ -286,6 +330,8 @@ class _RegionModalBottomSheet extends StatelessWidget {
   }
 
   Widget _stationRow(
+    BuildContext context,
+    WidgetRef ref,
     ColorScheme colorScheme,
     StationIntensityNode station,
   ) {
@@ -307,7 +353,36 @@ class _RegionModalBottomSheet extends StatelessWidget {
             ),
           ),
         ),
+        if (eventId != null)
+          _mapFocusButton(
+            context,
+            ref,
+            EarthquakeIntensityMapFocus(
+              kind: EarthquakeIntensityMapFocusKind.station,
+              code: station.station.code,
+            ),
+          ),
       ],
+    );
+  }
+
+  Widget _mapFocusButton(
+    BuildContext context,
+    WidgetRef ref,
+    EarthquakeIntensityMapFocus focus,
+  ) {
+    return IconButton(
+      tooltip: '地図で表示',
+      icon: const Icon(Icons.map_outlined, size: 20),
+      visualDensity: VisualDensity.compact,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+      onPressed: () {
+        ref.read(earthquakeHistoryMapFocusProvider(eventId!).notifier).select(
+              focus,
+            );
+        Navigator.of(context).maybePop();
+      },
     );
   }
 

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -68,7 +68,10 @@ class EarthquakeHistoryDetailsPage extends HookConsumerWidget {
     return Scaffold(
       body: Stack(
         children: [
-          EarthquakeHistoryDetailsMapView(earthquake: earthquake),
+          EarthquakeHistoryDetailsMapView(
+            earthquake: earthquake,
+            eventId: eventId,
+          ),
           if (maxLgIntensity != null)
             _IntensityIcons(maxLgIntensity: maxLgIntensity),
           _Sheet(sheetController: sheetController, item: earthquake),
@@ -168,7 +171,7 @@ class _Sheet extends StatelessWidget {
                 children: [
                   EarthquakeHypocenterInformationCard(item: item),
                   CurrentLocationIntensityCard(item: item),
-                  RegionIntensityWidget(item: item),
+                  RegionIntensityWidget(item: item, eventId: eventId),
                   _TelegramListButton(eventId: item.eventId),
                 ],
               ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
地震履歴詳細画面の `EarthquakeHistoryDetailsMapView` を、既存のホーム地図と同様に MapLibre で表示するよう実装しました。

## 変更内容
- **ベースマップ**: `mapConfigurationProvider` のスタイルを使用
- **推計震度**: API の `estimatedIntensityTileUrl` がある場合のみ `RasterSource` + `RasterStyleLayer` で重ね表示（既存の `countriesFill` の下に挿入）
- **震源**: 緯度経度がある場合は EEW と同様のアイコンで GeoJSON シンボル表示
- **各地の震度**: 詳細シートの都道府県・市区町村・観測点行に「地図で表示」ボタンを追加。タップで `earthquakeHistoryMapFocusProvider` を更新し、代表座標へカメラをアニメーション（観測点はパラメータの緯度経度を使用）

## 注意
- ローカルで `dart analyze` は未実行です（環境に Dart SDK が無いため）。CI での解析を前提としています。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba866297-6d38-4e59-83e9-7a00620b9008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba866297-6d38-4e59-83e9-7a00620b9008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

