### PR TITLE
feat: SnackBar → AdaptiveSnackBar に移行 (adaptive_platform_ui 導入)

### DIFF
--- a/app/lib/core/extension/async_value.dart
+++ b/app/lib/core/extension/async_value.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_positional_boolean_parameters
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -52,9 +53,7 @@ extension AsyncValueX<T> on AsyncValue<T> {
     String defaultMessage = 'エラーが発生しました',
   }) {
     if (!isLoading && hasError) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(error!.toString())));
+      AdaptiveSnackBar.show(context, message: error!.toString());
     }
   }
 }

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -1,3 +1,4 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
@@ -37,10 +38,11 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
           slivers: [
             switch (sessionAsync) {
               AsyncData(:final value) => _DeviceSettingsSliverList(
-                  snapshot: value,
-                  historyAsync: historyAsync,
-                ),
-              AsyncError(:final error, :final stackTrace) => SliverFillRemaining(
+                snapshot: value,
+                historyAsync: historyAsync,
+              ),
+              AsyncError(:final error, :final stackTrace) =>
+                SliverFillRemaining(
                   child: _LoadErrorBody(
                     message: error.toString(),
                     stackTrace: stackTrace,
@@ -48,8 +50,8 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
                   ),
                 ),
               _ => const SliverFillRemaining(
-                  child: Center(child: CircularProgressIndicator.adaptive()),
-                ),
+                child: Center(child: CircularProgressIndicator.adaptive()),
+              ),
             },
           ],
         ),
@@ -97,9 +99,7 @@ class _LoadErrorBody extends StatelessWidget {
                 ClipboardData(text: '$message\n\n$stackTrace'),
               );
               if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('エラーをクリップボードにコピーしました')),
-                );
+                AdaptiveSnackBar.show(context, message: 'エラーをクリップボードにコピーしました');
               }
             },
             child: const Text('詳細をコピー'),
@@ -197,8 +197,9 @@ class _NotificationSettingsSection extends HookConsumerWidget {
         return;
       }
       isBusy.value = true;
-      final messenger = ScaffoldMessenger.of(context);
-      final notificationRepository = await ref.read(pushNotificationRepositoryProvider.future);
+      final notificationRepository = await ref.read(
+        pushNotificationRepositoryProvider.future,
+      );
       final result = await notificationRepository.patchNotificationSettings(
         deviceId: snapshot.deviceId,
         settings: GeneralNotificationSettings(
@@ -213,15 +214,12 @@ class _NotificationSettingsSection extends HookConsumerWidget {
       switch (result) {
         case Success():
           ref.invalidate(debugDeviceSessionProvider);
-          messenger.showSnackBar(
-            const SnackBar(content: Text('通知設定を更新しました')),
-          );
+          AdaptiveSnackBar.show(context, message: '通知設定を更新しました');
         case Failure(:final exception):
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text('更新に失敗しました: $exception'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
+          AdaptiveSnackBar.show(
+            context,
+            message: '更新に失敗しました: $exception',
+            type: AdaptiveSnackBarType.error,
           );
       }
     }
@@ -288,8 +286,9 @@ class _TestNotificationSection extends HookConsumerWidget {
 
     Future<void> send(TestNotificationKind kind) async {
       pendingKind.value = kind;
-      final messenger = ScaffoldMessenger.of(context);
-      final notificationRepository = await ref.read(pushNotificationRepositoryProvider.future);
+      final notificationRepository = await ref.read(
+        pushNotificationRepositoryProvider.future,
+      );
       final result = await notificationRepository.sendTestNotification(
         deviceId: deviceId,
         kind: kind,
@@ -300,19 +299,16 @@ class _TestNotificationSection extends HookConsumerWidget {
       }
       switch (result) {
         case Success(:final value):
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text(
+          AdaptiveSnackBar.show(
+            context,
+            message:
                 '送信しました（${value.framework.displayLabel}）: ${value.message}',
-              ),
-            ),
           );
         case Failure(:final exception):
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text('送信に失敗: $exception'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
+          AdaptiveSnackBar.show(
+            context,
+            message: '送信に失敗: $exception',
+            type: AdaptiveSnackBarType.error,
           );
       }
     }
@@ -323,27 +319,30 @@ class _TestNotificationSection extends HookConsumerWidget {
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
-        children: [
-          TestNotificationKind.silent,
-          TestNotificationKind.normal,
-          TestNotificationKind.critical,
-        ].map((kind) {
-          final isPending = pendingKind.value == kind;
-          return FilledButton.tonal(
-            onPressed: pendingKind.value != null && !isPending
-                ? null
-                : () async {
-                    await send(kind);
-                  },
-            child: isPending
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                  )
-                : Text(kind.displayLabel),
-          );
-        }).toList(),
+        children:
+            [
+              TestNotificationKind.silent,
+              TestNotificationKind.normal,
+              TestNotificationKind.critical,
+            ].map((kind) {
+              final isPending = pendingKind.value == kind;
+              return FilledButton.tonal(
+                onPressed: pendingKind.value != null && !isPending
+                    ? null
+                    : () async {
+                        await send(kind);
+                      },
+                child: isPending
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator.adaptive(
+                          strokeWidth: 2,
+                        ),
+                      )
+                    : Text(kind.displayLabel),
+              );
+            }).toList(),
       ),
     );
   }
@@ -367,31 +366,31 @@ class _HistorySection extends ConsumerWidget {
       ),
       child: switch (historyAsync) {
         AsyncData(:final value) when value.isEmpty => Text(
-            '履歴はまだありません',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+          '履歴はまだありません',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),
+        ),
         AsyncData(:final value) => ListView.separated(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: value.length,
-            separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (context, index) {
-              final item = value[index];
-              return _NotificationHistoryTile(item: item);
-            },
-          ),
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: value.length,
+          separatorBuilder: (_, _) => const Divider(height: 1),
+          itemBuilder: (context, index) {
+            final item = value[index];
+            return _NotificationHistoryTile(item: item);
+          },
+        ),
         AsyncError(:final error) => Text(
-            '履歴の取得に失敗: $error',
-            style: TextStyle(color: Theme.of(context).colorScheme.error),
-          ),
+          '履歴の取得に失敗: $error',
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
+        ),
         _ => const Center(
-            child: Padding(
-              padding: EdgeInsets.all(16),
-              child: CircularProgressIndicator.adaptive(),
-            ),
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: CircularProgressIndicator.adaptive(),
           ),
