### PR TITLE
feat: EEW一点観測フィルタ設定 (one_point_enabled)

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_notification_settings.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_notification_settings.dart
@@ -9,6 +9,8 @@ abstract class EewNotificationSettings with _$EewNotificationSettings {
   const factory EewNotificationSettings({
     required bool enabled,
     required JmaIntensity? criticalThreshold,
+    required bool startLiveActivity,
+    required bool onePointEnabled,
     required List<NotificationRegion> regions,
   }) = _EewNotificationSettings;
 }

--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_notification_settings.freezed.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_notification_settings.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EewNotificationSettings {
 
- bool get enabled; JmaIntensity? get criticalThreshold; List<NotificationRegion> get regions;
+ bool get enabled; JmaIntensity? get criticalThreshold; bool get startLiveActivity; bool get onePointEnabled; List<NotificationRegion> get regions;
 /// Create a copy of EewNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $EewNotificationSettingsCopyWith<EewNotificationSettings> get copyWith => _$EewN
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewNotificationSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.criticalThreshold, criticalThreshold) || other.criticalThreshold == criticalThreshold)&&const DeepCollectionEquality().equals(other.regions, regions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewNotificationSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.criticalThreshold, criticalThreshold) || other.criticalThreshold == criticalThreshold)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.onePointEnabled, onePointEnabled) || other.onePointEnabled == onePointEnabled)&&const DeepCollectionEquality().equals(other.regions, regions));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,enabled,criticalThreshold,const DeepCollectionEquality().hash(regions));
+int get hashCode => Object.hash(runtimeType,enabled,criticalThreshold,startLiveActivity,onePointEnabled,const DeepCollectionEquality().hash(regions));
 
 @override
 String toString() {
-  return 'EewNotificationSettings(enabled: $enabled, criticalThreshold: $criticalThreshold, regions: $regions)';
+  return 'EewNotificationSettings(enabled: $enabled, criticalThreshold: $criticalThreshold, startLiveActivity: $startLiveActivity, onePointEnabled: $onePointEnabled, regions: $regions)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $EewNotificationSettingsCopyWith<$Res>  {
   factory $EewNotificationSettingsCopyWith(EewNotificationSettings value, $Res Function(EewNotificationSettings) _then) = _$EewNotificationSettingsCopyWithImpl;
 @useResult
 $Res call({
- bool enabled, JmaIntensity? criticalThreshold, List<NotificationRegion> regions
+ bool enabled, JmaIntensity? criticalThreshold, bool startLiveActivity, bool onePointEnabled, List<NotificationRegion> regions
 });
 
 
@@ -62,11 +62,13 @@ class _$EewNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of EewNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? criticalThreshold = freezed,Object? regions = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? criticalThreshold = freezed,Object? startLiveActivity = null,Object? onePointEnabled = null,Object? regions = null,}) {
   return _then(_self.copyWith(
 enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool,criticalThreshold: freezed == criticalThreshold ? _self.criticalThreshold : criticalThreshold // ignore: cast_nullable_to_non_nullable
-as JmaIntensity?,regions: null == regions ? _self.regions : regions // ignore: cast_nullable_to_non_nullable
+as JmaIntensity?,startLiveActivity: null == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool,onePointEnabled: null == onePointEnabled ? _self.onePointEnabled : onePointEnabled // ignore: cast_nullable_to_non_nullable
+as bool,regions: null == regions ? _self.regions : regions // ignore: cast_nullable_to_non_nullable
 as List<NotificationRegion>,
   ));
 }
@@ -152,10 +154,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enabled,  JmaIntensity? criticalThreshold,  List<NotificationRegion> regions)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enabled,  JmaIntensity? criticalThreshold,  bool startLiveActivity,  bool onePointEnabled,  List<NotificationRegion> regions)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EewNotificationSettings() when $default != null:
-return $default(_that.enabled,_that.criticalThreshold,_that.regions);case _:
+return $default(_that.enabled,_that.criticalThreshold,_that.startLiveActivity,_that.onePointEnabled,_that.regions);case _:
   return orElse();
 
 }
