### PR TITLE
fix(eew): WebSocket切断時のREST APIフォールバック実装

### DIFF
--- a/app/lib/feature/eew/data/eew_telegram.dart
+++ b/app/lib/feature/eew/data/eew_telegram.dart
@@ -4,6 +4,8 @@ import 'dart:ui';
 
 import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
+import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart';
+import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_state.dart';
 import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
 import 'package:eqmonitor/core/realtime/realtime_event_provider.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
@@ -38,8 +40,11 @@ class Eew extends _$Eew {
 
     final refreshTimer = Timer.periodic(
       const Duration(seconds: 10),
-      (_) async {
-        // TODO(YumNumm): WebSocketが接続されていない場合には、API経由で取得する
+      (_) {
+        final wsPhase = ref.read(eqMonitorWsStatusProvider).phase;
+        if (wsPhase != WsPhase.connected) {
+          ref.invalidate(_eewRestProvider);
+        }
       },
     );
     ref.onDispose(refreshTimer.cancel);


### PR DESCRIPTION
## Summary
- `eew_telegram.dart` の空の `Timer.periodic` コールバックに WebSocket 切断時フォールバックを実装
- `eqMonitorWsStatusProvider` で接続状態を確認し、未接続時のみ `_eewRestProvider` を invalidate
- `docs/todo/083_eew_codegen_and_missing_features.md` の part 3 を対応

## Test plan
- [ ] `melos run analyze` エラー0

🤖 Generated with [Claude Code](https://claude.com/claude-code)