### PR TITLE
feat: バックグラウンド位置情報の権限管理とデバッグ通知

### DIFF
--- a/app/lib/core/fcm/channels.dart
+++ b/app/lib/core/fcm/channels.dart
@@ -9,6 +9,12 @@ final notificationChannels = <AndroidNotificationChannel>[
     groupId: 'fromdev',
     importance: Importance.high,
   ),
+  const AndroidNotificationChannel(
+    'bgl_debug',
+    'バックグラウンド位置デバッグ',
+    description: 'バックグラウンド位置情報の変化デバッグ通知（開発者向け）',
+    importance: Importance.low,
+  ),
 
   //! EEW
   const AndroidNotificationChannel(

--- a/app/lib/feature/location/data/background_location_debug_settings_provider.dart
+++ b/app/lib/feature/location/data/background_location_debug_settings_provider.dart
@@ -1,0 +1,59 @@
+import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'background_location_debug_settings_provider.g.dart';
+
+const _keyNotifyLatLng = 'bgl_debug_latlng';
+const _keyNotifyRegion = 'bgl_debug_region';
+const _keyNotifyPrefecture = 'bgl_debug_prefecture';
+
+typedef BackgroundLocationDebugSettingsState = ({
+  bool notifyLatLng,
+  bool notifyRegion,
+  bool notifyPrefecture,
+});
+
+/// バックグラウンド位置更新のデバッグ通知設定。
+/// デバッグ画面から ON/OFF できる。
+@Riverpod(keepAlive: true)
+class BackgroundLocationDebugSettings
+    extends _$BackgroundLocationDebugSettings {
+  @override
+  BackgroundLocationDebugSettingsState build() {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    return (
+      notifyLatLng: prefs.getBool(_keyNotifyLatLng) ?? false,
+      notifyRegion: prefs.getBool(_keyNotifyRegion) ?? false,
+      notifyPrefecture: prefs.getBool(_keyNotifyPrefecture) ?? false,
+    );
+  }
+
+  Future<void> setNotifyLatLng({required bool value}) async {
+    await ref.read(sharedPreferencesProvider).setBool(_keyNotifyLatLng, value);
+    state = (
+      notifyLatLng: value,
+      notifyRegion: state.notifyRegion,
+      notifyPrefecture: state.notifyPrefecture,
+    );
+  }
+
+  Future<void> setNotifyRegion({required bool value}) async {
+    await ref.read(sharedPreferencesProvider).setBool(_keyNotifyRegion, value);
+    state = (
+      notifyLatLng: state.notifyLatLng,
+      notifyRegion: value,
+      notifyPrefecture: state.notifyPrefecture,
+    );
+  }
+
+  Future<void> setNotifyPrefecture({required bool value}) async {
+    await ref
+        .read(sharedPreferencesProvider)
+        .setBool(_keyNotifyPrefecture, value);
+    state = (
+      notifyLatLng: state.notifyLatLng,
+      notifyRegion: state.notifyRegion,
+      notifyPrefecture: value,
+    );
+  }
+}

--- a/app/lib/feature/location/data/background_location_debug_settings_provider.g.dart
+++ b/app/lib/feature/location/data/background_location_debug_settings_provider.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'background_location_debug_settings_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// バックグラウンド位置更新のデバッグ通知設定。
+/// デバッグ画面から ON/OFF できる。
+
+@ProviderFor(BackgroundLocationDebugSettings)
+final backgroundLocationDebugSettingsProvider =
+    BackgroundLocationDebugSettingsProvider._();
+
+/// バックグラウンド位置更新のデバッグ通知設定。
+/// デバッグ画面から ON/OFF できる。
+final class BackgroundLocationDebugSettingsProvider
+    extends
+        $NotifierProvider<
+          BackgroundLocationDebugSettings,
+          BackgroundLocationDebugSettingsState
+        > {
+  /// バックグラウンド位置更新のデバッグ通知設定。
+  /// デバッグ画面から ON/OFF できる。
+  BackgroundLocationDebugSettingsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'backgroundLocationDebugSettingsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$backgroundLocationDebugSettingsHash();
+
+  @$internal
+  @override
+  BackgroundLocationDebugSettings create() => BackgroundLocationDebugSettings();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BackgroundLocationDebugSettingsState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $SyncValueProvider<BackgroundLocationDebugSettingsState>(value),
+    );
+  }
+}
+
+String _$backgroundLocationDebugSettingsHash() =>
+    r'3d90d11c73aba618878b81e0a89bd3e318e4be0f';
+
+/// バックグラウンド位置更新のデバッグ通知設定。
+/// デバッグ画面から ON/OFF できる。
+
+abstract class _$BackgroundLocationDebugSettings
+    extends $Notifier<BackgroundLocationDebugSettingsState> {
+  BackgroundLocationDebugSettingsState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              BackgroundLocationDebugSettingsState,
+              BackgroundLocationDebugSettingsState
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                BackgroundLocationDebugSettingsState,
+                BackgroundLocationDebugSettingsState
+              >,
+              BackgroundLocationDebugSettingsState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/location/data/background_location_permission_provider.dart
+++ b/app/lib/feature/location/data/background_location_permission_provider.dart
@@ -1,0 +1,18 @@
+import 'package:eqmonitor/core/provider/app_lifecycle.dart';
+import 'package:flutter/widgets.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'background_location_permission_provider.g.dart';
+
+/// バックグラウンド位置情報のパーミッション状態を保持する。
+/// アプリがフォアグラウンドに復帰した時に自動で再取得する。
+@Riverpod(keepAlive: true)
+Future<LocationPermission> backgroundLocationPermission(Ref ref) async {
+  ref.listen(appLifecycleProvider, (_, next) {
+    if (next == AppLifecycleState.resumed) {
+      ref.invalidateSelf();
+    }
+  });
+  return Geolocator.checkPermission();
+}

--- a/app/lib/feature/location/data/background_location_permission_provider.g.dart
+++ b/app/lib/feature/location/data/background_location_permission_provider.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'background_location_permission_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// バックグラウンド位置情報のパーミッション状態を保持する。
+/// アプリがフォアグラウンドに復帰した時に自動で再取得する。
+
+@ProviderFor(backgroundLocationPermission)
+final backgroundLocationPermissionProvider =
+    BackgroundLocationPermissionProvider._();
+
+/// バックグラウンド位置情報のパーミッション状態を保持する。
+/// アプリがフォアグラウンドに復帰した時に自動で再取得する。
+
+final class BackgroundLocationPermissionProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<LocationPermission>,
+          LocationPermission,
+          FutureOr<LocationPermission>
+        >
+    with
+        $FutureModifier<LocationPermission>,
+        $FutureProvider<LocationPermission> {
+  /// バックグラウンド位置情報のパーミッション状態を保持する。
+  /// アプリがフォアグラウンドに復帰した時に自動で再取得する。
+  BackgroundLocationPermissionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'backgroundLocationPermissionProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$backgroundLocationPermissionHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<LocationPermission> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<LocationPermission> create(Ref ref) {
+    return backgroundLocationPermission(ref);
+  }
+}
+
+String _$backgroundLocationPermissionHash() =>
+    r'0394ca365fe2979f20965e34a10ce8cd312f8a33';