@@ -173,10 +175,10 @@ return $default(_that.enabled,_that.criticalThreshold,_that.regions);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enabled,  JmaIntensity? criticalThreshold,  List<NotificationRegion> regions)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enabled,  JmaIntensity? criticalThreshold,  bool startLiveActivity,  bool onePointEnabled,  List<NotificationRegion> regions)  $default,) {final _that = this;
 switch (_that) {
 case _EewNotificationSettings():
-return $default(_that.enabled,_that.criticalThreshold,_that.regions);case _:
+return $default(_that.enabled,_that.criticalThreshold,_that.startLiveActivity,_that.onePointEnabled,_that.regions);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -193,10 +195,10 @@ return $default(_that.enabled,_that.criticalThreshold,_that.regions);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enabled,  JmaIntensity? criticalThreshold,  List<NotificationRegion> regions)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enabled,  JmaIntensity? criticalThreshold,  bool startLiveActivity,  bool onePointEnabled,  List<NotificationRegion> regions)?  $default,) {final _that = this;
 switch (_that) {
 case _EewNotificationSettings() when $default != null:
-return $default(_that.enabled,_that.criticalThreshold,_that.regions);case _:
+return $default(_that.enabled,_that.criticalThreshold,_that.startLiveActivity,_that.onePointEnabled,_that.regions);case _:
   return null;
 
 }
@@ -208,11 +210,13 @@ return $default(_that.enabled,_that.criticalThreshold,_that.regions);case _:
 
 
 class _EewNotificationSettings implements EewNotificationSettings {
-  const _EewNotificationSettings({required this.enabled, required this.criticalThreshold, required final  List<NotificationRegion> regions}): _regions = regions;
+  const _EewNotificationSettings({required this.enabled, required this.criticalThreshold, required this.startLiveActivity, required this.onePointEnabled, required final  List<NotificationRegion> regions}): _regions = regions;
   
 
 @override final  bool enabled;
 @override final  JmaIntensity? criticalThreshold;
+@override final  bool startLiveActivity;
+@override final  bool onePointEnabled;
  final  List<NotificationRegion> _regions;
 @override List<NotificationRegion> get regions {
   if (_regions is EqualUnmodifiableListView) return _regions;
@@ -231,16 +235,16 @@ _$EewNotificationSettingsCopyWith<_EewNotificationSettings> get copyWith => __$E
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewNotificationSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.criticalThreshold, criticalThreshold) || other.criticalThreshold == criticalThreshold)&&const DeepCollectionEquality().equals(other._regions, _regions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewNotificationSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.criticalThreshold, criticalThreshold) || other.criticalThreshold == criticalThreshold)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.onePointEnabled, onePointEnabled) || other.onePointEnabled == onePointEnabled)&&const DeepCollectionEquality().equals(other._regions, _regions));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,enabled,criticalThreshold,const DeepCollectionEquality().hash(_regions));
+int get hashCode => Object.hash(runtimeType,enabled,criticalThreshold,startLiveActivity,onePointEnabled,const DeepCollectionEquality().hash(_regions));
 
 @override
 String toString() {
-  return 'EewNotificationSettings(enabled: $enabled, criticalThreshold: $criticalThreshold, regions: $regions)';
+  return 'EewNotificationSettings(enabled: $enabled, criticalThreshold: $criticalThreshold, startLiveActivity: $startLiveActivity, onePointEnabled: $onePointEnabled, regions: $regions)';
 }
 
 
@@ -251,7 +255,7 @@ abstract mixin class _$EewNotificationSettingsCopyWith<$Res> implements $EewNoti
   factory _$EewNotificationSettingsCopyWith(_EewNotificationSettings value, $Res Function(_EewNotificationSettings) _then) = __$EewNotificationSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- bool enabled, JmaIntensity? criticalThreshold, List<NotificationRegion> regions
+ bool enabled, JmaIntensity? criticalThreshold, bool startLiveActivity, bool onePointEnabled, List<NotificationRegion> regions
 });
 
 
