### PR TITLE
chore(ci): dependabotにcooldown設定を追加

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,6 +12,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pub"
     directories:
       - /
@@ -26,3 +28,5 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## 概要

- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

```
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> ./.github/dependabot.yaml:4:5
  |
4 |   - package-ecosystem: "github-actions"
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
  |
  = note: audit confidence → High
  = note: this finding has an auto-fix

warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
  --> ./.github/dependabot.yaml:15:5
   |
15 |   - package-ecosystem: "pub"
   |     ^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

```