### PR TITLE
fix: 地震履歴詳細画面のマップタップ・レイヤー論理状態バグを修正

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -68,8 +68,10 @@ class _MapContent extends HookConsumerWidget {
   final Earthquake earthquake;
 
   static const _stationLayerId = 'eq-history-station-intensity-circle';
-  static const _regionFillLayerId = 'eq-history-fill-region';
-  static const _cityFillLayerId = 'eq-history-fill-city';
+  // Fill layers are created per intensity level (e.g. 'eq-history-jma-one-region-fill'),
+  // so we detect taps by source layer ID instead of individual layer IDs.
+  static const _regionSourceLayerId = 'areaForecastLocalE';
+  static const _citySourceLayerId = 'areaInformationCityQuake';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -240,10 +242,8 @@ class _MapContent extends HookConsumerWidget {
       return;
     }
 
-    final hitIds = hits.map((h) => h.layerId).toSet();
-
     // 観測点タップ
-    if (hitIds.contains(_stationLayerId)) {
+    if (hits.any((h) => h.layerId == _stationLayerId)) {
       final stationNode = _findNearestStation(event.point);
       if (stationNode == null) {
         return;
@@ -259,8 +259,8 @@ class _MapContent extends HookConsumerWidget {
       return;
     }
 
-    final isCity = hitIds.contains(_cityFillLayerId);
-    final isRegion = hitIds.contains(_regionFillLayerId);
+    final isCity = hits.any((h) => h.sourceLayer == _citySourceLayerId);
+    final isRegion = hits.any((h) => h.sourceLayer == _regionSourceLayerId);
     if (!isCity && !isRegion) {
       return;
     }

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_intensity_icon_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_intensity_icon_layer.dart
@@ -166,13 +166,17 @@ class EarthquakeHistoryIntensityIconLayer extends HookConsumerWidget {
         }());
 
         return () async {
-          try {
-            for (final intensity in JmaIntensity.values) {
+          for (final intensity in JmaIntensity.values) {
+            try {
               await styleController.removeLayer(_cityLayerId(intensity));
-              await styleController.removeLayer(_regionLayerId(intensity));
+            } on Exception catch (e) {
+              talker.log(e);
             }
-          } on Exception catch (e) {
-            talker.log(e);
+            try {
+              await styleController.removeLayer(_regionLayerId(intensity));
+            } on Exception catch (e) {
+              talker.log(e);
+            }
           }
         };
       },

--- a/app/lib/feature/earthquake_history/ui/layer/model/earthquake_history_map_layer_mode.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/model/earthquake_history_map_layer_mode.dart
@@ -215,10 +215,10 @@ class EarthquakeHistoryMapLayerModeResolver {
         EarthquakeHistoryMapLayerMode.none,
       EarthquakeHistoryIconMode.station when availability.station =>
         EarthquakeHistoryMapLayerMode.station,
-      EarthquakeHistoryIconMode.station when availability.region =>
-        EarthquakeHistoryMapLayerMode.region,
       EarthquakeHistoryIconMode.station when availability.city =>
         EarthquakeHistoryMapLayerMode.city,
+      EarthquakeHistoryIconMode.station when availability.region =>
+        EarthquakeHistoryMapLayerMode.region,
       EarthquakeHistoryIconMode.station => EarthquakeHistoryMapLayerMode.none,
       EarthquakeHistoryIconMode.auto
           when availability.region && availability.city =>


### PR DESCRIPTION
## 概要

地震履歴詳細画面のマップレイヤー操作で見つかった3つのバグを修正します。

## 修正内容

### Bug 1（重大）: 地域・市区町村タップでポップアップが表示されない
**ファイル**: `earthquake_history_details_map_view.dart`

fill レイヤは強度レベルごとに個別 ID で生成されます（例: `'eq-history-jma-one-region-fill'`）。
しかし `_handleTap` ではハードコードした `'eq-history-fill-region'` / `'eq-history-fill-city'`（語順が逆）で `queryLayers` のヒット判定していたため、**地域・市区町村タップ時のポップアップが一切表示されていませんでした**。

`QueriedLayer.sourceLayer`（`'areaForecastLocalE'` / `'areaInformationCityQuake'`）で判定するよう修正し、強度レベル数にかかわらず正しくポップアップが表示されるようにしました。観測点タップは `layerId` で判定しており引き続き正常に動作します。

### Bug 2: アイコンレイヤのクリーンアップでレイヤが残留する可能性
**ファイル**: `earthquake_history_intensity_icon_layer.dart`

`useEffect` のクリーンアップで try-catch がループ全体を囲んでいたため、存在しないレイヤを `removeLayer` しようとして例外が発生すると**残りのレイヤ削除が中断されレイヤが残留**する可能性がありました。
try-catch を各 `removeLayer` 呼び出しに個別に配置するよう修正しました。

**再現条件**: `iconMode` が `region` のみ（city レイヤが未追加）の状態で設定を変更すると、`removeLayer(_cityLayerId(...))` が例外を投げ、region レイヤが残り続けます。

### Bug 3: station モードのフォールバック順が municipality と非対称
**ファイル**: `earthquake_history_map_layer_mode.dart`

`iconMode = station` で観測点データが存在しない場合のフォールバック順が `region → city`（粒度が低い順）になっており、`municipality` モードの `city → region`（粒度が高い順）と逆でした。`station → city → region` に修正しました。

## 調査した点（問題なし）

- **ホーム→地震履歴画面遷移**: 「さらに表示」ボタンで `paramAsync.value` をそのまま `$extra` に渡していますが、ロード中・エラー時は `null` になりデフォルトパラメータ（全国）で遷移する設計で意図通りです。
- **auto モードの station 表示**: `stationIconOpacity` が auto モードのズーム境界を正しく処理しており問題なし。

## Test plan
- [ ] 詳細画面で地域塗りつぶしを有効にし、地図上の塗りつぶしエリアをタップ → ポップアップが表示されることを確認
- [ ] 詳細画面で観測点をタップ → 観測点ポップアップが表示されることを確認（既存動作の回帰がないことを確認）
- [ ] iconMode を region → city に切り替えたとき前のレイヤが正しく消えることを確認
- [ ] iconMode を station に設定し、観測点データがない地震（軽微地震など）でフォールバック先が city または region になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)