@@ -268,11 +272,13 @@ class __$EewNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of EewNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? criticalThreshold = freezed,Object? regions = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? criticalThreshold = freezed,Object? startLiveActivity = null,Object? onePointEnabled = null,Object? regions = null,}) {
   return _then(_EewNotificationSettings(
 enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool,criticalThreshold: freezed == criticalThreshold ? _self.criticalThreshold : criticalThreshold // ignore: cast_nullable_to_non_nullable
-as JmaIntensity?,regions: null == regions ? _self._regions : regions // ignore: cast_nullable_to_non_nullable
+as JmaIntensity?,startLiveActivity: null == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool,onePointEnabled: null == onePointEnabled ? _self.onePointEnabled : onePointEnabled // ignore: cast_nullable_to_non_nullable
+as bool,regions: null == regions ? _self._regions : regions // ignore: cast_nullable_to_non_nullable
 as List<NotificationRegion>,
   ));
 }

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/eew_settings_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/eew_settings_notifier.dart
@@ -14,6 +14,8 @@ part 'eew_settings_notifier.g.dart';
 class EewSettingsNotifier extends _$EewSettingsNotifier {
   static final saveSettingsMutation = Mutation<void>();
   static final updateRegionsMutation = Mutation<void>();
+  static final saveLiveActivityMutation = Mutation<void>();
+  static final saveOnePointMutation = Mutation<void>();
 
   @override
   Future<EewNotificationSettings> build() async {
@@ -46,6 +48,8 @@ class EewSettingsNotifier extends _$EewSettingsNotifier {
       deviceId: deviceId,
       enabled: enabled,
       criticalThreshold: current.criticalThreshold,
+      startLiveActivity: current.startLiveActivity,
+      onePointEnabled: current.onePointEnabled,
     );
     switch (result) {
       case Success(:final value):
@@ -65,6 +69,50 @@ class EewSettingsNotifier extends _$EewSettingsNotifier {
       deviceId: deviceId,
       enabled: current.enabled,
       criticalThreshold: threshold,
+      startLiveActivity: current.startLiveActivity,
+      onePointEnabled: current.onePointEnabled,
+    );
+    switch (result) {
+      case Success(:final value):
+        state = AsyncData(value.copyWith(regions: current.regions));
+      case Failure(:final exception):
+        throw exception;
+    }
+  }
+
+  Future<void> setStartLiveActivity({required bool startLiveActivity}) async {
+    final current = state.requireValue;
+    final deviceId = await ref.read(deviceIdProvider.future);
+    final repo = await ref.read(
+      deviceNotificationSettingsRepositoryProvider.future,
+    );
+    final result = await repo.patchEewSettings(
+      deviceId: deviceId,
+      enabled: current.enabled,
+      criticalThreshold: current.criticalThreshold,
+      startLiveActivity: startLiveActivity,
+      onePointEnabled: current.onePointEnabled,
+    );
+    switch (result) {
+      case Success(:final value):
+        state = AsyncData(value.copyWith(regions: current.regions));
+      case Failure(:final exception):
+        throw exception;
+    }
+  }
+
+  Future<void> setOnePointEnabled({required bool onePointEnabled}) async {
+    final current = state.requireValue;
+    final deviceId = await ref.read(deviceIdProvider.future);
+    final repo = await ref.read(
+      deviceNotificationSettingsRepositoryProvider.future,
+    );
+    final result = await repo.patchEewSettings(
+      deviceId: deviceId,
+      enabled: current.enabled,
+      criticalThreshold: current.criticalThreshold,
+      startLiveActivity: current.startLiveActivity,
+      onePointEnabled: onePointEnabled,
     );
     switch (result) {
       case Success(:final value):

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/eew_settings_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/eew_settings_notifier.g.dart
@@ -37,7 +37,7 @@ final class EewSettingsNotifierProvider
 }
 
 String _$eewSettingsNotifierHash() =>
-    r'3ce2175987395a485555b13ad9be5eabc2f922e0';
+    r'e14b35ea92c64bf6cd567a40e33f9f9b2fa32aac';
 
 abstract class _$EewSettingsNotifier
     extends $AsyncNotifier<EewNotificationSettings> {

--- a/app/lib/feature/settings/features/notification_settings/data/repository/device_notification_settings_repository.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/repository/device_notification_settings_repository.dart
@@ -49,12 +49,16 @@ class DeviceNotificationSettingsRepository {
     required String deviceId,
     required bool enabled,
     required JmaIntensity? criticalThreshold,
+    required bool startLiveActivity,
+    required bool onePointEnabled,
   }) => Result.capture(() async {
     final response = await _api.device.patchV2DeviceDeviceIdSettingsEew(
       deviceId: deviceId,
       body: api.EewSettingsRequest(
         enabled: enabled,
         notificationTiers: _toEewApiTiers(criticalThreshold),
+        startLiveActivity: startLiveActivity,
+        onePointEnabled: onePointEnabled,
       ),
     );
     final regionsResult = await _api.device
@@ -191,6 +195,8 @@ class DeviceNotificationSettingsRepository {
     criticalThreshold: _extractCriticalThresholdFromTiers3(
       resp.notificationTiers,
     ),
+    startLiveActivity: resp.startLiveActivity,
+    onePointEnabled: resp.onePointEnabled,
     regions: regions,
   );
 

--- a/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
@@ -40,6 +40,8 @@ class _Body extends ConsumerWidget {
         const EewNotificationSettings(
           enabled: true,
           criticalThreshold: null,
+          startLiveActivity: true,
+          onePointEnabled: true,
           regions: [],
         );
 
@@ -51,6 +53,10 @@ class _Body extends ConsumerWidget {
           _EnabledSection(settings: settings),
           const SettingsSectionHeader(text: 'クリティカル通知'),
           _ThresholdSection(settings: settings),
+          const SettingsSectionHeader(text: 'Live Activity'),
+          _LiveActivitySection(settings: settings),
+          const SettingsSectionHeader(text: '一点観測EEW'),
+          _OnePointSection(settings: settings),
           const SettingsSectionHeader(text: '通知地域'),
           _RegionsSection(settings: settings),
         ],
@@ -139,6 +145,64 @@ class _ThresholdSection extends ConsumerWidget {
                         picked == _kClearThreshold ? null : picked,
                       );
                 },
+              );
+            },
+    );
+  }
+}
+
+class _LiveActivitySection extends ConsumerWidget {
+  const _LiveActivitySection({required this.settings});
+
+  final EewNotificationSettings settings;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final saveState = ref.watch(EewSettingsNotifier.saveLiveActivityMutation);
+    final isSaving = saveState is MutationPending;
+
+    return AppSwitchListTile(
+      title: 'Live Activity を開始',
+      subtitle: 'EEW 発生時にダイナミックアイランド・ロック画面に情報を表示します（iOS のみ）',
+      value: settings.startLiveActivity,
+      onChanged: isSaving
+          ? null
+          : (value) {
+              unawaited(
+                EewSettingsNotifier.saveLiveActivityMutation.run(ref, (tsx) async {
+                  await tsx
+                      .get(eewSettingsProvider.notifier)
+                      .setStartLiveActivity(startLiveActivity: value);
+                }),
+              );
+            },
+    );
+  }
+}
+
+class _OnePointSection extends ConsumerWidget {
+  const _OnePointSection({required this.settings});
+
+  final EewNotificationSettings settings;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final saveState = ref.watch(EewSettingsNotifier.saveOnePointMutation);
+    final isSaving = saveState is MutationPending;
+
+    return AppSwitchListTile(
+      title: '一点観測EEWの通知',
+      subtitle: '単一の観測点のみで検出された速報（精度が低い場合があります）を受け取ります',
+      value: settings.onePointEnabled,
+      onChanged: isSaving
+          ? null
+          : (value) {
+              unawaited(
+                EewSettingsNotifier.saveOnePointMutation.run(ref, (tsx) async {
+                  await tsx
+                      .get(eewSettingsProvider.notifier)
+                      .setOnePointEnabled(onePointEnabled: value);
+                }),
               );
             },
     );

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_request.dart
@@ -18,6 +18,8 @@ abstract class EewSettingsRequest with _$EewSettingsRequest {
     List<NotificationTiers4>? notificationTiers,
     @JsonKey(includeIfNull: false,name: 'start_live_activity')
     bool? startLiveActivity,
+    @JsonKey(includeIfNull: false,name: 'one_point_enabled')
+    bool? onePointEnabled,
   }) = _EewSettingsRequest;
   
   factory EewSettingsRequest.fromJson(Map<String, Object?> json) => _$EewSettingsRequestFromJson(json);

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_request.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EewSettingsRequest {
 
-@JsonKey(includeIfNull: false) bool? get enabled;@JsonKey(includeIfNull: false, name: 'notification_tiers') List<NotificationTiers4>? get notificationTiers;@JsonKey(includeIfNull: false, name: 'start_live_activity') bool? get startLiveActivity;
+@JsonKey(includeIfNull: false) bool? get enabled;@JsonKey(includeIfNull: false, name: 'notification_tiers') List<NotificationTiers4>? get notificationTiers;@JsonKey(includeIfNull: false, name: 'start_live_activity') bool? get startLiveActivity;@JsonKey(includeIfNull: false, name: 'one_point_enabled') bool? get onePointEnabled;
 /// Create a copy of EewSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EewSettingsRequestCopyWith<EewSettingsRequest> get copyWith => _$EewSettingsReq
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewSettingsRequest&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other.notificationTiers, notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewSettingsRequest&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other.notificationTiers, notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.onePointEnabled, onePointEnabled) || other.onePointEnabled == onePointEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(notificationTiers),startLiveActivity);
+int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(notificationTiers),startLiveActivity,onePointEnabled);
 
 @override
 String toString() {
-  return 'EewSettingsRequest(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity)';
+  return 'EewSettingsRequest(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity, onePointEnabled: $onePointEnabled)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EewSettingsRequestCopyWith<$Res>  {
   factory $EewSettingsRequestCopyWith(EewSettingsRequest value, $Res Function(EewSettingsRequest) _then) = _$EewSettingsRequestCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(includeIfNull: false) bool? enabled,@JsonKey(includeIfNull: false, name: 'notification_tiers') List<NotificationTiers4>? notificationTiers,@JsonKey(includeIfNull: false, name: 'start_live_activity') bool? startLiveActivity
+@JsonKey(includeIfNull: false) bool? enabled,@JsonKey(includeIfNull: false, name: 'notification_tiers') List<NotificationTiers4>? notificationTiers,@JsonKey(includeIfNull: false, name: 'start_live_activity') bool? startLiveActivity,@JsonKey(includeIfNull: false, name: 'one_point_enabled') bool? onePointEnabled
 });
 
 
