### PR TITLE
feat(nied): implement F-net catalog data fetching

### DIFF
--- a/app/lib/feature/nied/ui/fnet/fnet_catalog_page.dart
+++ b/app/lib/feature/nied/ui/fnet/fnet_catalog_page.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:core/core.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:eqmonitor/feature/nied/data/provider/nied_api_client_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
@@ -46,11 +47,15 @@ class _FnetCatalogList extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final niedApiClient = ref.watch(niedApiClientProvider);
 
     final future = useMemoized(
       () async {
-        // TODO: 実装
-        return <FnetEvent>[];
+        final now = DateTime.now();
+        return niedApiClient.fnet.getCatalog(
+          year: selectedMonth?.year ?? now.year,
+          month: selectedMonth?.month ?? now.month,
+        );
       },
       [selectedMonth],
     );


### PR DESCRIPTION
## Summary

- `fnet_catalog_page.dart` のTODOスタブ（`return <FnetEvent>[];`）を実際のAPI呼び出しに置き換え
- `NiedApiClient.fnet.getCatalog()` を使用し、選択月があればその月、未選択時は当月のデータを取得
- `nied_api_client_provider` のimportを追加

## 背景

`docs/todo/080_fnet_catalog_implementation.md` に記載されていた未実装タスク。AQUAカタログ（同じNIEDページの隣タブ）は実装済みであり、F-netも同様のパターンで実装した。

## Test plan

- [ ] F-netタブを開き、当月のカタログデータが表示されることを確認
- [ ] 月選択ダイアログで別の月を選択し、データが切り替わることを確認
- [ ] `dart analyze` でエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)