### PR TITLE
refactor: top-level プライベート関数を廃止

### DIFF
--- a/app/lib/core/component/chip/status_filter_chip.dart
+++ b/app/lib/core/component/chip/status_filter_chip.dart
@@ -16,16 +16,19 @@ class StatusFilterChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final currentStatuses = statuses;
     final isDefault =
-        statuses == null ||
-        (statuses!.length == 1 && statuses!.first == TelegramStatus.normal);
+        currentStatuses == null ||
+        (currentStatuses.length == 1 &&
+            currentStatuses.first == TelegramStatus.normal);
 
     return RawChip(
       onSelected: (_) async {
         final result = await showModalBottomSheet<List<TelegramStatus>?>(
           clipBehavior: Clip.antiAlias,
           context: context,
-          builder: (context) => _StatusFilterModal(currentStatuses: statuses),
+          builder: (context) =>
+              _StatusFilterModal(currentStatuses: currentStatuses),
         );
         if (result != null) {
           onChanged?.call(result);
@@ -34,7 +37,9 @@ class StatusFilterChip extends StatelessWidget {
       label: isDefault
           ? const Text('ステータス')
           : Text(
-              _statusesToString(statuses!),
+              currentStatuses.length == TelegramStatus.values.length
+                  ? '全て'
+                  : currentStatuses.map((s) => s.label).join(', '),
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
       onDeleted: isDefault ? null : () => onChanged?.call(initialStatuses),
@@ -42,29 +47,6 @@ class StatusFilterChip extends StatelessWidget {
       selectedColor: Theme.of(context).colorScheme.secondaryContainer,
     );
   }
-}
-
-String _statusesToString(List<TelegramStatus> statuses) {
-  if (statuses.length == TelegramStatus.values.length) {
-    return '全て';
-  }
-  return statuses.map(_statusToJapanese).join(', ');
-}
-
-String _statusToJapanese(TelegramStatus status) {
-  return switch (status) {
-    TelegramStatus.normal => '通常',
-    TelegramStatus.training => '訓練',
-    TelegramStatus.test => '試験',
-  };
-}
-
-String _statusDescription(TelegramStatus status) {
-  return switch (status) {
-    TelegramStatus.normal => '通常発表された地震情報',
-    TelegramStatus.training => '訓練用の地震情報',
-    TelegramStatus.test => '試験用の地震情報',
-  };
 }
 
 class _StatusFilterModal extends HookWidget {
@@ -111,8 +93,8 @@ class _StatusFilterModal extends HookWidget {
           const SizedBox(height: 8),
           ...TelegramStatus.values.map(
             (status) => CheckboxListTile(
-              title: Text(_statusToJapanese(status)),
-              subtitle: Text(_statusDescription(status)),
+              title: Text(status.label),
+              subtitle: Text(status.description),
               value: selectedStatuses.value.contains(status),
               onChanged: (checked) {
                 final newSet = Set<TelegramStatus>.from(selectedStatuses.value);
@@ -149,4 +131,18 @@ class _StatusFilterModal extends HookWidget {
       ),
     );
   }
+}
+
+extension on TelegramStatus {
+  String get label => switch (this) {
+    TelegramStatus.normal => '通常',
+    TelegramStatus.training => '訓練',
+    TelegramStatus.test => '試験',
+  };
+
+  String get description => switch (this) {
+    TelegramStatus.normal => '通常発表された地震情報',
+    TelegramStatus.training => '訓練用の地震情報',
+    TelegramStatus.test => '試験用の地震情報',
+  };
 }

--- a/app/lib/feature/devices/data/repository/device_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.dart
@@ -139,6 +139,9 @@ class DeviceRepository {
     );
   });
 
+  static bool _isNotFound(Exception e) =>
+      e is DioException && e.response?.statusCode == 404;
+
   Future<Result<void, Exception>> syncPushTokens({
     required String deviceId,
     required NotificationToken token,
@@ -201,6 +204,3 @@ class DeviceRepository {
     return const Success(null);
   }
 }
-
-bool _isNotFound(Exception e) =>
-    e is DioException && e.response?.statusCode == 404;

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -37,10 +37,11 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
           slivers: [
             switch (sessionAsync) {
               AsyncData(:final value) => _DeviceSettingsSliverList(
-                  snapshot: value,
-                  historyAsync: historyAsync,
-                ),
-              AsyncError(:final error, :final stackTrace) => SliverFillRemaining(
+                snapshot: value,
+                historyAsync: historyAsync,
+              ),
+              AsyncError(:final error, :final stackTrace) =>
+                SliverFillRemaining(
                   child: _LoadErrorBody(
                     message: error.toString(),
                     stackTrace: stackTrace,
@@ -48,8 +49,8 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
                   ),
                 ),
               _ => const SliverFillRemaining(
-                  child: Center(child: CircularProgressIndicator.adaptive()),
-                ),
+                child: Center(child: CircularProgressIndicator.adaptive()),
+              ),
             },
           ],
         ),
@@ -157,17 +158,17 @@ class _DeviceSettingsSliverList extends ConsumerWidget {
             children: [
               _TokenChip(
                 label: 'FCM',
-                isPresent: _hasNonEmptyText(token?.fcmToken),
+                isPresent: (token?.fcmToken ?? '').isNotEmpty,
               ),
               const SizedBox(height: 8),
               _TokenChip(
                 label: 'APNs（通知）',
-                isPresent: _hasNonEmptyText(token?.apnsToken),
+                isPresent: (token?.apnsToken ?? '').isNotEmpty,
               ),
               const SizedBox(height: 8),
               _TokenChip(
                 label: 'Push to Start',
-                isPresent: _hasNonEmptyText(token?.apnsPushToStartToken),
+                isPresent: (token?.apnsPushToStartToken ?? '').isNotEmpty,
               ),
             ],
           ),
@@ -198,7 +199,9 @@ class _NotificationSettingsSection extends HookConsumerWidget {
       }
       isBusy.value = true;
       final messenger = ScaffoldMessenger.of(context);
-      final notificationRepository = await ref.read(pushNotificationRepositoryProvider.future);
+      final notificationRepository = await ref.read(
+        pushNotificationRepositoryProvider.future,
+      );
       final result = await notificationRepository.patchNotificationSettings(
         deviceId: snapshot.deviceId,
         settings: GeneralNotificationSettings(
@@ -289,7 +292,9 @@ class _TestNotificationSection extends HookConsumerWidget {
     Future<void> send(TestNotificationKind kind) async {
       pendingKind.value = kind;
       final messenger = ScaffoldMessenger.of(context);
-      final notificationRepository = await ref.read(pushNotificationRepositoryProvider.future);
+      final notificationRepository = await ref.read(
+        pushNotificationRepositoryProvider.future,
+      );
       final result = await notificationRepository.sendTestNotification(
         deviceId: deviceId,
         kind: kind,
@@ -323,27 +328,30 @@ class _TestNotificationSection extends HookConsumerWidget {
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
-        children: [
-          TestNotificationKind.silent,
-          TestNotificationKind.normal,
-          TestNotificationKind.critical,
-        ].map((kind) {
-          final isPending = pendingKind.value == kind;
-          return FilledButton.tonal(
-            onPressed: pendingKind.value != null && !isPending
-                ? null
-                : () async {
-                    await send(kind);
-                  },
-            child: isPending
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                  )
-                : Text(kind.displayLabel),
-          );
-        }).toList(),
+        children:
+            [
+              TestNotificationKind.silent,
+              TestNotificationKind.normal,
+              TestNotificationKind.critical,
+            ].map((kind) {
+              final isPending = pendingKind.value == kind;
+              return FilledButton.tonal(
+                onPressed: pendingKind.value != null && !isPending
+                    ? null
+                    : () async {
+                        await send(kind);
+                      },
+                child: isPending
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator.adaptive(
+                          strokeWidth: 2,
+                        ),
+                      )
+                    : Text(kind.displayLabel),
+              );
+            }).toList(),
       ),
     );
   }
@@ -367,31 +375,31 @@ class _HistorySection extends ConsumerWidget {
       ),
       child: switch (historyAsync) {
         AsyncData(:final value) when value.isEmpty => Text(
-            '履歴はまだありません',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+          '履歴はまだありません',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),
+        ),
         AsyncData(:final value) => ListView.separated(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: value.length,
-            separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (context, index) {
-              final item = value[index];
-              return _NotificationHistoryTile(item: item);
-            },
-          ),
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: value.length,
+          separatorBuilder: (_, _) => const Divider(height: 1),
+          itemBuilder: (context, index) {
+            final item = value[index];
+            return _NotificationHistoryTile(item: item);
+          },
+        ),
         AsyncError(:final error) => Text(
-            '履歴の取得に失敗: $error',
-            style: TextStyle(color: Theme.of(context).colorScheme.error),
-          ),
+          '履歴の取得に失敗: $error',
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
+        ),
         _ => const Center(
-            child: Padding(
-              padding: EdgeInsets.all(16),
-              child: CircularProgressIndicator.adaptive(),
-            ),
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: CircularProgressIndicator.adaptive(),
           ),
+        ),
       },
     );
   }
