### PR TITLE
feat(kyoshin_monitor): 長周期地震動モニタ(LMoni)への切り替え機能を追加

### DIFF
--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.g.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.g.dart
@@ -58,7 +58,7 @@ final class EqMonitorWsStatusProvider
   }
 }
 
-String _$eqMonitorWsStatusHash() => r'82c1a2269e1bb5c0cbf316255b589c6c648930fb';
+String _$eqMonitorWsStatusHash() => r'9d588019d3d23a3ce9b44a03d247dde182feb581';
 
 /// WebSocket の接続状態・ping 情報を保持する keepAlive Notifier。
 ///

--- a/app/lib/feature/home/ui/page/home_map_layer_page.dart
+++ b/app/lib/feature/home/ui/page/home_map_layer_page.dart
@@ -177,6 +177,7 @@ class HomeMapLayerPage extends HookConsumerWidget {
                     },
                     children: const [
                       _KyoshinMonitorEnabledTile(),
+                      _KyoshinMonitorSourceTile(),
                       _KyoshinMonitorAboutTile(),
                       _KyoshinRealtimeDataTypeTile(),
                       _KyoshinRealtimeLayerTile(),
@@ -796,6 +797,53 @@ class _KyoshinMonitorEnabledTile extends ConsumerWidget {
   }
 }
 