@@ -65,11 +65,12 @@ class _$EewSettingsRequestCopyWithImpl<$Res>
 
 /// Create a copy of EewSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? enabled = freezed,Object? notificationTiers = freezed,Object? startLiveActivity = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = freezed,Object? notificationTiers = freezed,Object? startLiveActivity = freezed,Object? onePointEnabled = freezed,}) {
   return _then(_self.copyWith(
 enabled: freezed == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool?,notificationTiers: freezed == notificationTiers ? _self.notificationTiers : notificationTiers // ignore: cast_nullable_to_non_nullable
 as List<NotificationTiers4>?,startLiveActivity: freezed == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool?,onePointEnabled: freezed == onePointEnabled ? _self.onePointEnabled : onePointEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,
   ));
 }
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  bool? enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers')  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity')  bool? startLiveActivity)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  bool? enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers')  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity')  bool? startLiveActivity, @JsonKey(includeIfNull: false, name: 'one_point_enabled')  bool? onePointEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EewSettingsRequest() when $default != null:
-return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);case _:
+return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity,_that.onePointEnabled);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  bool? enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers')  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity')  bool? startLiveActivity)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false)  bool? enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers')  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity')  bool? startLiveActivity, @JsonKey(includeIfNull: false, name: 'one_point_enabled')  bool? onePointEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _EewSettingsRequest():
-return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);case _:
+return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity,_that.onePointEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false)  bool? enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers')  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity')  bool? startLiveActivity)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false)  bool? enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers')  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity')  bool? startLiveActivity, @JsonKey(includeIfNull: false, name: 'one_point_enabled')  bool? onePointEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _EewSettingsRequest() when $default != null:
-return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);case _:
+return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity,_that.onePointEnabled);case _:
   return null;
 
 }
