### PR TITLE
fix: Firebase App Check ヘッダー名の修正と SSE / Talker ログ

### DIFF
--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -43,6 +43,8 @@ Future<Dio> dio(Ref ref) async {
         errorPen: AnsiPen()..red(),
         requestPen: AnsiPen()..yellow(),
         responsePen: AnsiPen()..green(),
+        printRequestHeaders: true,
+        hiddenHeaders: {'X-Firebase-AppCheck'},
         printResponseData: false,
         printErrorMessage: false,
       ),

--- a/app/lib/core/provider/interceptor/app_check_interceptor.dart
+++ b/app/lib/core/provider/interceptor/app_check_interceptor.dart
@@ -2,7 +2,8 @@ import 'package:dio/dio.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 
 class AppCheckInterceptor extends Interceptor {
-  static const _headerName = 'X-EQMonitor-Device-Check';
+  /// Firebase / バックエンドが検証する標準ヘッダー（REST カスタムリソースと同じ）。
+  static const _headerName = 'X-Firebase-AppCheck';
   static final _deviceUpsertPattern = RegExp(r'/v2/device/[^/]+$');
 
   @override
@@ -30,7 +31,11 @@ class AppCheckInterceptor extends Interceptor {
   }
 
   bool _requiresAppCheck(RequestOptions options) {
-    return options.method == 'GET' &&
-        options.path.contains('/v2/websocket/ticket');
+    if (options.method != 'GET') {
+      return false;
+    }
+    final path = options.path;
+    return path.contains('/v2/websocket/ticket') ||
+        path.contains('/v2/realtime/stream');
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

- デバイス登録（`PUT /v2/device/{id}`）および SSE（`GET /v2/realtime/stream`）で、バックエンドが検証する **Firebase 標準の `X-Firebase-AppCheck` ヘッダー** に App Check トークンを付与するよう変更しました（従来の `X-EQMonitor-Device-Check` はサーバ側で認識されず 401 になっていた想定）。
- SSE は `GET` のため `_requiresAppCheck` に `/v2/realtime/stream` を追加し、ストリーム接続にもトークンが載るようにしました。
- `TalkerDioLogger` で `printRequestHeaders: true` とし、App Check トークンは `hiddenHeaders` でマスクします。

## 検証

- この環境では `dart` / `melos` が利用できず `flutter analyze` は未実行です。ローカルで `melos run analyze` をお願いします。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca158ad7-7d18-4c11-8c26-712cb2b5191f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca158ad7-7d18-4c11-8c26-712cb2b5191f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

