### PR TITLE
fix: unawaited() を async/await に置換 (debug_replay_modal, earthquake_history_details_map_view)

### DIFF
--- a/app/lib/feature/debug/replay/debug_replay_modal.dart
+++ b/app/lib/feature/debug/replay/debug_replay_modal.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/debug/replay/debug_replay_provider.dart';
 import 'package:flutter/material.dart';
@@ -10,13 +8,11 @@ const _kNotoScenarioPath = 'assets/debug/eew/noto_peninsula_20240101';
 class DebugReplayModal extends ConsumerWidget {
   const DebugReplayModal({super.key});
 
-  static void show(BuildContext context) {
-    unawaited(
-      showModalBottomSheet<void>(
-        context: context,
-        isScrollControlled: true,
-        builder: (_) => const DebugReplayModal(),
-      ),
+  static Future<void> show(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const DebugReplayModal(),
     );
   }
 

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:eqmonitor/core/component/error/error_card.dart';
@@ -83,7 +82,7 @@ class _MapContent extends HookConsumerWidget {
     ref.listen(earthquakeHistoryMapFocusProvider(earthquake.eventId), (
       _,
       next,
-    ) {
+    ) async {
       if (next == null) {
         return;
       }
@@ -98,11 +97,9 @@ class _MapContent extends HookConsumerWidget {
       if (geo == null) {
         return;
       }
-      unawaited(
-        controller.animateCamera(
-          center: geo,
-          zoom: kEarthquakeHistoryMapFocusZoom,
-        ),
+      await controller.animateCamera(
+        center: geo,
+        zoom: kEarthquakeHistoryMapFocusZoom,
       );
       ref
           .read(earthquakeHistoryMapFocusProvider(earthquake.eventId).notifier)
@@ -124,24 +121,14 @@ class _MapContent extends HookConsumerWidget {
     );
     const debugDialogAction = EarthquakeHistoryMapLayerDebugDialogAction();
 
-    void openModal(BuildContext ctx) {
-      unawaited(
-        EarthquakeHistoryMapDisplayModeModal.show(
-          context: ctx,
-          hasLpgmIntensity: earthquake.intensity?.maxLpgmIntensity != null,
-          hasTileUrl: tileUrl != null,
-        ),
-      );
-    }
-
     return Stack(
       children: [
         MapLibreMap(
           options: mapOptions,
-          onEvent: (event) {
+          onEvent: (event) async {
             MapLibreEventProvider.of(context).emit(event);
             if (event is MapEventClick) {
-              _handleTap(
+              await _handleTap(
                 context: context,
                 event: event,
                 config: config,
@@ -195,16 +182,25 @@ class _MapContent extends HookConsumerWidget {
           right: 8,
           child: SafeArea(
             child: _MapControllerCard(
-              onLayersTap: () => openModal(context),
-              onFitBoundsTap: () => _fitBounds(context),
+              onLayersTap: () async {
+                await EarthquakeHistoryMapDisplayModeModal.show(
+                  context: context,
+                  hasLpgmIntensity:
+                      earthquake.intensity?.maxLpgmIntensity != null,
+                  hasTileUrl: tileUrl != null,
+                );
+              },
+              onFitBoundsTap: () async {
+                await _fitBounds(context);
+              },
               onDebugTap: kDebugMode
-                  ? () => unawaited(
-                      debugDialogAction.show(
+                  ? () async {
+                      await debugDialogAction.show(
                         context: context,
                         earthquake: earthquake,
                         config: config,
-                      ),
-                    )
+                      );
+                    }
                   : null,
             ),
           ),
@@ -226,12 +222,12 @@ class _MapContent extends HookConsumerWidget {
     );
   }
 
-  void _handleTap({
+  Future<void> _handleTap({
     required BuildContext context,
     required MapEventClick event,
     required EarthquakeHistoryDetailConfig config,
     required Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
-  }) {
+  }) async {
     final controller = MapController.maybeOf(context);
     if (controller == null) {
       return;
@@ -248,13 +244,11 @@ class _MapContent extends HookConsumerWidget {
       if (stationNode == null) {
         return;
       }
-      unawaited(
-        showStationPopup(
-          context,
-          stationName: stationNode.station.name.ja,
-          intensity: stationNode.intensity?.maxIntensity,
-          lpgmIntensity: stationNode.intensity?.maxLpgmIntensity,
-        ),
+      await showStationPopup(
+        context,
+        stationName: stationNode.station.name.ja,
+        intensity: stationNode.intensity?.maxIntensity,
+        lpgmIntensity: stationNode.intensity?.maxLpgmIntensity,
       );
       return;
     }
@@ -280,21 +274,17 @@ class _MapContent extends HookConsumerWidget {
 
     if (isCity) {
       final cityNode = _findCityByCode(code);
-      unawaited(
-        showAreaPopup(
-          context,
-          areaName: name,
-          maxIntensity: cityNode?.maxIntensity,
-        ),
+      await showAreaPopup(
+        context,
+        areaName: name,
+        maxIntensity: cityNode?.maxIntensity,
       );
     } else {
       final region = _findRegionByCode(code);
-      unawaited(
-        showAreaPopup(
-          context,
-          areaName: name,
-          maxIntensity: region?.maxIntensity,
-        ),
+      await showAreaPopup(
+        context,
+        areaName: name,
+        maxIntensity: region?.maxIntensity,
       );
     }
   }
@@ -360,7 +350,7 @@ class _MapContent extends HookConsumerWidget {
     return null;
   }
 
-  void _fitBounds(BuildContext context) {
+  Future<void> _fitBounds(BuildContext context) async {
     final controller = MapController.maybeOf(context);
     if (controller == null) {
       return;
@@ -391,12 +381,10 @@ class _MapContent extends HookConsumerWidget {
       return;
     }
 
-    unawaited(
-      controller.fitBounds(
-        bounds: LngLatBounds.fromPoints(points),
-        padding: const EdgeInsets.all(48),
-        webMaxZoom: 10,
-      ),
+    await controller.fitBounds(
+      bounds: LngLatBounds.fromPoints(points),
+      padding: const EdgeInsets.all(48),
+      webMaxZoom: 10,
     );
   }
 }
@@ -409,9 +397,9 @@ class _MapControllerCard extends StatelessWidget {
     required this.onDebugTap,
   });
 
-  final VoidCallback onLayersTap;
-  final VoidCallback onFitBoundsTap;
-  final VoidCallback? onDebugTap;
+  final Future<void> Function() onLayersTap;
+  final Future<void> Function() onFitBoundsTap;
+  final Future<void> Function()? onDebugTap;
 
   @override
   Widget build(BuildContext context) {
@@ -419,10 +407,6 @@ class _MapControllerCard extends StatelessWidget {
     const divider = Padding(
       padding: EdgeInsets.symmetric(horizontal: 4),
       child: Divider(height: 0),
-    );
-
-    void haptic() => unawaited(
-      HapticFeedback.lightImpact(),
     );
 
     return Card(
@@ -435,9 +419,9 @@ class _MapControllerCard extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             InkWell(
-              onTap: () {
-                haptic();
-                onLayersTap();
+              onTap: () async {
+                await HapticFeedback.lightImpact();
+                await onLayersTap();
               },
               child: const Padding(
                 padding: EdgeInsets.all(8),
@@ -446,9 +430,9 @@ class _MapControllerCard extends StatelessWidget {
             ),
             divider,
             InkWell(
-              onTap: () {
-                haptic();
-                onFitBoundsTap();
+              onTap: () async {
+                await HapticFeedback.lightImpact();
+                await onFitBoundsTap();
               },
               child: const Padding(
                 padding: EdgeInsets.all(8),
@@ -458,9 +442,9 @@ class _MapControllerCard extends StatelessWidget {
             if (onDebugTap != null) ...[
               divider,
               InkWell(
-                onTap: () {
-                  haptic();
-                  onDebugTap?.call();
+                onTap: () async {
+                  await HapticFeedback.lightImpact();
+                  await onDebugTap?.call();
                 },
                 child: const Padding(
                   padding: EdgeInsets.all(8),


### PR DESCRIPTION
## 概要

PR #1186 に続く `unawaited()` 修正の第2弾。flutter-rules.mdc のルールに従い、残る UI コールバック・private メソッドの `unawaited()` を `async/await` に変換。

## 変更内容

### `debug_replay_modal.dart`

```dart
// Before
static void show(BuildContext context) {
  unawaited(showModalBottomSheet<void>(...));
}

// After
static Future<void> show(BuildContext context) async {
  await showModalBottomSheet<void>(...);
}
```

### `earthquake_history_details_map_view.dart`

| 変更箇所 | Before | After |
|---|---|---|
| `ref.listen` コールバック | `void` + `unawaited(controller.animateCamera(...))` | `async` + `await controller.animateCamera(...)` |
| `_handleTap` | `void` + `unawaited(showStationPopup/showAreaPopup)` | `Future<void>` + `await` |
| `_fitBounds` | `void` + `unawaited(controller.fitBounds(...))` | `Future<void>` + `await` |
| `openModal` ローカル関数 | `void` + `unawaited(...)` | 廃止し呼び出し箇所でインライン `async` 化 |
| `_MapControllerCard` コールバック型 | `VoidCallback` | `Future<void> Function()` |
| 各 `InkWell.onTap` | `() { haptic(); onXxx(); }` | `() async { await HapticFeedback.lightImpact(); await onXxx(); }` |
| `haptic()` ローカル関数 | `void haptic() => unawaited(...)` | 廃止し各 onTap でインライン化 |

## 検証

- [x] `flutter analyze` → No issues found!
- [x] `dart fix --apply` → Nothing to fix!

🤖 Generated with [Claude Code](https://claude.com/claude-code)