@@ -523,8 +531,8 @@ class _KeyValueRow extends StatelessWidget {
             child: Text(
               label,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
           Expanded(
@@ -566,5 +574,3 @@ class _TokenChip extends StatelessWidget {
     );
   }
 }
-
-bool _hasNonEmptyText(String? value) => value != null && value.isNotEmpty;

--- a/app/lib/feature/migration/data/workflow/v3_migration_workflow.dart
+++ b/app/lib/feature/migration/data/workflow/v3_migration_workflow.dart
@@ -41,7 +41,10 @@ Future<void> runV3MigrationWorkflow({
           final result = await repository.getDevice(deviceId);
           return switch (result) {
             Success() => true,
-            Failure(:final exception) when _isNotFound(exception) => false,
+            Failure(:final exception)
+                when exception is DioException &&
+                    exception.response?.statusCode == 404 =>
+              false,
             Failure(:final exception, :final stackTrace) =>
               Error.throwWithStackTrace(
                 exception,
@@ -112,6 +115,3 @@ Future<bool> isV3MigrationComplete(WorkflowPersistence persistence) async {
   );
   return completed;
 }
-
-bool _isNotFound(Exception e) =>
-    e is DioException && e.response?.statusCode == 404;

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -60,7 +60,8 @@ class _DebugDeviceAdminBody extends HookConsumerWidget {
           };
           return (device: value, settings: settings);
         case Failure(:final exception):
-          if (_isNotFound(exception)) {
+          if (exception is DioException &&
+              exception.response?.statusCode == 404) {
             return (device: null, settings: null);
           }
           throw exception;
@@ -463,6 +464,3 @@ class _ErrorBody extends StatelessWidget {
     );
   }
 }
-
-bool _isNotFound(Object e) =>
-    e is DioException && e.response?.statusCode == 404;

--- a/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
+++ b/app/lib/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart
@@ -95,105 +95,105 @@ class DebugNotificationDeliveryLogPage extends HookConsumerWidget {
       ),
       body: switch (ref.watch(deviceIdProvider)) {
         AsyncError(:final error) => Center(child: Text('端末 ID 取得エラー: $error')),
-        AsyncLoading() => const Center(child: CircularProgressIndicator.adaptive()),
+        AsyncLoading() => const Center(
+          child: CircularProgressIndicator.adaptive(),
+        ),
         AsyncData<String>(:final value) => Builder(
-            builder: (context) {
-              if (loading.value && items.value.isEmpty && error.value == null) {
-                return const Center(child: CircularProgressIndicator.adaptive());
-              }
-              if (error.value != null && items.value.isEmpty) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          error.value.toString(),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 16),
-                        FilledButton.icon(
-                          onPressed: () {
-                            refreshTick.value++;
-                          },
-                          icon: const Icon(Icons.refresh),
-                          label: const Text('再試行'),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              }
-              if (items.value.isEmpty) {
-                return RefreshIndicator(
-                  onRefresh: loadFirstPage,
-                  child: ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
+          builder: (context) {
+            if (loading.value && items.value.isEmpty && error.value == null) {
+              return const Center(child: CircularProgressIndicator.adaptive());
+            }
+            if (error.value != null && items.value.isEmpty) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      SizedBox(
-                        height: MediaQuery.sizeOf(context).height * 0.3,
+                      Text(
+                        error.value.toString(),
+                        textAlign: TextAlign.center,
                       ),
-                      Center(
-                        child: Text(
-                          '配信ログはまだありません',
-                          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSurfaceVariant,
-                              ),
-                        ),
-                      ),
-                      ListTile(
-                        dense: true,
-                        title: const Text('対象端末 ID'),
-                        subtitle: SelectableText(value),
+                      const SizedBox(height: 16),
+                      FilledButton.icon(
+                        onPressed: () {
+                          refreshTick.value++;
+                        },
+                        icon: const Icon(Icons.refresh),
+                        label: const Text('再試行'),
                       ),
                     ],
                   ),
-                );
-              }
-              return RefreshIndicator(
-                onRefresh: loadFirstPage,
-                child: ListView.builder(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  padding: const EdgeInsets.only(bottom: 24),
-                  itemCount:
-                      items.value.length + (nextCursor.value != null ? 1 : 0),
-                  itemBuilder: (context, index) {
-                    if (index == items.value.length) {
-                      return Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Center(
-                          child: loadingMore.value
-                              ? const CircularProgressIndicator.adaptive()
-                              : TextButton.icon(
-                                  onPressed: () async {
-                                    await loadMore();
-                                  },
-                                  icon: const Icon(Icons.expand_more),
-                                  label: const Text('さらに読み込む'),
-                                ),
-                        ),
-                      );
-                    }
-                    final item = items.value[index];
-                    return _NotificationLogTile(
-                      item: item,
-                      onTap: () async {
-                        await showModalBottomSheet<void>(
-                          context: context,
-                          showDragHandle: true,
-                          isScrollControlled: true,
-                          builder: (context) => _LogDetailSheet(item: item),
-                        );
-                      },
-                    );
-                  },
                 ),
               );
-            },
-          ),
+            }
+            if (items.value.isEmpty) {
+              return RefreshIndicator(
+                onRefresh: loadFirstPage,
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: [
+                    SizedBox(
+                      height: MediaQuery.sizeOf(context).height * 0.3,
+                    ),
+                    Center(
+                      child: Text(
+                        '配信ログはまだありません',
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    ListTile(
+                      dense: true,
+                      title: const Text('対象端末 ID'),
+                      subtitle: SelectableText(value),
+                    ),
+                  ],
+                ),
+              );
+            }
+            return RefreshIndicator(
+              onRefresh: loadFirstPage,
+              child: ListView.builder(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.only(bottom: 24),
+                itemCount:
+                    items.value.length + (nextCursor.value != null ? 1 : 0),
+                itemBuilder: (context, index) {
+                  if (index == items.value.length) {
+                    return Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Center(
+                        child: loadingMore.value
+                            ? const CircularProgressIndicator.adaptive()
+                            : TextButton.icon(
+                                onPressed: () async {
+                                  await loadMore();
+                                },
+                                icon: const Icon(Icons.expand_more),
+                                label: const Text('さらに読み込む'),
+                              ),
+                      ),
+                    );
+                  }
+                  final item = items.value[index];
+                  return _NotificationLogTile(
+                    item: item,
+                    onTap: () async {
+                      await showModalBottomSheet<void>(
+                        context: context,
+                        showDragHandle: true,
+                        isScrollControlled: true,
+                        builder: (context) => _LogDetailSheet(item: item),
+                      );
+                    },
+                  );
+                },
+              ),
+            );
+          },
+        ),
       },
     );
   }
