### PR TITLE
fix: error_card の google_fonts を廃止・AlertDialog を adaptive に修正

### DIFF
--- a/app/lib/core/component/error/error_card.dart
+++ b/app/lib/core/component/error/error_card.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/util/fullscreen_loading_overlay.dart';
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:eqmonitor/core/gen/fonts.gen.dart';
 
 class ErrorCard extends StatelessWidget {
   const ErrorCard({
@@ -69,26 +69,26 @@ class ErrorCard extends StatelessWidget {
                 message,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onErrorContainer,
-                  fontFamily: GoogleFonts.notoSansMono().fontFamily,
+                  fontFamily: FontFamily.notoSansMono,
                 ),
               ),
-              if (suffixMessage != null) ...[
+              if (suffixMessage case final suffix?) ...[
                 const SizedBox(height: 8),
                 Text(
-                  suffixMessage!,
+                  suffix,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.onErrorContainer,
-                    fontFamily: GoogleFonts.notoSansMono().fontFamily,
+                    fontFamily: FontFamily.notoSansMono,
                   ),
                 ),
               ],
-              if (onReload != null) ...[
+              if (onReload case final reload?) ...[
                 const SizedBox(height: 8),
                 FilledButton.tonalIcon(
                   onPressed: () =>
                       FullScreenCircularProgressIndicator.showUntil(
                         context,
-                        onReload!,
+                        reload,
                       ),
                   icon: const Icon(Icons.refresh),
                   label: const Text('再読み込み'),

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -524,7 +524,7 @@ class _MapLayerModeDebugDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
+    return AlertDialog.adaptive(
       title: const Text('Map Layer Mode Debug'),
       content: SingleChildScrollView(
         child: _MapLayerModeDebugContent(


### PR DESCRIPTION
## Summary

DESIGN.md の指針に従い2つの残存違反を修正。

### 1. error_card.dart — google_fonts の廃止
PR #1183 で全体対応したが error_card.dart が漏れていた。
- `GoogleFonts.notoSansMono().fontFamily` → `FontFamily.notoSansMono`（アセットベースのフォント）
- `suffixMessage!` / `onReload!` → Dart パターンマッチング (`case final x?`) で null-safe に

### 2. earthquake_history_details_map_view.dart — AlertDialog → AlertDialog.adaptive
- デバッグ用ダイアログが `AlertDialog` のままだったため `AlertDialog.adaptive` に変更

## Test plan

- [ ] dart analyze → No issues found
- [ ] dart fix --apply → Nothing to fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)