### PR TITLE
fix: EEW推定震度レイヤーの初期フィルターがレースコンディションで未適用になるバグを修正

### DIFF
--- a/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
@@ -51,12 +51,24 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
                 final color =
                     colorModel.fromJmaIntensity(intensity).background;
 
+                final codes = regionMaxIntensities
+                    .where((r) => r.intensity == intensity)
+                    .map((r) => r.code)
+                    .toList();
+                final initialFilter = codes.isEmpty
+                    ? const <Object>['==', '1', '2']
+                    : <Object>[
+                        'in',
+                        ['get', 'code'],
+                        ['literal', codes],
+                      ];
+
                 return styleController.addLayer(
                   FillStyleLayer(
                     id: layerId,
                     sourceId: 'eqmonitor_map',
                     sourceLayerId: 'areaForecastLocalEew',
-                    filter: const ['==', '1', '2'],
+                    filter: initialFilter,
                     paint: {
                       'fill-color': color.toHexString(),
                       'fill-opacity': 0.7,


### PR DESCRIPTION
## 問題

`EewEstimatedIntensityLayer` でレースコンディションが発生し、EEW受信中にホーム画面を開いた場合にEEW推定震度の区域が地図上に表示されなかった。

### 原因

`addLayer` を呼ぶ最初の `useEffect`（依存配列 `[styleController]`）と、フィルターを更新する2番目の `useEffect`（依存配列 `[styleController, regionMaxIntensities, colorModel]`）が同一フレームで実行される。

1. `styleController` が利用可能になると両方の useEffect が起動
2. 第1の useEffect が非同期で `addLayer` を開始し、完了後に `isInitialized.value = true` をセット
3. 第2の useEffect が同フレームで走り、`isInitialized.value == false` で早期リターン
4. `addLayer` 完了 → `isInitialized.value = true` がセットされるが、`useRef` のため再レンダー発生なし
5. 以降 `regionMaxIntensities` が変化しない限り第2の useEffect は再実行されず、フィルターは `['==', '1', '2']`（常に false）のまま → **EEW区域が永遠に表示されない**

## 修正

`eew_warning_regions_layer.dart` と同じパターンで、`addLayer` 時点の `regionMaxIntensities` から各震度の正しい初期フィルターを計算するよう変更。

EEWデータがマップ初期化より先に確定している場合でも、レイヤー追加時点から正しく区域が表示される。

## テスト

- `dart analyze` パス（エラーなし）

## 関連

- `faa24771 fix: 地震履歴震度アイコンのMapLibre filterを修正` と同様のパターン修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)