+class _KyoshinMonitorSourceTile extends ConsumerWidget {
+  const _KyoshinMonitorSourceTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final setting = ref.watch(kyoshinMonitorSettingsProvider).requireValue;
+    if (!setting.useKmoni) {
+      return const SizedBox.shrink();
+    }
+    return _SettingSegmentedField<KyoshinMonitorSource>(
+      title: 'データソース',
+      subtitle: '強震モニタ(KMoni)か長周期地震動モニタ(LMoni)を選択します。\n'
+          'LMoniでは長周期地震動階級などの追加データ種別が利用できます。',
+      segments: const [
+        ButtonSegment(
+          value: KyoshinMonitorSource.kmoni,
+          label: Text('強震モニタ'),
+          tooltip: 'KMoni',
+        ),
+        ButtonSegment(
+          value: KyoshinMonitorSource.lmoni,
+          label: Text('長周期地震動'),
+          tooltip: 'LMoni',
+        ),
+      ],
+      selected: {setting.monitorSource},
+      onSelectionChanged: (next) async {
+        final newSource = next.first;
+        var newDataType = setting.realtimeDataType;
+        // kmoniに切り替えた場合、LPGMデータ種別が選択されていたらshindoにリセット
+        if (newSource == KyoshinMonitorSource.kmoni &&
+            newDataType.isLpgm) {
+          newDataType = RealtimeDataType.shindo;
+        }
+        await ref
+            .read(kyoshinMonitorSettingsProvider.notifier)
+            .save(
+              setting.copyWith(
+                monitorSource: newSource,
+                realtimeDataType: newDataType,
+              ),
+            );
+      },
+    );
+  }
+}
+
 class _KyoshinMonitorAboutTile extends StatelessWidget {
   const _KyoshinMonitorAboutTile();
 
@@ -821,6 +869,12 @@ class _KyoshinRealtimeDataTypeTile extends ConsumerWidget {
     if (!setting.useKmoni) {
       return const SizedBox.shrink();
     }
+    // LMoniのときはLPGMデータ種別も含む全種別を表示
+    final isLmoni = setting.monitorSource == KyoshinMonitorSource.lmoni;
+    final availableTypes = RealtimeDataType.values
+        .where((value) => isLmoni || !value.isLpgm)
+        .toList();
+
     return _SettingDropdownField<RealtimeDataType>(
       title: 'リアルタイムデータの種類',
       subtitle: '観測点が示す値を切り替えます。',
@@ -829,8 +883,7 @@ class _KyoshinRealtimeDataTypeTile extends ConsumerWidget {
         onPressed: () async => RealtimeDataTypeInfoDialog.show(context),
         icon: const Icon(Icons.info_outline_rounded),
       ),
-      entries: RealtimeDataType.values
-          .where((value) => !value.isLpgm)
+      entries: availableTypes
           .map(
             (value) => DropdownMenuEntry<RealtimeDataType>(
               value: value,

--- a/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart
+++ b/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart
@@ -20,6 +20,11 @@ abstract class KyoshinMonitorSettingsModel with _$KyoshinMonitorSettingsModel {
     @Default(KyoshinMonitorMarkerType.onlyEew)
     KyoshinMonitorMarkerType kmoniMarkerType,
 
+    /// データソース (強震モニタ / 長周期地震動モニタ)
+    @Default(KyoshinMonitorSource.kmoni)
+    @JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni)
+    KyoshinMonitorSource monitorSource,
+
     /// 強震モニタのリアルタイムデータの種類
     @Default(RealtimeDataType.shindo) RealtimeDataType realtimeDataType,
 
@@ -69,6 +74,15 @@ enum KyoshinMonitorEndpoint {
   const KyoshinMonitorEndpoint(this.url);
 
   final String url;
+}
+
+/// データソースの種類
+enum KyoshinMonitorSource {
+  /// 強震モニタ (K-NET / KiK-net)
+  kmoni,
+
+  /// 長周期地震動モニタ (長周期地震動階級など追加データ種別あり)
+  lmoni,
 }
 
 enum KyoshinMonitorMarkerType {

--- a/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.freezed.dart
+++ b/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.freezed.dart
@@ -19,7 +19,8 @@ mixin _$KyoshinMonitorSettingsModel {
  double? get minRealtimeShindo;/// スケールを表示するかどうか
  bool get showScale;/// 強震モニタを使用するかどうか
  bool get useKmoni;/// 強震モニタ観測点のマーカーの種類
- KyoshinMonitorMarkerType get kmoniMarkerType;/// 強震モニタのリアルタイムデータの種類
+ KyoshinMonitorMarkerType get kmoniMarkerType;/// データソース (強震モニタ / 長周期地震動モニタ)
+@JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni) KyoshinMonitorSource get monitorSource;/// 強震モニタのリアルタイムデータの種類
  RealtimeDataType get realtimeDataType;/// 強震モニタのリアルタイムデータのレイヤー
  RealtimeLayer get realtimeLayer;/// 強震モニタ API関連の設定
  KyoshinMonitorSettingsApiModel get api;
@@ -35,16 +36,16 @@ $KyoshinMonitorSettingsModelCopyWith<KyoshinMonitorSettingsModel> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is KyoshinMonitorSettingsModel&&(identical(other.minRealtimeShindo, minRealtimeShindo) || other.minRealtimeShindo == minRealtimeShindo)&&(identical(other.showScale, showScale) || other.showScale == showScale)&&(identical(other.useKmoni, useKmoni) || other.useKmoni == useKmoni)&&(identical(other.kmoniMarkerType, kmoniMarkerType) || other.kmoniMarkerType == kmoniMarkerType)&&(identical(other.realtimeDataType, realtimeDataType) || other.realtimeDataType == realtimeDataType)&&(identical(other.realtimeLayer, realtimeLayer) || other.realtimeLayer == realtimeLayer)&&(identical(other.api, api) || other.api == api));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is KyoshinMonitorSettingsModel&&(identical(other.minRealtimeShindo, minRealtimeShindo) || other.minRealtimeShindo == minRealtimeShindo)&&(identical(other.showScale, showScale) || other.showScale == showScale)&&(identical(other.useKmoni, useKmoni) || other.useKmoni == useKmoni)&&(identical(other.kmoniMarkerType, kmoniMarkerType) || other.kmoniMarkerType == kmoniMarkerType)&&(identical(other.monitorSource, monitorSource) || other.monitorSource == monitorSource)&&(identical(other.realtimeDataType, realtimeDataType) || other.realtimeDataType == realtimeDataType)&&(identical(other.realtimeLayer, realtimeLayer) || other.realtimeLayer == realtimeLayer)&&(identical(other.api, api) || other.api == api));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,minRealtimeShindo,showScale,useKmoni,kmoniMarkerType,realtimeDataType,realtimeLayer,api);
+int get hashCode => Object.hash(runtimeType,minRealtimeShindo,showScale,useKmoni,kmoniMarkerType,monitorSource,realtimeDataType,realtimeLayer,api);
 
 @override
 String toString() {
-  return 'KyoshinMonitorSettingsModel(minRealtimeShindo: $minRealtimeShindo, showScale: $showScale, useKmoni: $useKmoni, kmoniMarkerType: $kmoniMarkerType, realtimeDataType: $realtimeDataType, realtimeLayer: $realtimeLayer, api: $api)';
+  return 'KyoshinMonitorSettingsModel(minRealtimeShindo: $minRealtimeShindo, showScale: $showScale, useKmoni: $useKmoni, kmoniMarkerType: $kmoniMarkerType, monitorSource: $monitorSource, realtimeDataType: $realtimeDataType, realtimeLayer: $realtimeLayer, api: $api)';
 }
 
 
@@ -55,7 +56,7 @@ abstract mixin class $KyoshinMonitorSettingsModelCopyWith<$Res>  {
   factory $KyoshinMonitorSettingsModelCopyWith(KyoshinMonitorSettingsModel value, $Res Function(KyoshinMonitorSettingsModel) _then) = _$KyoshinMonitorSettingsModelCopyWithImpl;
 @useResult
 $Res call({
- double? minRealtimeShindo, bool showScale, bool useKmoni, KyoshinMonitorMarkerType kmoniMarkerType, RealtimeDataType realtimeDataType, RealtimeLayer realtimeLayer, KyoshinMonitorSettingsApiModel api
+ double? minRealtimeShindo, bool showScale, bool useKmoni, KyoshinMonitorMarkerType kmoniMarkerType,@JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni) KyoshinMonitorSource monitorSource, RealtimeDataType realtimeDataType, RealtimeLayer realtimeLayer, KyoshinMonitorSettingsApiModel api
 });
 
 
@@ -72,13 +73,14 @@ class _$KyoshinMonitorSettingsModelCopyWithImpl<$Res>
 
 /// Create a copy of KyoshinMonitorSettingsModel
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? minRealtimeShindo = freezed,Object? showScale = null,Object? useKmoni = null,Object? kmoniMarkerType = null,Object? realtimeDataType = null,Object? realtimeLayer = null,Object? api = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? minRealtimeShindo = freezed,Object? showScale = null,Object? useKmoni = null,Object? kmoniMarkerType = null,Object? monitorSource = null,Object? realtimeDataType = null,Object? realtimeLayer = null,Object? api = null,}) {
   return _then(_self.copyWith(
 minRealtimeShindo: freezed == minRealtimeShindo ? _self.minRealtimeShindo : minRealtimeShindo // ignore: cast_nullable_to_non_nullable
 as double?,showScale: null == showScale ? _self.showScale : showScale // ignore: cast_nullable_to_non_nullable
 as bool,useKmoni: null == useKmoni ? _self.useKmoni : useKmoni // ignore: cast_nullable_to_non_nullable
 as bool,kmoniMarkerType: null == kmoniMarkerType ? _self.kmoniMarkerType : kmoniMarkerType // ignore: cast_nullable_to_non_nullable
-as KyoshinMonitorMarkerType,realtimeDataType: null == realtimeDataType ? _self.realtimeDataType : realtimeDataType // ignore: cast_nullable_to_non_nullable
+as KyoshinMonitorMarkerType,monitorSource: null == monitorSource ? _self.monitorSource : monitorSource // ignore: cast_nullable_to_non_nullable
+as KyoshinMonitorSource,realtimeDataType: null == realtimeDataType ? _self.realtimeDataType : realtimeDataType // ignore: cast_nullable_to_non_nullable
 as RealtimeDataType,realtimeLayer: null == realtimeLayer ? _self.realtimeLayer : realtimeLayer // ignore: cast_nullable_to_non_nullable
 as RealtimeLayer,api: null == api ? _self.api : api // ignore: cast_nullable_to_non_nullable
 as KyoshinMonitorSettingsApiModel,
@@ -175,10 +177,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double? minRealtimeShindo,  bool showScale,  bool useKmoni,  KyoshinMonitorMarkerType kmoniMarkerType,  RealtimeDataType realtimeDataType,  RealtimeLayer realtimeLayer,  KyoshinMonitorSettingsApiModel api)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double? minRealtimeShindo,  bool showScale,  bool useKmoni,  KyoshinMonitorMarkerType kmoniMarkerType, @JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni)  KyoshinMonitorSource monitorSource,  RealtimeDataType realtimeDataType,  RealtimeLayer realtimeLayer,  KyoshinMonitorSettingsApiModel api)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _KyoshinMonitorSettingsModel() when $default != null:
-return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmoniMarkerType,_that.realtimeDataType,_that.realtimeLayer,_that.api);case _:
+return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmoniMarkerType,_that.monitorSource,_that.realtimeDataType,_that.realtimeLayer,_that.api);case _:
   return orElse();
 
 }