@@ -211,7 +212,7 @@ return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);c
 @JsonSerializable()
 
 class _EewSettingsRequest implements EewSettingsRequest {
-  const _EewSettingsRequest({@JsonKey(includeIfNull: false) this.enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers') final  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity') this.startLiveActivity}): _notificationTiers = notificationTiers;
+  const _EewSettingsRequest({@JsonKey(includeIfNull: false) this.enabled, @JsonKey(includeIfNull: false, name: 'notification_tiers') final  List<NotificationTiers4>? notificationTiers, @JsonKey(includeIfNull: false, name: 'start_live_activity') this.startLiveActivity, @JsonKey(includeIfNull: false, name: 'one_point_enabled') this.onePointEnabled}): _notificationTiers = notificationTiers;
   factory _EewSettingsRequest.fromJson(Map<String, dynamic> json) => _$EewSettingsRequestFromJson(json);
 
 @override@JsonKey(includeIfNull: false) final  bool? enabled;
@@ -225,6 +226,7 @@ class _EewSettingsRequest implements EewSettingsRequest {
 }
 
 @override@JsonKey(includeIfNull: false, name: 'start_live_activity') final  bool? startLiveActivity;
+@override@JsonKey(includeIfNull: false, name: 'one_point_enabled') final  bool? onePointEnabled;
 
 /// Create a copy of EewSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -239,16 +241,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewSettingsRequest&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other._notificationTiers, _notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewSettingsRequest&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other._notificationTiers, _notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.onePointEnabled, onePointEnabled) || other.onePointEnabled == onePointEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(_notificationTiers),startLiveActivity);
+int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(_notificationTiers),startLiveActivity,onePointEnabled);
 
 @override
 String toString() {
-  return 'EewSettingsRequest(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity)';
+  return 'EewSettingsRequest(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity, onePointEnabled: $onePointEnabled)';
 }
 
 
@@ -259,7 +261,7 @@ abstract mixin class _$EewSettingsRequestCopyWith<$Res> implements $EewSettingsR
   factory _$EewSettingsRequestCopyWith(_EewSettingsRequest value, $Res Function(_EewSettingsRequest) _then) = __$EewSettingsRequestCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(includeIfNull: false) bool? enabled,@JsonKey(includeIfNull: false, name: 'notification_tiers') List<NotificationTiers4>? notificationTiers,@JsonKey(includeIfNull: false, name: 'start_live_activity') bool? startLiveActivity
+@JsonKey(includeIfNull: false) bool? enabled,@JsonKey(includeIfNull: false, name: 'notification_tiers') List<NotificationTiers4>? notificationTiers,@JsonKey(includeIfNull: false, name: 'start_live_activity') bool? startLiveActivity,@JsonKey(includeIfNull: false, name: 'one_point_enabled') bool? onePointEnabled
 });
 
 