+        ),
       },
     );
   }
@@ -523,8 +522,8 @@ class _KeyValueRow extends StatelessWidget {
             child: Text(
               label,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
           Expanded(

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_search_parameter_modal.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/component/selector/city_selector.dart';
 import 'package:eqmonitor/core/component/selector/prefecture_selector.dart';
@@ -139,14 +140,13 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
         if (permission == LocationPermission.denied ||
             permission == LocationPermission.deniedForever) {
           if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('位置情報の権限がありません')),
-            );
+            AdaptiveSnackBar.show(context, message: '位置情報の権限がありません');
           }
           return;
         }
 
-        final position = ref.read(locationStreamProvider).value ??
+        final position =
+            ref.read(locationStreamProvider).value ??
             await Geolocator.getCurrentPosition(
               locationSettings: const LocationSettings(
                 accuracy: LocationAccuracy.low,
@@ -168,8 +168,9 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
           );
           if (city?.property != null) {
             final cityCode = city!.property!.code;
-            final prefix =
-                cityCode.length >= 2 ? cityCode.substring(0, 2) : cityCode;
+            final prefix = cityCode.length >= 2
+                ? cityCode.substring(0, 2)
+                : cityCode;
             final jmaCodeTable = ref.read(jmaCodeTableProvider).value;
             final prefecture = jmaCodeTable
                 ?.codeTables
@@ -185,9 +186,7 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
         }
       } on Exception catch (_) {
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('現在地の取得に失敗しました')),
-          );
+          AdaptiveSnackBar.show(context, message: '現在地の取得に失敗しました');
         }
       } finally {
         isResolvingLocation.value = false;
@@ -239,47 +238,56 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
                 onPressed: () {
                   unawaited(HapticFeedback.lightImpact());
                   final parameter = EarthquakeHistoryParameter(
-                    intensityGte: isIntensityEnabled.value &&
+                    intensityGte:
+                        isIntensityEnabled.value &&
                             intensityMin.value !=
                                 _IntensityRangeSelector.initialMin
                         ? intensityMin.value
                         : null,
-                    intensityLte: isIntensityEnabled.value &&
+                    intensityLte:
+                        isIntensityEnabled.value &&
                             intensityMax.value !=
                                 _IntensityRangeSelector.initialMax
                         ? intensityMax.value
                         : null,
-                    depthGte: isDepthEnabled.value &&
+                    depthGte:
+                        isDepthEnabled.value &&
                             depthMin.value != _DepthRangeSelector.initialMin
                         ? depthMin.value
                         : null,
-                    depthLte: isDepthEnabled.value &&
+                    depthLte:
+                        isDepthEnabled.value &&
                             depthMax.value != _DepthRangeSelector.initialMax
                         ? depthMax.value
                         : null,
-                    magnitudeGte: isMagnitudeEnabled.value &&
+                    magnitudeGte:
+                        isMagnitudeEnabled.value &&
                             magnitudeMin.value !=
                                 _MagnitudeRangeSelector.initialMin
                         ? magnitudeMin.value
                         : null,
-                    magnitudeLte: isMagnitudeEnabled.value &&
+                    magnitudeLte:
+                        isMagnitudeEnabled.value &&
                             magnitudeMax.value !=
                                 _MagnitudeRangeSelector.initialMax
                         ? magnitudeMax.value
                         : null,
-                    epicenterCode: isEpicenterEnabled.value &&
+                    epicenterCode:
+                        isEpicenterEnabled.value &&
                             selectedEpicenterCode.value != null
                         ? int.tryParse(selectedEpicenterCode.value!)
                         : null,
-                    epicenterName: isEpicenterEnabled.value &&
+                    epicenterName:
+                        isEpicenterEnabled.value &&
                             selectedEpicenterCode.value != null
                         ? selectedEpicenterName.value
                         : null,
-                    regionSearchType: isRegionIntensityEnabled.value &&
+                    regionSearchType:
+                        isRegionIntensityEnabled.value &&
                             selectedRegionCode.value != null
                         ? (selectedRegionType.value == 'prefecture'
-                            ? RegionSearchType.prefecture
-                            : RegionSearchType.city)
+                              ? RegionSearchType.prefecture
+                              : RegionSearchType.city)
                         : null,
                     regionCode: isRegionIntensityEnabled.value
                         ? selectedRegionCode.value
@@ -287,13 +295,15 @@ class EarthquakeHistorySearchParameterModal extends HookConsumerWidget {
                     regionName: isRegionIntensityEnabled.value
                         ? selectedRegionName.value
                         : null,
-                    regionIntensityGte: isRegionIntensityEnabled.value &&
+                    regionIntensityGte:
+                        isRegionIntensityEnabled.value &&
                             selectedRegionCode.value != null &&
                             regionIntensityMin.value !=
                                 _IntensityRangeSelector.initialMin
                         ? regionIntensityMin.value
                         : null,
-                    regionIntensityLte: isRegionIntensityEnabled.value &&
+                    regionIntensityLte:
+                        isRegionIntensityEnabled.value &&
                             selectedRegionCode.value != null &&
                             regionIntensityMax.value !=
                                 _IntensityRangeSelector.initialMax
@@ -646,8 +656,7 @@ class _EpicenterSelector extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final epicenters =
-        ref.watch(jmaCodeTableProvider).value?.codeTables.areaEpicenter
-        ?? [];
+        ref.watch(jmaCodeTableProvider).value?.codeTables.areaEpicenter ?? [];
 
     return DropdownMenu<String>(
       expandedInsets: EdgeInsets.zero,
@@ -655,8 +664,7 @@ class _EpicenterSelector extends HookConsumerWidget {
       hintText: '震央地名を選択',
       onSelected: (code) {
         if (code != null && code.isNotEmpty) {
-          final epicenter = epicenters
-              .firstWhereOrNull((e) => e.code == code);
+          final epicenter = epicenters.firstWhereOrNull((e) => e.code == code);
           if (epicenter == null) {
             return;
           }

--- a/app/lib/feature/earthquake_replay/ui/earthquake_replay_page.dart
+++ b/app/lib/feature/earthquake_replay/ui/earthquake_replay_page.dart
@@ -1,3 +1,4 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/feature/earthquake_replay/data/notifier/replay_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_replay/ui/components/replay_controls.dart';
@@ -75,11 +76,7 @@ class EarthquakeReplayPage extends HookConsumerWidget {
       if (file.bytes == null) {
         isLoading.value = false;
         if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('ファイルの読み込みに失敗しました'),
-            ),
-          );
+          AdaptiveSnackBar.show(context, message: 'ファイルの読み込みに失敗しました');
         }
         return;
       }
@@ -92,9 +89,7 @@ class EarthquakeReplayPage extends HookConsumerWidget {
           );
     } on Exception catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラー: $e')),
-        );
+        AdaptiveSnackBar.show(context, message: 'エラー: $e');
       }
     } finally {
       isLoading.value = false;

--- a/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
+++ b/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
@@ -1,3 +1,4 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/provider/app_group_preferences.dart';
 import 'package:eqmonitor/core/provider/app_group_settings_writer.dart';
@@ -66,9 +67,7 @@ class DebugAppGroupAction {
     await ref.read(appGroupSettingsWriterProvider.future);
     ref.invalidate(appGroupValuesProvider);
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('App Groups を再同期しました')),
-      );
+      AdaptiveSnackBar.show(context, message: 'App Groups を再同期しました');
     }
   }
 }

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/provider/environment/environment.dart';
@@ -65,7 +66,9 @@ class _DebugWidget extends ConsumerWidget {
             title: const Text('ビルド時刻'),
             leading: const Icon(Icons.schedule),
             subtitle: Text(
-              buildCfg.buildTimestamp.isEmpty ? '(not set)' : buildCfg.buildTimestamp,
+              buildCfg.buildTimestamp.isEmpty
+                  ? '(not set)'
+                  : buildCfg.buildTimestamp,
               style: const TextStyle(fontFamily: FontFamily.notoSansMono),
             ),
           ),
