### PR TITLE
WebSocket の起動時接続を修正

### DIFF
--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.dart
@@ -1,0 +1,105 @@
+import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
+import 'package:eqmonitor/core/realtime/model/realtime_shake_data.dart';
+import 'package:eqmonitor_websocket/eqmonitor_websocket.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eqmonitor_realtime_event_mapper.g.dart';
+
+@Riverpod(keepAlive: true)
+EqMonitorRealtimeEventMapper eqMonitorRealtimeEventMapper(Ref ref) =>
+    const EqMonitorRealtimeEventMapper();
+
+class EqMonitorRealtimeEventMapper {
+  const EqMonitorRealtimeEventMapper();
+
+  static const tilesBaseUrl = 'https://tiles.eqmonitor.app';
+
+  List<RealtimeEvent> map(WsMessage message) => switch (message) {
+    WsSnapshotMessage(:final data) => [
+      RealtimeEvent.snapshot(
+        eews: data.eews,
+        earthquakes: data.earthquakes,
+        shakes: data.shakes.map(mapSnapshotShakeEntry).toList(),
+        source: RealtimeSource.eqmonitor,
+      ),
+    ],
+    WsRealtimeMessage(:final data) => switch (data) {
+      WsEewRealtimeEvent(:final item) => [
+        RealtimeEvent.eewUpsert(
+          item: item,
+          source: RealtimeSource.eqmonitor,
+        ),
+      ],
+      WsEarthquakeRealtimeEvent(
+        :final operation,
+        :final eventId,
+        :final record,
+      ) =>
+        switch (operation) {
+          'upsert' when record != null => [
+            RealtimeEvent.earthquakeUpsert(
+              record: record,
+              source: RealtimeSource.eqmonitor,
+            ),
+          ],
+          'delete' => [
+            RealtimeEvent.earthquakeDelete(
+              eventId: eventId,
+              source: RealtimeSource.eqmonitor,
+            ),
+          ],
+          _ => const <RealtimeEvent>[],
+        },
+      WsShakeDetectedRealtimeEvent(
+        :final eventId,
+        :final createdAt,
+        :final level,
+        :final changeReasons,
+        :final isReplay,
+        :final pointCount,
+        :final region,
+      ) =>
+        [
+          RealtimeEvent.shakeDetected(
+            data: RealtimeShakeData(
+              eventId: eventId,
+              createdAt: createdAt,
+              level: level,
+              isReplay: isReplay,
+              pointCount: pointCount,
+              minLat: region.bottomRight.latitude,
+              maxLat: region.topLeft.latitude,
+              minLng: region.topLeft.longitude,
+              maxLng: region.bottomRight.longitude,
+              changeReasons: changeReasons,
+            ),
+            source: RealtimeSource.eqmonitor,
+          ),
+        ],
+      WsEstimatedIntensityRealtimeEvent(:final estimatedIntensity) => [
+        RealtimeEvent.estimatedIntensityUpsert(
+          eventId: estimatedIntensity.eventId,
+          estimatedIntensityTile:
+              '$tilesBaseUrl/${estimatedIntensity.estimatedIntensityKey}',
+          source: RealtimeSource.eqmonitor,
+        ),
+      ],
+      _ => const <RealtimeEvent>[],
+    },
+    WsPingMessage() => const <RealtimeEvent>[],
+  };
+
+  RealtimeShakeData mapSnapshotShakeEntry(WsSnapshotShakeEntry entry) =>
+      RealtimeShakeData(
+        eventId: entry.eventId,
+        createdAt: entry.createdAt,
+        level: entry.level,
+        isReplay: entry.isReplay,
+        pointCount: entry.pointCount,
+        minLat: entry.region.bottomRight.latitude,
+        maxLat: entry.region.topLeft.latitude,
+        minLng: entry.region.topLeft.longitude,
+        maxLng: entry.region.bottomRight.longitude,
+        changeReasons: entry.changeReasons,
+      );
+}