@@ -196,10 +198,10 @@ return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmo
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double? minRealtimeShindo,  bool showScale,  bool useKmoni,  KyoshinMonitorMarkerType kmoniMarkerType,  RealtimeDataType realtimeDataType,  RealtimeLayer realtimeLayer,  KyoshinMonitorSettingsApiModel api)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double? minRealtimeShindo,  bool showScale,  bool useKmoni,  KyoshinMonitorMarkerType kmoniMarkerType, @JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni)  KyoshinMonitorSource monitorSource,  RealtimeDataType realtimeDataType,  RealtimeLayer realtimeLayer,  KyoshinMonitorSettingsApiModel api)  $default,) {final _that = this;
 switch (_that) {
 case _KyoshinMonitorSettingsModel():
-return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmoniMarkerType,_that.realtimeDataType,_that.realtimeLayer,_that.api);case _:
+return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmoniMarkerType,_that.monitorSource,_that.realtimeDataType,_that.realtimeLayer,_that.api);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -216,10 +218,10 @@ return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmo
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double? minRealtimeShindo,  bool showScale,  bool useKmoni,  KyoshinMonitorMarkerType kmoniMarkerType,  RealtimeDataType realtimeDataType,  RealtimeLayer realtimeLayer,  KyoshinMonitorSettingsApiModel api)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double? minRealtimeShindo,  bool showScale,  bool useKmoni,  KyoshinMonitorMarkerType kmoniMarkerType, @JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni)  KyoshinMonitorSource monitorSource,  RealtimeDataType realtimeDataType,  RealtimeLayer realtimeLayer,  KyoshinMonitorSettingsApiModel api)?  $default,) {final _that = this;
 switch (_that) {
 case _KyoshinMonitorSettingsModel() when $default != null:
-return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmoniMarkerType,_that.realtimeDataType,_that.realtimeLayer,_that.api);case _:
+return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmoniMarkerType,_that.monitorSource,_that.realtimeDataType,_that.realtimeLayer,_that.api);case _:
   return null;
 
 }