@@ -73,7 +76,9 @@ class _DebugWidget extends ConsumerWidget {
             title: const Text('ビルド時コミットメッセージ'),
             leading: const Icon(Icons.commit),
             subtitle: Text(
-              buildCfg.buildCommitMessage.isEmpty ? '(not set)' : buildCfg.buildCommitMessage,
+              buildCfg.buildCommitMessage.isEmpty
+                  ? '(not set)'
+                  : buildCfg.buildCommitMessage,
               style: const TextStyle(fontFamily: FontFamily.notoSansMono),
             ),
           ),
@@ -306,15 +311,11 @@ class _AppCheckSection extends ConsumerWidget {
               final token = await FirebaseAppCheck.instance
                   .getLimitedUseToken();
               if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Token: $token')),
-                );
+                AdaptiveSnackBar.show(context, message: 'Token: $token');
               }
             } on Exception catch (e) {
               if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('エラー: $e')),
-                );
+                AdaptiveSnackBar.show(context, message: 'エラー: $e');
               }
             }
           },
@@ -369,22 +370,20 @@ class _ParameterDebugSectionState
                   tooltip: '強制再取得',
                   onPressed: () async {
                     setState(() => _isRefreshing = true);
-                    final messenger = ScaffoldMessenger.of(context);
                     try {
                       final updated = await ref
                           .read(parameterSetProvider.notifier)
                           .refresh();
-                      messenger.showSnackBar(
-                        SnackBar(
-                          content: Text(
-                            updated ? 'パラメータを更新しました' : 'パラメータは最新です',
-                          ),
-                        ),
-                      );
+                      if (context.mounted) {
+                        AdaptiveSnackBar.show(
+                          context,
+                          message: updated ? 'パラメータを更新しました' : 'パラメータは最新です',
+                        );
+                      }
                     } on Exception catch (e) {
-                      messenger.showSnackBar(
-                        SnackBar(content: Text('エラー: $e')),
-                      );
+                      if (context.mounted) {
+                        AdaptiveSnackBar.show(context, message: 'エラー: $e');
+                      }
                     } finally {
                       if (mounted) {
                         setState(() => _isRefreshing = false);

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
@@ -152,7 +153,6 @@ class _Body extends HookConsumerWidget {
 
     Future<void> registerOrRefresh() async {
       await runWithBusy(() async {
-        final messenger = ScaffoldMessenger.of(context);
         final repo = await ref.read(deviceRepositoryProvider.future);
         final result = await repo.registerDevice(
           deviceId: deviceId,
@@ -168,16 +168,13 @@ class _Body extends HookConsumerWidget {
         }
         switch (result) {
           case Success():
-            messenger.showSnackBar(
-              const SnackBar(content: Text('サーバーにデバイスを登録しました')),
-            );
+            AdaptiveSnackBar.show(context, message: 'サーバーにデバイスを登録しました');
             await onReload();
           case Failure(:final exception):
-            messenger.showSnackBar(
-              SnackBar(
-                content: Text('登録に失敗しました: $exception'),
-                backgroundColor: Theme.of(context).colorScheme.error,
-              ),
+            AdaptiveSnackBar.show(
+              context,
+              message: '登録に失敗しました: $exception',
+              type: AdaptiveSnackBarType.error,
             );
         }
       });
@@ -214,7 +211,6 @@ class _Body extends HookConsumerWidget {
         return;
       }
       await runWithBusy(() async {
-        final messenger = ScaffoldMessenger.of(context);
         final repo = await ref.read(deviceRepositoryProvider.future);
         final result = await repo.deleteDevice(deviceId);
         if (!context.mounted) {
@@ -222,16 +218,13 @@ class _Body extends HookConsumerWidget {
         }
         switch (result) {
           case Success():
-            messenger.showSnackBar(
-              const SnackBar(content: Text('サーバーからデバイスを削除しました')),
-            );
+            AdaptiveSnackBar.show(context, message: 'サーバーからデバイスを削除しました');
             await onReload();
           case Failure(:final exception):
-            messenger.showSnackBar(
-              SnackBar(
-                content: Text('削除に失敗しました: $exception'),
-                backgroundColor: Theme.of(context).colorScheme.error,
-              ),
+            AdaptiveSnackBar.show(
+              context,
+              message: '削除に失敗しました: $exception',
+              type: AdaptiveSnackBarType.error,
             );
         }
       });
@@ -239,13 +232,10 @@ class _Body extends HookConsumerWidget {
 
     Future<void> saveNotificationSettings() async {
       if (device == null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('先にデバイスを登録してください')),
-        );
+        AdaptiveSnackBar.show(context, message: '先にデバイスを登録してください');
         return;
       }
       await runWithBusy(() async {
-        final messenger = ScaffoldMessenger.of(context);
         final repo = await ref.read(pushNotificationRepositoryProvider.future);
         final result = await repo.patchNotificationSettings(
           deviceId: deviceId,
@@ -259,16 +249,13 @@ class _Body extends HookConsumerWidget {
         }
         switch (result) {
           case Success():
-            messenger.showSnackBar(
-              const SnackBar(content: Text('通知条件を更新しました')),
-            );
+            AdaptiveSnackBar.show(context, message: '通知条件を更新しました');
             await onReload();
           case Failure(:final exception):
-            messenger.showSnackBar(
-              SnackBar(
-                content: Text('更新に失敗しました: $exception'),
-                backgroundColor: Theme.of(context).colorScheme.error,
-              ),
+            AdaptiveSnackBar.show(
+              context,
+              message: '更新に失敗しました: $exception',
+              type: AdaptiveSnackBarType.error,
             );
         }
       });

--- a/app/lib/feature/settings/children/config/debug/jma_map/debug_jma_map_page.dart
+++ b/app/lib/feature/settings/children/config/debug/jma_map/debug_jma_map_page.dart
@@ -1,3 +1,4 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/provider/jma_parameter/jma_earthquake_nearest_observation_point.dart';
 import 'package:eqmonitor/core/provider/jma_parameter/jma_parameter.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
@@ -97,15 +98,11 @@ class DebugJmaMapPage extends HookConsumerWidget {
         final noResults =
             searchResult.value == null && observationPointResult.value == null;
         if (noResults && context.mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(const SnackBar(content: Text('検索結果がありません')));
+          AdaptiveSnackBar.show(context, message: '検索結果がありません');
         }
       } on Exception catch (e) {
         if (context.mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('エラー: $e')));
+          AdaptiveSnackBar.show(context, message: 'エラー: $e');
         }
       } finally {
         isLoading.value = false;

--- a/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
+++ b/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/feature/notification/data/model/push_notification_log.dart';
@@ -63,11 +64,10 @@ class DebugNotificationDeliveryLogPage extends HookConsumerWidget {
           nextCursor.value = value.nextCursor;
         case Failure(:final exception):
           if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text('追加読み込みに失敗: $exception'),
-                backgroundColor: Theme.of(context).colorScheme.error,
-              ),
+            AdaptiveSnackBar.show(
+              context,
+              message: '追加読み込みに失敗: $exception',
+              type: AdaptiveSnackBarType.error,
             );
           }
       }
@@ -95,105 +95,105 @@ class DebugNotificationDeliveryLogPage extends HookConsumerWidget {
       ),
       body: switch (ref.watch(deviceIdProvider)) {
         AsyncError(:final error) => Center(child: Text('端末 ID 取得エラー: $error')),
-        AsyncLoading() => const Center(child: CircularProgressIndicator.adaptive()),
+        AsyncLoading() => const Center(
+          child: CircularProgressIndicator.adaptive(),
+        ),
         AsyncData<String>(:final value) => Builder(
-            builder: (context) {
-              if (loading.value && items.value.isEmpty && error.value == null) {
-                return const Center(child: CircularProgressIndicator.adaptive());
-              }
-              if (error.value != null && items.value.isEmpty) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          error.value.toString(),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 16),
-                        FilledButton.icon(
-                          onPressed: () {
-                            refreshTick.value++;
-                          },
-                          icon: const Icon(Icons.refresh),
-                          label: const Text('再試行'),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              }
-              if (items.value.isEmpty) {
-                return RefreshIndicator(
-                  onRefresh: loadFirstPage,
-                  child: ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
+          builder: (context) {
+            if (loading.value && items.value.isEmpty && error.value == null) {
+              return const Center(child: CircularProgressIndicator.adaptive());
+            }
+            if (error.value != null && items.value.isEmpty) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      SizedBox(
-                        height: MediaQuery.sizeOf(context).height * 0.3,
+                      Text(
+                        error.value.toString(),
+                        textAlign: TextAlign.center,
                       ),
-                      Center(
-                        child: Text(
-                          '配信ログはまだありません',
-                          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSurfaceVariant,
-                              ),
-                        ),
-                      ),
-                      ListTile(
-                        dense: true,
-                        title: const Text('対象端末 ID'),
-                        subtitle: SelectableText(value),
+                      const SizedBox(height: 16),
+                      FilledButton.icon(
+                        onPressed: () {
+                          refreshTick.value++;
+                        },
+                        icon: const Icon(Icons.refresh),
+                        label: const Text('再試行'),
                       ),
                     ],
                   ),
-                );
-              }
-              return RefreshIndicator(
-                onRefresh: loadFirstPage,
-                child: ListView.builder(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  padding: const EdgeInsets.only(bottom: 24),
-                  itemCount:
-                      items.value.length + (nextCursor.value != null ? 1 : 0),
-                  itemBuilder: (context, index) {
-                    if (index == items.value.length) {
-                      return Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Center(
-                          child: loadingMore.value
-                              ? const CircularProgressIndicator.adaptive()
-                              : TextButton.icon(
-                                  onPressed: () async {
-                                    await loadMore();
-                                  },
-                                  icon: const Icon(Icons.expand_more),
-                                  label: const Text('さらに読み込む'),
-                                ),
-                        ),
-                      );
-                    }
-                    final item = items.value[index];
-                    return _NotificationLogTile(
-                      item: item,
-                      onTap: () async {
-                        await showModalBottomSheet<void>(
-                          context: context,
-                          showDragHandle: true,
-                          isScrollControlled: true,
-                          builder: (context) => _LogDetailSheet(item: item),
-                        );
-                      },
-                    );
-                  },
                 ),
               );
-            },
-          ),
+            }
+            if (items.value.isEmpty) {
+              return RefreshIndicator(
+                onRefresh: loadFirstPage,
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: [
+                    SizedBox(
+                      height: MediaQuery.sizeOf(context).height * 0.3,
+                    ),
+                    Center(
+                      child: Text(
+                        '配信ログはまだありません',
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    ListTile(
+                      dense: true,
+                      title: const Text('対象端末 ID'),
+                      subtitle: SelectableText(value),
+                    ),
+                  ],
+                ),
+              );
+            }
+            return RefreshIndicator(
+              onRefresh: loadFirstPage,
+              child: ListView.builder(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.only(bottom: 24),
+                itemCount:
+                    items.value.length + (nextCursor.value != null ? 1 : 0),
+                itemBuilder: (context, index) {
+                  if (index == items.value.length) {
+                    return Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Center(
+                        child: loadingMore.value
+                            ? const CircularProgressIndicator.adaptive()
+                            : TextButton.icon(
+                                onPressed: () async {
+                                  await loadMore();
+                                },
+                                icon: const Icon(Icons.expand_more),
+                                label: const Text('さらに読み込む'),
+                              ),
+                      ),
+                    );
+                  }
+                  final item = items.value[index];
+                  return _NotificationLogTile(
+                    item: item,
+                    onTap: () async {
+                      await showModalBottomSheet<void>(
+                        context: context,
+                        showDragHandle: true,
+                        isScrollControlled: true,
+                        builder: (context) => _LogDetailSheet(item: item),
+                      );
+                    },
+                  );
+                },
+              ),
+            );
+          },
+        ),
       },
     );
   }
@@ -298,9 +298,7 @@ class _LogDetailSheet extends StatelessWidget {
                         ClipboardData(text: buffer.toString()),
                       );
                       if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('コピーしました')),
