### PR TITLE
fix: ! 演算子を null-safe な実装に置き換え (batch 2)

### DIFF
--- a/app/lib/core/component/button/action_button.dart
+++ b/app/lib/core/component/button/action_button.dart
@@ -45,11 +45,12 @@ class ActionButton extends StatelessWidget {
       child: Center(
         child: Text(
           text,
-          style: Theme.of(context).textTheme.titleMedium!.copyWith(
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-            letterSpacing: 1.1,
-          ),
+          style: (Theme.of(context).textTheme.titleMedium ?? const TextStyle())
+              .copyWith(
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+                letterSpacing: 1.1,
+              ),
         ),
       ),
     ),
@@ -68,11 +69,12 @@ class ActionButton extends StatelessWidget {
     child: Center(
       child: Text(
         text,
-        style: Theme.of(context).textTheme.titleMedium!.copyWith(
-          fontWeight: FontWeight.bold,
-          color: textColor,
-          letterSpacing: 1.1,
-        ),
+        style: (Theme.of(context).textTheme.titleMedium ?? const TextStyle())
+            .copyWith(
+              fontWeight: FontWeight.bold,
+              color: textColor,
+              letterSpacing: 1.1,
+            ),
       ),
     ),
   );

--- a/app/lib/core/component/chip/date_range_filter_chip.dart
+++ b/app/lib/core/component/chip/date_range_filter_chip.dart
@@ -63,20 +63,22 @@ extension MinMaxDateTime on (DateTime?, DateTime?) {
     if (isAllSelected) {
       return '全て';
     }
+    final effectiveMin = min ?? DateRangeFilterChip.initialMin;
+    final effectiveMax = max ?? DateRangeFilterChip.initialMax;
     // どちらも同じの時
-    if (min == max) {
-      return DateRangeFilterChip.format.format(min!);
+    if (effectiveMin == effectiveMax) {
+      return DateRangeFilterChip.format.format(effectiveMin);
     }
     // 下限値のみ指定している時
     if (isMaxSelected) {
-      return '${DateRangeFilterChip.format.format(min!)} 以降';
+      return '${DateRangeFilterChip.format.format(effectiveMin)} 以降';
     }
     // 上限値のみ指定している時
     if (isMinSelected) {
-      return '${DateRangeFilterChip.format.format(max!)} 以前';
+      return '${DateRangeFilterChip.format.format(effectiveMax)} 以前';
     }
     // それ以外
-    return '${DateRangeFilterChip.format.format(min!)} ~ '
-        '${DateRangeFilterChip.format.format(max!)}';
+    return '${DateRangeFilterChip.format.format(effectiveMin)} ~ '
+        '${DateRangeFilterChip.format.format(effectiveMax)}';
   }
 }

--- a/app/lib/core/component/error/error_card.dart
+++ b/app/lib/core/component/error/error_card.dart
@@ -72,23 +72,23 @@ class ErrorCard extends StatelessWidget {
                   fontFamily: GoogleFonts.notoSansMono().fontFamily,
                 ),
               ),
-              if (suffixMessage != null) ...[
+              if (suffixMessage case final msg?) ...[
                 const SizedBox(height: 8),
                 Text(
-                  suffixMessage!,
+                  msg,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.onErrorContainer,
                     fontFamily: GoogleFonts.notoSansMono().fontFamily,
                   ),
                 ),
               ],
