### PR TITLE
fix: unsafe な ! 演算子を null-safe な実装に置き換え

### DIFF
--- a/app/lib/core/component/intenisty/jma_lpgm_intensity_icon.dart
+++ b/app/lib/core/component/intenisty/jma_lpgm_intensity_icon.dart
@@ -26,7 +26,7 @@ class JmaLpgmIntensityIcon extends ConsumerWidget {
     final colorScheme = intensityColorModel.fromJmaLpgmIntensity(intensity);
     final (fg, bg) = (colorScheme.foreground, colorScheme.background);
 
-    final borderColor = Color.lerp(bg, fg, 0.3)!;
+    final borderColor = Color.lerp(bg, fg, 0.3) ?? bg;
     return switch (type) {
       .small => SizedBox(
         height: size,

--- a/app/lib/core/component/selector/city_selector.dart
+++ b/app/lib/core/component/selector/city_selector.dart
@@ -93,8 +93,8 @@ class _CitySelectionBody extends HookWidget {
             ),
           ],
         ),
-        if (selectedPrefectureCode.value != null &&
-            selectedPrefectureCode.value!.isNotEmpty) ...[
+        if (selectedPrefectureCode.value case final prefCode?
+            when prefCode.isNotEmpty) ...[
           const SizedBox(height: 12),
           Text(
             '市区町村',
@@ -104,7 +104,7 @@ class _CitySelectionBody extends HookWidget {
           ),
           const SizedBox(height: 4),
           _CityDropdown(
-            prefectureCode: selectedPrefectureCode.value!,
+            prefectureCode: prefCode,
             selectedCode: selectedCode,
             regions: allRegions,
             prefectures: prefectures,

--- a/app/lib/core/component/widget/app_empty_state.dart
+++ b/app/lib/core/component/widget/app_empty_state.dart
@@ -33,10 +33,10 @@ class AppEmptyState extends StatelessWidget {
               style: designSystem.typography.titleSmall,
               textAlign: TextAlign.center,
             ),
-            if (description != null) ...[
+            if (description case final description?) ...[
               SizedBox(height: designSystem.spacing.xs),
               Text(
-                description!,
+                description,
                 style: designSystem.typography.bodySmall.copyWith(
                   color: designSystem.textColor.secondary,
                 ),

--- a/app/lib/core/extension/async_value.dart
+++ b/app/lib/core/extension/async_value.dart
@@ -54,7 +54,7 @@ extension AsyncValueX<T> on AsyncValue<T> {
     if (!isLoading && hasError) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text(error!.toString())));
+      ).showSnackBar(SnackBar(content: Text(error?.toString() ?? 'エラーが発生しました')));
     }
   }
 }

--- a/app/lib/core/provider/ntp/ntp_config_provider.dart
+++ b/app/lib/core/provider/ntp/ntp_config_provider.dart
@@ -32,20 +32,23 @@ class NtpConfig extends _$NtpConfig {
 
   Future<void> changeLookUpAddress(String url) async {
     final current = state.value ?? const NtpConfigModel();
-    state = AsyncValue.data(current.copyWith(lookUpAddress: url));
-    await _save(state.value!);
+    final updated = current.copyWith(lookUpAddress: url);
+    state = AsyncValue.data(updated);
+    await _save(updated);
   }
 
   Future<void> changeTimeout(Duration timeout) async {
     final current = state.value ?? const NtpConfigModel();
-    state = AsyncValue.data(current.copyWith(timeout: timeout));
-    await _save(state.value!);
+    final updated = current.copyWith(timeout: timeout);
+    state = AsyncValue.data(updated);
+    await _save(updated);
   }
 
   Future<void> changeInterval(Duration interval) async {
     final current = state.value ?? const NtpConfigModel();
-    state = AsyncValue.data(current.copyWith(interval: interval));
-    await _save(state.value!);
+    final updated = current.copyWith(interval: interval);
+    state = AsyncValue.data(updated);
+    await _save(updated);
   }
 
   Future<void> _save(NtpConfigModel config) async {

--- a/app/lib/page/splash_page.dart
+++ b/app/lib/page/splash_page.dart
@@ -44,7 +44,7 @@ class SplashPage extends HookConsumerWidget {
       body: SafeArea(
         child: hasError
             ? ErrorCard(
-                error: error!,
+                error: error ?? Exception('Unknown error'),
                 onReload: () async {
                   ref.invalidate(parameterSetProvider);
                   ref.invalidate(travelTimeInternalProvider);


### PR DESCRIPTION
## Summary

flutter-rules.mdc の指針（! 演算子の使用禁止）に従い、null-safe でない実装を安全なコードに置き換え。

### 変更内容

- `lib/page/splash_page.dart`: error! → error ?? Exception('Unknown error')
- `lib/core/extension/async_value.dart`: error!.toString() → error?.toString() ?? '...'
- `lib/core/provider/ntp/ntp_config_provider.dart`: state.value! → ローカル変数に抽出して再利用
- `lib/core/component/widget/app_empty_state.dart`: description! → パターンマッチング (case final x?)
- `lib/core/component/selector/city_selector.dart`: selectedPrefectureCode.value! → パターンマッチング
- `lib/core/component/intenisty/jma_lpgm_intensity_icon.dart`: Color.lerp(...)! → ?? bg フォールバック

残存する ! 演算子（フロー解析で安全が証明できないもの）は Issue #1180 に記録済み。

## Test plan

- [ ] dart analyze → No issues found
- [ ] dart fix --apply → Nothing to fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)