### PR TITLE
feat(earthquake_history): 速報値の震度表示を実装

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/region_intensity.dart
+++ b/app/lib/feature/earthquake_history/ui/components/region_intensity.dart
@@ -30,15 +30,14 @@ class EarthquakeIntensityWidget extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    // TODO(YumNumm): 速報値の表示実装
-    final intensityTree =
-        // <JmaIntensity, List<PrefectureIntensityNode>>{};
-        intensity.intensityTree;
+    final intensityTree = intensity.intensityTree;
+    final regions = intensity.regions;
     if (intensityTree.isEmpty) {
       return BorderedContainer(
         elevation: 1,
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
               children: [
@@ -57,6 +56,27 @@ class EarthquakeIntensityWidget extends ConsumerWidget {
                 ),
               ],
             ),
+            if (regions.isEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                child: Text(
+                  '各地の詳細な震度情報はまだ発表されていません',
+                  style: TextStyle(
+                    fontFamily: FontFamily.notoSansJP,
+                    fontSize: 13,
+                  ),
+                ),
+              )
+            else
+              ...regions.entries.map(
+                (entry) => _PreliminaryIntensityLevelSection(
+                  intensity: entry.key,
+                  regions: entry.value,
+                  dividerColor: colorModel
+                      .fromJmaIntensity(entry.key)
+                      .background,
+                ),
+              ),
           ],
         ),
       );
@@ -81,6 +101,73 @@ class EarthquakeIntensityWidget extends ConsumerWidget {
         ),
       );
     }
+  }
+}
+
+/// 速報値（細分区域単位）の震度レベル別セクション。
+/// 市区町村以下のデータがまだ無いため、震度速報の細分区域名を一覧表示する。
+class _PreliminaryIntensityLevelSection extends StatelessWidget {
+  const _PreliminaryIntensityLevelSection({
+    required this.intensity,
+    required this.regions,
+    required this.dividerColor,
+  });
+
+  final JmaIntensity intensity;
+  final List<IntensityRegion> regions;
+  final Color dividerColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final regionNames = regions.map((e) => e.region.name.ja).join('、');
+
+    return ListTile(
+      dense: true,
+      isThreeLine: true,
+      visualDensity: VisualDensity.compact,
+      titleAlignment: ListTileTitleAlignment.titleHeight,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+      leading: JmaIntensityIcon(
+        intensity: intensity,
+        type: .filled,
+        size: 40,
+      ),
+      title: Row(
+        children: [
+          Text(
+            '震度${intensity.mainText}',
+            style: theme.textTheme.titleSmall,
+          ),
+          const SizedBox(width: 6),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+            decoration: BoxDecoration(
+              color: dividerColor.withValues(alpha: 0.15),
+              border: Border.all(color: dividerColor),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: const Text(
+              '速報値',
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+                fontFamily: FontFamily.notoSansJP,
+              ),
+            ),
+          ),
+        ],
+      ),
+      subtitle: Text(
+        regionNames,
+        maxLines: 4,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          fontFamily: FontFamily.notoSansJP,
+          fontSize: 13,
+        ),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

地震履歴画面の `EarthquakeIntensityWidget` で、市区町村以下の詳細震度がまだ発表されていない段階の速報値（震度速報の細分区域単位）を表示するように改修しました。

これまで `intensityTree` が空のケースでは「震度情報なし」相当の見た目しか出ていませんでしたが、震度速報で先に得られる `regions`（細分区域単位の震度）がある場合はそれを震度レベル別に一覧表示します。

## 速報値の判定

- `intensity.intensityTree.isEmpty` （市区町村以下のツリーがまだ無い）
- かつ `intensity.regions` に値あり

この条件で「速報値モード」のセクションを描画します。

## UIの変更

`app/lib/feature/earthquake_history/ui/components/region_intensity.dart`

- `_PreliminaryIntensityLevelSection` を新規追加
  - 震度アイコン（`JmaIntensityIcon` filled, size 40）+ `震度{x}` ラベル + `速報値` バッジ
  - サブタイトルに細分区域名（`region.name.ja`）を `、` 区切りで連結表示（最大4行）
- `intensityTree` が空かつ `regions` も空の場合は「各地の詳細な震度情報はまだ発表されていません」を表示
- `regions` がある場合は震度レベル別に `_PreliminaryIntensityLevelSection` を並べる

`速報値` バッジは該当震度色（`colorModel.fromJmaIntensity(...).background`）の枠線 + 15%背景で視覚的に区別。

## dart analyze

```
$ flutter analyze app/lib/feature/earthquake_history/
Analyzing earthquake_history...
No issues found! (ran in 5.3s)
```

## Test plan

- [ ] 震度速報のみ受信時、細分区域単位で震度レベル別に表示されること
- [ ] 詳細震度受信後、従来の市区町村ツリー表示に切り替わること
- [ ] `intensityTree` も `regions` も空のケースで「各地の詳細な震度情報はまだ発表されていません」が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)