### PR TITLE
eqmonitor_api の intensityTree 変更に対応（アプリ側の解析・検索・EEW座標）

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/coordinate.dart
+++ b/app/lib/feature/earthquake_history/data/model/coordinate.dart
@@ -18,25 +18,8 @@ sealed class Coordinate with _$Coordinate {
 }
 
 extension CoordinateApiExtension on api.Coordinate {
-  Coordinate get toCoordinate => switch (type) {
-    .latLng => .latLng(
-      latitude:
-          latitude?.toDouble() ??
-          (throw CheckedFromJsonException(
-            toJson(),
-            'latitude',
-            'Coordinate',
-            'latitude',
-          )),
-      longitude:
-          longitude?.toDouble() ??
-          (throw CheckedFromJsonException(
-            toJson(),
-            'longitude',
-            'Coordinate',
-            'longitude',
-          )),
-    ),
-    .unknown => const .unknown(),
-  };
+  Coordinate get toCoordinate => Coordinate.latLng(
+    latitude: latitude.toDouble(),
+    longitude: longitude.toDouble(),
+  );
 }

--- a/app/lib/feature/earthquake_history/data/model/earthquake_intensity.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_intensity.dart
@@ -41,3 +41,26 @@ extension EarthquakeIntensityApiExtension on api.Intensity {
     );
   }
 }