@@ -231,7 +233,7 @@ return $default(_that.minRealtimeShindo,_that.showScale,_that.useKmoni,_that.kmo
 @JsonSerializable()
 
 class _KyoshinMonitorSettingsModel implements KyoshinMonitorSettingsModel {
-  const _KyoshinMonitorSettingsModel({this.minRealtimeShindo = null, this.showScale = true, this.useKmoni = true, this.kmoniMarkerType = KyoshinMonitorMarkerType.onlyEew, this.realtimeDataType = RealtimeDataType.shindo, this.realtimeLayer = RealtimeLayer.surface, this.api = const KyoshinMonitorSettingsApiModel()});
+  const _KyoshinMonitorSettingsModel({this.minRealtimeShindo = null, this.showScale = true, this.useKmoni = true, this.kmoniMarkerType = KyoshinMonitorMarkerType.onlyEew, @JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni) this.monitorSource = KyoshinMonitorSource.kmoni, this.realtimeDataType = RealtimeDataType.shindo, this.realtimeLayer = RealtimeLayer.surface, this.api = const KyoshinMonitorSettingsApiModel()});
   factory _KyoshinMonitorSettingsModel.fromJson(Map<String, dynamic> json) => _$KyoshinMonitorSettingsModelFromJson(json);
 
 /// 強震モニタの表示最低リアルタイム震度
@@ -242,6 +244,8 @@ class _KyoshinMonitorSettingsModel implements KyoshinMonitorSettingsModel {
 @override@JsonKey() final  bool useKmoni;
 /// 強震モニタ観測点のマーカーの種類
 @override@JsonKey() final  KyoshinMonitorMarkerType kmoniMarkerType;
+/// データソース (強震モニタ / 長周期地震動モニタ)
+@override@JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni) final  KyoshinMonitorSource monitorSource;
 /// 強震モニタのリアルタイムデータの種類
 @override@JsonKey() final  RealtimeDataType realtimeDataType;
 /// 強震モニタのリアルタイムデータのレイヤー
@@ -262,16 +266,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _KyoshinMonitorSettingsModel&&(identical(other.minRealtimeShindo, minRealtimeShindo) || other.minRealtimeShindo == minRealtimeShindo)&&(identical(other.showScale, showScale) || other.showScale == showScale)&&(identical(other.useKmoni, useKmoni) || other.useKmoni == useKmoni)&&(identical(other.kmoniMarkerType, kmoniMarkerType) || other.kmoniMarkerType == kmoniMarkerType)&&(identical(other.realtimeDataType, realtimeDataType) || other.realtimeDataType == realtimeDataType)&&(identical(other.realtimeLayer, realtimeLayer) || other.realtimeLayer == realtimeLayer)&&(identical(other.api, api) || other.api == api));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _KyoshinMonitorSettingsModel&&(identical(other.minRealtimeShindo, minRealtimeShindo) || other.minRealtimeShindo == minRealtimeShindo)&&(identical(other.showScale, showScale) || other.showScale == showScale)&&(identical(other.useKmoni, useKmoni) || other.useKmoni == useKmoni)&&(identical(other.kmoniMarkerType, kmoniMarkerType) || other.kmoniMarkerType == kmoniMarkerType)&&(identical(other.monitorSource, monitorSource) || other.monitorSource == monitorSource)&&(identical(other.realtimeDataType, realtimeDataType) || other.realtimeDataType == realtimeDataType)&&(identical(other.realtimeLayer, realtimeLayer) || other.realtimeLayer == realtimeLayer)&&(identical(other.api, api) || other.api == api));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,minRealtimeShindo,showScale,useKmoni,kmoniMarkerType,realtimeDataType,realtimeLayer,api);
+int get hashCode => Object.hash(runtimeType,minRealtimeShindo,showScale,useKmoni,kmoniMarkerType,monitorSource,realtimeDataType,realtimeLayer,api);
 
 @override
 String toString() {
-  return 'KyoshinMonitorSettingsModel(minRealtimeShindo: $minRealtimeShindo, showScale: $showScale, useKmoni: $useKmoni, kmoniMarkerType: $kmoniMarkerType, realtimeDataType: $realtimeDataType, realtimeLayer: $realtimeLayer, api: $api)';
+  return 'KyoshinMonitorSettingsModel(minRealtimeShindo: $minRealtimeShindo, showScale: $showScale, useKmoni: $useKmoni, kmoniMarkerType: $kmoniMarkerType, monitorSource: $monitorSource, realtimeDataType: $realtimeDataType, realtimeLayer: $realtimeLayer, api: $api)';
 }
 
 
