### PR TITLE
fix: dart analyze エラー（TimeOfDay・AsyncValue・LatLng・eventId）を解消

### DIFF
--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -171,7 +171,7 @@ class _Sheet extends StatelessWidget {
                 children: [
                   EarthquakeHypocenterInformationCard(item: item),
                   CurrentLocationIntensityCard(item: item),
-                  RegionIntensityWidget(item: item, eventId: eventId),
+                  RegionIntensityWidget(item: item, eventId: item.eventId),
                   _TelegramListButton(eventId: item.eventId),
                 ],
               ),

--- a/app/lib/feature/home/ui/component/eew/eew_widget.dart
+++ b/app/lib/feature/home/ui/component/eew/eew_widget.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:eqmonitor/core/component/container/bordered_container.dart';
 import 'package:eqmonitor/core/component/intenisty/jma_forecast_intensity_icon.dart';
 import 'package:eqmonitor/core/component/intenisty/jma_forecast_lg_intensity_icon.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
@@ -15,7 +16,6 @@ import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/location/data/location.dart';
 import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
-import 'package:eqmonitor/core/component/container/bordered_container.dart';
 import 'package:extensions/extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -97,15 +97,15 @@ class EewWidget extends ConsumerWidget {
 
     final positionAsync = ref.watch(locationStreamProvider);
     final travelTimeAsync = ref.watch(travelTimeProvider);
-    final position = positionAsync.valueOrNull;
+    final position = positionAsync.value;
     final regionItem = position != null
         ? ref
             .watch(
               jmaMapAreaForecastLocalEewInsideProvider(
-                lat_lng.LatLng(lat: position.latitude, lon: position.longitude),
+                lat_lng.LatLng(position.latitude, position.longitude),
               ),
             )
-            .valueOrNull
+            .value
         : null;
 
     final regionCode = regionItem?.property.code;

--- a/app/lib/feature/settings/children/config/debug/eew/debug_eew_card_page.dart
+++ b/app/lib/feature/settings/children/config/debug/eew/debug_eew_card_page.dart
@@ -254,7 +254,7 @@ class DebugEewCardPage extends HookConsumerWidget {
                         d.day,
                         t.hour,
                         t.minute,
-                        t.second,
+                        base.second,
                       );
                     },
                     child: Text(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
CI で報告されていた `dart analyze` のエラーを修正しました。

## 変更内容
- **debug_eew_card_page**: `TimeOfDay` に秒はないため、元の `DateTime`（`base`）の秒を引き継ぐように変更。
- **eew_widget**: `lat_lng.LatLng` は位置引数のコンストラクタのため `LatLng(lat, lon)` に変更。Riverpod 3 の `AsyncValue` では `valueOrNull` がないため `value` に変更。
- **earthquake_history_details_page**: `RegionIntensityWidget` に渡す `eventId` を `item.eventId` に修正（未定義 `eventId` の解消）。
- **eew_widget**: import の並びを `directives_ordering` に合わせて調整。

## 確認
`mise exec --` 経由で `app` ディレクトリで `dart analyze` を実行し、エラー 0（info のみ）であることを確認しました。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-456746c7-3d78-40e6-a1df-9cbe5271783b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-456746c7-3d78-40e6-a1df-9cbe5271783b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