--- a/app/lib/feature/location/data/background_location_service.dart
+++ b/app/lib/feature/location/data/background_location_service.dart
@@ -1,6 +1,8 @@
 import 'package:background_location_tracker/background_location_tracker.dart';
+import 'package:eqmonitor/feature/location/data/background_location_debug_settings_provider.dart';
 import 'package:eqmonitor/feature/location/data/jma_region_resolver.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_settings_notifier.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'background_location_service.g.dart';
@@ -53,7 +55,10 @@ Future<void> _applyPendingLocation(Ref ref) async {
 
 Future<void> _applyLocation(Ref ref, double latitude, double longitude) async {
   try {
-    await ref.read(eewSettingsProvider.future);
+    final settings = await ref.read(eewSettingsProvider.future);
+    final prevRegionCode =
+        settings.regions.where((r) => r.isCurrentLocation).firstOrNull?.regionId;
+
     final resolver = await ref.read(jmaRegionResolverProvider.future);
     final code = resolver.resolveRegionCode(latitude, longitude);
     if (code == null) {
@@ -63,7 +68,83 @@ Future<void> _applyLocation(Ref ref, double latitude, double longitude) async {
     await ref
         .read(eewSettingsProvider.notifier)
         .updateCurrentLocationRegion(regionCode: code, regionName: name);
+
+    // デバッグ通知
+    await _fireDebugNotifications(
+      ref,
+      latitude: latitude,
+      longitude: longitude,
+      prevRegionCode: prevRegionCode,
+      newRegionCode: code,
+    );
   } on Object {
     // バックグラウンドサービスのエラーはサイレントに無視する
+  }
+}
+
+Future<void> _fireDebugNotifications(
+  Ref ref, {
+  required double latitude,
+  required double longitude,
+  required int? prevRegionCode,
+  required int newRegionCode,
+}) async {
+  try {
+    final debugSettings = ref.read(backgroundLocationDebugSettingsProvider);
+    if (!debugSettings.notifyLatLng &&
+        !debugSettings.notifyRegion &&
+        !debugSettings.notifyPrefecture) {
+      return;
+    }
+
+    final plugin = FlutterLocalNotificationsPlugin();
+    var notifId = DateTime.now().millisecondsSinceEpoch & 0xFFFF;
+    const details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        'bgl_debug',
+        'バックグラウンド位置デバッグ',
+        importance: Importance.low,
+        priority: Priority.low,
+      ),
+      iOS: DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: false,
+        presentSound: false,
+      ),
+    );
+
+    if (debugSettings.notifyLatLng) {
+      await plugin.show(
+        id: notifId++,
+        title: '[Debug] 位置更新',
+        body:
+            'lat=${latitude.toStringAsFixed(4)}, lon=${longitude.toStringAsFixed(4)}',
+        notificationDetails: details,
+      );
+    }
+
+    if (debugSettings.notifyRegion && prevRegionCode != newRegionCode) {
+      await plugin.show(
+        id: notifId++,
+        title: '[Debug] 細分区域 変化',
+        body: '$prevRegionCode → $newRegionCode',
+        notificationDetails: details,
+      );
+    }
+
+    if (debugSettings.notifyPrefecture) {
+      final prevPref = prevRegionCode != null ? prevRegionCode ~/ 1000 : null;
+      final newPref = newRegionCode ~/ 1000;
+      if (prevPref != newPref) {
+        await plugin.show(
+          id: notifId,
+          title: '[Debug] 都道府県コード 変化',
+          body: '$prevPref → $newPref',
+          notificationDetails: details,
+        );
+      }
+    }
+  } on Object {
+    // デバッグ通知失敗はサイレントに無視する
   }
 }

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
 import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/location/data/background_location_debug_settings_provider.dart';
 import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.dart';
 import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dart';
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
@@ -205,6 +206,8 @@ class _DebugWidget extends ConsumerWidget {
               context,
             ),
           ),
