### PR TITLE
揺れ検知Live Activityの表示を改善

### DIFF
--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -325,10 +325,22 @@ struct ShakeExpandedCenterView: View {
     let state: ShakeDetectionContentState
 
     var body: some View {
-        if let level = state.shakeLevel {
-            Text(level.displayString)
-                .font(.system(size: 14, weight: .bold))
+        VStack(alignment: .leading, spacing: 1) {
+            Text("観測地点")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundColor(.secondary)
+            Text(locationText)
+                .font(.system(size: 15, weight: .bold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
         }
+    }
+
+    private var locationText: String {
+        guard let regionName = state.location?.regionName, !regionName.isEmpty else {
+            return "地点情報なし"
+        }
+        return regionName
     }
 }
 
@@ -337,12 +349,29 @@ struct ShakeExpandedBottomView: View {
     let state: ShakeDetectionContentState
 
     var body: some View {
-        HStack {
-            if let location = state.location {
-                Text(location.regionName)
-                    .font(.system(size: 13, weight: .semibold))
+        HStack(alignment: .firstTextBaseline) {
+            if let level = state.shakeLevel {
+                Text(level.displayString)
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
             }
+
             Spacer()
+
+            if let intensity = state.location?.intensity {
+                HStack(alignment: .firstTextBaseline, spacing: 2) {
+                    Text("計測震度")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.secondary)
+                    Text(String(format: "%.1f", intensity))
+                        .font(.system(size: 14, weight: .bold, design: .monospaced))
+                        .monospacedDigit()
+                }
+            } else if let date = state.detectedDate {
+                Text(date, style: .time)
+                    .font(.system(size: 13, weight: .bold, design: .monospaced))
+            }
         }
     }
 }

--- a/app/ios/Widget/LiveActivity/ShakeDetection/ShakeDetectionLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/ShakeDetection/ShakeDetectionLiveActivityView.swift
@@ -101,6 +101,62 @@ struct ShakeLevelChip: View {
     }
 }
 
+// MARK: - Location Summary
+
+@available(iOS 16.1, *)
+struct ShakeDetectionLocationSummaryView: View {
+    let location: LocationInfo?
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "location.fill")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(.white.opacity(0.86))
+                .frame(width: 28, height: 28)
+                .background(Color.white.opacity(0.12))
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("観測地点")
+                    .liveActivityLabelStyle()
+                Text(locationText)
+                    .font(.system(size: 19, weight: .heavy))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var locationText: String {
+        guard let regionName = location?.regionName, !regionName.isEmpty else {
+            return "観測地点情報なし"
+        }
+        return "\(regionName)で検知"
+    }
+}
+
+@available(iOS 16.1, *)
+struct ShakeObservedIntensityPill: View {
+    let intensity: Double
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text("計測震度")
+                .liveActivityLabelStyle()
+            Text(String(format: "%.1f", intensity))
+                .font(.system(size: 18, weight: .black, design: .monospaced))
+                .foregroundColor(.primary)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(Color.primary.opacity(0.08))
+        .clipShape(Capsule())
+    }
+}
+
 // MARK: - Lock Screen View
 
 @available(iOS 16.1, *)
@@ -122,25 +178,26 @@ struct ShakeDetectionLockScreenView: View {
             .padding(.bottom, 8)
 
             // メインコンテンツ
-            HStack(alignment: .center, spacing: 12) {
-                // 揺れレベルChip
-                if let level = state.shakeLevel {
-                    ShakeLevelChip(level: level)
-                }
+            VStack(alignment: .leading, spacing: 10) {
+                ShakeDetectionLocationSummaryView(location: state.location)
 
-                // 地名
-                if let location = state.location {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("観測地点")
-                            .liveActivityLabelStyle()
-                        Text(location.regionName)
-                            .font(.system(size: 16, weight: .heavy))
-                            .foregroundColor(.primary)
-                            .lineLimit(1)
+                HStack(alignment: .center, spacing: 8) {
+                    if let level = state.shakeLevel {
+                        ShakeLevelChip(level: level)
+                    }
+
+                    Text("端末周辺で揺れを検知しました")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(liveActivitySecondaryTextColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+
+                    Spacer(minLength: 0)
+
+                    if let intensity = state.location?.intensity {
+                        ShakeObservedIntensityPill(intensity: intensity)
                     }
                 }
-
-                Spacer()
             }
             .padding(.horizontal, standardMargin)
             .padding(.bottom, standardMargin)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- 揺れ検知 Live Activity のロック画面表示で観測地点を主情報として表示
- 揺れレベル、補足文、計測震度を下段に整理
- Dynamic Island 展開表示でも観測地点と計測震度が見えるように調整

## 確認
- `git --no-pager diff --check`

## 備考
- この Linux 環境では `mise` / Swift / Xcode ツールチェーンが利用できず、iOS Widget のビルド確認は未実施です。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7828f929-cc9f-48c0-8b28-b492eeca170d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7828f929-cc9f-48c0-8b28-b492eeca170d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

