### PR TITLE
refactor: _screen.dart を _page.dart にリネーム

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -25,8 +25,8 @@ import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.d
 import 'package:eqmonitor/feature/onboarding/ui/onboarding_page.dart';
 import 'package:eqmonitor/feature/settings/children/application_info/about_this_app.dart';
 import 'package:eqmonitor/feature/settings/children/application_info/license_page.dart';
-import 'package:eqmonitor/feature/settings/children/application_info/privacy_policy_screen.dart';
-import 'package:eqmonitor/feature/settings/children/application_info/term_of_service_screen.dart';
+import 'package:eqmonitor/feature/settings/children/application_info/privacy_policy_page.dart';
+import 'package:eqmonitor/feature/settings/children/application_info/term_of_service_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/api_endpoint_selector/http_api_endpoint_selector_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/app_group/debug_app_group_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/debug_page.dart';
@@ -46,7 +46,7 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/ui/pag
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart';
-import 'package:eqmonitor/feature/settings/settings_screen.dart';
+import 'package:eqmonitor/feature/settings/settings_page.dart';
 import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
 import 'package:eqmonitor/feature/shake_detection/ui/shake_detection_history_details_page.dart';
 import 'package:eqmonitor/feature/shake_detection/ui/shake_detection_history_page.dart';
@@ -337,7 +337,7 @@ class SettingsRoute extends GoRouteData with $SettingsRoute {
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>
-      const SettingsScreen();
+      const SettingsPage();
 }
 
 class DisplayRoute extends GoRouteData with $DisplayRoute {
@@ -428,7 +428,7 @@ class TermOfServiceRoute extends GoRouteData with $TermOfServiceRoute {
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>
-      TermOfServiceScreen(onResult: $extra, showAcceptButton: showAcceptButton);
+      TermOfServicePage(onResult: $extra, showAcceptButton: showAcceptButton);
 }
 
 class ColorSchemeConfigRoute extends GoRouteData with $ColorSchemeConfigRoute {
@@ -450,7 +450,7 @@ class PrivacyPolicyRoute extends GoRouteData with $PrivacyPolicyRoute {
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>
-      PrivacyPolicyScreen(onResult: $extra, showAcceptButton: showAcceptButton);
+      PrivacyPolicyPage(onResult: $extra, showAcceptButton: showAcceptButton);
 }
 
 class LicenseRoute extends GoRouteData with $LicenseRoute {

--- a/app/lib/feature/eew/ui/page/eew_details_page.dart
+++ b/app/lib/feature/eew/ui/page/eew_details_page.dart
@@ -6,8 +6,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
-class EewDetailsScreen extends HookConsumerWidget {
-  const EewDetailsScreen({required this.eventId, super.key});
+class EewDetailsPage extends HookConsumerWidget {
+  const EewDetailsPage({required this.eventId, super.key});
 
   final String eventId;
 
@@ -19,7 +19,7 @@ class EewDetailsScreen extends HookConsumerWidget {
       appBar: AppBar(title: Text('緊急地震速報 詳細 ($eventId)')),
       body: eewsAsyncValue.when(
         data: _buildEewList,
-        loading: () => const _EewDetailsScreenSkeleton(),
+        loading: () => const _EewDetailsPageSkeleton(),
         error: (error, stack) => Center(child: Text('エラーが発生しました: $error')),
       ),
     );
@@ -43,8 +43,8 @@ class EewDetailsScreen extends HookConsumerWidget {
   }
 }
 
-class _EewDetailsScreenSkeleton extends StatelessWidget {
-  const _EewDetailsScreenSkeleton();
+class _EewDetailsPageSkeleton extends StatelessWidget {
+  const _EewDetailsPageSkeleton();
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/feature/settings/children/application_info/privacy_policy_page.dart
+++ b/app/lib/feature/settings/children/application_info/privacy_policy_page.dart
@@ -5,8 +5,8 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class TermOfServiceScreen extends HookWidget {
-  const TermOfServiceScreen({
+class PrivacyPolicyPage extends HookWidget {
+  const PrivacyPolicyPage({
     required this.onResult,
     this.showAcceptButton = false,
     super.key,
@@ -18,19 +18,19 @@ class TermOfServiceScreen extends HookWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('利用規約')),
-      body: const _TermOfServiceScreenBody(),
+      appBar: AppBar(title: const Text('プライバシーポリシー')),
+      body: const _PrivacyPolicyPageBody(),
     );
   }
 }
 
-class _TermOfServiceScreenBody extends HookWidget {
-  const _TermOfServiceScreenBody();
+class _PrivacyPolicyPageBody extends HookWidget {
+  const _PrivacyPolicyPageBody();
 
   @override
   Widget build(BuildContext context) {
     final markdownBody = useFuture(
-      useMemoized(() async => rootBundle.loadString(Assets.docs.termOfService)),
+      useMemoized(() async => rootBundle.loadString(Assets.docs.privacyPolicy)),
       initialData: '',
     );
     final data = markdownBody.data;

--- a/app/lib/feature/settings/children/application_info/term_of_service_page.dart
+++ b/app/lib/feature/settings/children/application_info/term_of_service_page.dart
@@ -5,8 +5,8 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class PrivacyPolicyScreen extends HookWidget {
-  const PrivacyPolicyScreen({
+class TermOfServicePage extends HookWidget {
+  const TermOfServicePage({
     required this.onResult,
     this.showAcceptButton = false,
     super.key,
@@ -18,19 +18,19 @@ class PrivacyPolicyScreen extends HookWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('プライバシーポリシー')),
-      body: const _PrivacyPolicyScreenBody(),
+      appBar: AppBar(title: const Text('利用規約')),
+      body: const _TermOfServicePageBody(),
     );
   }
 }
 
-class _PrivacyPolicyScreenBody extends HookWidget {
-  const _PrivacyPolicyScreenBody();
+class _TermOfServicePageBody extends HookWidget {
+  const _TermOfServicePageBody();
 
   @override
   Widget build(BuildContext context) {
     final markdownBody = useFuture(
-      useMemoized(() async => rootBundle.loadString(Assets.docs.privacyPolicy)),
+      useMemoized(() async => rootBundle.loadString(Assets.docs.termOfService)),
       initialData: '',
     );
     final data = markdownBody.data;

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -8,8 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
-class SettingsScreen extends ConsumerWidget {
-  const SettingsScreen({super.key});
+class SettingsPage extends ConsumerWidget {
+  const SettingsPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {


### PR DESCRIPTION
## Summary

- `.cursor/rules/flutter-rules.mdc` の命名規則「画面ファイルは `*_page.dart` に統一、`*_screen.dart` は使わない」に合わせて4ファイルをリネーム
- クラス名・内部参照・ルーターの import もあわせて変更

## 変更ファイル

| 旧ファイル | 新ファイル |
|-----------|-----------|
| `settings_screen.dart` | `settings_page.dart` |
| `privacy_policy_screen.dart` | `privacy_policy_page.dart` |
| `term_of_service_screen.dart` | `term_of_service_page.dart` |
| `eew/ui/screen/eew_details_screen.dart` | `eew/ui/page/eew_details_page.dart` |

クラス名も対応して `Screen` → `Page` に変更（例: `SettingsScreen` → `SettingsPage`）。

## Test plan

- [x] `flutter analyze` で No issues found
- [x] `dart fix --apply` で Nothing to fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)