### PR TITLE
feat: ホーム地震履歴リストで現在地スコープ時に都道府県・市区町村と震度を表示

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart
@@ -1,15 +1,22 @@
+import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/current_location_intensity_display.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/current_location_intensity_provider.dart';
+import 'package:eqmonitor/feature/location/data/location.dart';
+import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:lat_lng/lat_lng.dart';
 
 class EarthquakeHistoryListTile extends HookConsumerWidget {
   const EarthquakeHistoryListTile({
@@ -23,6 +30,7 @@ class EarthquakeHistoryListTile extends HookConsumerWidget {
     this.visualDensity,
     this.dense = false,
     this.contentPadding,
+    this.showCurrentLocationIntensity = false,
     super.key,
   });
 
@@ -36,6 +44,7 @@ class EarthquakeHistoryListTile extends HookConsumerWidget {
   final VisualDensity? visualDensity;
   final bool dense;
   final EdgeInsets? contentPadding;
+  final bool showCurrentLocationIntensity;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -110,12 +119,101 @@ class EarthquakeHistoryListTile extends HookConsumerWidget {
       null => '',
     };
 
+    // 現在地情報（スコープが現在地の場合のみ取得）
+    final position = showCurrentLocationIntensity
+        ? ref.watch(locationStreamProvider).value
+        : null;
+    final latLng = position != null
+        ? LatLng(position.latitude, position.longitude)
+        : null;
+
+    final city = latLng != null
+        ? ref.watch(jmaMapAreaInformationCityInsideProvider(latLng)).value
+        : null;
+    final region = latLng != null
+        ? ref.watch(jmaMapAreaForecastLocalEInsideProvider(latLng)).value
+        : null;
+
+    final cityCode = city?.property?.code;
+    final cityParam = showCurrentLocationIntensity && cityCode != null
+        ? ref.watch(
+            parameterSetProvider.select(
+              (v) => v.value?.earthquake.prefectures
+                  .expand(
+                    (p) => p.regions.expand(
+                      (r) => r.cities.map((c) => (prefecture: p, city: c)),
+                    ),
+                  )
+                  .firstWhereOrNull((e) => e.city.code == cityCode),
+            ),
+          )
+        : null;
+
+    final regionCode = region?.property?.code;
+    final regionParam = showCurrentLocationIntensity && regionCode != null
+        ? ref.watch(
+            parameterSetProvider.select(
+              (v) => v.value?.earthquake.prefectures
+                  .expand((p) => p.regions.map((r) => (prefecture: p, region: r)))
+                  .firstWhereOrNull((e) => e.region.code == regionCode),
+            ),
+          )
+        : null;
+
+    final currentLocationIntensityAsync = showCurrentLocationIntensity
+        ? ref.watch(
+            currentLocationIntensityProvider(
+              eventId: item.eventId,
+              cityAreaCode: cityCode,
+              regionAreaCode: regionCode,
+            ),
+          )
+        : null;
+
+    // 現在地の地名を解決
+    String? currentLocationName;
+    if (cityParam != null) {
+      currentLocationName =
+          '${cityParam.prefecture.name.ja}${cityParam.city.name.ja}';
+    } else if (regionParam != null) {
+      currentLocationName =
+          '${regionParam.prefecture.name.ja}${regionParam.region.name.ja}';
+    }
+
+    // 現在地の震度チップテキストを解決
+    String? currentLocationChipLabel;
+    switch (currentLocationIntensityAsync?.value) {
+      case CurrentLocationIntensityDisplayQuick(:final intensity):
+        currentLocationChipLabel =
+            '${currentLocationName != null ? "$currentLocationName " : ""}現在地で震度${intensity.label}を観測(速報)';
+      case CurrentLocationIntensityDisplayResult(:final intensity):
+        currentLocationChipLabel =
+            '${currentLocationName != null ? "$currentLocationName " : ""}現在地で震度${intensity.label}を観測';
+      case CurrentLocationIntensityDisplayNone():
+      case null:
+        if (currentLocationName != null) {
+          currentLocationChipLabel = currentLocationName;
+        }
+    }
+
+    // 現在地チップを構築
+    Widget? currentLocationChip;
+    if (showCurrentLocationIntensity && currentLocationChipLabel != null) {
+      currentLocationChip = Chip(
+        label: Text(currentLocationChipLabel),
+        padding: EdgeInsets.zero,
+        visualDensity: VisualDensity.compact,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      );
+    }
+
     final chips = <Widget>[
       if (maxLpgmIntensity != null && maxLpgmIntensity != JmaLpgmIntensity.zero)
         Chip(
           label: Text('最大長周期地震動階級 ${maxLpgmIntensity.label}'),
           padding: EdgeInsets.zero,
         ),
+      ?currentLocationChip,
     ];
 
     return ListTile(

--- a/app/lib/feature/home/ui/component/sheet/component/home_earthquake_list.dart
+++ b/app/lib/feature/home/ui/component/sheet/component/home_earthquake_list.dart
@@ -7,10 +7,12 @@ import 'package:flutter/material.dart';
 class HomeEarthquakeList extends StatelessWidget {
   const HomeEarthquakeList({
     required this.earthquakes,
+    this.showCurrentLocationIntensity = false,
     super.key,
   });
 
   final List<EarthquakePartial> earthquakes;
+  final bool showCurrentLocationIntensity;
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +42,7 @@ class HomeEarthquakeList extends StatelessWidget {
                   magnitudeTextColor: textColor.primary,
                   dense: true,
                   contentPadding: EdgeInsets.zero,
+                  showCurrentLocationIntensity: showCurrentLocationIntensity,
                 ),
               ),
             ),

--- a/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
+++ b/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
@@ -102,7 +102,11 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                     AsyncData(:final value) =>
                       value.items.isEmpty
                           ? const EarthquakeHistoryNotFound()
-                          : HomeEarthquakeList(earthquakes: value.items),
+                          : HomeEarthquakeList(
+                              earthquakes: value.items,
+                              showCurrentLocationIntensity: scope ==
+                                  HomeEarthquakeHistoryScope.currentLocation,
+                            ),
                     AsyncError(:final error) => ErrorCard(
                       error: error,
                       margin: EdgeInsets.zero,


### PR DESCRIPTION
## Summary

- ホームの地震履歴一覧で「現在地」スコープを選択中、各地震アイテムのsubtitleに現在地の都道府県・市区町村と震度を表示するようにした
- 表示形式: `東京都新宿区 現在地で震度3を観測`（速報値の場合は末尾に `(速報)`）
- 市区町村が解決できない場合は地方区分名（都道府県＋地域名）にフォールバック
- 現在地スコープ以外（全国・カスタム）では従来通り何も表示しない

## 変更ファイル

- `earthquake_history_list_tile.dart`: `showCurrentLocationIntensity` フラグを追加。true 時に位置情報・市区町村・震度を内部で取得してChipとしてsubtitleに表示
- `home_earthquake_list.dart`: `showCurrentLocationIntensity` フラグを受け取り各タイルに伝播
- `home_earthquake_history_sheet.dart`: スコープが `currentLocation` の場合にフラグを有効化

## Test plan

- [ ] 現在地スコープに切り替えて地震履歴リストを表示し、各アイテムのsubtitleに都道府県・市区町村と震度が表示されることを確認
- [ ] 震度なし（`none`）の地震では都道府県・市区町村のみ表示されることを確認
- [ ] 速報値の地震では `(速報)` が付くことを確認
- [ ] 全国・カスタムスコープでは現在地情報が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)