### PR TITLE
fix: live_activity_util の native asset id をファイルパスに合わせる

### DIFF
--- a/packages/live_activity_util/hook/build.dart
+++ b/packages/live_activity_util/hook/build.dart
@@ -292,7 +292,7 @@ Future<void> main(List<String> args) => build(
     final objcSourcePath = libDir.uri.resolve('live_activity_util.dart.m');
     final cBuilder = CBuilder.library(
       name: 'live_activity_util',
-      assetName: 'live_activity_util.g.dart',
+      assetName: 'src/live_activity_util.dart',
       sources: [
         objcSourcePath.toFilePath(),
       ],


### PR DESCRIPTION
## 問題

`liveActivityPushTokenUpdatesProvider` 初期化時に以下のランタイムエラーが発生していた:

```
Invalid argument(s): Couldn't resolve native function '_NativeLibrary_wrapListenerBlock_pfv6jd'
in 'package:live_activity_util/src/live_activity_util.dart' :
No asset with id 'package:live_activity_util/src/live_activity_util.dart' found.
Available native assets: package:live_activity_util/live_activity_util.g.dart
```

## 原因

`packages/live_activity_util/hook/build.dart` の `CBuilder` に `assetName: 'live_activity_util.g.dart'` が設定されていたため、native library が `package:live_activity_util/live_activity_util.g.dart` として登録されていた。

一方、FFI バインディングファイル `lib/src/live_activity_util.dart` 内の `@ffi.Native` アノテーションは、明示的な `assetId` が指定されない場合、**宣言ファイル自身の package URI** (`package:live_activity_util/src/live_activity_util.dart`) をデフォルト asset id として使用する。この不一致がランタイムエラーの原因。

## 修正

`assetName` を `'src/live_activity_util.dart'` に変更し、登録される native asset id を生成された Dart ファイルのパスと一致させた。

## 検証

- `dart analyze` パス
- worktree で iOS ビルドを実行し、native_assets.json に `package:live_activity_util/src/live_activity_util.dart` として正しく登録されていることを確認:
  ```json
  "package:live_activity_util/src/live_activity_util.dart": [
    "absolute",
    "live_activity_util.framework/live_activity_util"
  ]
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)