-              if (onReload != null) ...[
+              if (onReload case final reload?) ...[
                 const SizedBox(height: 8),
                 FilledButton.tonalIcon(
                   onPressed: () =>
                       FullScreenCircularProgressIndicator.showUntil(
                         context,
-                        onReload!,
+                        reload,
                       ),
                   icon: const Icon(Icons.refresh),
                   label: const Text('再読み込み'),

--- a/app/lib/core/component/intenisty/jma_intensity_icon.dart
+++ b/app/lib/core/component/intenisty/jma_intensity_icon.dart
@@ -108,9 +108,9 @@ class JmaIntensityIcon extends ConsumerWidget {
                 crossAxisAlignment: .baseline,
                 textBaseline: .alphabetic,
                 children: [
-                  if (customText != null)
+                  if (customText case final ct?)
                     Text(
-                      customText!,
+                      ct,
                       style: TextStyle(
                         color: fg,
                         fontSize: 100,

--- a/app/lib/core/component/widget/app_list_tile.dart
+++ b/app/lib/core/component/widget/app_list_tile.dart
@@ -68,7 +68,7 @@ class AppListTile extends StatelessWidget {
         tileColor: backgroundColor,
         title: title,
         subtitle: subtitle,
-        value: value!,
+        value: value ?? false,
         onChanged: onChanged,
         trailing: trailing,
       ),

--- a/app/lib/core/component/widget/app_switch.dart
+++ b/app/lib/core/component/widget/app_switch.dart
@@ -218,7 +218,10 @@ class AppSwitchListTile extends StatelessWidget {
       textColor: textColor,
       visualDensity: visualDensity,
       title: Text(title),
-      subtitle: subtitle == null ? null : Text(subtitle!),
+      subtitle: switch (subtitle) {
+        final s? => Text(s),
+        null => null,
+      },
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/app/lib/core/provider/telegram_url/provider/telegram_url_provider.dart
+++ b/app/lib/core/provider/telegram_url/provider/telegram_url_provider.dart
@@ -53,7 +53,8 @@ class TelegramUrl extends _$TelegramUrl {
 
   Future<void> updateRestUrl(String url) async {
     final current = state.value ?? _defaultTelegramUrl();
-    state = AsyncValue.data(current.copyWith(restApiUrl: url));
-    await _save(state.value!);
+    final updated = current.copyWith(restApiUrl: url);
+    state = AsyncValue.data(updated);
+    await _save(updated);
   }
 }

--- a/app/lib/core/theme/custom_colors.dart
+++ b/app/lib/core/theme/custom_colors.dart
@@ -21,6 +21,6 @@ class CustomColors extends ThemeExtension<CustomColors> {
   }
 
   CustomColors harmonized(ColorScheme dynamic) {
-    return copyWith(danger: danger!.harmonizeWith(dynamic.primary));
+    return copyWith(danger: danger?.harmonizeWith(dynamic.primary));
   }
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -190,13 +190,14 @@ Future<void> _main() async {
         SharedPreferencesAsync(results.$1.$1),
       ),
       packageInfoProvider.overrideWithValue(results.$1.$2),
-      if (results.$1.$3 != null)
-        androidDeviceInfoProvider.overrideWithValue(results.$1.$3!),
-      if (results.$1.$4 != null)
-        iosDeviceInfoProvider.overrideWithValue(results.$1.$4!),
-      applicationDocumentsDirectoryProvider.overrideWithValue(results.$1.$6!),
-      if (results.$2.$1 != null)
-        kyoshinColorMapProvider.overrideWithValue(results.$2.$1!),
+      if (results.$1.$3 case final androidInfo?)
+        androidDeviceInfoProvider.overrideWithValue(androidInfo),
+      if (results.$1.$4 case final iosInfo?)
+        iosDeviceInfoProvider.overrideWithValue(iosInfo),
+      if (results.$1.$6 case final appDir?)
+        applicationDocumentsDirectoryProvider.overrideWithValue(appDir),
+      if (results.$2.$1 case final colorMap?)
+        kyoshinColorMapProvider.overrideWithValue(colorMap),
     ],
     observers: [if (kDebugMode) CustomProviderObserver(talker)],
     retry: (_, _) => null,


### PR DESCRIPTION
## Summary

flutter-rules.mdc のルール「Null Safety: `!` 演算子の使用を禁止する」に従い、9ファイルの null assertion operator を null-safe な実装に置き換えました。

### 修正内容

| ファイル | 修正前 | 修正後 |
|---|---|---|
| `telegram_url_provider.dart` | `state.value!` | ローカル変数 `updated` を使用 |
| `app_switch.dart` | `subtitle!` | `switch` パターンマッチング |
| `date_range_filter_chip.dart` | `min!` / `max!` | `effectiveMin` / `effectiveMax` ローカル変数 |
| `action_button.dart` | `textTheme.titleMedium!` | `?? const TextStyle()` フォールバック (2箇所) |
| `error_card.dart` | `suffixMessage!` / `onReload!` | `if-case` パターンマッチング |
| `custom_colors.dart` | `danger!` | `?.` null-safe アクセス |
| `jma_intensity_icon.dart` | `customText!` | `if-case` パターンマッチング |
| `main.dart` | `results.$1.$3!` 等 | `if-case` パターンマッチング |
| `app_list_tile.dart` | `value!` | `?? false` フォールバック |

## Test plan

- [x] `dart analyze app/lib` — No issues found
- [x] `dart fix --apply` 適用済み
- [x] `dart format` 適用済み
- [x] 生成ファイル (`*.g.dart`, `*.freezed.dart`) は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)