### PR TITLE
地震履歴詳細地図の描画不具合を修正

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/intensity_tree_converter.dart
+++ b/app/lib/feature/earthquake_history/data/model/intensity_tree_converter.dart
@@ -75,6 +75,18 @@ class IntensityTreeConverter {
     return map;
   }
 
+  Map<String, String> _stationCityCodeMap() {
+    final map = <String, String>{};
+    for (final r in parameter.regions) {
+      for (final c in r.cities) {
+        for (final s in c.stations) {
+          map[s.code] = c.code;
+        }
+      }
+    }
+    return map;
+  }
+
   String? _prefectureCode(EarthquakeParameterCityItem city) {
     for (final r in parameter.regions) {
       for (final c in r.cities) {
@@ -92,7 +104,10 @@ class IntensityTreeConverter {
   ) {
     final cityParam = _cityParamMap();
     final stationParam = _stationParamMap();
-    final byPrefix = _stationsByCityPrefix(apiStations);
+    final byCityCode = _stationsByCityCode(
+      stations: apiStations,
+      stationCityCode: _stationCityCodeMap(),
+    );
     final grouped = <JmaIntensity, Map<String, List<CityIntensityNode>>>{};
 
     for (final apiCity in apiCities) {
@@ -116,13 +131,8 @@ class IntensityTreeConverter {
         continue;
       }
 
-      final cityPrefix = code.substring(0, 5);
-      final matchedStations = (byPrefix[cityPrefix] ?? const [])
-          .where((s) => s.maxIntensity == apiCity.maxIntensity)
-          .toList();
-
       final stationNodes = <StationIntensityNode>[];
-      for (final st in matchedStations) {
+      for (final st in byCityCode[code] ?? const <api.IntensityStationItem>[]) {
         final paramSt = stationParam[st.value.code];
         if (paramSt == null) {
           continue;
@@ -202,12 +212,14 @@ class IntensityTreeConverter {
         continue;
       }
 
-      grouped.putIfAbsent(jma, () => []).add(
-        PrefectureIntensityNode(
-          region: IntensityRegion(region: regionItem, maxIntensity: jma),
-          cities: const [],
-        ),
-      );
+      grouped
+          .putIfAbsent(jma, () => [])
+          .add(
+            PrefectureIntensityNode(
+              region: IntensityRegion(region: regionItem, maxIntensity: jma),
+              cities: const [],
+            ),
+          );
     }
 
     for (final entry in grouped.entries) {
@@ -277,7 +289,10 @@ class IntensityTreeConverter {
   ) {
     final cityParam = _cityParamMap();
     final stationParam = _stationParamMap();
-    final byPrefix = _stationsByCityPrefix(apiStations);
+    final byCityCode = _stationsByCityCode(
+      stations: apiStations,
+      stationCityCode: _stationCityCodeMap(),
+    );
     final grouped =
         <JmaLpgmIntensity, Map<String, List<CityLpgmIntensityNode>>>{};
 
@@ -302,13 +317,8 @@ class IntensityTreeConverter {
         continue;
       }
 
-      final cityPrefix = code.substring(0, 5);
-      final matchedStations = (byPrefix[cityPrefix] ?? const [])
-          .where((s) => s.maxLpgmIntensity == apiCity.maxLpgmIntensity)
-          .toList();
-
       final stationNodes = <StationLpgmIntensityNode>[];
-      for (final st in matchedStations) {
+      for (final st in byCityCode[code] ?? const <api.IntensityStationItem>[]) {
         final paramSt = stationParam[st.value.code];
         if (paramSt == null) {
           continue;
@@ -372,9 +382,7 @@ class IntensityTreeConverter {
   }
 
   Map<JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>>
-  _lpgmFromPrefecturesOnly(
-    List<api.IntensityItem> prefectures,
-  ) {
+  _lpgmFromPrefecturesOnly(List<api.IntensityItem> prefectures) {
     final paramRegionMap = {for (final r in parameter.regions) r.code: r};
     final grouped = <JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>>{};
 
@@ -388,13 +396,15 @@ class IntensityTreeConverter {
         continue;
       }
 
-      grouped.putIfAbsent(lpgm, () => []).add(
-        PrefectureLpgmIntensityNode(
-          region: regionItem,
-          maxLpgmIntensity: lpgm,
-          cities: const [],
-        ),
-      );
+      grouped
+          .putIfAbsent(lpgm, () => [])
+          .add(
+            PrefectureLpgmIntensityNode(
+              region: regionItem,
+              maxLpgmIntensity: lpgm,
+              cities: const [],
+            ),
+          );
     }
 
     for (final entry in grouped.entries) {
@@ -453,17 +463,17 @@ class IntensityTreeConverter {
   }
 }
 
-Map<String, List<api.IntensityStationItem>> _stationsByCityPrefix(
-  List<api.IntensityStationItem> stations,
-) {
+Map<String, List<api.IntensityStationItem>> _stationsByCityCode({
+  required List<api.IntensityStationItem> stations,
+  required Map<String, String> stationCityCode,
+}) {
   final map = <String, List<api.IntensityStationItem>>{};
   for (final s in stations) {
-    final code = s.value.code;
-    if (code.length < 5) {
+    final cityCode = stationCityCode[s.value.code];
+    if (cityCode == null) {
       continue;
     }
-    final prefix = code.substring(0, 5);
-    map.putIfAbsent(prefix, () => []).add(s);
+    map.putIfAbsent(cityCode, () => []).add(s);
   }
   return map;
 }

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -94,6 +94,7 @@ class _MapContent extends HookConsumerWidget {
       initZoom: zoom,
       initStyle: styleString,
     );
+    final styleGeneration = useState(0);
 
     final intensity = earthquake.intensity;
 
@@ -146,6 +147,9 @@ class _MapContent extends HookConsumerWidget {
                 options: mapOptions,
                 onEvent: (event) {
                   MapLibreEventProvider.of(context).emit(event);
+                  if (event is MapEventStyleLoaded) {
+                    styleGeneration.value += 1;
+                  }
                   if (event is MapEventClick) {
                     _handleTap(
                       context: context,
@@ -158,46 +162,60 @@ class _MapContent extends HookConsumerWidget {
                 },
                 children: [
                   // 塗りつぶし（最背面）
-                  if (effectiveFillMode ==
+                  if (styleGeneration.value > 0 &&
+                      effectiveFillMode ==
                           EarthquakeHistoryFillMode.matchIcon &&
                       intensity != null)
                     EarthquakeHistoryFillLayer(
+                      key: ValueKey('fill-${styleGeneration.value}'),
                       intensity: intensity,
                       iconMode: resolvedIconMode,
                       showingLpgmIntensity: config.showingLpgmIntensity,
                     ),
                   // 地域・市区町村アイコン（塗りつぶしの上）
-                  if (intensity != null)
+                  if (styleGeneration.value > 0 && intensity != null)
                     EarthquakeHistoryIntensityIconLayer(
+                      key: ValueKey('area-icon-${styleGeneration.value}'),
                       intensity: intensity,
                       iconMode: resolvedIconMode,
                       hasStationData: hasStationData,
                       showingLpgmIntensity: config.showingLpgmIntensity,
                     ),
                   // 推計震度ラスタ
-                  if (tileUrl != null)
+                  if (styleGeneration.value > 0 &&
+                      tileUrl != null &&
+                      isOverriding.value)
                     EarthquakeHistoryDetailsEstimatedIntensityLayer(
+                      key: ValueKey('estimated-${styleGeneration.value}'),
                       tileUrl: tileUrl,
                     ),
                   // 震央誤差矩形
-                  if (config.showHypocenterError)
+                  if (styleGeneration.value > 0 && config.showHypocenterError)
                     EarthquakeHistoryHypocenterErrorLayer(
+                      key: ValueKey(
+                        'hypocenter-error-${styleGeneration.value}',
+                      ),
                       earthquake: earthquake,
                     ),
                   // 観測点・震央（z 順を HypocenterDisplayMode で制御）
-                  if (config.hypocenterDisplayMode ==
-                      HypocenterDisplayMode.belowStations)
+                  if (styleGeneration.value > 0 &&
+                      config.hypocenterDisplayMode ==
+                          HypocenterDisplayMode.belowStations)
                     hypocenterLayer,
-                  if (intensity != null && config.showStation)
+                  if (styleGeneration.value > 0 &&
+                      intensity != null &&
+                      config.showStation)
                     EarthquakeHistoryStationIntensityLayer(
+                      key: ValueKey('station-${styleGeneration.value}'),
                       intensity: intensity,
                       iconMode: resolvedIconMode,
                       stationDisplayMode: config.stationDisplayMode,
                       showLabel: config.showStationLabel,
                       showingLpgmIntensity: config.showingLpgmIntensity,
                     ),
-                  if (config.hypocenterDisplayMode !=
-                      HypocenterDisplayMode.belowStations)
+                  if (styleGeneration.value > 0 &&
+                      config.hypocenterDisplayMode !=
+                          HypocenterDisplayMode.belowStations)
                     hypocenterLayer,
                   EarthquakeHistoryDetailsMapCameraController(
                     eventId: eventId,
@@ -299,10 +317,7 @@ class _MapContent extends HookConsumerWidget {
     final mapData = isCity
         ? jmaMap.areaInformationCity
         : jmaMap.areaForecastLocalE;
-    final latLng = JmaMap_LatLng(
-      lat: event.point.lat,
-      lng: event.point.lon,
-    );
+    final latLng = JmaMap_LatLng(lat: event.point.lat, lng: event.point.lon);
     final result = JmaMapUtility().findNearestItem(latLng, mapData);
     final item = result.item;
     if (item == null) {

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart
@@ -80,10 +80,7 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
               return;
             }
             await styleController.addSource(
-              GeoJsonSource(
-                id: _sourceId,
-                data: geoJson,
-              ),
+              GeoJsonSource(id: _sourceId, data: geoJson),
             );
 
             if (disposed) {
@@ -258,22 +255,19 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
     // cachedBytes を別 effect で監視し、画像が揃ったタイミングで追加する。
     // メインの effect とは分離することで、アイコンキャッシュの更新が
     // source/layer の再構築を引き起こす race condition を防ぐ。
-    useEffect(
-      () {
-        if (styleController == null || cachedBytes.isEmpty) {
-          return null;
-        }
-        unawaited(() async {
-          try {
-            await styleController.addImages(cachedBytes);
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }());
+    useEffect(() {
+      if (styleController == null || cachedBytes.isEmpty) {
         return null;
-      },
-      [styleController, cachedBytes],
-    );
+      }
+      unawaited(() async {
+        try {
+          await styleController.addImages(cachedBytes);
+        } on Exception catch (e) {
+          talker.log(e);
+        }
+      }());
+      return null;
+    }, [styleController, cachedBytes]);
 
     return const SizedBox.shrink();
   }
@@ -300,25 +294,24 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
     IntensityColorModel colorModel,
   ) {
     if (intensity == null) {
-      return jsonEncode({
-        'type': 'FeatureCollection',
-        'features': <dynamic>[],
-      });
+      return jsonEncode({'type': 'FeatureCollection', 'features': <dynamic>[]});
     }
 
     final features = <Map<String, dynamic>>[];
     for (final entry in intensity.intensityTree.entries) {
-      final jmaIntensity = entry.key;
-      final color = colorModel
-          .fromJmaIntensity(jmaIntensity)
-          .background
-          .toHexStringRGB();
-      final isFocused = intensity.maxIntensity == jmaIntensity;
-      final iconId = _iconIdForStation(jmaIntensity.name, isFocused);
-
       for (final region in entry.value) {
         for (final city in region.cities) {
           for (final stationNode in city.stations) {
+            final jmaIntensity = stationNode.intensity?.maxIntensity;
+            if (jmaIntensity == null) {
+              continue;
+            }
+            final color = colorModel
+                .fromJmaIntensity(jmaIntensity)
+                .background
+                .toHexStringRGB();
+            final isFocused = intensity.maxIntensity == jmaIntensity;
+            final iconId = _iconIdForStation(jmaIntensity.name, isFocused);
             final station = stationNode.station;
             if (!station.hasLatitude() || !station.hasLongitude()) {
               continue;
@@ -357,16 +350,18 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
 
     final features = <Map<String, dynamic>>[];
     for (final entry in intensity.lpgmIntensityTree.entries) {
-      final lpgmIntensity = entry.key;
-      final color = colorModel
-          .fromJmaLpgmIntensity(lpgmIntensity)
-          .background
-          .toHexStringRGB();
-      final iconId = _lpgmIconIdForStation(lpgmIntensity.name);
-
       for (final region in entry.value) {
         for (final city in region.cities) {
           for (final stationNode in city.stations) {
+            final lpgmIntensity = stationNode.intensity?.maxLpgmIntensity;
+            if (lpgmIntensity == null) {
+              continue;
+            }
+            final color = colorModel
+                .fromJmaLpgmIntensity(lpgmIntensity)
+                .background
+                .toHexStringRGB();
+            final iconId = _lpgmIconIdForStation(lpgmIntensity.name);
             final station = stationNode.station;
             if (!station.hasLatitude() || !station.hasLongitude()) {
               continue;

--- a/app/test/feature/earthquake_history/data/model/intensity_tree_converter_test.dart
+++ b/app/test/feature/earthquake_history/data/model/intensity_tree_converter_test.dart
@@ -108,8 +108,9 @@ void main() {
       );
       final parameter = _buildParameter(regions: []);
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result, isEmpty);
     });
@@ -118,11 +119,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
         prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
+          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
         ],
         regions: [
           (
@@ -143,13 +140,17 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result.keys.toList(), [JmaIntensity.four]);
       expect(result[JmaIntensity.four]!.length, 1);
       expect(result[JmaIntensity.four]![0].region.region.name, '宮城県');
-      expect(result[JmaIntensity.four]![0].region.maxIntensity, JmaIntensity.four);
+      expect(
+        result[JmaIntensity.four]![0].region.maxIntensity,
+        JmaIntensity.four,
+      );
       expect(result[JmaIntensity.four]![0].cities.length, 1);
       expect(result[JmaIntensity.four]![0].cities[0].city.name, '宮城県北部');
       expect(
@@ -196,8 +197,9 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       // 震度5強と震度4の2グループが存在
       expect(result.keys.toList(), [JmaIntensity.fiveUpper, JmaIntensity.four]);
@@ -221,16 +223,8 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
         prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
-          (
-            code: '070000',
-            name: '福島県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
+          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
+          (code: '070000', name: '福島県', maxIntensity: api.JmaIntensity.value4),
         ],
         regions: [
           (
@@ -262,8 +256,9 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result.keys.toList(), [JmaIntensity.four]);
       expect(result[JmaIntensity.four]!.length, 2);
@@ -320,8 +315,9 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       final keys = result.keys.toList();
       expect(keys, [
@@ -335,11 +331,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
         prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
+          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
         ],
         regions: [
           (
@@ -363,8 +355,9 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result[JmaIntensity.four]![0].cities.length, 1);
       expect(result[JmaIntensity.four]![0].cities[0].city.name, '宮城県北部');
@@ -374,11 +367,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
         prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
+          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
         ],
         regions: [
           (
@@ -408,8 +397,9 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result.keys.toList(), [JmaIntensity.four]);
       expect(result[JmaIntensity.four]![0].cities.length, 1);
@@ -420,11 +410,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value3,
         prefectures: [
-          (
-            code: '130000',
-            name: '東京都',
-            maxIntensity: api.JmaIntensity.value3,
-          ),
+          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value3),
         ],
         regions: [
           (
@@ -445,8 +431,9 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result[JmaIntensity.three]![0].cities[0].stations, isEmpty);
     });
@@ -455,11 +442,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value3,
         prefectures: [
-          (
-            code: '130000',
-            name: '東京都',
-            maxIntensity: api.JmaIntensity.value3,
-          ),
+          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value3),
         ],
         regions: [
           (
@@ -494,9 +477,7 @@ void main() {
               (
                 code: '1310000',
                 name: '東京都23区',
-                stations: [
-                  (code: '13100000001', name: 'テスト観測点'),
-                ],
+                stations: [(code: '13100000001', name: 'テスト観測点')],
               ),
             ],
           ),
@@ -522,6 +503,55 @@ void main() {
       );
     });
 
+    test('観測点の所属市区町村はパラメータで解決し、観測点自身の震度を保持する', () {
+      final intensity = _buildIntensity(
+        maxIntensity: api.JmaIntensity.value4,
+        prefectures: [
+          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value4),
+        ],
+        regions: const [],
+      );
+      final cities = [
+        const api.IntensityItem(
+          value: api.CodeName(code: '1310000', name: '東京都23区'),
+          maxIntensity: api.JmaIntensity.value4,
+        ),
+      ];
+      final stations = [
+        _station(
+          code: '999999',
+          name: '市区町村コード接頭辞と一致しない観測点',
+          maxIntensity: api.JmaIntensity.value2,
+        ),
+      ];
+      final parameter = _buildParameter(
+        regions: [
+          (
+            code: '130000',
+            name: '東京都',
+            cities: [
+              (
+                code: '1310000',
+                name: '東京都23区',
+                stations: [(code: '999999', name: '市区町村コード接頭辞と一致しない観測点')],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final result = IntensityTreeConverter(parameter: parameter)
+          .convertToIntensityTree(
+            intensity: intensity,
+            cities: cities,
+            stations: stations,
+          );
+
+      final stationNode = result[JmaIntensity.four]![0].cities[0].stations[0];
+      expect(stationNode.station.name, '市区町村コード接頭辞と一致しない観測点');
+      expect(stationNode.intensity?.maxIntensity, JmaIntensity.two);
+    });
+
     test('regionsが空でIntensity.citiesのみの場合もツリーが構築される', () {
       final cities = [
         const api.IntensityItem(
@@ -532,11 +562,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value3,
         prefectures: [
-          (
-            code: '130000',
-            name: '東京都',
-            maxIntensity: api.JmaIntensity.value3,
-          ),
+          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value3),
         ],
         regions: [],
         cities: cities,
@@ -546,19 +572,14 @@ void main() {
           (
             code: '130000',
             name: '東京都',
-            cities: [
-              (
-                code: '1310000',
-                name: '東京都23区',
-                stations: const [],
-              ),
-            ],
+            cities: [(code: '1310000', name: '東京都23区', stations: const [])],
           ),
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result.keys.toList(), [JmaIntensity.three]);
       expect(result[JmaIntensity.three]![0].cities[0].city.name, '東京都23区');
@@ -568,11 +589,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
         prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
+          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
         ],
         regions: [],
       );
@@ -581,15 +598,14 @@ void main() {
           (
             code: '040000',
             name: '宮城県',
-            cities: [
-              (code: '0420100', name: '宮城県北部', stations: const []),
-            ],
+            cities: [(code: '0420100', name: '宮城県北部', stations: const [])],
           ),
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result.keys.toList(), [JmaIntensity.four]);
       expect(result[JmaIntensity.four]![0].region.region.name, '宮城県');
@@ -604,8 +620,9 @@ void main() {
       );
       final parameter = _buildParameter(regions: []);
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToIntensityTree(intensity: intensity);
 
       expect(result, isEmpty);
     });
@@ -620,8 +637,9 @@ void main() {
       );
       final parameter = _buildParameter(regions: []);
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToLpgmIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToLpgmIntensityTree(intensity: intensity);
 
       expect(result, isEmpty);
     });
@@ -665,13 +683,14 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToLpgmIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToLpgmIntensityTree(intensity: intensity);
 
-      expect(
-        result.keys.toList(),
-        [JmaLpgmIntensity.three, JmaLpgmIntensity.one],
-      );
+      expect(result.keys.toList(), [
+        JmaLpgmIntensity.three,
+        JmaLpgmIntensity.one,
+      ]);
 
       final group3 = result[JmaLpgmIntensity.three]!;
       expect(group3.length, 1);
@@ -688,11 +707,7 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
         prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
+          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
         ],
         regions: [
           (
@@ -722,15 +737,13 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToLpgmIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToLpgmIntensityTree(intensity: intensity);
 
       expect(result.keys.toList(), [JmaLpgmIntensity.two]);
       expect(result[JmaLpgmIntensity.two]![0].cities.length, 1);
-      expect(
-        result[JmaLpgmIntensity.two]![0].cities[0].city.name,
-        '宮城県南部',
-      );
+      expect(result[JmaLpgmIntensity.two]![0].cities[0].city.name, '宮城県南部');
     });
 
     test('LPGM震度キーは降順にソートされる', () {
@@ -743,11 +756,7 @@ void main() {
             name: '宮城県',
             maxIntensity: api.JmaIntensity.value5plus,
           ),
-          (
-            code: '070000',
-            name: '福島県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
+          (code: '070000', name: '福島県', maxIntensity: api.JmaIntensity.value4),
         ],
         regions: [
           (
@@ -788,8 +797,9 @@ void main() {
         ],
       );
 
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToLpgmIntensityTree(intensity: intensity);
+      final result = IntensityTreeConverter(
+        parameter: parameter,
+      ).convertToLpgmIntensityTree(intensity: intensity);
 
       final keys = result.keys.toList();
       expect(keys, [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- 地震履歴詳細地図のカスタムレイヤーを MapLibre の style 読み込み後にマウントするよう修正
- 推計震度の一時表示解除後は推計震度レイヤーを外し、通常の塗り潰しが隠れないよう修正
- 観測点を JMA パラメータ上の所属市区町村で紐づけ、観測点自身の震度・長周期地震動階級で描画するよう修正
- 観測点紐づけの回帰テストを追加

## 検証
- `flutter test test/feature/earthquake_history/data/model/intensity_tree_converter_test.dart`
- `flutter analyze app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart app/lib/feature/earthquake_history/data/model/intensity_tree_converter.dart app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart app/test/feature/earthquake_history/data/model/intensity_tree_converter_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6695ac5a-c088-4c97-bb1f-40093a1562b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6695ac5a-c088-4c97-bb1f-40093a1562b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