+          const Divider(),
+          const _BackgroundLocationDebugSection(),
           const Divider(),
           ListTile(
             title: const Text('FCM Token'),
@@ -423,6 +426,45 @@ class _ParameterDebugSectionState
             ],
           ),
         },
+      ],
+    );
+  }
+}
+
+class _BackgroundLocationDebugSection extends ConsumerWidget {
+  const _BackgroundLocationDebugSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(backgroundLocationDebugSettingsProvider);
+    final notifier = ref.read(backgroundLocationDebugSettingsProvider.notifier);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const ListTile(
+          title: Text('バックグラウンド位置情報デバッグ通知'),
+          leading: Icon(Icons.location_on_outlined),
+          subtitle: Text('位置情報の変化時にローカル通知を発行します'),
+        ),
+        AppSwitchListTile(
+          title: 'LatLng 変化通知',
+          subtitle: '位置更新のたびに通知',
+          value: settings.notifyLatLng,
+          onChanged: (v) => notifier.setNotifyLatLng(value: v),
+        ),
+        AppSwitchListTile(
+          title: '細分区域コード 変化通知',
+          subtitle: 'JMA細分区域が変わった時に通知',
+          value: settings.notifyRegion,
+          onChanged: (v) => notifier.setNotifyRegion(value: v),
+        ),
+        AppSwitchListTile(
+          title: '都道府県コード 変化通知',
+          subtitle: '都道府県（細分コード÷1000）が変わった時に通知',
+          value: settings.notifyPrefecture,
+          onChanged: (v) => notifier.setNotifyPrefecture(value: v),
+        ),
       ],
     );
   }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
@@ -362,7 +362,7 @@ class _RegionsSection extends ConsumerWidget {
 }
 
 /// 現在地通知のために位置情報の常時許可を取得し、現在位置を返す。