@@ -282,7 +286,7 @@ abstract mixin class _$KyoshinMonitorSettingsModelCopyWith<$Res> implements $Kyo
   factory _$KyoshinMonitorSettingsModelCopyWith(_KyoshinMonitorSettingsModel value, $Res Function(_KyoshinMonitorSettingsModel) _then) = __$KyoshinMonitorSettingsModelCopyWithImpl;
 @override @useResult
 $Res call({
- double? minRealtimeShindo, bool showScale, bool useKmoni, KyoshinMonitorMarkerType kmoniMarkerType, RealtimeDataType realtimeDataType, RealtimeLayer realtimeLayer, KyoshinMonitorSettingsApiModel api
+ double? minRealtimeShindo, bool showScale, bool useKmoni, KyoshinMonitorMarkerType kmoniMarkerType,@JsonKey(unknownEnumValue: KyoshinMonitorSource.kmoni) KyoshinMonitorSource monitorSource, RealtimeDataType realtimeDataType, RealtimeLayer realtimeLayer, KyoshinMonitorSettingsApiModel api
 });
 
 
@@ -299,13 +303,14 @@ class __$KyoshinMonitorSettingsModelCopyWithImpl<$Res>
 
 /// Create a copy of KyoshinMonitorSettingsModel
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? minRealtimeShindo = freezed,Object? showScale = null,Object? useKmoni = null,Object? kmoniMarkerType = null,Object? realtimeDataType = null,Object? realtimeLayer = null,Object? api = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? minRealtimeShindo = freezed,Object? showScale = null,Object? useKmoni = null,Object? kmoniMarkerType = null,Object? monitorSource = null,Object? realtimeDataType = null,Object? realtimeLayer = null,Object? api = null,}) {
   return _then(_KyoshinMonitorSettingsModel(
 minRealtimeShindo: freezed == minRealtimeShindo ? _self.minRealtimeShindo : minRealtimeShindo // ignore: cast_nullable_to_non_nullable
 as double?,showScale: null == showScale ? _self.showScale : showScale // ignore: cast_nullable_to_non_nullable
 as bool,useKmoni: null == useKmoni ? _self.useKmoni : useKmoni // ignore: cast_nullable_to_non_nullable
 as bool,kmoniMarkerType: null == kmoniMarkerType ? _self.kmoniMarkerType : kmoniMarkerType // ignore: cast_nullable_to_non_nullable
-as KyoshinMonitorMarkerType,realtimeDataType: null == realtimeDataType ? _self.realtimeDataType : realtimeDataType // ignore: cast_nullable_to_non_nullable
+as KyoshinMonitorMarkerType,monitorSource: null == monitorSource ? _self.monitorSource : monitorSource // ignore: cast_nullable_to_non_nullable
+as KyoshinMonitorSource,realtimeDataType: null == realtimeDataType ? _self.realtimeDataType : realtimeDataType // ignore: cast_nullable_to_non_nullable
 as RealtimeDataType,realtimeLayer: null == realtimeLayer ? _self.realtimeLayer : realtimeLayer // ignore: cast_nullable_to_non_nullable
 as RealtimeLayer,api: null == api ? _self.api : api // ignore: cast_nullable_to_non_nullable
 as KyoshinMonitorSettingsApiModel,

--- a/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.g.dart
+++ b/app/lib/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.g.dart
@@ -27,6 +27,16 @@ _KyoshinMonitorSettingsModel _$KyoshinMonitorSettingsModelFromJson(
             $enumDecodeNullable(_$KyoshinMonitorMarkerTypeEnumMap, v) ??
             KyoshinMonitorMarkerType.onlyEew,
       ),
+      monitorSource: $checkedConvert(
+        'monitor_source',
+        (v) =>
+            $enumDecodeNullable(
+              _$KyoshinMonitorSourceEnumMap,
+              v,
+              unknownValue: KyoshinMonitorSource.kmoni,
+            ) ??
+            KyoshinMonitorSource.kmoni,
+      ),
       realtimeDataType: $checkedConvert(
         'realtime_data_type',
         (v) =>
@@ -55,6 +65,7 @@ _KyoshinMonitorSettingsModel _$KyoshinMonitorSettingsModelFromJson(
     'showScale': 'show_scale',
     'useKmoni': 'use_kmoni',
     'kmoniMarkerType': 'kmoni_marker_type',
+    'monitorSource': 'monitor_source',
     'realtimeDataType': 'realtime_data_type',
     'realtimeLayer': 'realtime_layer',
   },
@@ -68,6 +79,7 @@ Map<String, dynamic> _$KyoshinMonitorSettingsModelToJson(
   'use_kmoni': instance.useKmoni,
   'kmoni_marker_type':
       _$KyoshinMonitorMarkerTypeEnumMap[instance.kmoniMarkerType]!,
+  'monitor_source': _$KyoshinMonitorSourceEnumMap[instance.monitorSource]!,
   'realtime_data_type': _$RealtimeDataTypeEnumMap[instance.realtimeDataType]!,
   'realtime_layer': _$RealtimeLayerEnumMap[instance.realtimeLayer]!,
   'api': instance.api,
@@ -77,6 +89,11 @@ const _$KyoshinMonitorMarkerTypeEnumMap = {
   KyoshinMonitorMarkerType.always: 'always',
   KyoshinMonitorMarkerType.onlyEew: 'onlyEew',
   KyoshinMonitorMarkerType.never: 'never',
+};
+
+const _$KyoshinMonitorSourceEnumMap = {
+  KyoshinMonitorSource.kmoni: 'kmoni',
+  KyoshinMonitorSource.lmoni: 'lmoni',
 };
 
 const _$RealtimeDataTypeEnumMap = {

--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/data_source/kyoshin_monitor_web_api_data_source.dart';
+import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_state.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_monitor_analyzer_isolate_provider.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_monitor_settings.dart';
@@ -46,7 +47,9 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
               next.requireValue.realtimeDataType ||
           previous.requireValue.realtimeLayer !=
               next.requireValue.realtimeLayer ||
-          previous.requireValue.useKmoni != next.requireValue.useKmoni) {
+          previous.requireValue.useKmoni != next.requireValue.useKmoni ||
+          previous.requireValue.monitorSource !=
+              next.requireValue.monitorSource) {
         onSettingsChanged();
       }
     });
@@ -71,29 +74,45 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
     final stopwatch = Stopwatch()..start();
     state = const AsyncLoading<KyoshinMonitorState>();
     state = await AsyncValue.guard(() async {
-      final dataSource = ref.read(kyoshinMonitorWebApiDataSourceProvider);
+      final settings = ref.read(kyoshinMonitorSettingsProvider).requireValue;
+      final realtimeDataType = settings.realtimeDataType;
+      final realtimeLayer = settings.realtimeLayer;
+      final monitorSource = settings.monitorSource;
+
       final analyzer = await ref.read(
         kyoshinMonitorAnalyzerIsolateProvider.future,
       );
-      // 画像を取得
-      final realtimeDataType = ref
-          .read(kyoshinMonitorSettingsProvider)
-          .requireValue
-          .realtimeDataType;
-      final realtimeLayer = ref
-          .read(kyoshinMonitorSettingsProvider)
-          .requireValue
-          .realtimeLayer;
 
       final fetchSw = Stopwatch()..start();
-      final image = await Timeline.timeSync(
-        'kmoni.fetchImage',
-        () async => dataSource.getRealtimeImageData(
-          type: realtimeDataType,
-          layer: realtimeLayer,
-          dateTime: targetTime,
-        ),
-      );
+      final List<int> image;
+
+      // LMoniデータソースを使うケース:
+      // 1. ソースがlmoniに設定されている
+      // 2. LPGMデータ種別が選択されている (LMoni専用)
+      if (monitorSource == KyoshinMonitorSource.lmoni ||
+          realtimeDataType.isLpgm) {
+        final lpgmDataSource = ref.read(
+          lpgmKyoshinMonitorWebApiDataSourceProvider,
+        );
+        image = await Timeline.timeSync(
+          'lmoni.fetchImage',
+          () async => lpgmDataSource.getRealtimeImageData(
+            realtimeDataType,
+            realtimeLayer,
+            targetTime,
+          ),
+        );
+      } else {
+        final dataSource = ref.read(kyoshinMonitorWebApiDataSourceProvider);
+        image = await Timeline.timeSync(
+          'kmoni.fetchImage',
+          () async => dataSource.getRealtimeImageData(
+            type: realtimeDataType,
+            layer: realtimeLayer,
+            dateTime: targetTime,
+          ),
+        );
+      }
       fetchSw.stop();
 
       final workerSw = Stopwatch()..start();

--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.g.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.g.dart
@@ -37,7 +37,7 @@ final class KyoshinMonitorNotifierProvider
 }
 
 String _$kyoshinMonitorNotifierHash() =>
-    r'6b290439bd05dc14c1878ccfbbf8cd69173b6400';
+    r'61354aee88ced782d96f647f721d76de1f18df87';
 
 abstract class _$KyoshinMonitorNotifier
     extends $AsyncNotifier<KyoshinMonitorState> {

--- a/app/lib/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart
+++ b/app/lib/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart
@@ -4,6 +4,7 @@ import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_monitor_
 import 'package:eqmonitor/feature/kyoshin_monitor/page/components/kyoshin_monitor_scale.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:kyoshin_monitor_api/kyoshin_monitor_api.dart';
 
 /// 強震モニタの設定状況を考慮したスケールカード
 class KyoshinMonitorScaleCard extends ConsumerWidget {
@@ -18,21 +19,52 @@ class KyoshinMonitorScaleCard extends ConsumerWidget {
         (v) => v.requireValue.realtimeDataType,
       ),
     );
+    // LPGMデータ種別は連続スケールを持たないためnullを返す
     final type = switch (realtimeDataType) {
-      .shindo => KyoshinMonitorScaleType.intensity,
-      .pga => KyoshinMonitorScaleType.pga,
-      .pgv ||
-      .response0125Hz ||
-      .response025Hz ||
-      .response05Hz ||
-      .response1Hz ||
-      .response2Hz ||
-      .response4Hz => KyoshinMonitorScaleType.pgv,
-      .pgd => KyoshinMonitorScaleType.pgd,
-      _ => throw ArgumentError('Invalid realtimeDataType: $realtimeDataType)'),
+      RealtimeDataType.shindo => KyoshinMonitorScaleType.intensity,
+      RealtimeDataType.pga => KyoshinMonitorScaleType.pga,
+      RealtimeDataType.pgv ||
+      RealtimeDataType.response0125Hz ||
+      RealtimeDataType.response025Hz ||
+      RealtimeDataType.response05Hz ||
+      RealtimeDataType.response1Hz ||
+      RealtimeDataType.response2Hz ||
+      RealtimeDataType.response4Hz =>
+        KyoshinMonitorScaleType.pgv,
+      RealtimeDataType.pgd => KyoshinMonitorScaleType.pgd,
+      _ => null,
     };
+
     final designSystem = context.designSystem;
     final color = designSystem.color;
+
+    // LPGMデータ種別の場合はスケールの代わりにラベルのみ表示
+    if (type == null) {
+      return GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: designSystem.spacing.sm,
+            vertical: designSystem.spacing.md,
+          ),
+          decoration: BoxDecoration(
+            color: color.surfaceCard.withValues(alpha: 0.9),
+            borderRadius: BorderRadius.circular(designSystem.shape.md),
+            border: Border.all(color: color.outlineSoft),
+          ),
+          child: Text(
+            realtimeDataType.displayName,
+            style: designSystem.typography.monoSmall.copyWith(
+              textBaseline: TextBaseline.alphabetic,
+              fontWeight: FontWeight.w700,
+              fontFamily: FontFamily.notoSansMono,
+              fontFamilyFallback: [FontFamily.notoSansJP],
+            ),
+          ),
+        ),
+      );
+    }
+
     return GestureDetector(
       onTap: onTap,
       child: Container(


### PR DESCRIPTION
## Summary

- `KyoshinMonitorSource` enum（`kmoni` / `lmoni`）をモデルに追加し、マップレイヤー設定画面でデータソースを切り替えられるようにした
- LMoni 選択時は LPGM 専用データ種別（長周期地震動階級 `abrspmx`、周期1〜7秒台 `abrsp1s-7s`）を含む全種別が選択可能になる
- KMoni 選択時に LPGM 種別が選ばれていた場合は自動的に `shindo` にリセットする
- `KyoshinMonitorNotifier` がモニタソース設定に応じて `LpgmKyoshinMonitorWebApiDataSource`（`lmoni.bosai.go.jp`）または `KyoshinMonitorWebApiDataSource`（`kmoni.bosai.go.jp`）を自動選択する
- スケールカードで LPGM 種別選択時にクラッシュしていた問題を修正し、名称のみ表示するよう対応

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `kyoshin_monitor_settings_model.dart` | `KyoshinMonitorSource` enum と `monitorSource` フィールドを追加 |
| `kyoshin_monitor_notifier.dart` | LMoni/KMoni データソース切り替えロジックを追加 |
| `kyoshin_monitor_scale_card.dart` | LPGM 種別選択時のクラッシュを修正 |
| `home_map_layer_page.dart` | データソース選択 UI (`_KyoshinMonitorSourceTile`) を追加、データ種別選択をソースに応じて制限 |
| `*.freezed.dart`, `*.g.dart` | コード再生成 |

## Test plan

- [ ] `dart analyze` が警告なしで通ること（CI で確認）
- [ ] `flutter test` が全 89 テスト合格すること（CI で確認）
- [ ] マップレイヤー設定 → 強震モニタセクション → データソース「強震モニタ」「長周期地震動」切り替えが動作する
- [ ] LMoni 選択時に長周期地震動階級（abrspmx 等）がデータ種別ドロップダウンに表示される
- [ ] KMoni に戻したとき LPGM 種別が shindo にリセットされる
- [ ] LMoni で shindo を選択しても観測点データが正常に取得・表示される（lmoni経由でもkmoniデータアクセス可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)