### PR TITLE
fix(eqmonitor_api): 生成enumの$unknownメッセージの文字列補間を修正

### DIFF
--- a/packages/eqmonitor_api/lib/src/models/apns_environment.dart
+++ b/packages/eqmonitor_api/lib/src/models/apns_environment.dart
@@ -19,7 +19,7 @@ enum ApnsEnvironment {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/apns_token_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/apns_token_type.dart
@@ -19,7 +19,7 @@ enum ApnsTokenType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/depth_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/depth_type.dart
@@ -23,7 +23,7 @@ enum DepthType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/device_locale.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_locale.dart
@@ -20,7 +20,7 @@ enum DeviceLocale {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/device_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_type.dart
@@ -18,7 +18,7 @@ enum DeviceType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/earthquake_datasource.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_datasource.dart
@@ -19,7 +19,7 @@ enum EarthquakeDatasource {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/earthquake_sort_by.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_sort_by.dart
@@ -27,7 +27,7 @@ enum EarthquakeSortBy {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/earthquake_station_status.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_station_status.dart
@@ -25,7 +25,7 @@ enum EarthquakeStationStatus {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_type.dart
@@ -18,7 +18,7 @@ enum EewIntensityRegionArrivalTimeType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/environment.dart
+++ b/packages/eqmonitor_api/lib/src/models/environment.dart
@@ -18,7 +18,7 @@ enum Environment {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/event_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/event_type.dart
@@ -18,7 +18,7 @@ enum EventType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/first_height_condition.dart
+++ b/packages/eqmonitor_api/lib/src/models/first_height_condition.dart
@@ -20,7 +20,7 @@ enum FirstHeightCondition {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/framework.dart
+++ b/packages/eqmonitor_api/lib/src/models/framework.dart
@@ -18,7 +18,7 @@ enum Framework {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/info_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/info_type.dart
@@ -22,7 +22,7 @@ enum InfoType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/interruption_level.dart
+++ b/packages/eqmonitor_api/lib/src/models/interruption_level.dart
@@ -22,7 +22,7 @@ enum InterruptionLevel {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/is_canceled.dart
+++ b/packages/eqmonitor_api/lib/src/models/is_canceled.dart
@@ -20,7 +20,7 @@ enum IsCanceled {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_intensity.dart
@@ -37,7 +37,7 @@ enum JmaIntensity {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/jma_lpgm_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_lpgm_intensity.dart
@@ -25,7 +25,7 @@ enum JmaLpgmIntensity {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point_type.dart
@@ -20,7 +20,7 @@ enum KyoshinObservationPointType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/live_activity_start_trigger.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_start_trigger.dart
@@ -19,7 +19,7 @@ enum LiveActivityStartTrigger {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/magnitude_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/magnitude_type.dart
@@ -20,7 +20,7 @@ enum MagnitudeType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/min_jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/min_jma_intensity.dart
@@ -36,7 +36,7 @@ enum MinJmaIntensity {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/observation_max_height_condition.dart
+++ b/packages/eqmonitor_api/lib/src/models/observation_max_height_condition.dart
@@ -20,7 +20,7 @@ enum ObservationMaxHeightCondition {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/origin_time_precision.dart
+++ b/packages/eqmonitor_api/lib/src/models/origin_time_precision.dart
@@ -27,7 +27,7 @@ enum OriginTimePrecision {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/parameter_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_type.dart
@@ -22,7 +22,7 @@ enum ParameterType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/qualitative_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/qualitative_height.dart
@@ -18,7 +18,7 @@ enum QualitativeHeight {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/result.dart
+++ b/packages/eqmonitor_api/lib/src/models/result.dart
@@ -18,7 +18,7 @@ enum Result {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/shake_detection_level.dart
+++ b/packages/eqmonitor_api/lib/src/models/shake_detection_level.dart
@@ -25,7 +25,7 @@ enum ShakeDetectionLevel {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/sort_order.dart
+++ b/packages/eqmonitor_api/lib/src/models/sort_order.dart
@@ -19,7 +19,7 @@ enum SortOrder {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/telegram_status.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_status.dart
@@ -21,7 +21,7 @@ enum TelegramStatus {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/telegram_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_type.dart
@@ -53,7 +53,7 @@ enum TelegramType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/test_notification_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/test_notification_type.dart
@@ -20,7 +20,7 @@ enum TestNotificationType {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/tsunami_warning_kind.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_warning_kind.dart
@@ -24,7 +24,7 @@ enum TsunamiWarningKind {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }

--- a/packages/eqmonitor_api/lib/src/models/wave_initial.dart
+++ b/packages/eqmonitor_api/lib/src/models/wave_initial.dart
@@ -18,7 +18,7 @@ enum WaveInitial {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for \\$unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }


### PR DESCRIPTION
## Summary

- `1d614dc6 regenerate openapi code` が `eqmonitor_api/lib/src/models/` 配下の 34 個の enum ファイルで `\$unknown` を `\\$unknown` に戻してしまい、Android ビルドが壊れていた
- `4f123fd91 fix(api): 生成enumの$unknownメッセージの文字列補間を修正` で一度修正されていたが、再生成時に再発

## Test plan

- [ ] `flutter build apk --debug` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)