### PR TITLE
refactor: Widget プライベートメソッドを private class に変換

### DIFF
--- a/app/lib/feature/eew/ui/page/eew_details_page.dart
+++ b/app/lib/feature/eew/ui/page/eew_details_page.dart
@@ -18,14 +18,21 @@ class EewDetailsPage extends HookConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: Text('緊急地震速報 詳細 ($eventId)')),
       body: eewsAsyncValue.when(
-        data: _buildEewList,
+        data: (eews) => _EewList(eews: eews),
         loading: () => const _EewDetailsPageSkeleton(),
         error: (error, stack) => Center(child: Text('エラーが発生しました: $error')),
       ),
     );
   }
+}
 
-  Widget _buildEewList(List<EewTelegramItem> eews) {
+class _EewList extends StatelessWidget {
+  const _EewList({required this.eews});
+
+  final List<EewTelegramItem> eews;
+
+  @override
+  Widget build(BuildContext context) {
     if (eews.isEmpty) {
       return const AppEmptyState(
         message: 'EEW情報はありません',

--- a/app/lib/feature/fnet_catalog/ui/components/fnet_catalog_list_tile.dart
+++ b/app/lib/feature/fnet_catalog/ui/components/fnet_catalog_list_tile.dart
@@ -231,89 +231,86 @@ class _DetailSheet extends StatelessWidget {
                   style: theme.textTheme.bodyMedium,
                 ),
                 const Divider(height: 32),
-                _buildSection(
-                  context,
-                  '基本情報',
-                  [
-                    _buildRow('緯度', '${event.latitude.toStringAsFixed(4)}°'),
-                    _buildRow('経度', '${event.longitude.toStringAsFixed(4)}°'),
-                    _buildRow(
-                      'JMA震源深さ',
-                      '${event.jmaDepth.toStringAsFixed(2)} km',
+                _Section(
+                  title: '基本情報',
+                  children: [
+                    _InfoRow(label: '緯度', value: '${event.latitude.toStringAsFixed(4)}°'),
+                    _InfoRow(label: '経度', value: '${event.longitude.toStringAsFixed(4)}°'),
+                    _InfoRow(
+                      label: 'JMA震源深さ',
+                      value: '${event.jmaDepth.toStringAsFixed(2)} km',
                     ),
-                    _buildRow(
-                      'JMAマグニチュード',
-                      event.jmaMagnitude.toStringAsFixed(1),
+                    _InfoRow(
+                      label: 'JMAマグニチュード',
+                      value: event.jmaMagnitude.toStringAsFixed(1),
                     ),
-                    _buildRow(
-                      'MT震源深さ',
-                      '${event.mtDepth.toStringAsFixed(2)} km',
+                    _InfoRow(
+                      label: 'MT震源深さ',
+                      value: '${event.mtDepth.toStringAsFixed(2)} km',
                     ),
-                    _buildRow(
-                      'モーメントマグニチュード',
-                      event.momentMagnitude.toStringAsFixed(1),
+                    _InfoRow(
+                      label: 'モーメントマグニチュード',
+                      value: event.momentMagnitude.toStringAsFixed(1),
                     ),
-                    _buildRow(
-                      '地震モーメント',
-                      '${event.seismicMoment.toStringAsExponential(2)} Nm',
+                    _InfoRow(
+                      label: '地震モーメント',
+                      value: '${event.seismicMoment.toStringAsExponential(2)} Nm',
                     ),
-                    _buildRow(
-                      'バリアンス・リダクション',
-                      '${event.varianceReduction.toStringAsFixed(2)}%',
+                    _InfoRow(
+                      label: 'バリアンス・リダクション',
+                      value: '${event.varianceReduction.toStringAsFixed(2)}%',
                     ),
-                    _buildRow(
-                      '使用観測点数',
-                      '${event.numberOfStations}',
-                    ),
-                  ],
-                ),
-                const Divider(height: 32),
-                _buildSection(
-                  context,
-                  '断層パラメータ',
-                  [
-                    _buildRow(
-                      '走向 (Strike)',
-                      '${event.strike.plane1.toStringAsFixed(0)}° / ${event.strike.plane2.toStringAsFixed(0)}°',
-                    ),
-                    _buildRow(
-                      '傾斜角 (Dip)',
-                      '${event.dip.plane1.toStringAsFixed(0)}° / ${event.dip.plane2.toStringAsFixed(0)}°',
-                    ),
-                    _buildRow(
-                      'すべり角 (Rake)',
-                      '${event.rake.plane1.toStringAsFixed(0)}° / ${event.rake.plane2.toStringAsFixed(0)}°',
+                    _InfoRow(
+                      label: '使用観測点数',
+                      value: '${event.numberOfStations}',
                     ),
                   ],
                 ),
                 const Divider(height: 32),
-                _buildSection(
-                  context,
-                  'モーメントテンソル成分',
-                  [
-                    _buildRow(
-                      'Mxx',
-                      '${event.momentTensor.mxx.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                _Section(
+                  title: '断層パラメータ',
+                  children: [
+                    _InfoRow(
+                      label: '走向 (Strike)',
+                      value: '${event.strike.plane1.toStringAsFixed(0)}° / ${event.strike.plane2.toStringAsFixed(0)}°',
                     ),
-                    _buildRow(
-                      'Mxy',
-                      '${event.momentTensor.mxy.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                    _InfoRow(
+                      label: '傾斜角 (Dip)',
+                      value: '${event.dip.plane1.toStringAsFixed(0)}° / ${event.dip.plane2.toStringAsFixed(0)}°',
                     ),
-                    _buildRow(
-                      'Mxz',
-                      '${event.momentTensor.mxz.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                    _InfoRow(
+                      label: 'すべり角 (Rake)',
+                      value: '${event.rake.plane1.toStringAsFixed(0)}° / ${event.rake.plane2.toStringAsFixed(0)}°',
                     ),
-                    _buildRow(
-                      'Myy',
-                      '${event.momentTensor.myy.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                  ],
+                ),
+                const Divider(height: 32),
+                _Section(
+                  title: 'モーメントテンソル成分',
+                  children: [
+                    _InfoRow(
+                      label: 'Mxx',
+                      value: '${event.momentTensor.mxx.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
                     ),
-                    _buildRow(
-                      'Myz',
-                      '${event.momentTensor.myz.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                    _InfoRow(
+                      label: 'Mxy',
+                      value: '${event.momentTensor.mxy.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
                     ),
-                    _buildRow(
-                      'Mzz',
-                      '${event.momentTensor.mzz.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                    _InfoRow(
+                      label: 'Mxz',
+                      value: '${event.momentTensor.mxz.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                    ),
+                    _InfoRow(
+                      label: 'Myy',
+                      value: '${event.momentTensor.myy.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                    ),
+                    _InfoRow(
+                      label: 'Myz',
+                      value: '${event.momentTensor.myz.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
+                    ),
+                    _InfoRow(
+                      label: 'Mzz',
+                      value: '${event.momentTensor.mzz.toStringAsFixed(4)} × ${event.unit.toStringAsExponential(0)} Nm',
                     ),
                   ],
                 ),
@@ -324,12 +321,19 @@ class _DetailSheet extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildSection(
-    BuildContext context,
-    String title,
-    List<Widget> children,
-  ) {
+class _Section extends StatelessWidget {
+  const _Section({
+    required this.title,
+    required this.children,
+  });
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -345,8 +349,19 @@ class _DetailSheet extends StatelessWidget {
       ],
     );
   }
+}
 
-  Widget _buildRow(String label, String value) {
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(

--- a/app/lib/feature/settings/children/config/debug/jma_map/debug_jma_map_page.dart
+++ b/app/lib/feature/settings/children/config/debug/jma_map/debug_jma_map_page.dart
@@ -228,7 +228,16 @@ class DebugJmaMapPage extends HookConsumerWidget {
                         items: JmaMapType.values.map((type) {
                           return DropdownMenuItem(
                             value: type,
-                            child: Text(_getMapTypeName(type)),
+                            child: Text(
+                              switch (type) {
+                                JmaMapType.areaForecastLocalEew =>
+                                  '地震情報／緊急地震速報',
+                                JmaMapType.areaForecastLocalE => '地震情報',
+                                JmaMapType.areaInformationCity => '市区町村等',
+                                JmaMapType.areaTsunami => '津波予報区',
+                                JmaMapType.observationPoint => '地震観測点',
+                              },
+                            ),
                           );
                         }).toList(),
                         onChanged: (value) {
@@ -263,7 +272,7 @@ class DebugJmaMapPage extends HookConsumerWidget {
                           ),
                         ),
                         const SizedBox(height: 16),
-                        _buildResultInfo(searchResult.value!),
+                        _ResultInfo(item: searchResult.value!),
                       ],
                     ),
                   ),
@@ -286,13 +295,13 @@ class DebugJmaMapPage extends HookConsumerWidget {
                           ),
                         ),
                         const SizedBox(height: 16),
-                        _buildObservationPointInfo(
-                          observationPointResult.value!,
+                        _ObservationPointInfo(
+                          item: observationPointResult.value!,
                         ),
                         if (distance.value != null)
-                          _buildInfoRow(
-                            '距離',
-                            '${distance.value!.toStringAsFixed(2)} km',
+                          _InfoRow(
+                            label: '距離',
+                            value: '${distance.value!.toStringAsFixed(2)} km',
                           ),
                       ],
                     ),
@@ -305,51 +314,73 @@ class DebugJmaMapPage extends HookConsumerWidget {
       ),
     );
   }
+}
 
-  Widget _buildResultInfo(MapDataItem item) {
+class _ResultInfo extends StatelessWidget {
+  const _ResultInfo({required this.item});
+
+  final MapDataItem item;
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (item.property != null) ...[
           if (item.property!.code.isNotEmpty)
-            _buildInfoRow('コード', item.property!.code),
+            _InfoRow(label: 'コード', value: item.property!.code),
           if (item.property!.name.isNotEmpty)
-            _buildInfoRow('名前', item.property!.name),
+            _InfoRow(label: '名前', value: item.property!.name),
           if (item.property!.nameKana.isNotEmpty)
-            _buildInfoRow('名前（カナ）', item.property!.nameKana),
+            _InfoRow(label: '名前（カナ）', value: item.property!.nameKana),
         ],
         if (item.polylabel != null) ...[
-          _buildInfoRow('緯度', item.polylabel!.lat.toString()),
-          _buildInfoRow('経度', item.polylabel!.lng.toString()),
+          _InfoRow(label: '緯度', value: item.polylabel!.lat.toString()),
+          _InfoRow(label: '経度', value: item.polylabel!.lng.toString()),
         ],
         if (item.bounds != null) ...[
-          _buildInfoRow('南西緯度', item.bounds!.southWest.lat.toString()),
-          _buildInfoRow('南西経度', item.bounds!.southWest.lng.toString()),
-          _buildInfoRow('北東緯度', item.bounds!.northEast.lat.toString()),
-          _buildInfoRow('北東経度', item.bounds!.northEast.lng.toString()),
+          _InfoRow(label: '南西緯度', value: item.bounds!.southWest.lat.toString()),
+          _InfoRow(label: '南西経度', value: item.bounds!.southWest.lng.toString()),
+          _InfoRow(label: '北東緯度', value: item.bounds!.northEast.lat.toString()),
+          _InfoRow(label: '北東経度', value: item.bounds!.northEast.lng.toString()),
         ],
         if (item.distanceToCoastlineKm != null)
-          _buildInfoRow(
-            '海岸線までの距離',
-            '${item.distanceToCoastlineKm!.toStringAsFixed(1)} km',
+          _InfoRow(
+            label: '海岸線までの距離',
+            value: '${item.distanceToCoastlineKm!.toStringAsFixed(1)} km',
           ),
       ],
     );
   }
+}
 
-  Widget _buildObservationPointInfo(EarthquakeParameterStationItem item) {
+class _ObservationPointInfo extends StatelessWidget {
+  const _ObservationPointInfo({required this.item});
+
+  final EarthquakeParameterStationItem item;
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _buildInfoRow('コード', item.code),
-        _buildInfoRow('名前', item.name.ja),
-        _buildInfoRow('緯度', item.location.lat.toString()),
-        _buildInfoRow('経度', item.location.lon.toString()),
+        _InfoRow(label: 'コード', value: item.code),
+        _InfoRow(label: '名前', value: item.name.ja),
+        _InfoRow(label: '緯度', value: item.location.lat.toString()),
+        _InfoRow(label: '経度', value: item.location.lon.toString()),
       ],
     );
   }
+}
 
-  Widget _buildInfoRow(String label, String value) {
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Row(
@@ -366,16 +397,6 @@ class DebugJmaMapPage extends HookConsumerWidget {
         ],
       ),
     );
-  }
-
-  String _getMapTypeName(JmaMapType type) {
-    return switch (type) {
-      JmaMapType.areaForecastLocalEew => '地震情報／緊急地震速報',
-      JmaMapType.areaForecastLocalE => '地震情報',
-      JmaMapType.areaInformationCity => '市区町村等',
-      JmaMapType.areaTsunami => '津波予報区',
-      JmaMapType.observationPoint => '地震観測点',
-    };
   }
 }
 


### PR DESCRIPTION
## Summary

flutter-rules.mdc のルール「Widget に関数やゲッターを定義することを禁止する」「クラス内でのプライベートメソッドは原則禁止する。Widget が肥大化してプライベートメソッドが必要になっているなら、まず Widget を private class に分割することを優先する」に従い、以下のファイルを修正した。

### 変更ファイル

- **`app/lib/feature/eew/ui/page/eew_details_page.dart`**
  - `EewDetailsPage._buildEewList()` メソッド → `_EewList` private Widget class

- **`app/lib/feature/fnet_catalog/ui/components/fnet_catalog_list_tile.dart`**
  - `_DetailSheet._buildSection()` メソッド → `_Section` private Widget class
  - `_DetailSheet._buildRow()` メソッド → `_InfoRow` private Widget class

- **`app/lib/feature/settings/children/config/debug/jma_map/debug_jma_map_page.dart`**
  - `DebugJmaMapPage._buildResultInfo()` メソッド → `_ResultInfo` private Widget class
  - `DebugJmaMapPage._buildObservationPointInfo()` メソッド → `_ObservationPointInfo` private Widget class
  - `DebugJmaMapPage._buildInfoRow()` メソッド → `_InfoRow` private Widget class
  - `DebugJmaMapPage._getMapTypeName()` メソッド → 呼び出し箇所の inline switch 式

## Test plan

- [ ] `dart analyze app/lib` でエラーなし（確認済み: No issues found）
- [ ] `dart fix --apply` 実行済み
- [ ] 生成ファイル (`*.g.dart`, `*.freezed.dart`) は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)