--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.g.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eqmonitor_realtime_event_mapper.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eqMonitorRealtimeEventMapper)
+final eqMonitorRealtimeEventMapperProvider =
+    EqMonitorRealtimeEventMapperProvider._();
+
+final class EqMonitorRealtimeEventMapperProvider
+    extends
+        $FunctionalProvider<
+          EqMonitorRealtimeEventMapper,
+          EqMonitorRealtimeEventMapper,
+          EqMonitorRealtimeEventMapper
+        >
+    with $Provider<EqMonitorRealtimeEventMapper> {
+  EqMonitorRealtimeEventMapperProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eqMonitorRealtimeEventMapperProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eqMonitorRealtimeEventMapperHash();
+
+  @$internal
+  @override
+  $ProviderElement<EqMonitorRealtimeEventMapper> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EqMonitorRealtimeEventMapper create(Ref ref) {
+    return eqMonitorRealtimeEventMapper(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EqMonitorRealtimeEventMapper value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EqMonitorRealtimeEventMapper>(value),
+    );
+  }
+}
+
+String _$eqMonitorRealtimeEventMapperHash() =>
+    r'cd9b3dbca30c7a755cfe43b1bbb935a1e54e9cbd';

--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_data_source.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_data_source.dart
@@ -6,5 +6,6 @@ part 'eqmonitor_ws_data_source.g.dart';
 
 @Riverpod(keepAlive: true)
 Stream<RealtimeEvent> eqMonitorWsDataSource(Ref ref) {
-  return ref.read(eqMonitorWsStatusProvider.notifier).eventStream;
+  ref.read(eqMonitorWsStatusProvider);
+  return ref.watch(eqMonitorWsStatusProvider.notifier).eventStream;
 }

--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart
@@ -7,9 +7,9 @@ import 'dart:ui';
 import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.dart';
 import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_state.dart';
 import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
-import 'package:eqmonitor/core/realtime/model/realtime_shake_data.dart';
 import 'package:eqmonitor_websocket/eqmonitor_websocket.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -29,6 +29,7 @@ class EqMonitorWsStatus extends _$EqMonitorWsStatus {
   EqMonitorWsStatusState build() {
     final version = ++_buildVersion;
     bool isActive() => _buildVersion == version && !_eventController.isClosed;
+    final realtimeEventMapper = ref.watch(eqMonitorRealtimeEventMapperProvider);
     _ws = null;
 
     ref.onDispose(() {
@@ -51,15 +52,18 @@ class EqMonitorWsStatus extends _$EqMonitorWsStatus {
       }
     });
 
-    unawaited(_connectWithRetry(isActive));
+    unawaited(_connectWithRetry(isActive, realtimeEventMapper));
     return const EqMonitorWsStatusState();
   }
 