@@ -276,11 +278,12 @@ class __$EewSettingsRequestCopyWithImpl<$Res>
 
 /// Create a copy of EewSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? enabled = freezed,Object? notificationTiers = freezed,Object? startLiveActivity = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = freezed,Object? notificationTiers = freezed,Object? startLiveActivity = freezed,Object? onePointEnabled = freezed,}) {
   return _then(_EewSettingsRequest(
 enabled: freezed == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool?,notificationTiers: freezed == notificationTiers ? _self._notificationTiers : notificationTiers // ignore: cast_nullable_to_non_nullable
 as List<NotificationTiers4>?,startLiveActivity: freezed == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool?,onePointEnabled: freezed == onePointEnabled ? _self.onePointEnabled : onePointEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,
   ));
 }

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_request.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_request.g.dart
@@ -8,37 +8,39 @@ part of 'eew_settings_request.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_EewSettingsRequest _$EewSettingsRequestFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(
-      '_EewSettingsRequest',
-      json,
-      ($checkedConvert) {
-        final val = _EewSettingsRequest(
-          enabled: $checkedConvert('enabled', (v) => v as bool?),
-          notificationTiers: $checkedConvert(
-            'notification_tiers',
-            (v) => (v as List<dynamic>?)
-                ?.map(
-                  (e) => NotificationTiers4.fromJson(e as Map<String, dynamic>),
-                )
-                .toList(),
-          ),
-          startLiveActivity: $checkedConvert(
-            'start_live_activity',
-            (v) => v as bool?,
-          ),
-        );
-        return val;
-      },
-      fieldKeyMap: const {
-        'notificationTiers': 'notification_tiers',
-        'startLiveActivity': 'start_live_activity',
-      },
+_EewSettingsRequest _$EewSettingsRequestFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_EewSettingsRequest',
+  json,
+  ($checkedConvert) {
+    final val = _EewSettingsRequest(
+      enabled: $checkedConvert('enabled', (v) => v as bool?),
+      notificationTiers: $checkedConvert(
+        'notification_tiers',
+        (v) => (v as List<dynamic>?)
+            ?.map((e) => NotificationTiers4.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      ),
+      startLiveActivity: $checkedConvert(
+        'start_live_activity',
+        (v) => v as bool?,
+      ),
+      onePointEnabled: $checkedConvert('one_point_enabled', (v) => v as bool?),
     );
+    return val;
+  },
+  fieldKeyMap: const {
+    'notificationTiers': 'notification_tiers',
+    'startLiveActivity': 'start_live_activity',
+    'onePointEnabled': 'one_point_enabled',
+  },
+);
 
 Map<String, dynamic> _$EewSettingsRequestToJson(_EewSettingsRequest instance) =>
     <String, dynamic>{
       'enabled': ?instance.enabled,
       'notification_tiers': ?instance.notificationTiers,
       'start_live_activity': ?instance.startLiveActivity,
+      'one_point_enabled': ?instance.onePointEnabled,
     };

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_response.dart
@@ -17,6 +17,8 @@ abstract class EewSettingsResponse with _$EewSettingsResponse {
     required List<NotificationTiers3> notificationTiers,
     @JsonKey(name: 'start_live_activity')
     required bool startLiveActivity,
+    @JsonKey(name: 'one_point_enabled')
+    required bool onePointEnabled,
   }) = _EewSettingsResponse;
   
   factory EewSettingsResponse.fromJson(Map<String, Object?> json) => _$EewSettingsResponseFromJson(json);

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_response.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EewSettingsResponse {
 
- bool get enabled;@JsonKey(name: 'notification_tiers') List<NotificationTiers3> get notificationTiers;@JsonKey(name: 'start_live_activity') bool get startLiveActivity;
+ bool get enabled;@JsonKey(name: 'notification_tiers') List<NotificationTiers3> get notificationTiers;@JsonKey(name: 'start_live_activity') bool get startLiveActivity;@JsonKey(name: 'one_point_enabled') bool get onePointEnabled;
 /// Create a copy of EewSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EewSettingsResponseCopyWith<EewSettingsResponse> get copyWith => _$EewSettingsR
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewSettingsResponse&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other.notificationTiers, notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewSettingsResponse&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other.notificationTiers, notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.onePointEnabled, onePointEnabled) || other.onePointEnabled == onePointEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(notificationTiers),startLiveActivity);
+int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(notificationTiers),startLiveActivity,onePointEnabled);
 
 @override
 String toString() {
-  return 'EewSettingsResponse(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity)';
+  return 'EewSettingsResponse(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity, onePointEnabled: $onePointEnabled)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EewSettingsResponseCopyWith<$Res>  {
   factory $EewSettingsResponseCopyWith(EewSettingsResponse value, $Res Function(EewSettingsResponse) _then) = _$EewSettingsResponseCopyWithImpl;
 @useResult
 $Res call({
- bool enabled,@JsonKey(name: 'notification_tiers') List<NotificationTiers3> notificationTiers,@JsonKey(name: 'start_live_activity') bool startLiveActivity
+ bool enabled,@JsonKey(name: 'notification_tiers') List<NotificationTiers3> notificationTiers,@JsonKey(name: 'start_live_activity') bool startLiveActivity,@JsonKey(name: 'one_point_enabled') bool onePointEnabled
 });
 
 
@@ -65,11 +65,12 @@ class _$EewSettingsResponseCopyWithImpl<$Res>
 
 /// Create a copy of EewSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? notificationTiers = null,Object? startLiveActivity = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? notificationTiers = null,Object? startLiveActivity = null,Object? onePointEnabled = null,}) {
   return _then(_self.copyWith(
 enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool,notificationTiers: null == notificationTiers ? _self.notificationTiers : notificationTiers // ignore: cast_nullable_to_non_nullable
 as List<NotificationTiers3>,startLiveActivity: null == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool,onePointEnabled: null == onePointEnabled ? _self.onePointEnabled : onePointEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enabled, @JsonKey(name: 'notification_tiers')  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity')  bool startLiveActivity)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enabled, @JsonKey(name: 'notification_tiers')  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity')  bool startLiveActivity, @JsonKey(name: 'one_point_enabled')  bool onePointEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EewSettingsResponse() when $default != null:
-return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);case _:
+return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity,_that.onePointEnabled);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enabled, @JsonKey(name: 'notification_tiers')  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity')  bool startLiveActivity)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enabled, @JsonKey(name: 'notification_tiers')  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity')  bool startLiveActivity, @JsonKey(name: 'one_point_enabled')  bool onePointEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _EewSettingsResponse():
-return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);case _:
+return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity,_that.onePointEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enabled, @JsonKey(name: 'notification_tiers')  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity')  bool startLiveActivity)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enabled, @JsonKey(name: 'notification_tiers')  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity')  bool startLiveActivity, @JsonKey(name: 'one_point_enabled')  bool onePointEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _EewSettingsResponse() when $default != null:
-return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);case _:
+return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity,_that.onePointEnabled);case _:
   return null;
 
 }