@@ -238,6 +238,16 @@ class _NotificationLogTile extends StatelessWidget {
       ),
       onTap: onTap,
     );
+  }
+
+  String _formatCreatedAt(String raw) {
+    final parsed = DateTime.tryParse(raw);
+    if (parsed == null) {
+      return raw;
+    }
+    final local = parsed.toLocal();
+    return '${local.year}/${local.month.toString().padLeft(2, '0')}/${local.day.toString().padLeft(2, '0')} '
+        '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
   }
 }
 
@@ -324,9 +334,9 @@ class _LogDetailSheet extends StatelessWidget {
                               e.$1,
                               style: Theme.of(context).textTheme.labelSmall
                                   ?.copyWith(
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurfaceVariant,
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
                                   ),
                             ),
                             const SizedBox(height: 4),
@@ -345,14 +355,4 @@ class _LogDetailSheet extends StatelessWidget {
       },
     );
   }
-}
-
-String _formatCreatedAt(String raw) {
-  final parsed = DateTime.tryParse(raw);
-  if (parsed == null) {
-    return raw;
-  }
-  final local = parsed.toLocal();
-  return '${local.year}/${local.month.toString().padLeft(2, '0')}/${local.day.toString().padLeft(2, '0')} '
-      '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
 }

--- a/app/lib/feature/telegram_list/ui/components/telegram_list_tile.dart
+++ b/app/lib/feature/telegram_list/ui/components/telegram_list_tile.dart
@@ -19,7 +19,10 @@ class TelegramListTile extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final dateFormat = DateFormat('yyyy/MM/dd HH:mm:ss');
 