-  Future<void> _connectWithRetry(bool Function() isActive) async {
+  Future<void> _connectWithRetry(
+    bool Function() isActive,
+    EqMonitorRealtimeEventMapper realtimeEventMapper,
+  ) async {
     var retryCount = 0;
     while (isActive()) {
       try {
-        await _connect(isActive);
+        await _connect(isActive, realtimeEventMapper);
         retryCount = 0;
       } on Exception catch (e, st) {
         if (!isActive()) {
@@ -76,7 +80,10 @@ class EqMonitorWsStatus extends _$EqMonitorWsStatus {
     }
   }
 
-  Future<void> _connect(bool Function() isActive) async {
+  Future<void> _connect(
+    bool Function() isActive,
+    EqMonitorRealtimeEventMapper realtimeEventMapper,
+  ) async {
     _setConnecting();
 
     final api = await ref.read(apiClientProvider.future);
@@ -120,7 +127,7 @@ class EqMonitorWsStatus extends _$EqMonitorWsStatus {
         }
 
         talker.log('EqMonitorWS message (${message.runtimeType})');
-        for (final event in _toRealtimeEvents(message)) {
+        for (final event in realtimeEventMapper.map(message)) {
           if (!_eventController.isClosed) {
             _eventController.add(event);
           }
@@ -166,97 +173,4 @@ class EqMonitorWsStatus extends _$EqMonitorWsStatus {
     }
     return uri.replace(queryParameters: params).toString();
   }
-
-  List<RealtimeEvent> _toRealtimeEvents(WsMessage msg) {
-    return switch (msg) {
-      WsSnapshotMessage(:final data) => [
-        RealtimeEvent.snapshot(
-          eews: data.eews,
-          earthquakes: data.earthquakes,
-          shakes: data.shakes.map(_toRealtimeShakeData).toList(),
-          source: RealtimeSource.eqmonitor,
-        ),
-      ],
-      WsRealtimeMessage(:final data) => switch (data) {
-        WsEewRealtimeEvent(:final item) => [
-          RealtimeEvent.eewUpsert(
-            item: item,
-            source: RealtimeSource.eqmonitor,
-          ),
-        ],
-        WsEarthquakeRealtimeEvent(
-          :final operation,
-          :final eventId,
-          :final record,
-        ) =>
-          switch (operation) {
-            'upsert' when record != null => [
-              RealtimeEvent.earthquakeUpsert(
-                record: record,
-                source: RealtimeSource.eqmonitor,
-              ),
-            ],
-            'delete' => [
-              RealtimeEvent.earthquakeDelete(
-                eventId: eventId,
-                source: RealtimeSource.eqmonitor,
-              ),
-            ],
-            _ => const <RealtimeEvent>[],
-          },
-        WsShakeDetectedRealtimeEvent(
-          :final eventId,
-          :final createdAt,
-          :final level,
-          :final changeReasons,
-          :final isReplay,
-          :final pointCount,
-          :final region,
-        ) =>
-          [
-            RealtimeEvent.shakeDetected(
-              data: RealtimeShakeData(
-                eventId: eventId,
-                createdAt: createdAt,
-                level: level,
-                isReplay: isReplay,
-                pointCount: pointCount,
-                minLat: region.bottomRight.latitude,
-                maxLat: region.topLeft.latitude,
-                minLng: region.topLeft.longitude,
-                maxLng: region.bottomRight.longitude,
-                changeReasons: changeReasons,
-              ),
-              source: RealtimeSource.eqmonitor,
-            ),
-          ],
-        WsEstimatedIntensityRealtimeEvent(:final estimatedIntensity) => [
-          RealtimeEvent.estimatedIntensityUpsert(
-            eventId: estimatedIntensity.eventId,
-            estimatedIntensityTile:
-                '$_tilesBaseUrl/${estimatedIntensity.estimatedIntensityKey}',
-            source: RealtimeSource.eqmonitor,
-          ),
-        ],
-        _ => const <RealtimeEvent>[],
-      },
-      WsPingMessage() => const <RealtimeEvent>[],
-    };
-  }
-
-  static const _tilesBaseUrl = 'https://tiles.eqmonitor.app';
-
-  RealtimeShakeData _toRealtimeShakeData(WsSnapshotShakeEntry e) =>
-      RealtimeShakeData(
-        eventId: e.eventId,
-        createdAt: e.createdAt,
-        level: e.level,
-        isReplay: e.isReplay,
-        pointCount: e.pointCount,
-        minLat: e.region.bottomRight.latitude,
-        maxLat: e.region.topLeft.latitude,
-        minLng: e.region.topLeft.longitude,
-        maxLng: e.region.bottomRight.longitude,
-        changeReasons: e.changeReasons,
-      );
 }

--- a/app/lib/core/realtime/realtime_event_bootstrap_provider.dart
+++ b/app/lib/core/realtime/realtime_event_bootstrap_provider.dart
@@ -1,0 +1,10 @@
+import 'package:eqmonitor/core/realtime/realtime_event_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'realtime_event_bootstrap_provider.g.dart';
+
+/// アプリ起動時にリアルタイムイベントの購読を開始する。
+@Riverpod(keepAlive: true)
+void realtimeEventBootstrap(Ref ref) {
+  ref.listen(realtimeEventsProvider, (_, _) {});
+}

--- a/app/lib/core/realtime/realtime_event_bootstrap_provider.g.dart
+++ b/app/lib/core/realtime/realtime_event_bootstrap_provider.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'realtime_event_bootstrap_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+@ProviderFor(realtimeEventBootstrap)
+final realtimeEventBootstrapProvider = RealtimeEventBootstrapProvider._();
+
+final class RealtimeEventBootstrapProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  RealtimeEventBootstrapProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'realtimeEventBootstrapProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$realtimeEventBootstrapHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return realtimeEventBootstrap(ref);
+  }
+}
+
+String _$realtimeEventBootstrapHash() =>
+    r'91f18185b6a2d3a50ad891c8d42202d466639b16';

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/provider/shared_preferences.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
+import 'package:eqmonitor/core/realtime/realtime_event_bootstrap_provider.dart';
 import 'package:eqmonitor/core/util/license/init_licenses.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/kyoshin_color_map_data_source.dart';
@@ -182,6 +183,8 @@ Future<void> main() async {
     container.read(travelTimeInternalProvider.future),
     container.read(earthquakeHistoryConfigProvider.future),
   ).wait;
+
+  container.read(realtimeEventBootstrapProvider);
 
   runApp(UncontrolledProviderScope(container: container, child: const App()));
 

--- a/app/test/core/realtime/eqmonitor_realtime_event_mapper_test.dart
+++ b/app/test/core/realtime/eqmonitor_realtime_event_mapper_test.dart
@@ -1,0 +1,93 @@
+import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.dart';
+import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
+import 'package:eqmonitor_websocket/eqmonitor_websocket.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const mapper = EqMonitorRealtimeEventMapper();
+
+  group('EqMonitorRealtimeEventMapper', () {
+    test('snapshot の揺れ検知範囲を RealtimeShakeData に変換できること', () {
+      final result = mapper.map(
+        WsMessage.snapshot(
+          data: WsSnapshotData(
+            revision: 1,
+            updatedAt: DateTime.utc(2026),
+            shakes: [
+              WsSnapshotShakeEntry(
+                eventId: 'shake-1',
+                createdAt: DateTime.utc(2026, 5, 1, 9),
+                level: 'medium',
+                isReplay: false,
+                pointCount: 12,
+                region: const WsShakeRegionPayload(
+                  topLeft: WsShakeLocationPayload(
+                    latitude: 36,
+                    longitude: 139,
+                  ),
+                  bottomRight: WsShakeLocationPayload(
+                    latitude: 35,
+                    longitude: 140,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(result, hasLength(1));
+      final event = result.single;
+      expect(event, isA<RealtimeSnapshotEvent>());
+      final snapshot = event as RealtimeSnapshotEvent;
+      expect(snapshot.source, RealtimeSource.eqmonitor);
+      expect(snapshot.shakes.single.eventId, 'shake-1');
+      expect(snapshot.shakes.single.minLat, 35);
+      expect(snapshot.shakes.single.maxLat, 36);
+      expect(snapshot.shakes.single.minLng, 139);
+      expect(snapshot.shakes.single.maxLng, 140);
+    });
+
+    test('earthquake delete を削除イベントに変換できること', () {
+      final result = mapper.map(
+        const WsMessage.realtime(
+          data: RealtimeEventEnvelope.earthquake(
+            operation: 'delete',
+            eventId: '20260501090000',
+          ),
+        ),
+      );
+
+      expect(result, hasLength(1));
+      final event = result.single;
+      expect(event, isA<RealtimeEarthquakeDeleteEvent>());
+      final delete = event as RealtimeEarthquakeDeleteEvent;
+      expect(delete.eventId, '20260501090000');
+      expect(delete.source, RealtimeSource.eqmonitor);
+    });
+
+    test('推計震度イベントのタイル URL を構築できること', () {
+      final result = mapper.map(
+        WsMessage.realtime(
+          data: RealtimeEventEnvelope.estimatedIntensity(
+            estimatedIntensity: WsEstimatedIntensityPayload(
+              eventId: '20260501090100',
+              estimatedIntensityKey: '20260501090100/1.json',
+              createdAt: DateTime.utc(2026, 5, 1, 9, 1),
+            ),
+          ),
+        ),
+      );
+
+      expect(result, hasLength(1));
+      final event = result.single;
+      expect(event, isA<RealtimeEstimatedIntensityUpsertEvent>());
+      final upsert = event as RealtimeEstimatedIntensityUpsertEvent;
+      expect(upsert.eventId, '20260501090100');
+      expect(
+        upsert.estimatedIntensityTile,
+        'https://tiles.eqmonitor.app/20260501090100/1.json',
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- アプリ起動時にリアルタイムイベント購読を bootstrap して WebSocket 接続を開始
- WebSocket data source が status provider を明示的に構築するよう修正
- WebSocket メッセージから RealtimeEvent への変換を mapper に切り出し、単体テストを追加

## 検証
- `git --no-pager diff --check`
- `mise exec -- dart run build_runner build --delete-conflicting-outputs` は Cloud 環境に `mise` が無く未実行
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92fad9a3-1083-49b7-ba12-9707e4b05dde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92fad9a3-1083-49b7-ba12-9707e4b05dde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