@@ -211,7 +212,7 @@ return $default(_that.enabled,_that.notificationTiers,_that.startLiveActivity);c
 @JsonSerializable()
 
 class _EewSettingsResponse implements EewSettingsResponse {
-  const _EewSettingsResponse({required this.enabled, @JsonKey(name: 'notification_tiers') required final  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity') required this.startLiveActivity}): _notificationTiers = notificationTiers;
+  const _EewSettingsResponse({required this.enabled, @JsonKey(name: 'notification_tiers') required final  List<NotificationTiers3> notificationTiers, @JsonKey(name: 'start_live_activity') required this.startLiveActivity, @JsonKey(name: 'one_point_enabled') required this.onePointEnabled}): _notificationTiers = notificationTiers;
   factory _EewSettingsResponse.fromJson(Map<String, dynamic> json) => _$EewSettingsResponseFromJson(json);
 
 @override final  bool enabled;
@@ -223,6 +224,7 @@ class _EewSettingsResponse implements EewSettingsResponse {
 }
 
 @override@JsonKey(name: 'start_live_activity') final  bool startLiveActivity;
+@override@JsonKey(name: 'one_point_enabled') final  bool onePointEnabled;
 
 /// Create a copy of EewSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -237,16 +239,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewSettingsResponse&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other._notificationTiers, _notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewSettingsResponse&&(identical(other.enabled, enabled) || other.enabled == enabled)&&const DeepCollectionEquality().equals(other._notificationTiers, _notificationTiers)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.onePointEnabled, onePointEnabled) || other.onePointEnabled == onePointEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(_notificationTiers),startLiveActivity);
+int get hashCode => Object.hash(runtimeType,enabled,const DeepCollectionEquality().hash(_notificationTiers),startLiveActivity,onePointEnabled);
 
 @override
 String toString() {
-  return 'EewSettingsResponse(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity)';
+  return 'EewSettingsResponse(enabled: $enabled, notificationTiers: $notificationTiers, startLiveActivity: $startLiveActivity, onePointEnabled: $onePointEnabled)';
 }
 
 
@@ -257,7 +259,7 @@ abstract mixin class _$EewSettingsResponseCopyWith<$Res> implements $EewSettings
   factory _$EewSettingsResponseCopyWith(_EewSettingsResponse value, $Res Function(_EewSettingsResponse) _then) = __$EewSettingsResponseCopyWithImpl;
 @override @useResult
 $Res call({
- bool enabled,@JsonKey(name: 'notification_tiers') List<NotificationTiers3> notificationTiers,@JsonKey(name: 'start_live_activity') bool startLiveActivity
+ bool enabled,@JsonKey(name: 'notification_tiers') List<NotificationTiers3> notificationTiers,@JsonKey(name: 'start_live_activity') bool startLiveActivity,@JsonKey(name: 'one_point_enabled') bool onePointEnabled
 });
 
 
@@ -274,11 +276,12 @@ class __$EewSettingsResponseCopyWithImpl<$Res>
 
 /// Create a copy of EewSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? notificationTiers = null,Object? startLiveActivity = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? notificationTiers = null,Object? startLiveActivity = null,Object? onePointEnabled = null,}) {
   return _then(_EewSettingsResponse(
 enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
 as bool,notificationTiers: null == notificationTiers ? _self._notificationTiers : notificationTiers // ignore: cast_nullable_to_non_nullable
 as List<NotificationTiers3>,startLiveActivity: null == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool,onePointEnabled: null == onePointEnabled ? _self.onePointEnabled : onePointEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_response.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_response.g.dart
@@ -8,33 +8,34 @@ part of 'eew_settings_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_EewSettingsResponse _$EewSettingsResponseFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(
-      '_EewSettingsResponse',
-      json,
-      ($checkedConvert) {
-        final val = _EewSettingsResponse(
-          enabled: $checkedConvert('enabled', (v) => v as bool),
-          notificationTiers: $checkedConvert(
-            'notification_tiers',
-            (v) => (v as List<dynamic>)
-                .map(
-                  (e) => NotificationTiers3.fromJson(e as Map<String, dynamic>),
-                )
-                .toList(),
-          ),
-          startLiveActivity: $checkedConvert(
-            'start_live_activity',
-            (v) => v as bool,
-          ),
-        );
-        return val;
-      },
-      fieldKeyMap: const {
-        'notificationTiers': 'notification_tiers',
-        'startLiveActivity': 'start_live_activity',
-      },
+_EewSettingsResponse _$EewSettingsResponseFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_EewSettingsResponse',
+  json,
+  ($checkedConvert) {
+    final val = _EewSettingsResponse(
+      enabled: $checkedConvert('enabled', (v) => v as bool),
+      notificationTiers: $checkedConvert(
+        'notification_tiers',
+        (v) => (v as List<dynamic>)
+            .map((e) => NotificationTiers3.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      ),
+      startLiveActivity: $checkedConvert(
+        'start_live_activity',
+        (v) => v as bool,
+      ),
+      onePointEnabled: $checkedConvert('one_point_enabled', (v) => v as bool),
     );
+    return val;
+  },
+  fieldKeyMap: const {
+    'notificationTiers': 'notification_tiers',
+    'startLiveActivity': 'start_live_activity',
+    'onePointEnabled': 'one_point_enabled',
+  },
+);
 
 Map<String, dynamic> _$EewSettingsResponseToJson(
   _EewSettingsResponse instance,
@@ -42,4 +43,5 @@ Map<String, dynamic> _$EewSettingsResponseToJson(
   'enabled': instance.enabled,
   'notification_tiers': instance.notificationTiers,
   'start_live_activity': instance.startLiveActivity,
+  'one_point_enabled': instance.onePointEnabled,
 };


### PR DESCRIPTION
## Summary

- **一点観測EEWの通知ON/OFF設定を追加**: 単一観測点のみで検出されたEEW（精度が低い場合あり）を通知するかどうかをユーザが選択できる
- **バックエンド**: `device_eew_settings` テーブルに `one_point_enabled boolean DEFAULT true` カラム追加、EEW設定API（GET/PATCH）に `one_point_enabled` フィールド追加、通知リゾルバで `isOnePoint=true` のEEWを `onePointEnabled=false` のデバイスに送らないフィルタを追加
- **Flutter**: `EewNotificationSettings` モデルに `onePointEnabled` フィールド追加、EEW設定ページに「一点観測EEW」トグルセクションを追加
- **おまけ**: Live Activity トグルも本PRで EEW設定ページに追加（`startLiveActivity` フィールド含む）

## 注意事項

このPRはバックエンドのDBマイグレーション（`one_point_enabled` カラム追加）を含む。マージ前にDBマイグレーションを実行する必要あり。

バックエンドPR: https://github.com/YumNumm/eqmonitor-backend/compare/feat/eew-one-point-setting

## Test plan

- [ ] EEW設定 → 「一点観測EEW」トグルを OFF にして保存されることを確認
- [ ] 一点観測EEWのテストイベントを送信して、OFF設定のデバイスには届かないことを確認
- [ ] EEW設定 → 「Live Activity を開始」トグルが保存されることを確認
- [ ] `dart analyze` が通ることを確認
- [ ] バックエンドの TypeScript 型チェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)