### PR TITLE
feat: ベータテスト同意画面・isBetaTesting フラグ・バナーを追加

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:dynamic_color/dynamic_color.dart';
+import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/core/theme/build_theme.dart';
@@ -77,17 +78,50 @@ class App extends HookConsumerWidget {
         );
       },
     );
-    if (kDebugMode) {
+    final buildCfg = ref.read(buildConfigProvider);
+    Widget result = app;
+
+    if (buildCfg.isBetaTesting) {
       final packageInfo = ref.watch(packageInfoProvider);
-      return Directionality(
+      result = Directionality(
+        textDirection: TextDirection.ltr,
+        child: Banner(
+          message: 'Beta',
+          location: BannerLocation.topEnd,
+          color: const Color(0xFFF4C75E),
+          textStyle: const TextStyle(
+            color: Color(0xFF0F141A),
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.5,
+          ),
+          child: Banner(
+            message: 'v${packageInfo.version}+${packageInfo.buildNumber}',
+            location: BannerLocation.bottomEnd,
+            color: const Color(0xFFF4C75E),
+            textStyle: const TextStyle(
+              color: Color(0xFF0F141A),
+              fontSize: 8,
+              fontWeight: FontWeight.w600,
+            ),
+            child: result,
+          ),
+        ),
+      );
+    }
+
+    if (kDebugMode && !buildCfg.isBetaTesting) {
+      final packageInfo = ref.watch(packageInfoProvider);
+      result = Directionality(
         textDirection: TextDirection.ltr,
         child: Banner(
           message: 'v${packageInfo.version}-${packageInfo.buildNumber}',
           location: BannerLocation.bottomStart,
-          child: app,
+          child: result,
         ),
       );
     }
-    return app;
+
+    return result;
   }
 }