-                        );
+                        AdaptiveSnackBar.show(context, message: 'コピーしました');
                       }
                     },
                     icon: const Icon(Icons.copy),
@@ -324,9 +322,9 @@ class _LogDetailSheet extends StatelessWidget {
                               e.$1,
                               style: Theme.of(context).textTheme.labelSmall
                                   ?.copyWith(
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurfaceVariant,
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
                                   ),
                             ),
                             const SizedBox(height: 4),

--- a/app/lib/feature/settings/children/config/debug/playground/playground_page.dart
+++ b/app/lib/feature/settings/children/config/debug/playground/playground_page.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart'; // 追加
 
@@ -263,8 +264,9 @@ class KyoshinMonitorScaleColorPage extends HookWidget {
     void onConvert() {
       final val = double.tryParse(inputText.value);
       if (val == null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('入力値が数値ではありません: ${inputText.value}')),
+        AdaptiveSnackBar.show(
+          context,
+          message: '入力値が数値ではありません: ${inputText.value}',
         );
         return;
       }

--- a/app/lib/feature/settings/features/display_settings/color_scheme/color_scheme_config_page.dart
+++ b/app/lib/feature/settings/features/display_settings/color_scheme/color_scheme_config_page.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+
 import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
@@ -19,21 +21,19 @@ class ColorSchemeConfigPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(intensityColorProvider);
-    final messenger = ScaffoldMessenger.of(context);
 
     Future<void> importFromJsonText(String text) async {
       final result = await ref
           .read(intensityColorProvider.notifier)
           .importFromJsonString(text);
+      if (!context.mounted) {
+        return;
+      }
       switch (result) {
         case Success<void, IntensityColorImportException>():
-          messenger.showSnackBar(
-            const SnackBar(content: Text('震度配色をインポートしました')),
-          );
+          AdaptiveSnackBar.show(context, message: '震度配色をインポートしました');
         case Failure<void, IntensityColorImportException>():
-          messenger.showSnackBar(
-            SnackBar(content: Text(result.exception.message)),
-          );
+          AdaptiveSnackBar.show(context, message: result.exception.message);
       }
     }
 
@@ -136,10 +136,12 @@ class ColorSchemeConfigPage extends HookConsumerWidget {
                               .read(intensityColorProvider.notifier)
                               .exportAsJsonString();
                           await Clipboard.setData(ClipboardData(text: json));
-                          messenger.showSnackBar(
-                            const SnackBar(
-                              content: Text('JSONをクリップボードにコピーしました'),
-                            ),
+                          if (!context.mounted) {
+                            return;
+                          }
+                          AdaptiveSnackBar.show(
+                            context,
+                            message: 'JSONをクリップボードにコピーしました',
                           );
                         },
                         child: const Text('クリップボードへエクスポート'),
@@ -159,8 +161,12 @@ class ColorSchemeConfigPage extends HookConsumerWidget {
                               .read(intensityColorProvider.notifier)
                               .exportAsJsonString();
                           await File(path).writeAsString(json);
-                          messenger.showSnackBar(
-                            const SnackBar(content: Text('JSONを保存しました')),
+                          if (!context.mounted) {
+                            return;
+                          }
+                          AdaptiveSnackBar.show(
+                            context,
+                            message: 'JSONを保存しました',
                           );
                         },
                         child: const Text('ファイルへエクスポート'),
@@ -170,12 +176,14 @@ class ColorSchemeConfigPage extends HookConsumerWidget {
                           final data = await Clipboard.getData(
                             Clipboard.kTextPlain,
                           );
+                          if (!context.mounted) {
+                            return;
+                          }
                           final text = data?.text;
                           if (text == null || text.isEmpty) {
-                            messenger.showSnackBar(
-                              const SnackBar(
-                                content: Text('クリップボードにJSON文字列がありません'),
-                              ),
+                            AdaptiveSnackBar.show(
+                              context,
+                              message: 'クリップボードにJSON文字列がありません',
                             );
                             return;
                           }
@@ -190,6 +198,9 @@ class ColorSchemeConfigPage extends HookConsumerWidget {
                             allowedExtensions: const ['json'],
                             withData: true,
                           );
+                          if (!context.mounted) {
+                            return;
+                          }
                           final files = result?.files;
                           if (files == null || files.isEmpty) {
                             return;
@@ -202,10 +213,9 @@ class ColorSchemeConfigPage extends HookConsumerWidget {
                           }
                           final path = file.path;
                           if (path == null) {
-                            messenger.showSnackBar(
-                              const SnackBar(
-                                content: Text('ファイルの読み込みに失敗しました'),
-                              ),
+                            AdaptiveSnackBar.show(
+                              context,
+                              message: 'ファイルの読み込みに失敗しました',
                             );
                             return;
                           }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/earthquake_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/earthquake_settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
@@ -203,11 +204,10 @@ class _RegionsSection extends ConsumerWidget {
       next,
     ) {
       if (next is MutationError) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('地域の更新に失敗しました: ${next.error}'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
+        AdaptiveSnackBar.show(
+          context,
+          message: '地域の更新に失敗しました: ${next.error}',
+          type: AdaptiveSnackBarType.error,
         );
       }
     });
@@ -244,7 +244,9 @@ class _RegionsSection extends ConsumerWidget {
                       ref,
                       (tsx) async {
                         await tsx
-                            .get(earthquakeNotificationSettingsProvider.notifier)
+                            .get(
+                              earthquakeNotificationSettingsProvider.notifier,
+                            )
                             .removeRegion(
                               regionId: region.regionId,
                               isCurrentLocation: region.isCurrentLocation,
@@ -271,7 +273,10 @@ class _RegionsSection extends ConsumerWidget {
                                 ref,
                                 (tsx) async {
                                   await tsx
-                                      .get(earthquakeNotificationSettingsProvider.notifier)
+                                      .get(
+                                        earthquakeNotificationSettingsProvider
+                                            .notifier,
+                                      )
                                       .addCurrentLocationRegion();
                                 },
                               ),
@@ -305,7 +310,10 @@ class _RegionsSection extends ConsumerWidget {
                                 ref,
                                 (tsx) async {
                                   await tsx
-                                      .get(earthquakeNotificationSettingsProvider.notifier)
+                                      .get(
+                                        earthquakeNotificationSettingsProvider
+                                            .notifier,
+                                      )
                                       .addRegion(
                                         regionId: result.regionId,
                                         regionName: result.regionName,

--- a/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/location/data/jma_region_resolver.dart';
@@ -38,7 +39,8 @@ class _Body extends ConsumerWidget {
       );
     }
 
-    final settings = settingsAsync.value ??
+    final settings =
+        settingsAsync.value ??
         const EewNotificationSettings(
           enabled: true,
           criticalThreshold: null,
@@ -171,7 +173,9 @@ class _LiveActivitySection extends ConsumerWidget {
           ? null
           : (value) {
               unawaited(
-                EewSettingsNotifier.saveLiveActivityMutation.run(ref, (tsx) async {
+                EewSettingsNotifier.saveLiveActivityMutation.run(ref, (
+                  tsx,
+                ) async {
                   await tsx
                       .get(eewSettingsProvider.notifier)
                       .setStartLiveActivity(startLiveActivity: value);
@@ -220,11 +224,10 @@ class _RegionsSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listen(EewSettingsNotifier.updateRegionsMutation, (_, next) {
       if (next is MutationError) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('地域の更新に失敗しました: ${next.error}'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
+        AdaptiveSnackBar.show(
+          context,
+          message: '地域の更新に失敗しました: ${next.error}',
+          type: AdaptiveSnackBarType.error,
         );
       }
     });
@@ -256,10 +259,12 @@ class _RegionsSection extends ConsumerWidget {
             onDelete: () {
               unawaited(
                 EewSettingsNotifier.updateRegionsMutation.run(ref, (tsx) async {
-                  await tsx.get(eewSettingsProvider.notifier).removeRegion(
-                    regionId: region.regionId,
-                    isCurrentLocation: region.isCurrentLocation,
-                  );
+                  await tsx
+                      .get(eewSettingsProvider.notifier)
+                      .removeRegion(
+                        regionId: region.regionId,
+                        isCurrentLocation: region.isCurrentLocation,
+                      );
                 }),
               );
             },
@@ -274,8 +279,9 @@ class _RegionsSection extends ConsumerWidget {
                 onPressed: isBusy || hasCurrentLocation
                     ? null
                     : () async {
-                        final location =
-                            await _ensurePermissionAndGetLocation(context);
+                        final location = await _ensurePermissionAndGetLocation(
+                          context,
+                        );
                         if (location == null || !context.mounted) {
                           return;
                         }
@@ -294,10 +300,9 @@ class _RegionsSection extends ConsumerWidget {
                           return;
                         }
                         if (code == null) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('現在地のJMA細分区域を解決できませんでした'),
-                            ),
+                          AdaptiveSnackBar.show(
+                            context,
+                            message: '現在地のJMA細分区域を解決できませんでした',
                           );
                           return;
                         }
@@ -446,9 +451,7 @@ Future<({double lat, double lon})?> _ensurePermissionAndGetLocation(
     return (lat: position.latitude, lon: position.longitude);
   } on Object {
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('現在地の取得に失敗しました')),
-      );
+      AdaptiveSnackBar.show(context, message: '現在地の取得に失敗しました');
     }
     return null;
   }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:app_settings/app_settings.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
@@ -41,7 +42,8 @@ class _Body extends ConsumerWidget {
         children: [
           const SettingsSectionHeader(text: '全般'),
           _GeneralSettingsSection(
-            settings: settingsAsync.value ??
+            settings:
+                settingsAsync.value ??
                 const GeneralNotificationSettings(
                   tsunamiEnabled: true,
                   trainingEnabled: false,
@@ -169,7 +171,6 @@ class _TestNotificationTile extends HookConsumerWidget {
 
     Future<void> send(TestNotificationKind kind) async {
       pendingKind.value = kind;
-      final messenger = ScaffoldMessenger.of(context);
       final deviceId = await ref.read(deviceIdProvider.future);
       final repo = await ref.read(pushNotificationRepositoryProvider.future);
       final result = await repo.sendTestNotification(
@@ -182,19 +183,16 @@ class _TestNotificationTile extends HookConsumerWidget {
       pendingKind.value = null;
       switch (result) {
         case Success(:final value):
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text(
+          AdaptiveSnackBar.show(
+            context,
+            message:
                 '送信しました（${value.framework.displayLabel}）: ${value.message}',
-              ),
-            ),
           );
         case Failure(:final exception):
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text('送信に失敗しました: $exception'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
+          AdaptiveSnackBar.show(
+            context,
+            message: '送信に失敗しました: $exception',
+            type: AdaptiveSnackBarType.error,
           );
       }
     }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/shake_detection_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
@@ -33,29 +34,28 @@ class _Body extends ConsumerWidget {
       );
     }
 
-    final state = stateAsync.value ??
+    final state =
+        stateAsync.value ??
         const (entries: <ShakeDetectionEntry>[], availableSubRegions: []);
 
     ref.listen(
       ShakeDetectionSettingsNotifier.addCurrentLocationMutation,
       (_, next) {
         if (next is MutationError) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('現在地の追加に失敗しました: ${next.error}'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
+          AdaptiveSnackBar.show(
+            context,
+            message: '現在地の追加に失敗しました: ${next.error}',
+            type: AdaptiveSnackBarType.error,
           );
         }
       },
     );
     ref.listen(ShakeDetectionSettingsNotifier.removeEntryMutation, (_, next) {
       if (next is MutationError) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('地域の削除に失敗しました: ${next.error}'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
+        AdaptiveSnackBar.show(
+          context,
+          message: '地域の削除に失敗しました: ${next.error}',
+          type: AdaptiveSnackBarType.error,
         );
       }
     });
@@ -68,7 +68,8 @@ class _Body extends ConsumerWidget {
     final updateState = ref.watch(
       ShakeDetectionSettingsNotifier.updateLevelMutation,
     );
-    final isBusy = addState is MutationPending ||
+    final isBusy =
+        addState is MutationPending ||
         removeState is MutationPending ||
         updateState is MutationPending;
 
@@ -129,18 +130,17 @@ class _Body extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: FilledButton.tonal(
-              onPressed: isBusy ||
-                      state.entries.any((e) => e.isCurrentLocation)
+              onPressed: isBusy || state.entries.any((e) => e.isCurrentLocation)
                   ? null
                   : () {
                       unawaited(
                         ShakeDetectionSettingsNotifier
                             .addCurrentLocationMutation
                             .run(ref, (tsx) async {
-                          await tsx
-                              .get(shakeDetectionSettingsProvider.notifier)
-                              .addCurrentLocation();
-                        }),
+                              await tsx
+                                  .get(shakeDetectionSettingsProvider.notifier)
+                                  .addCurrentLocation();
+                            }),
                       );
                     },
               child: isBusy

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -46,6 +46,7 @@ dependency_overrides:
       path: packages/maplibre_webview
 
 dependencies:
+  adaptive_platform_ui: ^0.1.107
   app_settings: ^7.0.0
   background_location_tracker:
     path: ../packages/background_location_tracker

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.69"
+  adaptive_platform_ui:
+    dependency: transitive
+    description:
+      name: adaptive_platform_ui
+      sha256: "72ebe76218ea43b6bef370f1daaf6f80f4abe75f4a7b75e10f1392c13a9f1ce4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.107"
   altive_lints:
     dependency: transitive
     description:


### PR DESCRIPTION
## 概要

DESIGN.md の以下のルールに準拠するための修正です (Issue #1179 の部分対応)。

> 一時的な通知は `SnackBar` を直接使わず、原則として `AdaptiveSnackBar` を利用する。

## 変更内容

### `adaptive_platform_ui: ^0.1.107` を pubspec.yaml に追加

### SnackBar → AdaptiveSnackBar 置換 (15ファイル)

| ファイル | 変更数 |
|---|---|
| `core/extension/async_value.dart` | 1 |
| `feature/devices/ui/page/debug_device_settings_page.dart` | 5 |
| `feature/earthquake_history/.../earthquake_history_search_parameter_modal.dart` | 2 |
| `feature/earthquake_replay/ui/earthquake_replay_page.dart` | 2 |
| `feature/settings/.../debug_app_group_action.dart` | 1 |
| `feature/settings/.../debug_page.dart` | 4 |
| `feature/settings/.../debug_device_admin_page.dart` | 6 |
| `feature/settings/.../debug_jma_map_page.dart` | 2 |
| `feature/settings/.../debug_notification_delivery_log_page.dart` | 2 |
| `feature/settings/.../playground_page.dart` | 1 |
| `feature/settings/.../color_scheme_config_page.dart` | 5 |
| `feature/settings/.../earthquake_settings_page.dart` | 1 |
| `feature/settings/.../eew_settings_page.dart` | 3 |
| `feature/settings/.../notification_settings_page.dart` | 2 |
| `feature/settings/.../shake_detection_settings_page.dart` | 2 |

### 変換パターン

```dart
// Before
ScaffoldMessenger.of(context).showSnackBar(
  const SnackBar(content: Text('メッセージ')),
);

// After
AdaptiveSnackBar.show(context, message: 'メッセージ');
```

iOS ではトップバナー、Android では Material SnackBar として自動分岐します。

## 対象外 (次のPR)

`AlertDialog.adaptive` → `AdaptiveAlertDialog` の移行は、`showDialog<T>` で戻り値を
持つパターンが多く API 差異が大きいため、Issue #1179 で段階対応とします。

## 検証

- [x] `flutter analyze` → No issues found!
- [x] `dart fix --apply` → Nothing to fix!

🤖 Generated with [Claude Code](https://claude.com/claude-code)