### PR TITLE
fix: unawaited() を async/await に置換しコールバック非同期安全性を改善

### DIFF
--- a/app/lib/core/component/widget/app_switch.dart
+++ b/app/lib/core/component/widget/app_switch.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:cue/cue.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:flutter/material.dart';
@@ -60,8 +58,8 @@ class AppSwitch extends HookWidget {
               radius: 28,
               borderRadius: BorderRadius.circular(shape.pill),
               onTap: isEnabled
-                  ? () {
-                      unawaited(HapticFeedback.selectionClick());
+                  ? () async {
+                      await HapticFeedback.selectionClick();
                       onChanged?.call(!value);
                     }
                   : null,

--- a/app/lib/core/util/haptic.dart
+++ b/app/lib/core/util/haptic.dart
@@ -3,21 +3,21 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 
 Future<void> lightHapticFunction(FutureOr<void> Function() fn) async {
-  unawaited(HapticFeedback.lightImpact());
+  await HapticFeedback.lightImpact();
   await fn();
 }
 
 Future<void> mediumHapticFunction(FutureOr<void> Function() fn) async {
-  unawaited(HapticFeedback.mediumImpact());
+  await HapticFeedback.mediumImpact();
   await fn();
 }
 
 Future<void> heavyHapticFunction(FutureOr<void> Function() fn) async {
-  unawaited(HapticFeedback.heavyImpact());
+  await HapticFeedback.heavyImpact();
   await fn();
 }
 
 Future<void> selectionHapticFunction(FutureOr<void> Function() fn) async {
-  unawaited(HapticFeedback.selectionClick());
+  await HapticFeedback.selectionClick();
   await fn();
 }

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_controller_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_controller_card.dart
@@ -25,7 +25,7 @@ class EarthquakeHistoryControllerCard extends StatelessWidget {
       child: Divider(height: 0),
     );
 
-    void hapticFeedback() => unawaited(HapticFeedback.lightImpact());
+    Future<void> hapticFeedback() async => HapticFeedback.lightImpact();
 
     return Card(
       color: colorScheme.surfaceContainerHighest,
@@ -43,7 +43,7 @@ class EarthquakeHistoryControllerCard extends StatelessWidget {
                         child: Icon(Icons.layers_rounded),
                       ),
                       onTap: () async {
-                        hapticFeedback();
+                        await hapticFeedback();
                         onLayerButtonTap?.call();
                       },
                     ),
@@ -52,8 +52,8 @@ class EarthquakeHistoryControllerCard extends StatelessWidget {
                         padding: EdgeInsets.all(8),
                         child: Icon(Icons.home_rounded),
                       ),
-                      onTap: () {
-                        hapticFeedback();
+                      onTap: () async {
+                        await hapticFeedback();
                         onLocationButtonTap?.call();
                       },
                     ),
@@ -63,7 +63,10 @@ class EarthquakeHistoryControllerCard extends StatelessWidget {
                         child: Icon(Icons.folder_copy_outlined),
                       ),
                       onTap: () async {
-                        hapticFeedback();
+                        await hapticFeedback();
+                        if (!context.mounted) {
+                          return;
+                        }
                         await showEarthquakeHistoryDetailConfigDialog(
                           context,
                           hasLpgmIntensity: false,

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:ui';
 
 import 'package:collection/collection.dart';
@@ -236,8 +235,9 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
             backgroundColor: Colors.transparent,
             actions: [
               IconButton.filledTonal(
-                onPressed: () {
-                  unawaited(HapticFeedback.lightImpact());
+                onPressed: () async {
+                  final navigator = Navigator.of(context);
+                  await HapticFeedback.lightImpact();
                   final parameter = EarthquakeHistoryParameter(
                     intensityGte: isIntensityEnabled.value &&
                             intensityMin.value !=
@@ -300,7 +300,7 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
                         ? regionIntensityMax.value
                         : null,
                   );
-                  Navigator.of(context).pop(parameter);
+                  navigator.pop(parameter);
                 },
                 icon: const Icon(Icons.check),
               ),
@@ -370,10 +370,10 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
                     },
                     onCurrentLocationPressed: isResolvingLocation.value
                         ? null
-                        : () => unawaited(resolveCurrentLocation()),
+                        : resolveCurrentLocation,
                     onSelectFromMapPressed: isResolvingLocation.value
                         ? null
-                        : () => unawaited(selectFromMap()),
+                        : selectFromMap,
                   ),
                 ),
                 _SettingSection(

--- a/app/lib/feature/earthquake_history/ui/components/modal/earthquake_history_details_map_layer_modal.dart
+++ b/app/lib/feature/earthquake_history/ui/components/modal/earthquake_history_details_map_layer_modal.dart
@@ -56,9 +56,10 @@ class EarthquakeHistoryDetailsMapLayerModal extends HookConsumerWidget {
             backgroundColor: Colors.transparent,
             actions: [
               IconButton.filledTonal(
-                onPressed: () {
-                  unawaited(HapticFeedback.lightImpact());
-                  Navigator.of(context).pop();
+                onPressed: () async {
+                  final navigator = Navigator.of(context);
+                  await HapticFeedback.lightImpact();
+                  navigator.pop();
                 },
                 icon: const Icon(Icons.close),
               ),

--- a/app/lib/feature/home/data/provider/map_camera_state_provider.dart
+++ b/app/lib/feature/home/data/provider/map_camera_state_provider.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/home/data/model/home_map_bounds.dart';
@@ -18,12 +16,12 @@ class HomeMapCameraState extends _$HomeMapCameraState {
 
   @override
   MapCameraState build() {
-    ref.listen(eewAliveTelegramProvider, (previous, next) {
+    ref.listen(eewAliveTelegramProvider, (previous, next) async {
       final eews = next ?? [];
       if (eews.isNotEmpty) {
-        unawaited(_fitToEews(eews));
+        await _fitToEews(eews);
       } else if (previous != null && previous.isNotEmpty) {
-        unawaited(_returnToHome());
+        await _returnToHome();
       }
     });
 

--- a/app/lib/feature/home/ui/component/map/home_map_controller_card.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_controller_card.dart
@@ -29,7 +29,7 @@ class HomeMapControllerCard extends StatelessWidget {
       child: Divider(height: 0, color: color.outlineSoft),
     );
 
-    void hapticFeedback() => unawaited(HapticFeedback.lightImpact());
+    Future<void> hapticFeedback() async => HapticFeedback.lightImpact();
 
     return Card(
       color: color.surfaceCard.withValues(alpha: 0.92),
@@ -50,7 +50,7 @@ class HomeMapControllerCard extends StatelessWidget {
                         child: const Icon(Icons.layers_rounded),
                       ),
                       onTap: () async {
-                        hapticFeedback();
+                        await hapticFeedback();
                         onLayerButtonTap?.call();
                       },
                     ),
@@ -59,8 +59,8 @@ class HomeMapControllerCard extends StatelessWidget {
                         padding: EdgeInsets.all(spacing.sm),
                         child: const Icon(Icons.home_rounded),
                       ),
-                      onTap: () {
-                        hapticFeedback();
+                      onTap: () async {
+                        await hapticFeedback();
                         onLocationButtonTap?.call();
                       },
                     ),
@@ -70,8 +70,8 @@ class HomeMapControllerCard extends StatelessWidget {
                           padding: EdgeInsets.all(spacing.sm),
                           child: const Icon(Icons.bug_report_rounded),
                         ),
-                        onTap: () {
-                          hapticFeedback();
+                        onTap: () async {
+                          await hapticFeedback();
                           onDebugButtonTap?.call();
                         },
                       ),

--- a/app/lib/feature/home/ui/component/map/home_map_view.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_view.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
@@ -103,14 +101,12 @@ class _MapContent extends ConsumerWidget {
           final mapWidget = MapLibreMap(
             key: ValueKey(mapKey),
             options: mapOptions,
-            onMapCreated: (controller) {
+            onMapCreated: (controller) async {
               ref
                   .read(homeMapCameraStateProvider.notifier)
                   .setController(controller);
               if (showLocation) {
-                unawaited(
-                  controller.enableLocation(),
-                );
+                await controller.enableLocation();
               }
             },
             onEvent: (event) =>

--- a/app/lib/feature/home/ui/page/home_map_layer_page.dart
+++ b/app/lib/feature/home/ui/page/home_map_layer_page.dart
@@ -373,20 +373,12 @@ class _SettingSwitchTile extends StatelessWidget {
       subtitle: Text(subtitle, style: typography.bodySmall),
       trailing: AppSwitch(
         value: value,
-        onChanged: (next) {
-          unawaited(
-            Future<void>.sync(() async {
-              await onChanged(next);
-            }),
-          );
+        onChanged: (next) async {
+          await onChanged(next);
         },
       ),
-      onTap: () {
-        unawaited(
-          Future<void>.sync(() async {
-            await onChanged(!value);
-          }),
-        );
+      onTap: () async {
+        await onChanged(!value);
       },
     );
   }
@@ -454,13 +446,9 @@ class _SettingDropdownField<T> extends StatelessWidget {
           DropdownMenu<T>(
             width: double.infinity,
             initialSelection: value,
-            onSelected: (next) {
+            onSelected: (next) async {
               if (next != null) {
-                unawaited(
-                  Future<void>.sync(() async {
-                    await onChanged(next);
-                  }),
-                );
+                await onChanged(next);
               }
             },
             dropdownMenuEntries: entries,
@@ -513,12 +501,8 @@ class _SettingSegmentedField<T> extends StatelessWidget {
           SegmentedButton<T>(
             segments: segments,
             selected: selected,
-            onSelectionChanged: (next) {
-              unawaited(
-                Future<void>.sync(() async {
-                  await onSelectionChanged(next);
-                }),
-              );
+            onSelectionChanged: (next) async {
+              await onSelectionChanged(next);
             },
           ),
         ],
@@ -570,12 +554,8 @@ class _SettingActionTile extends StatelessWidget {
           ),
           SizedBox(height: spacing.md),
           FilledButton.tonal(
-            onPressed: () {
-              unawaited(
-                Future<void>.sync(() async {
-                  await onPressed();
-                }),
-              );
+            onPressed: () async {
+              await onPressed();
             },
             style: FilledButton.styleFrom(
               backgroundColor: color.surfaceEmphasis,

--- a/app/lib/feature/onboarding/ui/onboarding_page.dart
+++ b/app/lib/feature/onboarding/ui/onboarding_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
 import 'package:eqmonitor/core/gen/assets.gen.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
@@ -56,11 +54,9 @@ class OnboardingPage extends HookConsumerWidget {
         return;
       }
 
-      unawaited(
-        pageController.nextPage(
-          duration: const Duration(milliseconds: 280),
-          curve: Curves.easeOutCubic,
-        ),
+      await pageController.nextPage(
+        duration: const Duration(milliseconds: 280),
+        curve: Curves.easeOutCubic,
       );
     }
 
@@ -416,7 +412,7 @@ class _BottomBar extends StatelessWidget {
             width: double.infinity,
             height: 52,
             child: FilledButton(
-              onPressed: () => unawaited(onNext()),
+              onPressed: onNext,
               style: FilledButton.styleFrom(
                 backgroundColor: ds.palette.brandPrimary,
                 foregroundColor: ds.textColor.inverse,

--- a/app/lib/feature/settings/features/notification_settings/ui/page/earthquake_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/earthquake_settings_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
@@ -81,16 +79,15 @@ class _EnabledSection extends ConsumerWidget {
       value: settings.enabled,
       onChanged: isSaving
           ? null
-          : (value) {
-              unawaited(
-                EarthquakeNotificationSettingsNotifier.saveSettingsMutation.run(
-                  ref,
-                  (tsx) async {
-                    await tsx
-                        .get(earthquakeNotificationSettingsProvider.notifier)
-                        .setEnabled(enabled: value);
-                  },
-                ),
+          : (value) async {
+              await EarthquakeNotificationSettingsNotifier.saveSettingsMutation
+                  .run(
+                ref,
+                (tsx) async {
+                  await tsx
+                      .get(earthquakeNotificationSettingsProvider.notifier)
+                      .setEnabled(enabled: value);
+                },
               );
             },
     );
@@ -175,16 +172,15 @@ class _EstimatedIntensitySection extends ConsumerWidget {
       value: settings.estimatedIntensityEnabled,
       onChanged: isSaving
           ? null
-          : (value) {
-              unawaited(
-                EarthquakeNotificationSettingsNotifier.saveSettingsMutation.run(
-                  ref,
-                  (tsx) async {
-                    await tsx
-                        .get(earthquakeNotificationSettingsProvider.notifier)
-                        .setEstimatedIntensityEnabled(enabled: value);
-                  },
-                ),
+          : (value) async {
+              await EarthquakeNotificationSettingsNotifier.saveSettingsMutation
+                  .run(
+                ref,
+                (tsx) async {
+                  await tsx
+                      .get(earthquakeNotificationSettingsProvider.notifier)
+                      .setEstimatedIntensityEnabled(enabled: value);
+                },
               );
             },
     );
@@ -237,21 +233,19 @@ class _RegionsSection extends ConsumerWidget {
           NotificationRegionListTile(
             region: region,
             isBusy: isBusy,
-            onDelete: () {
-              unawaited(
-                EarthquakeNotificationSettingsNotifier.updateRegionsMutation
-                    .run(
-                      ref,
-                      (tsx) async {
-                        await tsx
-                            .get(earthquakeNotificationSettingsProvider.notifier)
-                            .removeRegion(
-                              regionId: region.regionId,
-                              isCurrentLocation: region.isCurrentLocation,
-                            );
-                      },
-                    ),
-              );
+            onDelete: () async {
+              await EarthquakeNotificationSettingsNotifier.updateRegionsMutation
+                  .run(
+                    ref,
+                    (tsx) async {
+                      await tsx
+                          .get(earthquakeNotificationSettingsProvider.notifier)
+                          .removeRegion(
+                            regionId: region.regionId,
+                            isCurrentLocation: region.isCurrentLocation,
+                          );
+                    },
+                  );
             },
           ),
         Padding(
@@ -263,19 +257,20 @@ class _RegionsSection extends ConsumerWidget {
               FilledButton.tonal(
                 onPressed: isBusy || hasCurrentLocation
                     ? null
-                    : () {
-                        unawaited(
-                          EarthquakeNotificationSettingsNotifier
-                              .updateRegionsMutation
-                              .run(
-                                ref,
-                                (tsx) async {
-                                  await tsx
-                                      .get(earthquakeNotificationSettingsProvider.notifier)
-                                      .addCurrentLocationRegion();
-                                },
-                              ),
-                        );
+                    : () async {
+                        await EarthquakeNotificationSettingsNotifier
+                            .updateRegionsMutation
+                            .run(
+                              ref,
+                              (tsx) async {
+                                await tsx
+                                    .get(
+                                      earthquakeNotificationSettingsProvider
+                                          .notifier,
+                                    )
+                                    .addCurrentLocationRegion();
+                              },
+                            );
                       },
                 child: isBusy
                     ? const SizedBox(
@@ -298,22 +293,23 @@ class _RegionsSection extends ConsumerWidget {
                         if (result == null || !context.mounted) {
                           return;
                         }
-                        unawaited(
-                          EarthquakeNotificationSettingsNotifier
-                              .updateRegionsMutation
-                              .run(
-                                ref,
-                                (tsx) async {
-                                  await tsx
-                                      .get(earthquakeNotificationSettingsProvider.notifier)
-                                      .addRegion(
-                                        regionId: result.regionId,
-                                        regionName: result.regionName,
-                                        minIntensity: result.minIntensity,
-                                      );
-                                },
-                              ),
-                        );
+                        await EarthquakeNotificationSettingsNotifier
+                            .updateRegionsMutation
+                            .run(
+                              ref,
+                              (tsx) async {
+                                await tsx
+                                    .get(
+                                      earthquakeNotificationSettingsProvider
+                                          .notifier,
+                                    )
+                                    .addRegion(
+                                      regionId: result.regionId,
+                                      regionName: result.regionName,
+                                      minIntensity: result.minIntensity,
+                                    );
+                              },
+                            );
                       },
                 child: const Text('地域を追加'),
               ),

--- a/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/location/data/jma_region_resolver.dart';
@@ -83,13 +81,14 @@ class _EnabledSection extends ConsumerWidget {
       value: settings.enabled,
       onChanged: isSaving
           ? null
-          : (value) {
-              unawaited(
-                EewSettingsNotifier.saveSettingsMutation.run(ref, (tsx) async {
+          : (value) async {
+              await EewSettingsNotifier.saveSettingsMutation.run(
+                ref,
+                (tsx) async {
                   await tsx
                       .get(eewSettingsProvider.notifier)
                       .setEnabled(enabled: value);
-                }),
+                },
               );
             },
     );
@@ -169,13 +168,14 @@ class _LiveActivitySection extends ConsumerWidget {
       value: settings.startLiveActivity,
       onChanged: isSaving
           ? null
-          : (value) {
-              unawaited(
-                EewSettingsNotifier.saveLiveActivityMutation.run(ref, (tsx) async {
+          : (value) async {
+              await EewSettingsNotifier.saveLiveActivityMutation.run(
+                ref,
+                (tsx) async {
                   await tsx
                       .get(eewSettingsProvider.notifier)
                       .setStartLiveActivity(startLiveActivity: value);
-                }),
+                },
               );
             },
     );
@@ -198,13 +198,14 @@ class _OnePointSection extends ConsumerWidget {
       value: settings.onePointEnabled,
       onChanged: isSaving
           ? null
-          : (value) {
-              unawaited(
-                EewSettingsNotifier.saveOnePointMutation.run(ref, (tsx) async {
+          : (value) async {
+              await EewSettingsNotifier.saveOnePointMutation.run(
+                ref,
+                (tsx) async {
                   await tsx
                       .get(eewSettingsProvider.notifier)
                       .setOnePointEnabled(onePointEnabled: value);
-                }),
+                },
               );
             },
     );
@@ -253,14 +254,15 @@ class _RegionsSection extends ConsumerWidget {
           NotificationRegionListTile(
             region: region,
             isBusy: isBusy,
-            onDelete: () {
-              unawaited(
-                EewSettingsNotifier.updateRegionsMutation.run(ref, (tsx) async {
+            onDelete: () async {
+              await EewSettingsNotifier.updateRegionsMutation.run(
+                ref,
+                (tsx) async {
                   await tsx.get(eewSettingsProvider.notifier).removeRegion(
                     regionId: region.regionId,
                     isCurrentLocation: region.isCurrentLocation,
                   );
-                }),
+                },
               );
             },
           ),
@@ -301,18 +303,16 @@ class _RegionsSection extends ConsumerWidget {
                           );
                           return;
                         }
-                        unawaited(
-                          EewSettingsNotifier.updateRegionsMutation.run(
-                            ref,
-                            (tsx) async {
-                              await tsx
-                                  .get(eewSettingsProvider.notifier)
-                                  .addCurrentLocationRegion(
-                                    regionCode: code,
-                                    regionName: name,
-                                  );
-                            },
-                          ),
+                        await EewSettingsNotifier.updateRegionsMutation.run(
+                          ref,
+                          (tsx) async {
+                            await tsx
+                                .get(eewSettingsProvider.notifier)
+                                .addCurrentLocationRegion(
+                                  regionCode: code,
+                                  regionName: name,
+                                );
+                          },
                         );
                       },
                 child: isBusy
@@ -336,19 +336,17 @@ class _RegionsSection extends ConsumerWidget {
                         if (result == null || !context.mounted) {
                           return;
                         }
-                        unawaited(
-                          EewSettingsNotifier.updateRegionsMutation.run(
-                            ref,
-                            (tsx) async {
-                              await tsx
-                                  .get(eewSettingsProvider.notifier)
-                                  .addRegion(
-                                    regionId: result.regionId,
-                                    regionName: result.regionName,
-                                    minIntensity: result.minIntensity,
-                                  );
-                            },
-                          ),
+                        await EewSettingsNotifier.updateRegionsMutation.run(
+                          ref,
+                          (tsx) async {
+                            await tsx
+                                .get(eewSettingsProvider.notifier)
+                                .addRegion(
+                                  regionId: result.regionId,
+                                  regionName: result.regionName,
+                                  minIntensity: result.minIntensity,
+                                );
+                          },
                         );
                       },
                 child: const Text('地域を追加'),

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:app_settings/app_settings.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
@@ -117,19 +115,17 @@ class _GeneralSettingsSection extends ConsumerWidget {
           value: settings.tsunamiEnabled,
           onChanged: isSaving
               ? null
-              : (value) {
-                  unawaited(
-                    GeneralNotificationSettingsNotifier.saveMutation.run(
-                      ref,
-                      (tsx) async {
-                        await tsx
-                            .get(generalNotificationSettingsProvider.notifier)
-                            .save(
-                              tsunamiEnabled: value,
-                              trainingEnabled: settings.trainingEnabled,
-                            );
-                      },
-                    ),
+              : (value) async {
+                  await GeneralNotificationSettingsNotifier.saveMutation.run(
+                    ref,
+                    (tsx) async {
+                      await tsx
+                          .get(generalNotificationSettingsProvider.notifier)
+                          .save(
+                            tsunamiEnabled: value,
+                            trainingEnabled: settings.trainingEnabled,
+                          );
+                    },
                   );
                 },
         ),
@@ -139,19 +135,17 @@ class _GeneralSettingsSection extends ConsumerWidget {
           value: settings.trainingEnabled,
           onChanged: isSaving
               ? null
-              : (value) {
-                  unawaited(
-                    GeneralNotificationSettingsNotifier.saveMutation.run(
-                      ref,
-                      (tsx) async {
-                        await tsx
-                            .get(generalNotificationSettingsProvider.notifier)
-                            .save(
-                              tsunamiEnabled: settings.tsunamiEnabled,
-                              trainingEnabled: value,
-                            );
-                      },
-                    ),
+              : (value) async {
+                  await GeneralNotificationSettingsNotifier.saveMutation.run(
+                    ref,
+                    (tsx) async {
+                      await tsx
+                          .get(generalNotificationSettingsProvider.notifier)
+                          .save(
+                            tsunamiEnabled: settings.tsunamiEnabled,
+                            trainingEnabled: value,
+                          );
+                    },
                   );
                 },
         ),
@@ -233,9 +227,9 @@ class _TestNotificationTile extends HookConsumerWidget {
                           runSpacing: 8,
                           children: TestNotificationKind.values.map((kind) {
                             return FilledButton.tonal(
-                              onPressed: () {
+                              onPressed: () async {
                                 Navigator.of(context).pop();
-                                unawaited(send(kind));
+                                await send(kind);
                               },
                               child: Text(kind.displayLabel),
                             );

--- a/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/shake_detection_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
@@ -101,28 +99,24 @@ class _Body extends ConsumerWidget {
             _ShakeEntryCard(
               entry: entry,
               isBusy: isBusy,
-              onDelete: () {
-                unawaited(
-                  ShakeDetectionSettingsNotifier.removeEntryMutation.run(
-                    ref,
-                    (tsx) async {
-                      await tsx
-                          .get(shakeDetectionSettingsProvider.notifier)
-                          .removeEntry(entry.id);
-                    },
-                  ),
+              onDelete: () async {
+                await ShakeDetectionSettingsNotifier.removeEntryMutation.run(
+                  ref,
+                  (tsx) async {
+                    await tsx
+                        .get(shakeDetectionSettingsProvider.notifier)
+                        .removeEntry(entry.id);
+                  },
                 );
               },
-              onLevelChanged: (level) {
-                unawaited(
-                  ShakeDetectionSettingsNotifier.updateLevelMutation.run(
-                    ref,
-                    (tsx) async {
-                      await tsx
-                          .get(shakeDetectionSettingsProvider.notifier)
-                          .updateLevel(entry.id, level);
-                    },
-                  ),
+              onLevelChanged: (level) async {
+                await ShakeDetectionSettingsNotifier.updateLevelMutation.run(
+                  ref,
+                  (tsx) async {
+                    await tsx
+                        .get(shakeDetectionSettingsProvider.notifier)
+                        .updateLevel(entry.id, level);
+                  },
                 );
               },
             ),
@@ -132,16 +126,14 @@ class _Body extends ConsumerWidget {
               onPressed: isBusy ||
                       state.entries.any((e) => e.isCurrentLocation)
                   ? null
-                  : () {
-                      unawaited(
-                        ShakeDetectionSettingsNotifier
-                            .addCurrentLocationMutation
-                            .run(ref, (tsx) async {
-                          await tsx
-                              .get(shakeDetectionSettingsProvider.notifier)
-                              .addCurrentLocation();
-                        }),
-                      );
+                  : () async {
+                      await ShakeDetectionSettingsNotifier
+                          .addCurrentLocationMutation
+                          .run(ref, (tsx) async {
+                        await tsx
+                            .get(shakeDetectionSettingsProvider.notifier)
+                            .addCurrentLocation();
+                      });
                     },
               child: isBusy
                   ? const SizedBox(

--- a/app/lib/feature/shake_detection/ui/shake_detection_history_details_page.dart
+++ b/app/lib/feature/shake_detection/ui/shake_detection_history_details_page.dart
@@ -158,12 +158,10 @@ class _PageContent extends HookConsumerWidget {
                 Geographic(lat: event.minLat, lon: event.minLng),
                 Geographic(lat: event.maxLat, lon: event.maxLng),
               ]);
-              unawaited(
-                controller.fitBounds(
-                  bounds: bounds,
-                  padding: const EdgeInsets.all(64),
-                  webMaxZoom: 10,
-                ),
+              await controller.fitBounds(
+                bounds: bounds,
+                padding: const EdgeInsets.all(64),
+                webMaxZoom: 10,
               );
             },
           ),


### PR DESCRIPTION
## 概要

`flutter-rules.mdc` の以下のルールに準拠するための修正です。

> 内部で非同期処理を `unawaited` するくらいなら、関数自体を `async` にして `await` すること

## 変更内容

### unawaited() → async/await への変換 (15ファイル)

| ファイル | 変更内容 |
|---|---|
| `core/util/haptic.dart` | 全 haptic 関数を async 化し await |
| `core/component/widget/app_switch.dart` | `onTap` を async 化し await |
| `feature/onboarding/ui/onboarding_page.dart` | コールバックを async 化し await |
| `feature/settings/features/notification_settings/ui/page/*.dart` (4ファイル) | 各設定トグルコールバックを async 化し await |
| `feature/home/ui/component/map/home_map_controller_card.dart` | `hapticFeedback()` を async 化し await |
| `feature/home/ui/component/map/home_map_view.dart` | `onMapCreated` を async 化し await |
| `feature/home/ui/page/home_map_layer_page.dart` | `unawaited(Future.sync(...))` パターンをシンプルな async コールバックに変換 |
| `feature/home/data/provider/map_camera_state_provider.dart` | `ref.listen` コールバックを async 化し await |
| `feature/earthquake_history/ui/components/*.dart` (3ファイル) | コールバックを async 化し await |
| `feature/shake_detection/ui/shake_detection_history_details_page.dart` | `onEvent` コールバック内で await |

### 非同期ギャップをまたぐ BuildContext の安全化

await の前に `Navigator.of(context)` を変数にキャプチャ、または `context.mounted` チェックを追加。

## 対象外 (インターフェース制約)

以下は `void` 戻り値のインターフェースオーバーライドのため修正対象外（Issue #1181 として追跡済み）：
- `TalkerObserver` のオーバーライドメソッド
- `NavigatorObserver` のオーバーライドメソッド
- `ref.onDispose` コールバック
- `dispose()` オーバーライド

## 検証

- [x] `flutter analyze` → No issues found!
- [x] `dart fix --apply` → Nothing to fix!

🤖 Generated with [Claude Code](https://claude.com/claude-code)