-/// 権限が無い場合は設定アプリ誘導ダイアログを表示する。
+/// 権限が無い場合や whileInUse の場合は設定アプリ誘導ダイアログを表示する。
 Future<({double lat, double lon})?> _ensurePermissionAndGetLocation(
   BuildContext context,
 ) async {
@@ -400,6 +400,41 @@ Future<({double lat, double lon})?> _ensurePermissionAndGetLocation(
       await Geolocator.openAppSettings();
     }
     return null;
+  }
+
+  // whileInUse のみ許可されている場合は「常に許可」への昇格を促す。
+  // 昇格しなくても現在地を追加し続けることはできるが、バックグラウンドでは動かない。
+  if (permission == LocationPermission.whileInUse) {
+    if (!context.mounted) {
+      return null;
+    }
+    final shouldOpen = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog.adaptive(
+        title: const Text('「常に許可」への変更をお願いします'),
+        content: const Text(
+          'バックグラウンドでも位置情報を更新するには、'
+          '位置情報の許可を「常に許可」に変更する必要があります。\n'
+          '設定アプリで「位置情報」→「常に許可」を選択してください。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('後で'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('設定を開く'),
+          ),
+        ],
+      ),
+    );
+    if (shouldOpen ?? false) {
+      await Geolocator.openAppSettings();
+      // 設定アプリから戻るまで待つ（ユーザーが変更した場合に備えて）
+      return null;
+    }
+    // 「後で」を選択した場合はそのまま現在地を取得して追加する
   }
 
   try {

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -7,8 +7,11 @@ import 'package:eqmonitor/feature/home/ui/component/eew/eew_card.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/home_map_view.dart';
 import 'package:eqmonitor/feature/home/ui/component/shake_detection/shake_detection_card.dart';
 import 'package:eqmonitor/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart';
+import 'package:eqmonitor/feature/location/data/background_location_permission_provider.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_settings_notifier.dart';
 import 'package:eqmonitor/feature/shake_detection/data/provider/shake_detection_merge_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class HomePage extends HookConsumerWidget {
@@ -43,6 +46,16 @@ class _SheetBody extends ConsumerWidget {
     final color = designSystem.color;
     final spacing = designSystem.spacing;
     final typography = designSystem.typography;
+
+    final hasCurrentLocationRegion = ref.watch(
+      eewSettingsProvider.select(
+        (s) => s.value?.regions.any((r) => r.isCurrentLocation) ?? false,
+      ),
+    );
+    final permission = ref.watch(backgroundLocationPermissionProvider).value;
+    final showPermissionBanner = hasCurrentLocationRegion &&
+        permission != null &&
+        permission != LocationPermission.always;
 
     final eewCards = Column(
       children: state.reversed
@@ -104,6 +117,11 @@ class _SheetBody extends ConsumerWidget {
                 children: [
                   SizedBox(height: spacing.xs),
                   if (state.isNotEmpty) eewCards,
+                  if (showPermissionBanner) ...[
+                    _BackgroundLocationPermissionBanner(
+                      bottomSpacing: spacing.md,
+                    ),
+                  ],
                   if (shakeEvents.isNotEmpty)
                     Column(
                       children: shakeEvents
@@ -126,6 +144,65 @@ class _SheetBody extends ConsumerWidget {
                 height: spacing.sm,
               ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BackgroundLocationPermissionBanner extends StatelessWidget {
+  const _BackgroundLocationPermissionBanner({required this.bottomSpacing});
+
+  final double bottomSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottomSpacing),
+      child: Material(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () async => Geolocator.openAppSettings(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.location_off_outlined,
+                  color: colorScheme.onErrorContainer,
+                  size: 20,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '位置情報の「常に許可」が必要です',
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                              color: colorScheme.onErrorContainer,
+                            ),
+                      ),
+                      Text(
+                        'バックグラウンド位置更新が無効のため、通知は過去の位置情報を使用しています',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onErrorContainer,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.arrow_forward_ios,
+                  color: colorScheme.onErrorContainer,
+                  size: 14,
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary

- **`BackgroundLocationPermissionProvider`**: `Geolocator.checkPermission()` を呼び出し、アプリが foreground に復帰するたびに自動再取得。`appLifecycleProvider` を listen して `resumed` 時に `invalidateSelf()`
- **Home Sheet バナー**: 現在地通知設定がある & `always` 権限が未取得の場合、EEW カード直下に警告バナーを表示。タップで設定アプリへ遷移
- **`whileInUse` → `always` 昇格フロー**: EEW 設定の「現在地を追加」ボタン押下時、`whileInUse` の場合に「設定アプリで常に許可へ変更を」ダイアログを表示
- **デバッグ通知**: `BackgroundLocationDebugSettingsProvider` で LatLng/細分区域/都道府県コード変化通知を SharedPreferences に永続化。デバッグ画面にトグル追加。`background_location_service` で変化時にローカル通知を発行
- **Android 通知チャンネル `bgl_debug`** を追加

## Test plan

- [ ] 位置情報権限が `whileInUse` の状態で「現在地を追加」→ 昇格ダイアログが表示される
- [ ] `always` 権限がない & 現在地通知設定ありの状態でホーム画面を開く → バナーが表示される
- [ ] バナーをタップ → 設定アプリが開く
- [ ] デバッグ画面で各トグルを ON にしてバックグラウンドで移動 → 対応するローカル通知が届く
- [ ] 各トグルの設定値がアプリ再起動後も保持される

## Build

- iOS/Android ビルドは Shorebird スクリプト (`--no-codesign`) および `eqmonitor_api` の問題により現地ビルドが失敗するが、これらは `develop` ブランチでも同様に再現する既存の問題。`dart analyze` はクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)