### PR TITLE
Fix replay EEW timing alignment and card horizontal padding

### DIFF
--- a/app/lib/feature/debug/replay/debug_replay_provider.dart
+++ b/app/lib/feature/debug/replay/debug_replay_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:eqmonitor/feature/eew/data/eew_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';
@@ -69,10 +70,38 @@ class DebugReplay extends _$DebugReplay {
   }
 
   void _inject(EewItemWithRelations item, Duration offset) {
+    final replayShiftedForecastIntensity = item.forecastIntensity?.copyWith(
+      regions: item.forecastIntensity!.regions
+          .map(
+            (region) => region.copyWith(
+              arrivalTime: region.arrivalTime.copyWith(
+                value: region.arrivalTime.value?.add(offset),
+              ),
+            ),
+          )
+          .toList(),
+    );
+    final existingMagnitude = ref
+        .read(eewProvider)
+        .value
+        ?.where((eew) => eew.eventId == item.eventId)
+        .firstOrNull
+        ?.hypocenter
+        ?.magnitude;
+
+    final replayShiftedHypocenter =
+        item.hypocenter != null &&
+            item.hypocenter!.magnitude == null &&
+            existingMagnitude != null
+        ? item.hypocenter!.copyWith(magnitude: existingMagnitude)
+        : item.hypocenter;
+
     final shifted = item.copyWith(
       reportTime: item.reportTime.add(offset),
       originTime: item.originTime?.add(offset),
       arrivalTime: item.arrivalTime?.add(offset),
+      forecastIntensity: replayShiftedForecastIntensity,
+      hypocenter: replayShiftedHypocenter,
     );
     ref.read(eewProvider.notifier).upsert(shifted.toEewTelegramItem());
 

--- a/app/lib/feature/home/ui/component/eew/eew_card.dart
+++ b/app/lib/feature/home/ui/component/eew/eew_card.dart
@@ -164,18 +164,16 @@ class _EewMainCard extends StatelessWidget {
         regionDisplayName != null &&
         regionDisplayName!.isNotEmpty;
 
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: spacing.lg),
-      child: Card(
-        elevation: 0,
-        clipBehavior: Clip.antiAlias,
-        margin: EdgeInsets.zero,
-        color: color.surfaceCard,
-        shape: RoundedSuperellipseBorder(
-          borderRadius: BorderRadius.circular(shape.card),
-          side: BorderSide(color: color.outlineSoft),
-        ),
-        child: Column(
+    return Card(
+      elevation: 0,
+      clipBehavior: Clip.antiAlias,
+      margin: EdgeInsets.zero,
+      color: color.surfaceCard,
+      shape: RoundedSuperellipseBorder(
+        borderRadius: BorderRadius.circular(shape.card),
+        side: BorderSide(color: color.outlineSoft),
+      ),
+      child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _EewCardHeader(
@@ -219,7 +217,6 @@ class _EewMainCard extends StatelessWidget {
             ),
           ],
         ),
-      ),
     );
   }
 }

--- a/docs/knowledge/20260501_debug_replay_eew_time_shift.md
+++ b/docs/knowledge/20260501_debug_replay_eew_time_shift.md
@@ -1,0 +1,9 @@
+# Debug Replay時のEEW到達時刻のシフト
+
+## ルール
+- `feature/debug/replay/debug_replay_provider.dart` でEEWをリプレイ注入する際は、`reportTime` / `originTime` / `arrivalTime` だけでなく、`forecastIntensity.regions[].arrivalTime.value` も同じ `offset` でシフトする。
+- 上記を行わないと、カード上の「主要動到達まで/到達済み」判定が過去時刻基準になり、リプレイ再生時刻と表示が一致しない。
+
+## 実装ポイント
+- `item.forecastIntensity?.copyWith(regions: ...)` でリージョン配列を再構築し、各 `arrivalTime.value` に `add(offset)` を適用する。
+- 既存イベントを再注入するケースでは、`hypocenter.magnitude` が欠損していた場合に既存EEWの値を補完することで、表示の欠落を避けられる。


### PR DESCRIPTION
### Motivation
- Replay-injected EEW frames showed missing magnitude and incorrect local arrival display because only `reportTime`/`originTime`/`arrivalTime` were shifted during replay injection. 
- Local "到達まで/到達済み" state must follow the replayed timeline so UI countdowns match replay time.  
- EEW card had extra horizontal padding causing unnecessary side margins in the layout.

### Description
- In `debug_replay_provider.dart` updated `_inject` to shift per-region arrival timestamps by constructing `replayShiftedForecastIntensity` where each `forecastIntensity.regions[].arrivalTime.value` is `add(offset)` and applied it via `copyWith` to the replayed item.  
- Added magnitude backfill logic that reads the current `eewProvider` and, when the incoming replay `hypocenter.magnitude` is `null`, reuses an existing known magnitude for the same `eventId` and injects it into the replay frame.  
- Wired the shifted forecast intensity and (possibly backfilled) hypocenter into the `shifted` item so injected EEW items reflect replayed timing and available magnitude.  
- Removed outer horizontal `Padding` around the `Card` in `EewCard` to eliminate the extra left/right margins and adjusted imports (`package:collection/collection.dart`) and added a knowledge note `docs/knowledge/20260501_debug_replay_eew_time_shift.md` documenting the replay timestamp shift rule.

### Testing
- Verified the code changes by inspecting the git diff for `app/lib/feature/debug/replay/debug_replay_provider.dart` and `app/lib/feature/home/ui/component/eew/eew_card.dart` which reflect the intended modifications.  
- Commit succeeded locally (`fix リプレイ時のEEW到達時刻補正とカード余白を調整`).  
- Attempt to run `dart format` via the project `mise` wrapper failed due to a `mise` version/trust mismatch and direct `dart` was not available in the environment.  
- `git push` was not performed because no remote is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f4e457e3dc8320a8619162cab17720)