+
+extension EarthquakeIntensityMapLayer on EarthquakeIntensity {
+  /// `areaForecastLocalE` の `code` と塗り分け震度（都道府県のみ／細分化地域）
+  Iterable<({String code, JmaIntensity intensity})>
+  get forecastLocalEIntensityPairs sync* {
+    for (final entry in intensityTree.entries) {
+      final level = entry.key;
+      for (final pref in entry.value) {
+        if (pref.cities.isEmpty) {
+          final j = pref.region.maxIntensity ?? level;
+          yield (code: pref.region.region.code, intensity: j);
+        } else {
+          for (final city in pref.cities) {
+            final j = city.maxIntensity;
+            if (j != null) {
+              yield (code: city.city.code, intensity: j);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/lib/feature/earthquake_history/data/model/earthquake_intensity_partial.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_intensity_partial.dart
@@ -1,6 +1,5 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
-import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:jma_parameter_types/earthquake_param.pb.dart';
@@ -13,7 +12,6 @@ abstract class EarthquakeIntensityPartial with _$EarthquakeIntensityPartial {
   const factory EarthquakeIntensityPartial({
     required JmaIntensity maxIntensity,
     required JmaLpgmIntensity? maxLpgmIntensity,
-    required List<IntensityRegion> regions,
   }) = _EarthquakeIntensityPartial;
 
   factory EarthquakeIntensityPartial.fromJson(Map<String, dynamic> json) =>
@@ -24,23 +22,9 @@ extension EarthquakeIntensityPartialApiExtension on api.IntensityPartial {
   EarthquakeIntensityPartial toEarthquakeIntensityPartial({
     required EarthquakeParameter parameter,
   }) {
-    final paramRegionMap = {for (final r in parameter.regions) r.code: r};
     return EarthquakeIntensityPartial(
       maxIntensity: maxIntensity.toJmaIntensity,
       maxLpgmIntensity: maxLpgmIntensity?.toJmaLpgmIntensity,
-      regions: regions
-          .map((e) {
-            final paramRegion = paramRegionMap[e.value.code];
-            if (paramRegion == null) {
-              return null;
-            }
-            return IntensityRegion(
-              region: paramRegion,
-              maxIntensity: e.maxIntensity?.toJmaIntensity,
-            );
-          })
-          .whereType<IntensityRegion>()
-          .toList(),
     );
   }
 }

--- a/app/lib/feature/earthquake_history/data/model/earthquake_intensity_partial.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_intensity_partial.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EarthquakeIntensityPartial {
 
- JmaIntensity get maxIntensity; JmaLpgmIntensity? get maxLpgmIntensity; List<IntensityRegion> get regions;
+ JmaIntensity get maxIntensity; JmaLpgmIntensity? get maxLpgmIntensity;
 /// Create a copy of EarthquakeIntensityPartial
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EarthquakeIntensityPartialCopyWith<EarthquakeIntensityPartial> get copyWith => 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeIntensityPartial&&(identical(other.maxIntensity, maxIntensity) || other.maxIntensity == maxIntensity)&&(identical(other.maxLpgmIntensity, maxLpgmIntensity) || other.maxLpgmIntensity == maxLpgmIntensity)&&const DeepCollectionEquality().equals(other.regions, regions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeIntensityPartial&&(identical(other.maxIntensity, maxIntensity) || other.maxIntensity == maxIntensity)&&(identical(other.maxLpgmIntensity, maxLpgmIntensity) || other.maxLpgmIntensity == maxLpgmIntensity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,maxIntensity,maxLpgmIntensity,const DeepCollectionEquality().hash(regions));
+int get hashCode => Object.hash(runtimeType,maxIntensity,maxLpgmIntensity);
 
 @override
 String toString() {
-  return 'EarthquakeIntensityPartial(maxIntensity: $maxIntensity, maxLpgmIntensity: $maxLpgmIntensity, regions: $regions)';
+  return 'EarthquakeIntensityPartial(maxIntensity: $maxIntensity, maxLpgmIntensity: $maxLpgmIntensity)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EarthquakeIntensityPartialCopyWith<$Res>  {
   factory $EarthquakeIntensityPartialCopyWith(EarthquakeIntensityPartial value, $Res Function(EarthquakeIntensityPartial) _then) = _$EarthquakeIntensityPartialCopyWithImpl;
 @useResult
 $Res call({
- JmaIntensity maxIntensity, JmaLpgmIntensity? maxLpgmIntensity, List<IntensityRegion> regions
+ JmaIntensity maxIntensity, JmaLpgmIntensity? maxLpgmIntensity
 });
 
 
@@ -65,12 +65,11 @@ class _$EarthquakeIntensityPartialCopyWithImpl<$Res>
 
 /// Create a copy of EarthquakeIntensityPartial
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? maxIntensity = null,Object? maxLpgmIntensity = freezed,Object? regions = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? maxIntensity = null,Object? maxLpgmIntensity = freezed,}) {
   return _then(_self.copyWith(
 maxIntensity: null == maxIntensity ? _self.maxIntensity : maxIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity,maxLpgmIntensity: freezed == maxLpgmIntensity ? _self.maxLpgmIntensity : maxLpgmIntensity // ignore: cast_nullable_to_non_nullable
-as JmaLpgmIntensity?,regions: null == regions ? _self.regions : regions // ignore: cast_nullable_to_non_nullable
-as List<IntensityRegion>,
+as JmaLpgmIntensity?,
   ));
 }
 
@@ -155,10 +154,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( JmaIntensity maxIntensity,  JmaLpgmIntensity? maxLpgmIntensity,  List<IntensityRegion> regions)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( JmaIntensity maxIntensity,  JmaLpgmIntensity? maxLpgmIntensity)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EarthquakeIntensityPartial() when $default != null:
-return $default(_that.maxIntensity,_that.maxLpgmIntensity,_that.regions);case _:
+return $default(_that.maxIntensity,_that.maxLpgmIntensity);case _:
   return orElse();
 
 }
@@ -176,10 +175,10 @@ return $default(_that.maxIntensity,_that.maxLpgmIntensity,_that.regions);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( JmaIntensity maxIntensity,  JmaLpgmIntensity? maxLpgmIntensity,  List<IntensityRegion> regions)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( JmaIntensity maxIntensity,  JmaLpgmIntensity? maxLpgmIntensity)  $default,) {final _that = this;
 switch (_that) {
 case _EarthquakeIntensityPartial():
-return $default(_that.maxIntensity,_that.maxLpgmIntensity,_that.regions);case _:
+return $default(_that.maxIntensity,_that.maxLpgmIntensity);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +195,10 @@ return $default(_that.maxIntensity,_that.maxLpgmIntensity,_that.regions);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( JmaIntensity maxIntensity,  JmaLpgmIntensity? maxLpgmIntensity,  List<IntensityRegion> regions)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( JmaIntensity maxIntensity,  JmaLpgmIntensity? maxLpgmIntensity)?  $default,) {final _that = this;
 switch (_that) {
 case _EarthquakeIntensityPartial() when $default != null:
-return $default(_that.maxIntensity,_that.maxLpgmIntensity,_that.regions);case _:
+return $default(_that.maxIntensity,_that.maxLpgmIntensity);case _:
   return null;
 
 }
@@ -211,18 +210,11 @@ return $default(_that.maxIntensity,_that.maxLpgmIntensity,_that.regions);case _:
 @JsonSerializable()
 
 class _EarthquakeIntensityPartial implements EarthquakeIntensityPartial {
-  const _EarthquakeIntensityPartial({required this.maxIntensity, required this.maxLpgmIntensity, required final  List<IntensityRegion> regions}): _regions = regions;
+  const _EarthquakeIntensityPartial({required this.maxIntensity, required this.maxLpgmIntensity});
   factory _EarthquakeIntensityPartial.fromJson(Map<String, dynamic> json) => _$EarthquakeIntensityPartialFromJson(json);
 
 @override final  JmaIntensity maxIntensity;
 @override final  JmaLpgmIntensity? maxLpgmIntensity;
- final  List<IntensityRegion> _regions;
-@override List<IntensityRegion> get regions {
-  if (_regions is EqualUnmodifiableListView) return _regions;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_regions);
-}
-
 
 /// Create a copy of EarthquakeIntensityPartial
 /// with the given fields replaced by the non-null parameter values.
@@ -237,16 +229,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeIntensityPartial&&(identical(other.maxIntensity, maxIntensity) || other.maxIntensity == maxIntensity)&&(identical(other.maxLpgmIntensity, maxLpgmIntensity) || other.maxLpgmIntensity == maxLpgmIntensity)&&const DeepCollectionEquality().equals(other._regions, _regions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeIntensityPartial&&(identical(other.maxIntensity, maxIntensity) || other.maxIntensity == maxIntensity)&&(identical(other.maxLpgmIntensity, maxLpgmIntensity) || other.maxLpgmIntensity == maxLpgmIntensity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,maxIntensity,maxLpgmIntensity,const DeepCollectionEquality().hash(_regions));
+int get hashCode => Object.hash(runtimeType,maxIntensity,maxLpgmIntensity);
 
 @override
 String toString() {
-  return 'EarthquakeIntensityPartial(maxIntensity: $maxIntensity, maxLpgmIntensity: $maxLpgmIntensity, regions: $regions)';
+  return 'EarthquakeIntensityPartial(maxIntensity: $maxIntensity, maxLpgmIntensity: $maxLpgmIntensity)';
 }
 
 
@@ -257,7 +249,7 @@ abstract mixin class _$EarthquakeIntensityPartialCopyWith<$Res> implements $Eart
   factory _$EarthquakeIntensityPartialCopyWith(_EarthquakeIntensityPartial value, $Res Function(_EarthquakeIntensityPartial) _then) = __$EarthquakeIntensityPartialCopyWithImpl;
 @override @useResult
 $Res call({
- JmaIntensity maxIntensity, JmaLpgmIntensity? maxLpgmIntensity, List<IntensityRegion> regions
+ JmaIntensity maxIntensity, JmaLpgmIntensity? maxLpgmIntensity
 });
 
 
@@ -274,12 +266,11 @@ class __$EarthquakeIntensityPartialCopyWithImpl<$Res>
 
 /// Create a copy of EarthquakeIntensityPartial
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? maxIntensity = null,Object? maxLpgmIntensity = freezed,Object? regions = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? maxIntensity = null,Object? maxLpgmIntensity = freezed,}) {
   return _then(_EarthquakeIntensityPartial(
 maxIntensity: null == maxIntensity ? _self.maxIntensity : maxIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity,maxLpgmIntensity: freezed == maxLpgmIntensity ? _self.maxLpgmIntensity : maxLpgmIntensity // ignore: cast_nullable_to_non_nullable
-as JmaLpgmIntensity?,regions: null == regions ? _self._regions : regions // ignore: cast_nullable_to_non_nullable
-as List<IntensityRegion>,
+as JmaLpgmIntensity?,
   ));
 }
 

--- a/app/lib/feature/earthquake_history/data/model/earthquake_intensity_partial.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_intensity_partial.g.dart
@@ -23,12 +23,6 @@ _EarthquakeIntensityPartial _$EarthquakeIntensityPartialFromJson(
         'max_lpgm_intensity',
         (v) => $enumDecodeNullable(_$JmaLpgmIntensityEnumMap, v),
       ),
-      regions: $checkedConvert(
-        'regions',
-        (v) => (v as List<dynamic>)
-            .map((e) => IntensityRegion.fromJson(e as Map<String, dynamic>))
-            .toList(),
-      ),
     );
     return val;
   },
@@ -43,7 +37,6 @@ Map<String, dynamic> _$EarthquakeIntensityPartialToJson(
 ) => <String, dynamic>{
   'max_intensity': _$JmaIntensityEnumMap[instance.maxIntensity]!,
   'max_lpgm_intensity': _$JmaLpgmIntensityEnumMap[instance.maxLpgmIntensity],
-  'regions': instance.regions,
 };
 
 const _$JmaIntensityEnumMap = {

--- a/app/lib/feature/earthquake_history/data/model/earthquake_search_response.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_search_response.dart
@@ -1,10 +1,11 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/epicenter_search_info.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_area_info.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/station_search_info.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:jma_parameter_types/earthquake_param.pb.dart' show EarthquakeParameter;
+import 'package:jma_parameter_types/earthquake_param.pb.dart';
 
 part 'earthquake_search_response.freezed.dart';
 part 'earthquake_search_response.g.dart';
@@ -70,12 +71,19 @@ extension IntensityRegionSearchResponseToApp
     on api.IntensityRegionSearchResponse {
   PaginatedSearchResponse<IntensityAreaSearchItem> toAppResponse({
     required EarthquakeParameter parameter,
+    required String areaCode,
+    required String areaName,
   }) => PaginatedSearchResponse(
     items: items
         .map(
           (e) => IntensityAreaSearchItem(
             eventId: e.eventId,
-            area: e.region.toIntensityAreaInfo,
+            area: IntensityAreaInfo(
+              code: areaCode,
+              name: areaName,
+              intensity: e.intensity.toJmaIntensity,
+              lpgmIntensity: null,
+            ),
             earthquake: e.earthquake.toEarthquakePartial(parameter: parameter),
           ),
         )
@@ -88,12 +96,19 @@ extension IntensityPrefectureSearchResponseToApp
     on api.IntensityPrefectureSearchResponse {
   PaginatedSearchResponse<IntensityAreaSearchItem> toAppResponse({
     required EarthquakeParameter parameter,
+    required String areaCode,
+    required String areaName,
   }) => PaginatedSearchResponse(
     items: items
         .map(
           (e) => IntensityAreaSearchItem(
             eventId: e.eventId,
-            area: e.prefecture.toIntensityAreaInfo,
+            area: IntensityAreaInfo(
+              code: areaCode,
+              name: areaName,
+              intensity: e.intensity.toJmaIntensity,
+              lpgmIntensity: null,
+            ),
             earthquake: e.earthquake.toEarthquakePartial(parameter: parameter),
           ),
         )
@@ -105,12 +120,19 @@ extension IntensityPrefectureSearchResponseToApp
 extension IntensityCitySearchResponseToApp on api.IntensityCitySearchResponse {
   PaginatedSearchResponse<IntensityAreaSearchItem> toAppResponse({
     required EarthquakeParameter parameter,
+    required String areaCode,
+    required String areaName,
   }) => PaginatedSearchResponse(
     items: items
         .map(
           (e) => IntensityAreaSearchItem(
             eventId: e.eventId,
-            area: e.city.toIntensityAreaInfo,
+            area: IntensityAreaInfo(
+              code: areaCode,
+              name: areaName,
+              intensity: e.intensity.toJmaIntensity,
+              lpgmIntensity: null,
+            ),
             earthquake: e.earthquake.toEarthquakePartial(parameter: parameter),
           ),
         )
@@ -123,12 +145,21 @@ extension IntensityStationSearchResponseToApp
     on api.IntensityStationSearchResponse {
   PaginatedSearchResponse<StationSearchItem> toAppResponse({
     required EarthquakeParameter parameter,
+    required String stationCode,
+    required String stationName,
   }) => PaginatedSearchResponse(
     items: items
         .map(
           (e) => StationSearchItem(
             eventId: e.eventId,
-            station: e.station.toStationSearchInfo,
+            station: StationSearchInfo(
+              code: stationCode,
+              name: stationName,
+              intensity: e.intensity.toJmaIntensity,
+              lpgmIntensity: null,
+              sva: null,
+              prePeriods: null,
+            ),
             earthquake: e.earthquake.toEarthquakePartial(parameter: parameter),
           ),
         )

--- a/app/lib/feature/earthquake_history/data/model/intensity_area_info.dart
+++ b/app/lib/feature/earthquake_history/data/model/intensity_area_info.dart
@@ -1,6 +1,5 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
-import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'intensity_area_info.freezed.dart';
@@ -18,13 +17,4 @@ abstract class IntensityAreaInfo with _$IntensityAreaInfo {
 
   factory IntensityAreaInfo.fromJson(Map<String, dynamic> json) =>
       _$IntensityAreaInfoFromJson(json);
-}
-
-extension IntensityRegionInfoToApp on api.IntensityRegionInfo {
-  IntensityAreaInfo get toIntensityAreaInfo => IntensityAreaInfo(
-    code: code,
-    name: name,
-    intensity: intensity?.toJmaIntensity,
-    lpgmIntensity: lpgmIntensity?.toJmaLpgmIntensity,
-  );
 }

--- a/app/lib/feature/earthquake_history/data/model/intensity_station.dart
+++ b/app/lib/feature/earthquake_history/data/model/intensity_station.dart
@@ -35,12 +35,12 @@ abstract class PrePeriod with _$PrePeriod {
 
 extension IntensityStationApiExtension on api.IntensityStationItem {
   IntensityStation get toIntensityStation => IntensityStation(
-    code: value.code,
-    name: value.name,
+    code: code,
+    name: code,
     sva: sva?.toDouble(),
     prePeriods: prePeriods?.map((e) => e.toPrePeriod).toList(),
-    maxIntensity: maxIntensity?.toJmaIntensity,
-    maxLpgmIntensity: maxLpgmIntensity?.toJmaLpgmIntensity,
+    maxIntensity: null,
+    maxLpgmIntensity: null,
   );
 }
 

--- a/app/lib/feature/earthquake_history/data/model/intensity_tree_converter.dart
+++ b/app/lib/feature/earthquake_history/data/model/intensity_tree_converter.dart
@@ -19,46 +19,104 @@ class IntensityTreeConverter {
   Map<JmaIntensity, List<PrefectureIntensityNode>> convertToIntensityTree({
     required api.Intensity intensity,
   }) {
-    final citiesList = intensity.cities ?? [];
-    final stationsList = intensity.stations ?? [];
-    if (citiesList.isNotEmpty) {
-      return _fromCities(citiesList, stationsList);
+    final trees = intensity.intensityTree;
+    if (trees.isEmpty) {
+      return {};
     }
-    if (intensity.regions.isNotEmpty) {
-      return _fromRegions(intensity.regions);
+
+    final cityPrefixToCityCode = _cityIdentificationPrefixMap();
+    final stationParam = _stationParamMap();
+    final stationCityCode = _stationCityCodeMap();
+
+    final result = <JmaIntensity, List<PrefectureIntensityNode>>{};
+
+    for (final tree in trees) {
+      final jma = tree.intensity.toJmaIntensity;
+      final prefecturesByCode = _buildJmaPrefectureCityStations(
+        tree: tree,
+        cityPrefixToCityCode: cityPrefixToCityCode,
+        stationCityCode: stationCityCode,
+      );
+      if (prefecturesByCode.isEmpty) {
+        continue;
+      }
+
+      final nodes = _toPrefectureIntensityNodes(
+        prefecturesByCode: prefecturesByCode,
+        treeIntensity: tree.intensity,
+        stationParam: stationParam,
+        levelJma: jma,
+      );
+      final existing = result[jma];
+      result[jma] = existing == null
+          ? nodes
+          : _mergePrefectureIntensityNodeLists(existing, nodes);
     }
-    if (intensity.prefectures.isNotEmpty) {
-      return _fromPrefecturesOnly(intensity.prefectures);
-    }
-    return {};
+
+    return Map.fromEntries(
+      result.entries.toList()
+        ..sort((a, b) => b.key.orderIndex.compareTo(a.key.orderIndex)),
+    );
   }
 
-  Map<JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>>
-  convertToLpgmIntensityTree({
+  Map<JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>> convertToLpgmIntensityTree({
     required api.Intensity intensity,
   }) {
-    final cities = intensity.cities ?? [];
-    final stations = intensity.stations ?? [];
-    if (cities.isNotEmpty) {
-      return _lpgmFromCities(cities, stations);
+    final trees = intensity.lpgmIntensityTree;
+    if (trees == null || trees.isEmpty) {
+      return {};
     }
-    if (intensity.regions.isNotEmpty) {
-      return _lpgmFromRegions(intensity.regions);
+
+    final cityPrefixToCityCode = _cityIdentificationPrefixMap();
+    final stationParam = _stationParamMap();
+    final stationCityCode = _stationCityCodeMap();
+
+    final result = <JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>>{};
+
+    for (final tree in trees) {
+      final lpgm = tree.lpgmIntensity.toJmaLpgmIntensity;
+      final prefecturesByCode = _buildLpgmPrefectureCityStations(
+        tree: tree,
+        cityPrefixToCityCode: cityPrefixToCityCode,
+        stationCityCode: stationCityCode,
+      );
+      if (prefecturesByCode.isEmpty) {
+        continue;
+      }
+
+      final nodes = _toPrefectureLpgmIntensityNodes(
+        prefecturesByCode: prefecturesByCode,
+        tree: tree,
+        stationParam: stationParam,
+        levelLpgm: lpgm,
+      );
+      final existing = result[lpgm];
+      result[lpgm] = existing == null
+          ? nodes
+          : _mergePrefectureLpgmIntensityNodeLists(existing, nodes);
     }
-    if (intensity.prefectures.isNotEmpty) {
-      return _lpgmFromPrefecturesOnly(intensity.prefectures);
-    }
-    return {};
+
+    return Map.fromEntries(
+      result.entries.toList()
+        ..sort((a, b) => b.key.orderIndex.compareTo(a.key.orderIndex)),
+    );
   }
 
-  Map<String, EarthquakeParameterCityItem> _cityParamMap() {
-    final map = <String, EarthquakeParameterCityItem>{};
-    for (final region in parameter.regions) {
-      for (final city in region.cities) {
-        map[city.code] = city;
-      }
-    }
-    return map;
+  /// 市区町村コードの先頭5桁 → 市区町村コード（パラメータ由来、ソート済みで後勝ち）
+  Map<String, String> _cityIdentificationPrefixMap() {
+    final cityCodes = parameter.regions
+        .expand((r) => r.cities)
+        .map((c) => c.code)
+        .toList()
+      ..sort();
+    return Map.fromEntries(
+      cityCodes.map((cityCode) {
+        final prefix = cityCode.length >= 5
+            ? cityCode.substring(0, 5)
+            : cityCode;
+        return MapEntry(prefix, cityCode);
+      }),
+    );
   }
 
   Map<String, EarthquakeParameterStationItem> _stationParamMap() {
@@ -85,392 +143,426 @@ class IntensityTreeConverter {
     return map;
   }
 
-  String? _prefectureCode(EarthquakeParameterCityItem city) {
+  Map<String, EarthquakeParameterCityItem> _cityParamMap() {
+    final map = <String, EarthquakeParameterCityItem>{};
     for (final region in parameter.regions) {
-      for (final parameterCity in region.cities) {
-        if (parameterCity.code == city.code) {
+      for (final city in region.cities) {
+        map[city.code] = city;
+      }
+    }
+    return map;
+  }
+
+  Map<String, EarthquakeParameterRegionItem> _regionParamMap() {
+    return {for (final r in parameter.regions) r.code: r};
+  }
+
+  String _prefectureCodeForCity(String cityCode) {
+    for (final region in parameter.regions) {
+      for (final city in region.cities) {
+        if (city.code == cityCode) {
           return region.code;
         }
       }
     }
-    return null;
+    return cityCode.length >= 2 ? cityCode.substring(0, 2) : cityCode;
   }
 
-  Map<JmaIntensity, List<PrefectureIntensityNode>> _fromCities(
-    List<api.IntensityItem> apiCities,
-    List<api.IntensityStationItem> apiStations,
-  ) {
+  /// 震度ツリー1要素分: 都道府県コード → 市区町村コード → 観測点コード集合
+  Map<String, Map<String, Set<String>>> _buildJmaPrefectureCityStations({
+    required api.IntensityTree tree,
+    required Map<String, String> cityPrefixToCityCode,
+    required Map<String, String> stationCityCode,
+  }) {
+    final prefecturesByCode = <String, Map<String, Set<String>>>{};
     final cityParam = _cityParamMap();
-    final stationParam = _stationParamMap();
-    final byCityCode = _stationsByCityCode(
-      stations: apiStations,
-      stationCityCode: _stationCityCodeMap(),
-    );
-    final grouped = <JmaIntensity, Map<String, List<CityIntensityNode>>>{};
+    final paramRegionMap = _regionParamMap();
 
-    for (final apiCity in apiCities) {
-      final jma = apiCity.maxIntensity?.toJmaIntensity;
-      if (jma == null) {
-        continue;
-      }
-
-      final cityItem = cityParam[apiCity.value.code];
-      if (cityItem == null) {
-        continue;
-      }
-
-      final code = apiCity.value.code;
-      if (code.length < 5) {
-        continue;
-      }
-
-      final prefCode = _prefectureCode(cityItem);
-      if (prefCode == null) {
-        continue;
-      }
-
-      final stationNodes = <StationIntensityNode>[];
-      for (final st in byCityCode[code] ?? const <api.IntensityStationItem>[]) {
-        final paramSt = stationParam[st.value.code];
-        if (paramSt == null) {
-          continue;
-        }
-        stationNodes.add(
-          StationIntensityNode(
-            station: paramSt,
-            intensity: st.toIntensityStation,
-          ),
-        );
-      }
-      stationNodes.sort((a, b) => a.station.name.compareTo(b.station.name));
-
-      grouped
-          .putIfAbsent(jma, () => {})
-          .putIfAbsent(prefCode, () => [])
-          .add(
-            CityIntensityNode(
-              city: cityItem,
-              maxIntensity: jma,
-              maxLpgmIntensity: apiCity.maxLpgmIntensity?.toJmaLpgmIntensity,
-              stations: stationNodes,
-            ),
-          );
-    }
-
-    return _finalize(grouped);
-  }
-
-  Map<JmaIntensity, List<PrefectureIntensityNode>> _fromRegions(
-    List<api.IntensityItem> regions,
-  ) {
-    final regionIntensityMap = {for (final r in regions) r.value.code: r};
-    final grouped = <JmaIntensity, Map<String, List<CityIntensityNode>>>{};
-
-    for (final region in parameter.regions) {
-      for (final city in region.cities) {
-        final item = regionIntensityMap[city.code];
-        if (item == null) {
-          continue;
-        }
-        final jma = item.maxIntensity?.toJmaIntensity;
-        if (jma == null) {
-          continue;
-        }
-
-        grouped
-            .putIfAbsent(jma, () => {})
-            .putIfAbsent(region.code, () => [])
-            .add(
-              CityIntensityNode(
-                city: city,
-                maxIntensity: jma,
-                maxLpgmIntensity: item.maxLpgmIntensity?.toJmaLpgmIntensity,
-                stations: const [],
-              ),
-            );
+    for (final regionId in tree.regions) {
+      if (paramRegionMap.containsKey(regionId)) {
+        _ensurePrefecture(prefecturesByCode, regionId);
       }
     }
 
-    return _finalize(grouped);
+    for (final regionId in tree.regions) {
+      if (regionId.length >= 5) {
+        final cityItem = cityParam[regionId];
+        if (cityItem != null) {
+          _ensureCity(prefecturesByCode, regionId);
+        }
+      }
+    }
+
+    for (final stationCode in tree.stations ?? const <String>[]) {
+      final prefix = stationCode.length >= 5
+          ? stationCode.substring(0, 5)
+          : stationCode;
+      final cityCode =
+          cityPrefixToCityCode[prefix] ?? stationCityCode[stationCode];
+      if (cityCode == null) {
+        continue;
+      }
+      _ensureCity(prefecturesByCode, cityCode).add(stationCode);
+    }
+
+    return prefecturesByCode;
   }
 
-  Map<JmaIntensity, List<PrefectureIntensityNode>> _fromPrefecturesOnly(
-    List<api.IntensityItem> prefectures,
-  ) {
-    final paramRegionMap = {for (final r in parameter.regions) r.code: r};
-    final grouped = <JmaIntensity, List<PrefectureIntensityNode>>{};
+  Map<String, Map<String, Set<String>>> _buildLpgmPrefectureCityStations({
+    required api.LpgmIntensityTree tree,
+    required Map<String, String> cityPrefixToCityCode,
+    required Map<String, String> stationCityCode,
+  }) {
+    final prefecturesByCode = <String, Map<String, Set<String>>>{};
+    final cityParam = _cityParamMap();
+    final paramRegionMap = _regionParamMap();
 
-    for (final pref in prefectures) {
-      final regionItem = paramRegionMap[pref.value.code];
+    for (final regionId in tree.regions) {
+      if (paramRegionMap.containsKey(regionId)) {
+        _ensurePrefecture(prefecturesByCode, regionId);
+      }
+    }
+
+    for (final regionId in tree.regions) {
+      if (regionId.length >= 5) {
+        final cityItem = cityParam[regionId];
+        if (cityItem != null) {
+          _ensureCity(prefecturesByCode, regionId);
+        }
+      }
+    }
+
+    for (final station in tree.stations) {
+      final prefix = station.code.length >= 5
+          ? station.code.substring(0, 5)
+          : station.code;
+      final cityCode =
+          cityPrefixToCityCode[prefix] ?? stationCityCode[station.code];
+      if (cityCode == null) {
+        continue;
+      }
+      _ensureCity(prefecturesByCode, cityCode).add(station.code);
+    }
+
+    return prefecturesByCode;
+  }
+
+  Map<String, Set<String>> _ensurePrefecture(
+    Map<String, Map<String, Set<String>>> prefecturesByCode,
+    String prefectureCode,
+  ) {
+    final current = prefecturesByCode[prefectureCode];
+    if (current != null) {
+      return current;
+    }
+    final citiesByCode = <String, Set<String>>{};
+    prefecturesByCode[prefectureCode] = citiesByCode;
+    return citiesByCode;
+  }
+
+  Set<String> _ensureCity(
+    Map<String, Map<String, Set<String>>> prefecturesByCode,
+    String cityCode,
+  ) {
+    final prefCode = _prefectureCodeForCity(cityCode);
+    final citiesByCode = _ensurePrefecture(prefecturesByCode, prefCode);
+    final current = citiesByCode[cityCode];
+    if (current != null) {
+      return current;
+    }
+    final stationCodes = <String>{};
+    citiesByCode[cityCode] = stationCodes;
+    return stationCodes;
+  }
+
+  List<PrefectureIntensityNode> _toPrefectureIntensityNodes({
+    required Map<String, Map<String, Set<String>>> prefecturesByCode,
+    required api.JmaIntensity treeIntensity,
+    required Map<String, EarthquakeParameterStationItem> stationParam,
+    required JmaIntensity levelJma,
+  }) {
+    final paramRegionMap = _regionParamMap();
+    final cityParam = _cityParamMap();
+    final regionNodes = <PrefectureIntensityNode>[];
+
+    for (final prefEntry in prefecturesByCode.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key))) {
+      final prefCode = prefEntry.key;
+      final citiesByCode = prefEntry.value;
+      final regionItem = paramRegionMap[prefCode];
       if (regionItem == null) {
         continue;
       }
-      final jma = pref.maxIntensity?.toJmaIntensity;
-      if (jma == null) {
-        continue;
-      }
 
-      grouped
-          .putIfAbsent(jma, () => [])
-          .add(
-            PrefectureIntensityNode(
-              region: IntensityRegion(region: regionItem, maxIntensity: jma),
-              cities: const [],
-            ),
-          );
-    }
-
-    for (final entry in grouped.entries) {
-      entry.value.sort(
-        (a, b) => a.region.region.name.compareTo(b.region.region.name),
-      );
-    }
-
-    return Map.fromEntries(
-      grouped.entries.toList()
-        ..sort((a, b) => b.key.orderIndex.compareTo(a.key.orderIndex)),
-    );
-  }
-
-  Map<JmaIntensity, List<PrefectureIntensityNode>> _finalize(
-    Map<JmaIntensity, Map<String, List<CityIntensityNode>>> grouped,
-  ) {
-    final paramRegionMap = {for (final r in parameter.regions) r.code: r};
-    final result = <JmaIntensity, List<PrefectureIntensityNode>>{};
-
-    for (final entry in grouped.entries) {
-      final intensityKey = entry.key;
-      final regionNodes = <PrefectureIntensityNode>[];
-
-      for (final prefEntry in entry.value.entries) {
-        final regionItem = paramRegionMap[prefEntry.key];
-        if (regionItem == null) {
+      final cities = <CityIntensityNode>[];
+      for (final cityEntry in citiesByCode.entries.toList()
+        ..sort((a, b) => a.key.compareTo(b.key))) {
+        final cityCode = cityEntry.key;
+        final stationCodes = cityEntry.value.toList()..sort();
+        final cityItem = cityParam[cityCode];
+        if (cityItem == null) {
           continue;
         }
 
-        final cities = prefEntry.value
-          ..sort((a, b) {
-            final aOrder = a.maxIntensity?.orderIndex ?? -1;
-            final bOrder = b.maxIntensity?.orderIndex ?? -1;
-            if (aOrder != bOrder) {
-              return bOrder.compareTo(aOrder);
-            }
-            return a.city.name.compareTo(b.city.name);
-          });
-
-        regionNodes.add(
-          PrefectureIntensityNode(
-            region: IntensityRegion(
-              region: regionItem,
-              maxIntensity: intensityKey,
-            ),
-            cities: cities,
-          ),
-        );
-      }
-
-      regionNodes.sort(
-        (a, b) => a.region.region.name.compareTo(b.region.region.name),
-      );
-      result[intensityKey] = regionNodes;
-    }
-
-    return Map.fromEntries(
-      result.entries.toList()
-        ..sort((a, b) => b.key.orderIndex.compareTo(a.key.orderIndex)),
-    );
-  }
-
-  Map<JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>> _lpgmFromCities(
-    List<api.IntensityItem> apiCities,
-    List<api.IntensityStationItem> apiStations,
-  ) {
-    final cityParam = _cityParamMap();
-    final stationParam = _stationParamMap();
-    final byCityCode = _stationsByCityCode(
-      stations: apiStations,
-      stationCityCode: _stationCityCodeMap(),
-    );
-    final grouped =
-        <JmaLpgmIntensity, Map<String, List<CityLpgmIntensityNode>>>{};
-
-    for (final apiCity in apiCities) {
-      final lpgm = apiCity.maxLpgmIntensity?.toJmaLpgmIntensity;
-      if (lpgm == null) {
-        continue;
-      }
-
-      final cityItem = cityParam[apiCity.value.code];
-      if (cityItem == null) {
-        continue;
-      }
-
-      final prefCode = _prefectureCode(cityItem);
-      if (prefCode == null) {
-        continue;
-      }
-
-      final stationNodes = <StationLpgmIntensityNode>[];
-      for (final station
-          in byCityCode[apiCity.value.code] ??
-              const <api.IntensityStationItem>[]) {
-        final parameterStation = stationParam[station.value.code];
-        if (parameterStation == null) {
-          continue;
-        }
-        stationNodes.add(
-          StationLpgmIntensityNode(
-            station: parameterStation,
-            intensity: station.toIntensityStation,
-          ),
-        );
-      }
-      stationNodes.sort((a, b) => a.station.name.compareTo(b.station.name));
-
-      grouped
-          .putIfAbsent(lpgm, () => {})
-          .putIfAbsent(prefCode, () => [])
-          .add(
-            CityLpgmIntensityNode(
-              city: cityItem,
-              maxLpgmIntensity: lpgm,
-              stations: stationNodes,
-            ),
-          );
-    }
-
-    return _finalizeLpgm(grouped);
-  }
-
-  Map<JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>> _lpgmFromRegions(
-    List<api.IntensityItem> regions,
-  ) {
-    final regionIntensityMap = {for (final r in regions) r.value.code: r};
-    final grouped =
-        <JmaLpgmIntensity, Map<String, List<CityLpgmIntensityNode>>>{};
-
-    for (final region in parameter.regions) {
-      for (final city in region.cities) {
-        final item = regionIntensityMap[city.code];
-        if (item == null) {
-          continue;
-        }
-        final lpgm = item.maxLpgmIntensity?.toJmaLpgmIntensity;
-        if (lpgm == null) {
-          continue;
-        }
-
-        grouped
-            .putIfAbsent(lpgm, () => {})
-            .putIfAbsent(region.code, () => [])
-            .add(
-              CityLpgmIntensityNode(
-                city: city,
-                maxLpgmIntensity: lpgm,
-                stations: const [],
+        final stationNodes = <StationIntensityNode>[];
+        for (final code in stationCodes) {
+          final paramSt = stationParam[code];
+          if (paramSt == null) {
+            continue;
+          }
+          stationNodes.add(
+            StationIntensityNode(
+              station: paramSt,
+              intensity: IntensityStation(
+                code: code,
+                name: paramSt.name,
+                sva: null,
+                prePeriods: const [],
+                maxIntensity: treeIntensity.toJmaIntensity,
+                maxLpgmIntensity: null,
               ),
-            );
-      }
-    }
-
-    return _finalizeLpgm(grouped);
-  }
-
-  Map<JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>>
-  _lpgmFromPrefecturesOnly(List<api.IntensityItem> prefectures) {
-    final paramRegionMap = {for (final r in parameter.regions) r.code: r};
-    final grouped = <JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>>{};
-
-    for (final pref in prefectures) {
-      final regionItem = paramRegionMap[pref.value.code];
-      if (regionItem == null) {
-        continue;
-      }
-      final lpgm = pref.maxLpgmIntensity?.toJmaLpgmIntensity;
-      if (lpgm == null) {
-        continue;
-      }
-
-      grouped
-          .putIfAbsent(lpgm, () => [])
-          .add(
-            PrefectureLpgmIntensityNode(
-              region: regionItem,
-              maxLpgmIntensity: lpgm,
-              cities: const [],
             ),
           );
-    }
-
-    for (final entry in grouped.entries) {
-      entry.value.sort((a, b) => a.region.name.compareTo(b.region.name));
-    }
-
-    return Map.fromEntries(
-      grouped.entries.toList()
-        ..sort((a, b) => b.key.orderIndex.compareTo(a.key.orderIndex)),
-    );
-  }
-
-  Map<JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>> _finalizeLpgm(
-    Map<JmaLpgmIntensity, Map<String, List<CityLpgmIntensityNode>>> grouped,
-  ) {
-    final paramRegionMap = {for (final r in parameter.regions) r.code: r};
-    final result = <JmaLpgmIntensity, List<PrefectureLpgmIntensityNode>>{};
-
-    for (final entry in grouped.entries) {
-      final lpgmKey = entry.key;
-      final regionNodes = <PrefectureLpgmIntensityNode>[];
-
-      for (final prefEntry in entry.value.entries) {
-        final regionItem = paramRegionMap[prefEntry.key];
-        if (regionItem == null) {
-          continue;
         }
 
-        final cities = prefEntry.value
-          ..sort((a, b) {
-            final aOrder = a.maxLpgmIntensity?.orderIndex ?? -1;
-            final bOrder = b.maxLpgmIntensity?.orderIndex ?? -1;
-            if (aOrder != bOrder) {
-              return bOrder.compareTo(aOrder);
-            }
-            return a.city.name.compareTo(b.city.name);
-          });
+        cities.add(
+          CityIntensityNode(
+            city: cityItem,
+            maxIntensity: levelJma,
+            stations: stationNodes,
+          ),
+        );
+      }
 
-        regionNodes.add(
-          PrefectureLpgmIntensityNode(
+      regionNodes.add(
+        PrefectureIntensityNode(
+          region: IntensityRegion(
             region: regionItem,
-            maxLpgmIntensity: lpgmKey,
-            cities: cities,
+            maxIntensity: levelJma,
+          ),
+          cities: cities,
+        ),
+      );
+    }
+
+    regionNodes.sort(
+      (a, b) => a.region.region.name.compareTo(b.region.region.name),
+    );
+    return regionNodes;
+  }
+
+  List<PrefectureLpgmIntensityNode> _toPrefectureLpgmIntensityNodes({
+    required Map<String, Map<String, Set<String>>> prefecturesByCode,
+    required api.LpgmIntensityTree tree,
+    required Map<String, EarthquakeParameterStationItem> stationParam,
+    required JmaLpgmIntensity levelLpgm,
+  }) {
+    final paramRegionMap = _regionParamMap();
+    final cityParam = _cityParamMap();
+    final apiStationByCode = {
+      for (final s in tree.stations) s.code: s,
+    };
+
+    final regionNodes = <PrefectureLpgmIntensityNode>[];
+
+    for (final prefEntry in prefecturesByCode.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key))) {
+      final prefCode = prefEntry.key;
+      final citiesByCode = prefEntry.value;
+      final regionItem = paramRegionMap[prefCode];
+      if (regionItem == null) {
+        continue;
+      }
+
+      final cities = <CityLpgmIntensityNode>[];
+      for (final cityEntry in citiesByCode.entries.toList()
+        ..sort((a, b) => a.key.compareTo(b.key))) {
+        final cityCode = cityEntry.key;
+        final stationCodes = cityEntry.value.toList()..sort();
+        final cityItem = cityParam[cityCode];
+        if (cityItem == null) {
+          continue;
+        }
+
+        final stationNodes = <StationLpgmIntensityNode>[];
+        for (final code in stationCodes) {
+          final parameterStation = stationParam[code];
+          if (parameterStation == null) {
+            continue;
+          }
+          final apiStation = apiStationByCode[code];
+          if (apiStation == null) {
+            continue;
+          }
+          stationNodes.add(
+            StationLpgmIntensityNode(
+              station: parameterStation,
+              intensity: IntensityStation(
+                code: apiStation.code,
+                name: parameterStation.name,
+                sva: apiStation.sva?.toDouble(),
+                prePeriods: apiStation.prePeriods
+                        ?.map((e) => e.toPrePeriod)
+                        .toList() ??
+                    const [],
+                maxIntensity: null,
+                maxLpgmIntensity: tree.lpgmIntensity.toJmaLpgmIntensity,
+              ),
+            ),
+          );
+        }
+
+        cities.add(
+          CityLpgmIntensityNode(
+            city: cityItem,
+            maxLpgmIntensity: levelLpgm,
+            stations: stationNodes,
           ),
         );
       }
 
-      regionNodes.sort((a, b) => a.region.name.compareTo(b.region.name));
-      result[lpgmKey] = regionNodes;
+      regionNodes.add(
+        PrefectureLpgmIntensityNode(
+          region: regionItem,
+          maxLpgmIntensity: levelLpgm,
+          cities: cities,
+        ),
+      );
     }
 
-    return Map.fromEntries(
-      result.entries.toList()
-        ..sort((a, b) => b.key.orderIndex.compareTo(a.key.orderIndex)),
+    regionNodes.sort((a, b) => a.region.name.compareTo(b.region.name));
+    return regionNodes;
+  }
+
+  List<PrefectureIntensityNode> _mergePrefectureIntensityNodeLists(
+    List<PrefectureIntensityNode> a,
+    List<PrefectureIntensityNode> b,
+  ) {
+    final byPref = <String, PrefectureIntensityNode>{};
+    for (final n in a) {
+      byPref[n.region.region.code] = n;
+    }
+    for (final n in b) {
+      final code = n.region.region.code;
+      final existing = byPref[code];
+      byPref[code] = existing == null
+          ? n
+          : _mergeSinglePrefectureIntensity(existing, n);
+    }
+    final merged = byPref.values.toList()
+      ..sort((x, y) => x.region.region.name.compareTo(y.region.region.name));
+    return merged;
+  }
+
+  PrefectureIntensityNode _mergeSinglePrefectureIntensity(
+    PrefectureIntensityNode a,
+    PrefectureIntensityNode b,
+  ) {
+    final byCity = <String, CityIntensityNode>{};
+    for (final c in a.cities) {
+      byCity[c.city.code] = c;
+    }
+    for (final c in b.cities) {
+      final existing = byCity[c.city.code];
+      byCity[c.city.code] = existing == null
+          ? c
+          : CityIntensityNode(
+              city: existing.city,
+              maxIntensity: existing.maxIntensity ?? c.maxIntensity,
+              maxLpgmIntensity: existing.maxLpgmIntensity ?? c.maxLpgmIntensity,
+              stations: _mergeStationIntensityNodes(existing.stations, c.stations),
+            );
+    }
+    final cities = byCity.values.toList()
+      ..sort((x, y) => x.city.name.compareTo(y.city.name));
+    return PrefectureIntensityNode(
+      region: IntensityRegion(
+        region: a.region.region,
+        maxIntensity: a.region.maxIntensity ?? b.region.maxIntensity,
+      ),
+      cities: cities,
     );
   }
-}
 
-Map<String, List<api.IntensityStationItem>> _stationsByCityCode({
-  required List<api.IntensityStationItem> stations,
-  required Map<String, String> stationCityCode,
-}) {
-  final map = <String, List<api.IntensityStationItem>>{};
-  for (final s in stations) {
-    final cityCode = stationCityCode[s.value.code];
-    if (cityCode == null) {
-      continue;
+  List<StationIntensityNode> _mergeStationIntensityNodes(
+    List<StationIntensityNode> a,
+    List<StationIntensityNode> b,
+  ) {
+    final byCode = <String, StationIntensityNode>{};
+    for (final n in a) {
+      byCode[n.station.code] = n;
     }
-    map.putIfAbsent(cityCode, () => []).add(s);
+    for (final n in b) {
+      byCode[n.station.code] = n;
+    }
+    final merged = byCode.values.toList()
+      ..sort((x, y) => x.station.name.compareTo(y.station.name));
+    return merged;
   }
-  return map;
+
+  List<PrefectureLpgmIntensityNode> _mergePrefectureLpgmIntensityNodeLists(
+    List<PrefectureLpgmIntensityNode> a,
+    List<PrefectureLpgmIntensityNode> b,
+  ) {
+    final byPref = <String, PrefectureLpgmIntensityNode>{};
+    for (final n in a) {
+      byPref[n.region.code] = n;
+    }
+    for (final n in b) {
+      final code = n.region.code;
+      final existing = byPref[code];
+      byPref[code] = existing == null
+          ? n
+          : _mergeSinglePrefectureLpgm(existing, n);
+    }
+    final merged = byPref.values.toList()
+      ..sort((x, y) => x.region.name.compareTo(y.region.name));
+    return merged;
+  }
+
+  PrefectureLpgmIntensityNode _mergeSinglePrefectureLpgm(
+    PrefectureLpgmIntensityNode a,
+    PrefectureLpgmIntensityNode b,
+  ) {
+    final byCity = <String, CityLpgmIntensityNode>{};
+    for (final c in a.cities) {
+      byCity[c.city.code] = c;
+    }
+    for (final c in b.cities) {
+      final existing = byCity[c.city.code];
+      byCity[c.city.code] = existing == null
+          ? c
+          : CityLpgmIntensityNode(
+              city: existing.city,
+              maxLpgmIntensity:
+                  existing.maxLpgmIntensity ?? c.maxLpgmIntensity,
+              stations: _mergeStationLpgmNodes(existing.stations, c.stations),
+            );
+    }
+    final cities = byCity.values.toList()
+      ..sort((x, y) => x.city.name.compareTo(y.city.name));
+    return PrefectureLpgmIntensityNode(
+      region: a.region,
+      maxLpgmIntensity: a.maxLpgmIntensity ?? b.maxLpgmIntensity,
+      cities: cities,
+    );
+  }
+
+  List<StationLpgmIntensityNode> _mergeStationLpgmNodes(
+    List<StationLpgmIntensityNode> a,
+    List<StationLpgmIntensityNode> b,
+  ) {
+    final byCode = <String, StationLpgmIntensityNode>{};
+    for (final n in a) {
+      byCode[n.station.code] = n;
+    }
+    for (final n in b) {
+      byCode[n.station.code] = n;
+    }
+    final merged = byCode.values.toList()
+      ..sort((x, y) => x.station.name.compareTo(y.station.name));
+    return merged;
+  }
 }
 
 @Riverpod(keepAlive: true)

--- a/app/lib/feature/earthquake_history/data/model/station_search_info.dart
+++ b/app/lib/feature/earthquake_history/data/model/station_search_info.dart
@@ -1,7 +1,6 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_station.dart';
-import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'station_search_info.freezed.dart';
@@ -21,30 +20,4 @@ abstract class StationSearchInfo with _$StationSearchInfo {
 
   factory StationSearchInfo.fromJson(Map<String, dynamic> json) =>
       _$StationSearchInfoFromJson(json);
-}
-
-extension IntensityStationInfoToApp on api.IntensityStationInfo {
-  StationSearchInfo get toStationSearchInfo => StationSearchInfo(
-    code: code,
-    name: name,
-    intensity: intensity?.toJmaIntensity,
-    lpgmIntensity: lpgmIntensity?.toJmaLpgmIntensity,
-    sva: sva?.toDouble(),
-    prePeriods: prePeriods
-        ?.map(
-          (e) => PrePeriod(
-            band: e.band.toDouble(),
-            lpgmIntensity: switch (e.lpgmIntensity) {
-              '0' => JmaLpgmIntensity.zero,
-              '1' => JmaLpgmIntensity.one,
-              '2' => JmaLpgmIntensity.two,
-              '3' => JmaLpgmIntensity.three,
-              '4' => JmaLpgmIntensity.four,
-              _ => JmaLpgmIntensity.unknown,
-            },
-            sva: e.sva.toDouble(),
-          ),
-        )
-        .toList(),
-  );
 }

--- a/app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart
+++ b/app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart
@@ -31,6 +31,33 @@ class EarthquakeHistoryRepository {
   final api.ApiClient _api;
   final EarthquakeParameter earthquakeParameter;
 
+  String? _resolveAreaDisplayName(String areaCode) {
+    for (final region in earthquakeParameter.regions) {
+      if (region.code == areaCode) {
+        return region.name;
+      }
+      for (final city in region.cities) {
+        if (city.code == areaCode) {
+          return city.name;
+        }
+      }
+    }
+    return null;
+  }
+
+  String? _resolveStationDisplayName(String stationCode) {
+    for (final region in earthquakeParameter.regions) {
+      for (final city in region.cities) {
+        for (final station in city.stations) {
+          if (station.code == stationCode) {
+            return station.name;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
   Future<EarthquakeListResponse> fetchEarthquakeList({
     int? limit,
     String? cursor,
@@ -75,7 +102,11 @@ class EarthquakeHistoryRepository {
       limit: limit?.toString(),
       cursor: cursor,
     );
-    return response.data.toAppResponse(parameter: earthquakeParameter);
+    return response.data.toAppResponse(
+      parameter: earthquakeParameter,
+      areaCode: code,
+      areaName: _resolveAreaDisplayName(code) ?? code,
+    );
   }
 
   Future<PaginatedSearchResponse<IntensityAreaSearchItem>> searchByPrefecture({
@@ -89,7 +120,11 @@ class EarthquakeHistoryRepository {
           limit: limit?.toString(),
           cursor: cursor,
         );
-    return response.data.toAppResponse(parameter: earthquakeParameter);
+    return response.data.toAppResponse(
+      parameter: earthquakeParameter,
+      areaCode: code,
+      areaName: _resolveAreaDisplayName(code) ?? code,
+    );
   }
 
   Future<PaginatedSearchResponse<IntensityAreaSearchItem>> searchByCity({
@@ -102,7 +137,11 @@ class EarthquakeHistoryRepository {
       limit: limit?.toString(),
       cursor: cursor,
     );
-    return response.data.toAppResponse(parameter: earthquakeParameter);
+    return response.data.toAppResponse(
+      parameter: earthquakeParameter,
+      areaCode: code,
+      areaName: _resolveAreaDisplayName(code) ?? code,
+    );
   }
 
   Future<PaginatedSearchResponse<StationSearchItem>> searchByStation({
@@ -115,7 +154,11 @@ class EarthquakeHistoryRepository {
       limit: limit?.toString(),
       cursor: cursor,
     );
-    return response.data.toAppResponse(parameter: earthquakeParameter);
+    return response.data.toAppResponse(
+      parameter: earthquakeParameter,
+      stationCode: code,
+      stationName: _resolveStationDisplayName(code) ?? code,
+    );
   }
 
   Future<PaginatedSearchResponse<EpicenterSearchItem>> searchByEpicenter({

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
@@ -49,10 +49,7 @@ class EarthquakeHistoryListTile extends HookConsumerWidget {
     final hypoName = hypocenter?.name;
     final hypoDetailName = hypocenter?.detailedName;
 
-    final maxIntensityPrefectures = intensity?.regions
-        .where((e) => e.maxIntensity == intensity.maxIntensity)
-        .map((e) => e.region.name)
-        .toList();
+    const maxIntensityPrefectures = <String>[];
     final title = switch ((
       hypoName,
       hypoDetailName,

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart
@@ -57,7 +57,7 @@ class EarthquakeHypocenterInformationCard extends HookConsumerWidget {
                     item: item,
                     hypocenter: hypocenter,
                     hasIntensityDetails:
-                        item.intensity?.regions.isNotEmpty ?? false,
+                        item.intensity?.intensityTree.isNotEmpty ?? false,
                   ),
                 ),
               ],

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_region_intensity_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_region_intensity_layer.dart
@@ -88,21 +88,17 @@ class EarthquakeHistoryRegionIntensityLayer extends HookConsumerWidget {
     EarthquakeIntensity? intensity,
     IntensityColorModel colorModel,
   ) {
-    final regions = intensity?.regions ?? [];
+    final pairs = intensity?.forecastLocalEIntensityPairs ?? [];
     final args = <Object>[
       'match',
       <Object>['get', 'code'],
     ];
 
-    for (final r in regions) {
-      final maxIntensity = r.maxIntensity;
-      if (maxIntensity == null) {
-        continue;
-      }
+    for (final p in pairs) {
       args
-        ..add(r.region.code)
+        ..add(p.code)
         ..add(
-          colorModel.fromJmaIntensity(maxIntensity).background.toHexStringRGB(),
+          colorModel.fromJmaIntensity(p.intensity).background.toHexStringRGB(),
         );
     }
 

--- a/app/lib/feature/eew/data/model/eew_telegram_item.dart
+++ b/app/lib/feature/eew/data/model/eew_telegram_item.dart
@@ -129,16 +129,14 @@ extension EewItemWithRelationsConverter on api.EewItemWithRelations {
 
 extension on api.EewHypocenter {
   EewHypocenterInfo _toEewHypocenterInfo() {
-    final isLatLng = coordinates.type == api.CoordinateType.latLng;
     return EewHypocenterInfo(
       code: value.code,
       name: value.name,
       detailedCode: detailed?.code,
       detailedName: detailed?.name,
-      latitude: isLatLng ? coordinates.latitude?.toDouble() : null,
-      longitude: isLatLng ? coordinates.longitude?.toDouble() : null,
-      hasLatLng: isLatLng,
-      coordinateCondition: coordinates.condition,
+      latitude: coordinates.latitude.toDouble(),
+      longitude: coordinates.longitude.toDouble(),
+      hasLatLng: true,
       magnitude: magnitude?.toDouble(),
       depth: depth?.toInt(),
     );

--- a/app/test/feature/earthquake_history/data/earthquake_history_repository_current_location_intensity_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_history_repository_current_location_intensity_test.dart
@@ -44,43 +44,11 @@ EarthquakeParameter _param({
 
 api.Intensity _intensity({
   required api.JmaIntensity maxIntensity,
-  required List<({String code, String name, api.JmaIntensity? maxIntensity})>
-  prefectures,
-  required List<
-    ({
-      String code,
-      String name,
-      api.JmaIntensity? maxIntensity,
-      api.JmaLpgmIntensity? maxLpgmIntensity,
-    })
-  >
-  regions,
-  api.JmaLpgmIntensity? maxLpgmIntensity,
-  List<api.IntensityItem>? cities,
-  List<api.IntensityStationItem>? stations,
+  required List<api.IntensityTree> intensityTree,
 }) {
   return api.Intensity(
     maxIntensity: maxIntensity,
-    maxLpgmIntensity: maxLpgmIntensity,
-    prefectures: prefectures
-        .map(
-          (p) => api.IntensityItem(
-            value: api.CodeName(code: p.code, name: p.name),
-            maxIntensity: p.maxIntensity,
-          ),
-        )
-        .toList(),
-    regions: regions
-        .map(
-          (r) => api.IntensityItem(
-            value: api.CodeName(code: r.code, name: r.name),
-            maxIntensity: r.maxIntensity,
-            maxLpgmIntensity: r.maxLpgmIntensity,
-          ),
-        )
-        .toList(),
-    cities: cities,
-    stations: stations,
+    intensityTree: intensityTree,
   );
 }
 
@@ -96,19 +64,10 @@ void main() {
     test('市区町村コードで細分区域ノードに一致すれば震度を返す', () {
       final intensity = _intensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
+        intensityTree: const [
+          api.IntensityTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['0420100'],
           ),
         ],
       );
@@ -138,19 +97,10 @@ void main() {
     test('市区町村に無く細分区域コードでフォールバックする', () {
       final intensity = _intensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
-          ),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
+        intensityTree: const [
+          api.IntensityTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['0420100'],
           ),
         ],
       );
@@ -180,14 +130,12 @@ void main() {
     test('prefecturesのみのツリーでは都道府県コードで解決する', () {
       final intensity = _intensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value4,
+        intensityTree: const [
+          api.IntensityTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['040000'],
           ),
         ],
-        regions: [],
       );
       final parameter = _param(
         regions: [

--- a/app/test/feature/earthquake_history/data/model/intensity_tree_converter_test.dart
+++ b/app/test/feature/earthquake_history/data/model/intensity_tree_converter_test.dart
@@ -43,68 +43,36 @@ EarthquakeParameter _buildParameter({
 
 api.Intensity _buildIntensity({
   required api.JmaIntensity maxIntensity,
-  required List<({String code, String name, api.JmaIntensity? maxIntensity})>
-  prefectures,
-  required List<
-    ({
-      String code,
-      String name,
-      api.JmaIntensity? maxIntensity,
-      api.JmaLpgmIntensity? maxLpgmIntensity,
-    })
-  >
-  regions,
+  required List<api.IntensityTree> intensityTree,
   api.JmaLpgmIntensity? maxLpgmIntensity,
-  List<api.IntensityItem>? cities,
-  List<api.IntensityStationItem>? stations,
+  List<api.LpgmIntensityTree>? lpgmIntensityTree,
 }) {
   return api.Intensity(
     maxIntensity: maxIntensity,
     maxLpgmIntensity: maxLpgmIntensity,
-    prefectures: prefectures
-        .map(
-          (p) => api.IntensityItem(
-            value: api.CodeName(code: p.code, name: p.name),
-            maxIntensity: p.maxIntensity,
-          ),
-        )
-        .toList(),
-    regions: regions
-        .map(
-          (r) => api.IntensityItem(
-            value: api.CodeName(code: r.code, name: r.name),
-            maxIntensity: r.maxIntensity,
-            maxLpgmIntensity: r.maxLpgmIntensity,
-          ),
-        )
-        .toList(),
-    cities: cities,
-    stations: stations,
+    intensityTree: intensityTree,
+    lpgmIntensityTree: lpgmIntensityTree,
   );
 }
 
-api.IntensityStationItem _station({
-  required String code,
-  required String name,
-  api.JmaIntensity? maxIntensity,
-  api.JmaLpgmIntensity? maxLpgm,
+api.IntensityTree _jmaTree({
+  required api.JmaIntensity intensity,
+  required List<String> regions,
+  List<String>? stations,
 }) {
-  return api.IntensityStationItem(
-    value: api.CodeName(code: code, name: name),
-    sva: 0,
-    prePeriods: const [],
-    maxIntensity: maxIntensity,
-    maxLpgmIntensity: maxLpgm,
+  return api.IntensityTree(
+    intensity: intensity,
+    regions: regions,
+    stations: stations,
   );
 }
 
 void main() {
   group('convertToIntensityTree', () {
-    test('空のデータの場合、空のMapを返す', () {
+    test('空の intensity_tree の場合、空のMapを返す', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [],
-        regions: [],
+        intensityTree: [],
       );
       final parameter = _buildParameter(regions: []);
 
@@ -118,15 +86,10 @@ void main() {
     test('1都道府県・1地域の場合、正しくツリーが構築される', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['0420100'],
           ),
         ],
       );
@@ -162,25 +125,14 @@ void main() {
     test('同じ都道府県が複数の震度グループに出現する', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value5plus,
-        prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value5plus,
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value5plus,
+            regions: ['0420100'],
           ),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value5plus,
-            maxLpgmIntensity: null,
-          ),
-          (
-            code: '0420200',
-            name: '宮城県南部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
+          _jmaTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['0420200'],
           ),
         ],
       );
@@ -201,17 +153,14 @@ void main() {
         parameter: parameter,
       ).convertToIntensityTree(intensity: intensity);
 
-      // 震度5強と震度4の2グループが存在
       expect(result.keys.toList(), [JmaIntensity.fiveUpper, JmaIntensity.four]);
 
-      // 震度5強グループ: 宮城県 -> 宮城県北部
       final group5Plus = result[JmaIntensity.fiveUpper]!;
       expect(group5Plus.length, 1);
       expect(group5Plus[0].region.region.name, '宮城県');
       expect(group5Plus[0].cities.length, 1);
       expect(group5Plus[0].cities[0].city.name, '宮城県北部');
 
-      // 震度4グループ: 宮城県 -> 宮城県南部
       final group4 = result[JmaIntensity.four]!;
       expect(group4.length, 1);
       expect(group4[0].region.region.name, '宮城県');
@@ -222,22 +171,10 @@ void main() {
     test('複数都道府県が同一震度グループに含まれる', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
-          (code: '070000', name: '福島県', maxIntensity: api.JmaIntensity.value4),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
-          ),
-          (
-            code: '0720100',
-            name: '中通り',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['0420100', '0720100'],
           ),
         ],
       );
@@ -273,31 +210,18 @@ void main() {
     test('震度キーは降順にソートされる', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value6minus,
-        prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value6minus,
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value6minus,
+            regions: ['0420100'],
           ),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value6minus,
-            maxLpgmIntensity: null,
+          _jmaTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['0420200'],
           ),
-          (
-            code: '0420200',
-            name: '宮城県南部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
-          ),
-          (
-            code: '0420300',
-            name: '宮城県中部',
-            maxIntensity: api.JmaIntensity.value5minus,
-            maxLpgmIntensity: null,
+          _jmaTree(
+            intensity: api.JmaIntensity.value5minus,
+            regions: ['0420300'],
           ),
         ],
       );
@@ -330,15 +254,10 @@ void main() {
     test('regionsに存在しないcityコードはスキップされる', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['0420100'],
           ),
         ],
       );
@@ -363,61 +282,13 @@ void main() {
       expect(result[JmaIntensity.four]![0].cities[0].city.name, '宮城県北部');
     });
 
-    test('maxIntensityがnullのregionはスキップされる', () {
-      final intensity = _buildIntensity(
-        maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: null,
-            maxLpgmIntensity: null,
-          ),
-          (
-            code: '0420200',
-            name: '宮城県南部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
-          ),
-        ],
-      );
-      final parameter = _buildParameter(
-        regions: [
-          (
-            code: '040000',
-            name: '宮城県',
-            cities: [
-              (code: '0420100', name: '宮城県北部', stations: const []),
-              (code: '0420200', name: '宮城県南部', stations: const []),
-            ],
-          ),
-        ],
-      );
-
-      final result = IntensityTreeConverter(
-        parameter: parameter,
-      ).convertToIntensityTree(intensity: intensity);
-
-      expect(result.keys.toList(), [JmaIntensity.four]);
-      expect(result[JmaIntensity.four]![0].cities.length, 1);
-      expect(result[JmaIntensity.four]![0].cities[0].city.name, '宮城県南部');
-    });
-
     test('regionsのみの場合はstationノードは空リスト', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value3,
-        prefectures: [
-          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value3),
-        ],
-        regions: [
-          (
-            code: '1310000',
-            name: '東京都23区',
-            maxIntensity: api.JmaIntensity.value3,
-            maxLpgmIntensity: null,
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value3,
+            regions: ['1310000'],
           ),
         ],
       );
@@ -438,92 +309,17 @@ void main() {
       expect(result[JmaIntensity.three]![0].cities[0].stations, isEmpty);
     });
 
-    test('citiesフィールドがある場合は市区町村・観測点ツリーを優先する', () {
-      final intensity = _buildIntensity(
-        maxIntensity: api.JmaIntensity.value3,
-        prefectures: [
-          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value3),
-        ],
-        regions: [
-          (
-            code: '1310000',
-            name: '東京都23区_ regions側',
-            maxIntensity: api.JmaIntensity.value3,
-            maxLpgmIntensity: null,
-          ),
-        ],
-      );
-      final cities = [
-        const api.IntensityItem(
-          value: api.CodeName(code: '1310000', name: '東京都23区'),
-          maxIntensity: api.JmaIntensity.value3,
-          maxLpgmIntensity: api.JmaLpgmIntensity.value2,
-        ),
-      ];
-      final stations = [
-        _station(
-          code: '13100000001',
-          name: 'テスト観測点',
-          maxIntensity: api.JmaIntensity.value3,
-          maxLpgm: api.JmaLpgmIntensity.value2,
-        ),
-      ];
-      final parameter = _buildParameter(
-        regions: [
-          (
-            code: '130000',
-            name: '東京都',
-            cities: [
-              (
-                code: '1310000',
-                name: '東京都23区',
-                stations: [(code: '13100000001', name: 'テスト観測点')],
-              ),
-            ],
-          ),
-        ],
-      );
-
-      final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(
-            intensity: intensity,
-            cities: cities,
-            stations: stations,
-          );
-
-      final cityNode = result[JmaIntensity.three]![0].cities[0];
-      expect(cityNode.city.name, '東京都23区');
-      expect(cityNode.maxLpgmIntensity, JmaLpgmIntensity.two);
-      expect(cityNode.stations.length, 1);
-      expect(cityNode.stations[0].station.name, 'テスト観測点');
-      expect(cityNode.stations[0].intensity?.maxIntensity, JmaIntensity.three);
-      expect(
-        cityNode.stations[0].intensity?.maxLpgmIntensity,
-        JmaLpgmIntensity.two,
-      );
-    });
-
-    test('観測点の所属市区町村はパラメータで解決し、観測点自身の震度を保持する', () {
+    test('観測点コードはパラメータで市区町村に紐づけられる', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value4),
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['1310000'],
+            stations: ['999999'],
+          ),
         ],
-        regions: const [],
       );
-      final cities = [
-        const api.IntensityItem(
-          value: api.CodeName(code: '1310000', name: '東京都23区'),
-          maxIntensity: api.JmaIntensity.value4,
-        ),
-      ];
-      final stations = [
-        _station(
-          code: '999999',
-          name: '市区町村コード接頭辞と一致しない観測点',
-          maxIntensity: api.JmaIntensity.value2,
-        ),
-      ];
       final parameter = _buildParameter(
         regions: [
           (
@@ -533,7 +329,7 @@ void main() {
               (
                 code: '1310000',
                 name: '東京都23区',
-                stations: [(code: '999999', name: '市区町村コード接頭辞と一致しない観測点')],
+                stations: [(code: '999999', name: 'テスト観測点')],
               ),
             ],
           ),
@@ -541,57 +337,22 @@ void main() {
       );
 
       final result = IntensityTreeConverter(parameter: parameter)
-          .convertToIntensityTree(
-            intensity: intensity,
-            cities: cities,
-            stations: stations,
-          );
+          .convertToIntensityTree(intensity: intensity);
 
       final stationNode = result[JmaIntensity.four]![0].cities[0].stations[0];
-      expect(stationNode.station.name, '市区町村コード接頭辞と一致しない観測点');
-      expect(stationNode.intensity?.maxIntensity, JmaIntensity.two);
+      expect(stationNode.station.name, 'テスト観測点');
+      expect(stationNode.intensity?.maxIntensity, JmaIntensity.four);
     });
 
-    test('regionsが空でIntensity.citiesのみの場合もツリーが構築される', () {
-      final cities = [
-        const api.IntensityItem(
-          value: api.CodeName(code: '1310000', name: '東京都23区'),
-          maxIntensity: api.JmaIntensity.value3,
-        ),
-      ];
-      final intensity = _buildIntensity(
-        maxIntensity: api.JmaIntensity.value3,
-        prefectures: [
-          (code: '130000', name: '東京都', maxIntensity: api.JmaIntensity.value3),
-        ],
-        regions: [],
-        cities: cities,
-      );
-      final parameter = _buildParameter(
-        regions: [
-          (
-            code: '130000',
-            name: '東京都',
-            cities: [(code: '1310000', name: '東京都23区', stations: const [])],
-          ),
-        ],
-      );
-
-      final result = IntensityTreeConverter(
-        parameter: parameter,
-      ).convertToIntensityTree(intensity: intensity);
-
-      expect(result.keys.toList(), [JmaIntensity.three]);
-      expect(result[JmaIntensity.three]![0].cities[0].city.name, '東京都23区');
-    });
-
-    test('regions・citiesが空でprefecturesのみの場合は都道府県ノードのみ', () {
+    test('都道府県コードのみのツリーでは都道府県ノードのみ', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
+        intensityTree: [
+          _jmaTree(
+            intensity: api.JmaIntensity.value4,
+            regions: ['040000'],
+          ),
         ],
-        regions: [],
       );
       final parameter = _buildParameter(
         regions: [
@@ -611,29 +372,14 @@ void main() {
       expect(result[JmaIntensity.four]![0].region.region.name, '宮城県');
       expect(result[JmaIntensity.four]![0].cities, isEmpty);
     });
-
-    test('max_intensityのみで子要素がすべて空の場合は空のMap', () {
-      final intensity = _buildIntensity(
-        maxIntensity: api.JmaIntensity.value4,
-        prefectures: [],
-        regions: [],
-      );
-      final parameter = _buildParameter(regions: []);
-
-      final result = IntensityTreeConverter(
-        parameter: parameter,
-      ).convertToIntensityTree(intensity: intensity);
-
-      expect(result, isEmpty);
-    });
   });
 
   group('convertToLpgmIntensityTree', () {
     test('空のデータの場合、空のMapを返す', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value4,
-        prefectures: [],
-        regions: [],
+        intensityTree: [],
+        lpgmIntensityTree: const [],
       );
       final parameter = _buildParameter(regions: []);
 
@@ -648,25 +394,17 @@ void main() {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value5plus,
         maxLpgmIntensity: api.JmaLpgmIntensity.value3,
-        prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value5plus,
+        intensityTree: [],
+        lpgmIntensityTree: const [
+          api.LpgmIntensityTree(
+            lpgmIntensity: api.JmaLpgmIntensity.value3,
+            regions: ['0420100'],
+            stations: [],
           ),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value5plus,
-            maxLpgmIntensity: api.JmaLpgmIntensity.value3,
-          ),
-          (
-            code: '0420200',
-            name: '宮城県南部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: api.JmaLpgmIntensity.value1,
+          api.LpgmIntensityTree(
+            lpgmIntensity: api.JmaLpgmIntensity.value1,
+            regions: ['0420200'],
+            stations: [],
           ),
         ],
       );
@@ -703,79 +441,26 @@ void main() {
       expect(group1[0].cities[0].city.name, '宮城県南部');
     });
 
-    test('lpgmIntensityがnullのregionはスキップされる', () {
-      final intensity = _buildIntensity(
-        maxIntensity: api.JmaIntensity.value4,
-        prefectures: [
-          (code: '040000', name: '宮城県', maxIntensity: api.JmaIntensity.value4),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: null,
-          ),
-          (
-            code: '0420200',
-            name: '宮城県南部',
-            maxIntensity: api.JmaIntensity.value3,
-            maxLpgmIntensity: api.JmaLpgmIntensity.value2,
-          ),
-        ],
-      );
-      final parameter = _buildParameter(
-        regions: [
-          (
-            code: '040000',
-            name: '宮城県',
-            cities: [
-              (code: '0420100', name: '宮城県北部', stations: const []),
-              (code: '0420200', name: '宮城県南部', stations: const []),
-            ],
-          ),
-        ],
-      );
-
-      final result = IntensityTreeConverter(
-        parameter: parameter,
-      ).convertToLpgmIntensityTree(intensity: intensity);
-
-      expect(result.keys.toList(), [JmaLpgmIntensity.two]);
-      expect(result[JmaLpgmIntensity.two]![0].cities.length, 1);
-      expect(result[JmaLpgmIntensity.two]![0].cities[0].city.name, '宮城県南部');
-    });
-
     test('LPGM震度キーは降順にソートされる', () {
       final intensity = _buildIntensity(
         maxIntensity: api.JmaIntensity.value5plus,
         maxLpgmIntensity: api.JmaLpgmIntensity.value4,
-        prefectures: [
-          (
-            code: '040000',
-            name: '宮城県',
-            maxIntensity: api.JmaIntensity.value5plus,
+        intensityTree: [],
+        lpgmIntensityTree: const [
+          api.LpgmIntensityTree(
+            lpgmIntensity: api.JmaLpgmIntensity.value4,
+            regions: ['0420100'],
+            stations: [],
           ),
-          (code: '070000', name: '福島県', maxIntensity: api.JmaIntensity.value4),
-        ],
-        regions: [
-          (
-            code: '0420100',
-            name: '宮城県北部',
-            maxIntensity: api.JmaIntensity.value5plus,
-            maxLpgmIntensity: api.JmaLpgmIntensity.value4,
+          api.LpgmIntensityTree(
+            lpgmIntensity: api.JmaLpgmIntensity.value1,
+            regions: ['0420200'],
+            stations: [],
           ),
-          (
-            code: '0420200',
-            name: '宮城県南部',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: api.JmaLpgmIntensity.value1,
-          ),
-          (
-            code: '0720100',
-            name: '中通り',
-            maxIntensity: api.JmaIntensity.value4,
-            maxLpgmIntensity: api.JmaLpgmIntensity.value2,
+          api.LpgmIntensityTree(
+            lpgmIntensity: api.JmaLpgmIntensity.value2,
+            regions: ['0720100'],
+            stations: [],
           ),
         ],
       );

--- a/app/test/feature/earthquake_history/ui/region_intensity_widget_test.dart
+++ b/app/test/feature/earthquake_history/ui/region_intensity_widget_test.dart
@@ -93,14 +93,7 @@ void main() {
             ),
           ],
         },
-        regions: [
-          IntensityRegion(
-            region: miyagiRegion,
-            maxIntensity: JmaIntensity.four,
-          ),
-        ],
         lpgmIntensityTree: const {},
-        lpgmRegions: const [],
       ),
     );
 
@@ -136,14 +129,7 @@ void main() {
             ),
           ],
         },
-        regions: [
-          IntensityRegion(
-            region: miyagiRegion,
-            maxIntensity: JmaIntensity.four,
-          ),
-        ],
         lpgmIntensityTree: const {},
-        lpgmRegions: const [],
       ),
     );
 

--- a/docs/knowledge/20260503_eqmonitor_api_generated_enum_tojson_message.md
+++ b/docs/knowledge/20260503_eqmonitor_api_generated_enum_tojson_message.md
@@ -1,0 +1,23 @@
+# eqmonitor_api 生成 enum の toJson エラーメッセージと `\$unknown`
+
+## 事象
+
+`packages/eqmonitor_api` の `@JsonEnum` 付き enum で、`toJson()` 内に次のような文言が含まれることがある。
+
+```dart
+'This usually happens for \\$unknown or @JsonValue(null) entries.'
+```
+
+Dart の文字列では `\$` はエスケープされ **`$unknown` が識別子として解釈** される。当該 enum に `unknown` ゲッターが無いと **コンパイルエラー** になる。
+
+## 対処
+
+生成物を直す場合は、メッセージを **リテラルの `$` を含む形** にする。
+
+- 望ましい: `'...\$unknown...'`（ソース上は `\$unknown` 1 バックスラッシュ — Dart が `$` をエスケープ）
+
+コードジェネレータ側では、エラーメッセージ内の `$` は `\$` で出力するよう注意する。
+
+## 参照
+
+修正例: `packages/eqmonitor_api/lib/src/models/environment.dart` ほか多数の enum ファイル。

--- a/packages/eqmonitor_api/lib/src/models/apns_environment.dart
+++ b/packages/eqmonitor_api/lib/src/models/apns_environment.dart
@@ -19,7 +19,7 @@ enum ApnsEnvironment {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/apns_token_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/apns_token_type.dart
@@ -19,7 +19,7 @@ enum ApnsTokenType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/depth_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/depth_type.dart
@@ -23,7 +23,7 @@ enum DepthType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/device_locale.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_locale.dart
@@ -20,7 +20,7 @@ enum DeviceLocale {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/device_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_type.dart
@@ -18,7 +18,7 @@ enum DeviceType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/earthquake_datasource.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_datasource.dart
@@ -19,7 +19,7 @@ enum EarthquakeDatasource {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/earthquake_sort_by.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_sort_by.dart
@@ -27,7 +27,7 @@ enum EarthquakeSortBy {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_type.dart
@@ -18,7 +18,7 @@ enum EewIntensityRegionArrivalTimeType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/environment.dart
+++ b/packages/eqmonitor_api/lib/src/models/environment.dart
@@ -18,7 +18,7 @@ enum Environment {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/event_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/event_type.dart
@@ -18,7 +18,7 @@ enum EventType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/first_height_condition.dart
+++ b/packages/eqmonitor_api/lib/src/models/first_height_condition.dart
@@ -20,7 +20,7 @@ enum FirstHeightCondition {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/framework.dart
+++ b/packages/eqmonitor_api/lib/src/models/framework.dart
@@ -18,7 +18,7 @@ enum Framework {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/info_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/info_type.dart
@@ -22,7 +22,7 @@ enum InfoType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/interruption_level.dart
+++ b/packages/eqmonitor_api/lib/src/models/interruption_level.dart
@@ -22,7 +22,7 @@ enum InterruptionLevel {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/is_canceled.dart
+++ b/packages/eqmonitor_api/lib/src/models/is_canceled.dart
@@ -20,7 +20,7 @@ enum IsCanceled {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_intensity.dart
@@ -37,7 +37,7 @@ enum JmaIntensity {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/jma_lpgm_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_lpgm_intensity.dart
@@ -25,7 +25,7 @@ enum JmaLpgmIntensity {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/live_activity_start_trigger.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_start_trigger.dart
@@ -19,7 +19,7 @@ enum LiveActivityStartTrigger {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/locale.dart
+++ b/packages/eqmonitor_api/lib/src/models/locale.dart
@@ -20,7 +20,7 @@ enum Locale {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/min_jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/min_jma_intensity.dart
@@ -36,7 +36,7 @@ enum MinJmaIntensity {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/observation_max_height_condition.dart
+++ b/packages/eqmonitor_api/lib/src/models/observation_max_height_condition.dart
@@ -20,7 +20,7 @@ enum ObservationMaxHeightCondition {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/origin_time_precision.dart
+++ b/packages/eqmonitor_api/lib/src/models/origin_time_precision.dart
@@ -27,7 +27,7 @@ enum OriginTimePrecision {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/qualitative_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/qualitative_height.dart
@@ -18,7 +18,7 @@ enum QualitativeHeight {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/result.dart
+++ b/packages/eqmonitor_api/lib/src/models/result.dart
@@ -18,7 +18,7 @@ enum Result {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/shake_detection_level.dart
+++ b/packages/eqmonitor_api/lib/src/models/shake_detection_level.dart
@@ -25,7 +25,7 @@ enum ShakeDetectionLevel {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/sort_order.dart
+++ b/packages/eqmonitor_api/lib/src/models/sort_order.dart
@@ -19,7 +19,7 @@ enum SortOrder {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/status.dart
+++ b/packages/eqmonitor_api/lib/src/models/status.dart
@@ -20,7 +20,7 @@ enum Status {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/telegram_status.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_status.dart
@@ -21,7 +21,7 @@ enum TelegramStatus {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/telegram_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_type.dart
@@ -53,7 +53,7 @@ enum TelegramType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/telegram_types.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_types.dart
@@ -20,7 +20,7 @@ enum TelegramTypes {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/tsunami_warning_kind.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_warning_kind.dart
@@ -24,7 +24,7 @@ enum TsunamiWarningKind {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/type.dart
+++ b/packages/eqmonitor_api/lib/src/models/type.dart
@@ -18,7 +18,7 @@ enum Type {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/type2.dart
+++ b/packages/eqmonitor_api/lib/src/models/type2.dart
@@ -20,7 +20,7 @@ enum Type2 {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/type3.dart
+++ b/packages/eqmonitor_api/lib/src/models/type3.dart
@@ -20,7 +20,7 @@ enum Type3 {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/type4.dart
+++ b/packages/eqmonitor_api/lib/src/models/type4.dart
@@ -20,7 +20,7 @@ enum Type4 {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/wave_initial.dart
+++ b/packages/eqmonitor_api/lib/src/models/wave_initial.dart
@@ -18,7 +18,7 @@ enum WaveInitial {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`eqmonitor_api` の `Intensity` が `intensityTree` / `lpgmIntensityTree` 形式になったことに合わせ、アプリ側の震度ツリー変換と関連 UI・検索・型を更新しました。

## 主な変更

- **IntensityTreeConverter**: API の `[{intensity, regions, stations?}]` を、地震パラメータの都道府県→市区町村→観測点のツリーに変換。観測点は市区コード先頭5桁のマップに加え、パラメータ上の `stationCode → cityCode` で紐づけ（接頭辞と一致しない観測点コードに対応）。同一震度の複数ツリーを都道府県単位でマージ。
- **EarthquakeIntensityPartial**: API の `IntensityPartial` から `regions` を除去（max のみ）。
- **検索 API レスポンス**: `intensity` のみ返る形に合わせ、`IntensityAreaSearchItem` / `StationSearchItem` 作成時に検索コードとパラメータから名前を解決。
- **地図塗りつぶし**: `EarthquakeIntensity.forecastLocalEIntensityPairs` で細分区域コードと震度を組み立て。
- **EEW**: `Coordinate` が緯度経度のみになったため、`EewHypocenter` 変換を更新。
- **eqmonitor_api**: 生成 enum の `toJson()` 内メッセージで `\$unknown` が誤補間されていたため修正（ビルド・テスト時のコンパイルエラー解消）。
- **知見**: `docs/knowledge/20260503_eqmonitor_api_generated_enum_tojson_message.md` に記録。

## 検証

- `flutter analyze`（app）: No issues found
- 関連ユニット/ウィジェットテスト（震度ツリー・現在地・地域ウィジェット）: パス

## 注意

- リスト表示タイルの「最大震度を〇〇などで観測」は、簡易リストで地域一覧が取れないため **prefecture 名リストは空** にしてフォールバック文言になります。詳細画面では従来どおり `intensityTree` で表示されます。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e535b39-818d-478a-80dc-3b3e7c23786a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e535b39-818d-478a-80dc-3b3e7c23786a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

