### PR TITLE
fix(selector): firstWhereOrNull でクラッシュを防止 (085)

### DIFF
--- a/app/lib/core/component/selector/city_selector.dart
+++ b/app/lib/core/component/selector/city_selector.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
 import 'package:eqmonitor/core/provider/jma_parameter/jma_parameter.dart';
 import 'package:flutter/material.dart';
@@ -148,9 +149,8 @@ class _CityDropdown extends StatelessWidget {
       enableFilter: true,
       onSelected: (code) {
         if (code != null && code.isNotEmpty) {
-          final city = cities.firstWhere(
-            (c) => c.code == code,
-          );
+          final city = cities.firstWhereOrNull((c) => c.code == code);
+          if (city == null) return;
           onChanged((
             code: code,
             name: city.name,

--- a/app/lib/core/component/selector/prefecture_selector.dart
+++ b/app/lib/core/component/selector/prefecture_selector.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -29,9 +30,8 @@ class PrefectureSelector extends ConsumerWidget {
       hintText: hintText,
       onSelected: (code) {
         if (code != null && code.isNotEmpty) {
-          final prefecture = prefectures.firstWhere(
-            (p) => p.code == code,
-          );
+          final prefecture = prefectures.firstWhereOrNull((p) => p.code == code);
+          if (prefecture == null) return;
           onChanged((code: code, name: prefecture.name));
         } else {
           onChanged(null);

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
@@ -652,7 +652,8 @@ class _EpicenterSelector extends HookConsumerWidget {
       hintText: '震央地名を選択',
       onSelected: (code) {
         if (code != null && code.isNotEmpty) {
-          final epicenter = epicenters.firstWhere((e) => e.code == code);
+          final epicenter = epicenters.firstWhereOrNull((e) => e.code == code);
+          if (epicenter == null) return;
           onChanged(code, epicenter.name);
         } else {
           onChanged(null, null);


### PR DESCRIPTION
## Summary
- `city_selector.dart`, `prefecture_selector.dart`, `earthquake_history_search_parameter_modal.dart` の `firstWhere` を `firstWhereOrNull` に置き換え
- 対象コードが見つからない場合は早期リターンして `StateError` クラッシュを回避
- `collection` パッケージの import を追加 (city_selector, prefecture_selector)
- `docs/todo/085_firstwhere_without_orelse.md` のタスク対応

## Test plan
- [ ] `melos run analyze` エラー0

🤖 Generated with [Claude Code](https://claude.com/claude-code)