-    final isEew = _isEewTelegram(telegram.type);
+    final isEew = switch (telegram.type) {
+      TelegramType.vxse43 || TelegramType.vxse44 || TelegramType.vxse45 => true,
+      _ => false,
+    };
     final serialNo = telegram.serialNo;
 
     return ListTile(
@@ -117,11 +120,4 @@ class _InfoRow extends StatelessWidget {
       ],
     );
   }
-}
-
-bool _isEewTelegram(TelegramType type) {
-  return switch (type) {
-    TelegramType.vxse43 || TelegramType.vxse44 || TelegramType.vxse45 => true,
-    _ => false,
-  };
 }


### PR DESCRIPTION
## Summary

flutter-rules.mdc のルール「top-level / global 関数の定義は禁止する。プライベートな top-level 関数も禁止する」に従い、7ファイルの top-level プライベート関数を廃止した。

| ファイル | 関数 | 対処 |
|---|---|---|
| `status_filter_chip.dart` | `_statusesToString`, `_statusToJapanese`, `_statusDescription` | `extension on TelegramStatus` に変換 |
| `telegram_list_tile.dart` | `_isEewTelegram` | `build` 内インライン switch 式に変換 |
| `debug_device_admin_page.dart` | `_isNotFound` | インライン条件式に変換 |
| `device_repository.dart` | `_isNotFound` | `DeviceRepository.static` メソッドに変換（2箇所で使用） |
| `v3_migration_workflow.dart` | `_isNotFound` | パターンガード内にインライン化 |
| `debug_device_settings_page.dart` | `_hasNonEmptyText` | `(value ?? '').isNotEmpty` にインライン化（3箇所） |
| `debug_notification_delivery_log_page.dart` | `_formatCreatedAt` | `_NotificationLogTile` のインスタンスメソッドに移動 |

## Test plan

- [ ] `dart analyze app/lib` でエラーゼロを確認済み
- [ ] `dart format` 適用済み（CI フォーマットチェックに対応）
- [ ] gitleaks / pre-commit hooks パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)