### PR TITLE
fix: 地震履歴マップレイヤーのFlutter Hooksルール違反を修正

### DIFF
--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_details_estimated_intensity_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_details_estimated_intensity_layer.dart
@@ -23,12 +23,11 @@ class EarthquakeHistoryDetailsEstimatedIntensityLayer
   Widget build(BuildContext context, WidgetRef ref) {
     final styleController = MapController.maybeOf(context)?.style;
 
-    if (styleController == null) {
-      return const SizedBox.shrink();
-    }
-
     useEffect(
       () {
+        if (styleController == null) {
+          return null;
+        }
         unawaited(() async {
           await styleController.addSource(
             VectorSource(

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
@@ -79,12 +79,11 @@ class _ResolvedEarthquakeHistoryFillLayer extends HookConsumerWidget {
       () => EarthquakeHistoryFillLayerBuilder(modeResolver: modeResolver),
       [modeResolver],
     );
-    if (styleController == null) {
-      return const SizedBox.shrink();
-    }
-
     useEffect(
       () {
+        if (styleController == null) {
+          return null;
+        }
         final addedLayerIds = <String>[];
         var disposed = false;
 

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_intensity_icon_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_intensity_icon_layer.dart
@@ -56,12 +56,11 @@ class EarthquakeHistoryIntensityIconLayer extends HookConsumerWidget {
     final jmaMapAsync = ref.watch(jmaMapProvider);
     final cachedBytes = ref.watch(intensityIconProvider).value;
 
-    if (styleController == null) {
-      return const SizedBox.shrink();
-    }
-
     useEffect(
       () {
+        if (styleController == null) {
+          return null;
+        }
         final jmaMap = jmaMapAsync.value;
         if (jmaMap == null || cachedBytes == null) {
           return null;


### PR DESCRIPTION
## 概要

地震履歴詳細画面を表示した際にクラッシュする問題を修正します。

## 原因

以下の3つのマップレイヤーウィジェットで、Flutter Hooksのルール（Hooks must always be called in the same order and number）に違反していました。

MapLibreのマップは2段階で初期化されます：
1. プラットフォームビュー作成時（`isInitialized = true`、`style == null`）→ 子ウィジェットが初回レンダリング
2. スタイルロード完了時（`style != null`）→ 子ウィジェットが再ビルド

初回レンダリング時は `styleController == null` のため `useEffect` の前で早期returnし、スタイルロード後の再ビルドでは `useEffect` が呼ばれる → hook呼び出し回数が変わり FlutterError がスローされていました。

## 修正内容

`useEffect` コールバック前の `if (styleController == null) return` ガードを、コールバック内のnullチェックに移動しました。

**修正対象ファイル：**
- `earthquake_history_details_estimated_intensity_layer.dart`
- `earthquake_history_fill_layer.dart` (`_ResolvedEarthquakeHistoryFillLayer`)
- `earthquake_history_intensity_icon_layer.dart`

**修正パターン：**
```dart
// Before（hook違反）
if (styleController == null) {
  return const SizedBox.shrink();
}
useEffect(() { ... }, [...]);

// After（修正後）
useEffect(() {
  if (styleController == null) return null;
  // ...
}, [...]);
```

## 参考

同ディレクトリの `EarthquakeHistoryStationIntensityLayer`・`EarthquakeHistoryHypocenterLayer` は正しいパターンで実装されており、それに合わせた修正です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)