--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -11,6 +11,7 @@ enum SharedPreferencesKey {
   locationTrackingMode('location_tracking_mode'),
   homeConfiguration('home_configuration'),
   onboardingCompleted('onboarding_completed'),
+  betaTestingAgreed('beta_testing_agreed'),
   ;
 
   const SharedPreferencesKey(this.key);

--- a/app/lib/core/model/environment.dart
+++ b/app/lib/core/model/environment.dart
@@ -25,6 +25,8 @@ abstract class BuildConfig with _$BuildConfig {
 
   const BuildConfig._();
 
+  bool get isBetaTesting => const bool.fromEnvironment('IS_BETA_TESTING');
+
   factory BuildConfig.fromJson(Map<String, dynamic> json) =>
       _$BuildConfigFromJson(json);
 

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -18,6 +18,9 @@ import 'package:eqmonitor/feature/nied/ui/aqua/aqua_page.dart';
 import 'package:eqmonitor/feature/nied/ui/fnet/fnet_catalog_page.dart';
 import 'package:eqmonitor/feature/nied/ui/fnet/fnet_page.dart';
 import 'package:eqmonitor/feature/nied/ui/nied_page.dart';
+import 'package:eqmonitor/core/provider/environment/environment.dart';
+import 'package:eqmonitor/feature/beta_testing/data/notifier/beta_testing_notifier.dart';
+import 'package:eqmonitor/feature/beta_testing/ui/page/beta_testing_warning_page.dart';
 import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.dart';
 import 'package:eqmonitor/feature/onboarding/ui/onboarding_page.dart';
 import 'package:eqmonitor/feature/settings/children/application_info/about_this_app.dart';
@@ -67,6 +70,14 @@ GoRouter goRouter(Ref ref) => GoRouter(
     if (!isCompleted && state.matchedLocation != '/onboarding') {
       return '/onboarding';
     }
+
+    if (isCompleted && ref.read(buildConfigProvider).isBetaTesting) {
+      final betaAgreed = ref.read(betaTestingAgreedProvider);
+      if (!betaAgreed && state.matchedLocation != '/beta-warning') {
+        return '/beta-warning';
+      }
+    }
+
     return null;
   },
   observers: [
@@ -89,6 +100,15 @@ class OnboardingRoute extends GoRouteData with $OnboardingRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const OnboardingPage();
+}
+
+@TypedGoRoute<BetaTestingWarningRoute>(path: '/beta-warning')
+class BetaTestingWarningRoute extends GoRouteData with $BetaTestingWarningRoute {
+  const BetaTestingWarningRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const BetaTestingWarningPage();
 }
 
 @TypedGoRoute<EarthquakeHistoryRoute>(path: '/earthquake-history')

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -10,6 +10,7 @@ part of 'router.dart';
 
 List<RouteBase> get $appRoutes => [
   $onboardingRoute,
+  $betaTestingWarningRoute,
   $earthquakeHistoryRoute,
   $earthquakeSearchResultRoute,
   $earthquakeHistoryDetailsRoute,
@@ -32,6 +33,32 @@ mixin $OnboardingRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/onboarding');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $betaTestingWarningRoute => GoRouteData.$route(
+  path: '/beta-warning',
+  factory: $BetaTestingWarningRoute._fromState,
+);
+
+mixin $BetaTestingWarningRoute on GoRouteData {
+  static BetaTestingWarningRoute _fromState(GoRouterState state) =>
+      const BetaTestingWarningRoute();
+
+  @override
+  String get location => GoRouteData.$location('/beta-warning');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/beta_testing/data/notifier/beta_testing_notifier.dart
+++ b/app/lib/feature/beta_testing/data/notifier/beta_testing_notifier.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'beta_testing_notifier.g.dart';
+
+@riverpod
+class BetaTestingAgreed extends _$BetaTestingAgreed {
+  @override
+  bool build() {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    return prefs.getBool(SharedPreferencesKey.betaTestingAgreed.key) ?? false;
+  }
+
+  Future<void> agree() async {
+    state = true;
+    await ref
+        .read(sharedPreferencesProvider)
+        .setBool(SharedPreferencesKey.betaTestingAgreed.key, true);
+  }
+}

--- a/app/lib/feature/beta_testing/data/notifier/beta_testing_notifier.g.dart
+++ b/app/lib/feature/beta_testing/data/notifier/beta_testing_notifier.g.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'beta_testing_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(BetaTestingAgreed)
+final betaTestingAgreedProvider = BetaTestingAgreedProvider._();
+
+final class BetaTestingAgreedProvider
+    extends $NotifierProvider<BetaTestingAgreed, bool> {
+  BetaTestingAgreedProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'betaTestingAgreedProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$betaTestingAgreedHash();
+
+  @$internal
+  @override
+  BetaTestingAgreed create() => BetaTestingAgreed();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$betaTestingAgreedHash() =>
+    r'a3c8f2e1d7b4905c6e8f1a2b3d4e5f6a7b8c9d01';
+
+abstract class _$BetaTestingAgreed extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/beta_testing/ui/page/beta_testing_warning_page.dart
+++ b/app/lib/feature/beta_testing/ui/page/beta_testing_warning_page.dart
@@ -1,0 +1,230 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/beta_testing/data/notifier/beta_testing_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+const _warnings = [
+  'ベータテスト中のため、予期しないバグやクラッシュが発生する可能性があります。',
+  'サーバーのアップデートや構成変更により、通知配信やデータ取得に失敗する期間が発生する可能性があります。',
+  '実装の不具合等により、最新のデータが表示されない場合があります。',
+  'Beta 版の更新がリリースされた場合、強制アップデートが行われる可能性があります。',
+];
+
+class BetaTestingWarningPage extends ConsumerWidget {
+  const BetaTestingWarningPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ds = Theme.of(context).designSystemThemeExtension;
+
+    return Scaffold(
+      backgroundColor: ds.color.backgroundDefault,
+      body: CustomScrollView(
+        slivers: [
+          SliverSafeArea(
+            sliver: SliverList(
+              delegate: SliverChildListDelegate([
+                _WarningHeader(ds: ds),
+                SizedBox(height: ds.spacing.lg),
+                _WarningList(ds: ds),
+                SizedBox(height: ds.spacing.xxxxl),
+              ]),
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: _AgreementBottom(ds: ds),
+    );
+  }
+}
+
+class _WarningHeader extends StatelessWidget {
+  const _WarningHeader({required this.ds});
+
+  final DesignSystemThemeExtension ds;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        ds.spacing.lg,
+        ds.spacing.xxxxl,
+        ds.spacing.lg,
+        0,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              color: ds.palette.statusWarning.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(ds.shape.lg),
+            ),
+            child: Icon(
+              Icons.warning_amber_rounded,
+              color: ds.palette.statusWarning,
+              size: 36,
+            ),
+          ),
+          SizedBox(height: ds.spacing.lg),
+          Text(
+            'Beta 版をご利用の\n前に',
+            style: ds.typography.headlineLarge.copyWith(
+              color: ds.textColor.primary,
+            ),
+          ),
+          SizedBox(height: ds.spacing.sm),
+          Text(
+            'このアプリは現在ベータテスト中です。以下の事項をご確認のうえ、同意いただける場合のみご利用ください。',
+            style: ds.typography.bodyLarge.copyWith(
+              color: ds.textColor.secondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WarningList extends StatelessWidget {
+  const _WarningList({required this.ds});
+
+  final DesignSystemThemeExtension ds;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: ds.spacing.lg),
+      child: Column(
+        children: [
+          for (final (index, warning) in _warnings.indexed)
+            Padding(
+              padding: EdgeInsets.only(
+                bottom: index < _warnings.length - 1 ? ds.spacing.md : 0,
+              ),
+              child: _WarningCard(warning: warning, index: index, ds: ds),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WarningCard extends StatelessWidget {
+  const _WarningCard({
+    required this.warning,
+    required this.index,
+    required this.ds,
+  });
+
+  final String warning;
+  final int index;
+  final DesignSystemThemeExtension ds;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: ds.color.surfaceCard,
+        borderRadius: BorderRadius.circular(ds.shape.card),
+        border: Border.all(color: ds.color.outlineSoft),
+      ),
+      padding: EdgeInsets.all(ds.spacing.lg),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 28,
+            height: 28,
+            decoration: BoxDecoration(
+              color: ds.palette.statusWarning.withValues(alpha: 0.15),
+              shape: BoxShape.circle,
+            ),
+            child: Center(
+              child: Text(
+                '${index + 1}',
+                style: ds.typography.labelMedium.copyWith(
+                  color: ds.palette.statusWarning,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ),
+          SizedBox(width: ds.spacing.md),
+          Expanded(
+            child: Text(
+              warning,
+              style: ds.typography.bodyMedium.copyWith(
+                color: ds.textColor.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AgreementBottom extends ConsumerWidget {
+  const _AgreementBottom({required this.ds});
+
+  final DesignSystemThemeExtension ds;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          ds.spacing.lg,
+          ds.spacing.md,
+          ds.spacing.lg,
+          ds.spacing.xxl,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: () async {
+                  await ref
+                      .read(betaTestingAgreedProvider.notifier)
+                      .agree();
+                  if (context.mounted) {
+                    context.go('/');
+                  }
+                },
+                style: FilledButton.styleFrom(
+                  backgroundColor: ds.palette.statusWarning,
+                  foregroundColor: const Color(0xFF0F141A),
+                  padding: EdgeInsets.symmetric(vertical: ds.spacing.lg),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(ds.shape.button),
+                  ),
+                ),
+                child: Text(
+                  '同意して利用する',
+                  style: ds.typography.labelLarge.copyWith(
+                    color: const Color(0xFF0F141A),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: ds.spacing.md),
+            Text(
+              '同意しない場合は、アプリストアから最新の正式版アプリをダウンロードしてください。',
+              style: ds.typography.bodySmall.copyWith(
+                color: ds.textColor.tertiary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- `BuildConfig` に `isBetaTesting` getter を追加（`--dart-define IS_BETA_TESTING=true` で有効化、デフォルト `false`）
- `BetaTestingWarningPage` を新規作成：オンボーディング完了後、未同意ユーザーを `/beta-warning` へリダイレクトし、4 つの警告事項カードと同意ボタンを表示
- 同意状態を `SharedPreferences` に永続化（再起動後は再表示しない）
- `isBetaTesting` 時は画面右上に "Beta" バナー・右下にバージョンバナーを表示（`!kDebugMode` でも）

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `app/lib/core/model/environment.dart` | `isBetaTesting` getter 追加 |
| `app/lib/core/data/preferences/shared/shared_preferences_key.dart` | `betaTestingAgreed` キー追加 |
| `app/lib/feature/beta_testing/data/notifier/beta_testing_notifier.dart` | 同意状態 Riverpod Notifier（新規） |
| `app/lib/feature/beta_testing/ui/page/beta_testing_warning_page.dart` | 警告同意画面（新規） |
| `app/lib/core/router/router.dart` | `/beta-warning` ルート追加・redirect 拡張 |
| `app/lib/app.dart` | Beta/バージョンバナー追加 |

## 手動対応が必要な事項

### deploy-app.yaml への `IS_BETA_TESTING=true` 追加

GitHub App の `workflows` 権限がないため CI ファイルは push できませんでした。以下 2 箇所に `--dart-define IS_BETA_TESTING=true \` を追記してください。

**iOS ビルド（`flutter build ios --config-only ...` の末尾）:**
```yaml
            --dart-define BUILD_COMMIT_MESSAGE="$BUILD_COMMIT_MESSAGE" \
            --dart-define IS_BETA_TESTING=true
```

**Android ビルド（`flutter build appbundle ...` の末尾）:**
```yaml
            --dart-define BUILD_COMMIT_MESSAGE="$BUILD_COMMIT_MESSAGE" \
            --dart-define IS_BETA_TESTING=true
```

### コード生成の再実行

手動で生成した `.g.dart` の provider hash は参考値です。チェックアウト後に以下を実行してください：

```bash
cd app && dart run build_runner build --delete-conflicting-outputs
```

## Test plan

- [ ] `--dart-define IS_BETA_TESTING=true` でビルド → オンボーディング完了後に `/beta-warning` へリダイレクトされること
- [ ] 「同意して利用する」タップ → ホーム画面へ遷移すること
- [ ] 再起動後、同意画面が再表示されないこと（SharedPreferences 永続化）
- [ ] 右上 "Beta" バナー・右下バージョンバナーが表示されること
- [ ] `IS_BETA_TESTING` 未指定ビルドではバナーなし・警告画面なし
- [ ] kDebugMode のみのビルド → 左下バナーのみ（既存動作）
- [ ] 小画面でも overflow なし（CustomScrollView でスクロール可能）

https://claude.ai/code/session_01WYksRAE8pytLXCGZozxUkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYksRAE8pytLXCGZozxUkd)_