### PR TITLE
fix: AlertDialog を AdaptiveAlertDialog.show に統一

### DIFF
--- a/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
+++ b/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
@@ -1,4 +1,4 @@
-import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/provider/app_group_preferences.dart';
 import 'package:eqmonitor/core/provider/app_group_settings_writer.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/app_group/app_group_values_provider.dart';
@@ -14,34 +14,26 @@ DebugAppGroupAction debugAppGroupAction(Ref ref) => DebugAppGroupAction();
 class DebugAppGroupAction {
   Future<void> editApiServerUrl(WidgetRef ref, BuildContext context) async {
     final current = ref.read(appGroupValuesProvider).value?.apiServerUrl;
-    final controller = TextEditingController(text: current ?? '');
-    final result = await showDialog<String>(
+    final result = await AdaptiveAlertDialog.inputShow(
       context: context,
-      builder: (context) => AlertDialog.adaptive(
-        title: const Text('apiServerUrl を編集'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          style: const TextStyle(fontFamily: FontFamily.notoSansMono),
-          decoration: const InputDecoration(
-            hintText: 'https://v2.api.eqmonitor.app',
-            border: OutlineInputBorder(),
-          ),
-          keyboardType: TextInputType.url,
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('キャンセル'),
-          ),
-          FilledButton(
-            onPressed: () {
-              Navigator.of(context).pop(controller.text.trim());
-            },
-            child: const Text('保存'),
-          ),
-        ],
+      title: 'apiServerUrl を編集',
+      input: AdaptiveAlertDialogInput(
+        placeholder: 'https://v2.api.eqmonitor.app',
+        initialValue: current ?? '',
+        keyboardType: TextInputType.url,
       ),
+      actions: [
+        AlertAction(
+          title: 'キャンセル',
+          style: AlertActionStyle.cancel,
+          onPressed: () {},
+        ),
+        AlertAction(
+          title: '保存',
+          style: AlertActionStyle.primary,
+          onPressed: () {},
+        ),
+      ],
     );
     if (result == null) {
       return;

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
@@ -185,30 +186,23 @@ class _Body extends HookConsumerWidget {
 
     Future<void> deleteDevice() async {
       var confirmed = false;
-      await showAdaptiveDialog<void>(
+      await AdaptiveAlertDialog.show(
         context: context,
-        builder: (context) => AlertDialog.adaptive(
-          title: const Text('デバイスを削除'),
-          content: const Text(
+        title: 'デバイスを削除',
+        message:
             'この端末 ID に紐づくサーバー上のデバイスと関連データを削除します。よろしいですか？',
+        actions: [
+          AlertAction(
+            title: 'キャンセル',
+            style: AlertActionStyle.cancel,
+            onPressed: () {},
           ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('キャンセル'),
-            ),
-            TextButton(
-              onPressed: () {
-                confirmed = true;
-                Navigator.of(context).pop();
-              },
-              style: TextButton.styleFrom(
-                foregroundColor: Theme.of(context).colorScheme.error,
-              ),
-              child: const Text('削除'),
-            ),
-          ],
-        ),
+          AlertAction(
+            title: '削除',
+            style: AlertActionStyle.destructive,
+            onPressed: () => confirmed = true,
+          ),
+        ],
       );
       if (!confirmed || !context.mounted) {
         return;

--- a/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/location/data/jma_region_resolver.dart';
@@ -376,27 +377,25 @@ Future<({double lat, double lon})?> _ensurePermissionAndGetLocation(
     if (!context.mounted) {
       return null;
     }
-    final shouldOpen = await showDialog<bool>(
+    var shouldOpen = false;
+    await AdaptiveAlertDialog.show(
       context: context,
-      builder: (dialogContext) => AlertDialog.adaptive(
-        title: const Text('位置情報の許可が必要です'),
-        content: const Text(
-          'EEWの現在地通知には、位置情報の「常に許可」が必要です。\n'
+      title: '位置情報の許可が必要です',
+      message: 'EEWの現在地通知には、位置情報の「常に許可」が必要です。\n'
           '設定アプリで権限を変更してください。',
+      actions: [
+        AlertAction(
+          title: 'キャンセル',
+          style: AlertActionStyle.cancel,
+          onPressed: () {},
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('キャンセル'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('設定を開く'),
-          ),
-        ],
-      ),
+        AlertAction(
+          title: '設定を開く',
+          onPressed: () => shouldOpen = true,
+        ),
+      ],
     );
-    if (shouldOpen ?? false) {
+    if (shouldOpen) {
       await Geolocator.openAppSettings();
     }
     return null;
@@ -408,28 +407,27 @@ Future<({double lat, double lon})?> _ensurePermissionAndGetLocation(
     if (!context.mounted) {
       return null;
     }
-    final shouldOpen = await showDialog<bool>(
+    var shouldOpenSettings = false;
+    await AdaptiveAlertDialog.show(
       context: context,
-      builder: (dialogContext) => AlertDialog.adaptive(
-        title: const Text('「常に許可」への変更をお願いします'),
-        content: const Text(
+      title: '「常に許可」への変更をお願いします',
+      message:
           'バックグラウンドでも位置情報を更新するには、'
           '位置情報の許可を「常に許可」に変更する必要があります。\n'
           '設定アプリで「位置情報」→「常に許可」を選択してください。',
+      actions: [
+        AlertAction(
+          title: '後で',
+          style: AlertActionStyle.cancel,
+          onPressed: () {},
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: const Text('後で'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            child: const Text('設定を開く'),
-          ),
-        ],
-      ),
+        AlertAction(
+          title: '設定を開く',
+          onPressed: () => shouldOpenSettings = true,
+        ),
+      ],
     );
-    if (shouldOpen ?? false) {
+    if (shouldOpenSettings) {
       await Geolocator.openAppSettings();
       // 設定アプリから戻るまで待つ（ユーザーが変更した場合に備えて）
       return null;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -46,6 +46,7 @@ dependency_overrides:
       path: packages/maplibre_webview
 
 dependencies:
+  adaptive_platform_ui: ^0.1.107
   app_settings: ^7.0.0
   background_location_tracker:
     path: ../packages/background_location_tracker

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.69"
+  adaptive_platform_ui:
+    dependency: transitive
+    description:
+      name: adaptive_platform_ui
+      sha256: "72ebe76218ea43b6bef370f1daaf6f80f4abe75f4a7b75e10f1392c13a9f1ce4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.107"
   altive_lints:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- `showDialog<bool>` / `showAdaptiveDialog<void>` を `AdaptiveAlertDialog.show` に置き換え（`adaptive_platform_ui` パッケージ使用）
- クロージャ変数パターン（`var shouldOpen = false; await AdaptiveAlertDialog.show(..., onPressed: () => shouldOpen = true);`）で戻り値を取り出す実装に統一
- `debug_app_group_action.dart`: テキスト入力ダイアログを `AdaptiveAlertDialog.inputShow` に移行

対象ファイル:
- `app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart`
- `app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart`
- `app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart`

Closes #1179

## Test plan

- [ ] `dart analyze` → No issues found
- [ ] `dart fix --apply` → Nothing to fix
- [ ] EEW 設定画面で「現在地を追加」ボタン押下 → 位置情報ダイアログが表示される
- [ ] デバイス管理画面で「削除」ボタン押下 → 確認ダイアログが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)