### PR TITLE
feat(eew): EEW震度予報区域の塗りつぶしを実装

### DIFF
--- a/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
@@ -1,12 +1,20 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_display_mode.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
 
 /// EEW震度予報区域レイヤー
 ///
-/// 現在のMapLibreパッケージではベクタータイルのフィルター操作が
-/// サポートされていないため、この機能は後日実装予定です。
+/// `displayMode` に応じて、府県地震予報区（areaForecastLocalEew）を
+/// 予想震度別 or 警報発表区域として塗りつぶす。
 class EewForecastRegionLayer extends HookConsumerWidget {
   const EewForecastRegionLayer({
     required this.eew,
@@ -17,10 +25,216 @@ class EewForecastRegionLayer extends HookConsumerWidget {
   final EewTelegramItem? eew;
   final EewDisplayMode displayMode;
 
+  static const _sourceId = 'eqmonitor_map';
+  static const _sourceLayerId = 'areaForecastLocalEew';
+  static const _warningLayerId = 'eew-details-warning-fill';
+  static const _emptyFilter = <Object>['==', '1', '2'];
+
+  static String _intensityLayerId(JmaIntensity intensity) {
+    final base = intensity.label
+        .replaceAll('-', 'low')
+        .replaceAll('+', 'high')
+        .replaceAll('不明', 'unknown');
+    return 'eew-details-intensity-fill-$base';
+  }
+
+  static const List<JmaIntensity> _intensityLevels = [
+    JmaIntensity.one,
+    JmaIntensity.two,
+    JmaIntensity.three,
+    JmaIntensity.four,
+    JmaIntensity.fiveLower,
+    JmaIntensity.fiveUpper,
+    JmaIntensity.sixLower,
+    JmaIntensity.sixUpper,
+    JmaIntensity.seven,
+  ];
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // TODO(impl): ベクタータイルのフィルター操作が実装されたら
-    // 震度予報区域の塗りつぶしを実装する
+    final styleController = MapController.maybeOf(context)?.style;
+    final colorModel = ref.watch(intensityColorProvider);
+
+    // 震度別の region code 一覧
+    final intensityCodes = useMemoized(() {
+      final regions = eew?.forecastIntensity?.regions ?? const [];
+      final maxByRegion = regions
+          .groupListsBy((e) => e.code)
+          .map(
+            (key, values) => MapEntry(
+              key,
+              values.sortedBy((e) => e.intensity.orderIndex).last,
+            ),
+          )
+          .values
+          .toList();
+      return {
+        for (final intensity in _intensityLevels)
+          intensity: maxByRegion
+              .where((r) => r.intensity == intensity)
+              .map((r) => r.code)
+              .toList(),
+      };
+    }, [eew]);
+
+    // 警報発表区域の region code 一覧
+    final warningCodes = useMemoized(() {
+      final zones = eew?.warning?.regions ?? const [];
+      return zones.where((z) => z.hadWarning).map((z) => z.code).toList();
+    }, [eew]);
+
+    final isInitialized = useRef(false);
+
+    // 震度別レイヤーの初期化（intensity モードのみ）
+    useEffect(
+      () {
+        if (styleController == null ||
+            displayMode != EewDisplayMode.intensity) {
+          return null;
+        }
+
+        var disposed = false;
+        final addedIds = <String>[];
+
+        unawaited(() async {
+          for (final intensity in _intensityLevels) {
+            if (disposed) {
+              return;
+            }
+            final color = colorModel.fromJmaIntensity(intensity).background;
+            final layerId = _intensityLayerId(intensity);
+            await styleController.addLayer(
+              FillStyleLayer(
+                id: layerId,
+                sourceId: _sourceId,
+                sourceLayerId: _sourceLayerId,
+                filter: _emptyFilter,
+                paint: {
+                  'fill-color': color.toHexString(),
+                  'fill-opacity': 0.7,
+                },
+              ),
+            );
+            addedIds.add(layerId);
+          }
+          isInitialized.value = true;
+        }());
+
+        return () {
+          disposed = true;
+          isInitialized.value = false;
+          unawaited(() async {
+            for (final id in addedIds.reversed) {
+              try {
+                await styleController.removeLayer(id);
+              } on Exception {
+                // ignore
+              }
+            }
+          }());
+        };
+      },
+      [styleController, displayMode, colorModel],
+    );
+
+    // 警報レイヤーの初期化（warning モードのみ）
+    useEffect(
+      () {
+        if (styleController == null || displayMode != EewDisplayMode.warning) {
+          return null;
+        }
+
+        var disposed = false;
+
+        unawaited(() async {
+          await styleController.addLayer(
+            const FillStyleLayer(
+              id: _warningLayerId,
+              sourceId: _sourceId,
+              sourceLayerId: _sourceLayerId,
+              filter: _emptyFilter,
+              paint: {
+                'fill-color': '#FF0000',
+                'fill-opacity': 0.4,
+              },
+            ),
+          );
+          if (!disposed) {
+            isInitialized.value = true;
+          }
+        }());
+
+        return () {
+          disposed = true;
+          isInitialized.value = false;
+          unawaited(() async {
+            try {
+              await styleController.removeLayer(_warningLayerId);
+            } on Exception {
+              // ignore
+            }
+          }());
+        };
+      },
+      [styleController, displayMode],
+    );
+
+    // 震度モード: フィルター更新
+    useEffect(
+      () {
+        if (styleController == null ||
+            displayMode != EewDisplayMode.intensity ||
+            !isInitialized.value) {
+          return null;
+        }
+
+        unawaited(() async {
+          for (final intensity in _intensityLevels) {
+            final codes = intensityCodes[intensity] ?? const [];
+            final filter = codes.isEmpty
+                ? _emptyFilter
+                : <Object>[
+                    'in',
+                    ['get', 'code'],
+                    ['literal', codes],
+                  ];
+            await styleController.updateFilter(
+              id: _intensityLayerId(intensity),
+              filter: filter,
+            );
+          }
+        }());
+
+        return null;
+      },
+      [styleController, displayMode, intensityCodes, isInitialized.value],
+    );
+
+    // 警報モード: フィルター更新
+    useEffect(
+      () {
+        if (styleController == null ||
+            displayMode != EewDisplayMode.warning ||
+            !isInitialized.value) {
+          return null;
+        }
+
+        final filter = warningCodes.isEmpty
+            ? _emptyFilter
+            : <Object>[
+                'in',
+                ['get', 'code'],
+                ['literal', warningCodes],
+              ];
+        unawaited(
+          styleController.updateFilter(id: _warningLayerId, filter: filter),
+        );
+
+        return null;
+      },
+      [styleController, displayMode, warningCodes, isInitialized.value],
+    );
+
     return const SizedBox.shrink();
   }
 }


### PR DESCRIPTION
## Summary

EEW（緊急地震速報）の震度予報区域をマップ上で塗りつぶし表示する機能を実装しました。

### 背景・経緯

これまで MapLibre Flutter バインディングの制約から `FillStyleLayer` の `filter` プロパティ／data-driven expression が安定して扱えず、震度予報区域の塗りつぶしは見送られていました。現バージョンの `maplibre` パッケージで MapLibre filter / expression が利用可能であることを確認できたため、本実装に移行しています。

### 実装概要

`app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart` に以下を追加：

- **`EewDisplayMode.intensity`**: 震度（9段階）に応じた `FillStyleLayer` を区域ごとに塗り分け。`IntensityColorModel` から各震度色を引き、MapLibre の filter で対応 region code を絞り込む。
- **`EewDisplayMode.warning`**: 警報モード時は赤色単一の `FillStyleLayer` で対象区域を塗りつぶし。
- region code → `JmaIntensity` のマッピングを `eew_telegram_item` から取り出し、レイヤー生成時に1度だけ計算（`useMemoized`）。

### dart analyze

`flutter analyze lib/feature/eew/` 実行結果: 本ファイルに対する警告 **0件**。
※ 既存の `eew_telegram_item.dart` に `invalid_null_aware_operator` 等の warning が 3 件残っていますが、本PRの差分外のため本PRでは対応しません。

## Test plan

- [ ] EEW を受信した状態で `EewDisplayMode.intensity` が選択されたときに、震度予報区域が震度色で塗り分けられること
- [ ] `EewDisplayMode.warning` 切替時に、対象区域が赤色で塗りつぶされること
- [ ] EEW が解除された際にレイヤーが正しく除去されること
- [ ] 地震履歴など他のマップ画面でレイヤー残留や色干渉が起きていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)