### PR TITLE
feat: K-NET/KiK-net 強震波形 認証・ページ機能をアプリに追加

### DIFF
--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.g.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.g.dart
@@ -58,7 +58,7 @@ final class EqMonitorWsStatusProvider
   }
 }
 
-String _$eqMonitorWsStatusHash() => r'82c1a2269e1bb5c0cbf316255b589c6c648930fb';
+String _$eqMonitorWsStatusHash() => r'9d588019d3d23a3ce9b44a03d247dde182feb581';
 
 /// WebSocket の接続状態・ping 情報を保持する keepAlive Notifier。
 ///

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -14,6 +14,8 @@ import 'package:eqmonitor/feature/earthquake_search/data/model/earthquake_search
 import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_page.dart';
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
 import 'package:eqmonitor/feature/home/ui/page/home_map_layer_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/knet_waveform_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_observation_network_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_page.dart';
 import 'package:eqmonitor/feature/nied/ui/aqua/aqua_catalog_page.dart';
@@ -324,6 +326,14 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
               path: 'fnet',
               routes: [
                 TypedGoRoute<FnetCatalogRoute>(path: 'catalog'),
+              ],
+            ),
+            TypedGoRoute<KnetWaveformRoute>(
+              path: 'knet',
+              routes: [
+                TypedGoRoute<KnetCredentialsSettingsRoute>(
+                  path: 'settings',
+                ),
               ],
             ),
           ],
@@ -646,6 +656,23 @@ class FnetCatalogRoute extends GoRouteData with $FnetCatalogRoute {
   Widget build(BuildContext context, GoRouterState state) {
     return const FnetCatalogPage();
   }
+}
+
+class KnetWaveformRoute extends GoRouteData with $KnetWaveformRoute {
+  const KnetWaveformRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const KnetWaveformPage();
+}
+
+class KnetCredentialsSettingsRoute extends GoRouteData
+    with $KnetCredentialsSettingsRoute {
+  const KnetCredentialsSettingsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const KnetCredentialsSettingsPage();
 }
 
 class KyoshinMonitorAboutRoute extends GoRouteData

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -532,6 +532,16 @@ RouteBase get $settingsRoute => GoRouteData.$route(
                 ),
               ],
             ),
+            GoRouteData.$route(
+              path: 'knet',
+              factory: $KnetWaveformRoute._fromState,
+              routes: [
+                GoRouteData.$route(
+                  path: 'settings',
+                  factory: $KnetCredentialsSettingsRoute._fromState,
+                ),
+              ],
+            ),
           ],
         ),
       ],
@@ -1284,6 +1294,49 @@ mixin $FnetCatalogRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/settings/debug/nied/fnet/catalog');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetWaveformRoute on GoRouteData {
+  static KnetWaveformRoute _fromState(GoRouterState state) =>
+      const KnetWaveformRoute();
+
+  @override
+  String get location => GoRouteData.$location('/settings/debug/nied/knet');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetCredentialsSettingsRoute on GoRouteData {
+  static KnetCredentialsSettingsRoute _fromState(GoRouterState state) =>
+      const KnetCredentialsSettingsRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/nied/knet/settings');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart
@@ -1,0 +1,47 @@
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'knet_credentials_provider.g.dart';
+
+const _knetUserIdKey = 'knet_bosai_user_id';
+const _knetPasswordKey = 'knet_bosai_password';
+
+/// BOSAI 認証情報（ユーザーID + パスワード）
+class KnetCredentials {
+  const KnetCredentials({required this.userId, required this.password});
+
+  final String userId;
+  final String password;
+}
+
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+@Riverpod(keepAlive: true)
+class KnetCredentialsNotifier extends _$KnetCredentialsNotifier {
+  @override
+  Future<KnetCredentials?> build() async {
+    final storage = await ref.watch(secureStorageProvider.future);
+    final userId = await storage.read(key: _knetUserIdKey);
+    final password = await storage.read(key: _knetPasswordKey);
+    if (userId == null || password == null) {
+      return null;
+    }
+    return KnetCredentials(userId: userId, password: password);
+  }
+
+  Future<void> save({
+    required String userId,
+    required String password,
+  }) async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.write(key: _knetUserIdKey, value: userId);
+    await storage.write(key: _knetPasswordKey, value: password);
+    state = AsyncData(KnetCredentials(userId: userId, password: password));
+  }
+
+  Future<void> clear() async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.delete(key: _knetUserIdKey);
+    await storage.delete(key: _knetPasswordKey);
+    state = const AsyncData(null);
+  }
+}

--- a/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.g.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'knet_credentials_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+
+@ProviderFor(KnetCredentialsNotifier)
+final knetCredentialsProvider = KnetCredentialsNotifierProvider._();
+
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+final class KnetCredentialsNotifierProvider
+    extends $AsyncNotifierProvider<KnetCredentialsNotifier, KnetCredentials?> {
+  /// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+  KnetCredentialsNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'knetCredentialsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$knetCredentialsNotifierHash();
+
+  @$internal
+  @override
+  KnetCredentialsNotifier create() => KnetCredentialsNotifier();
+}
+
+String _$knetCredentialsNotifierHash() =>
+    r'e4c92ecfcaed3bfd9ffc32046c86869dc38a4a59';
+
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+
+abstract class _$KnetCredentialsNotifier
+    extends $AsyncNotifier<KnetCredentials?> {
+  FutureOr<KnetCredentials?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<KnetCredentials?>, KnetCredentials?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<KnetCredentials?>, KnetCredentials?>,
+              AsyncValue<KnetCredentials?>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.dart
@@ -1,0 +1,20 @@
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_credentials_provider.dart';
+import 'package:knet_api_client/knet_api_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'knet_download_client_provider.g.dart';
+
+/// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+///
+/// 認証情報が未設定の場合は null を返す。
+@Riverpod(keepAlive: true)
+Future<KnetDownloadClient?> knetDownloadClient(Ref ref) async {
+  final credentials = await ref.watch(knetCredentialsProvider.future);
+  if (credentials == null) {
+    return null;
+  }
+  return KnetDownloadClient(
+    userId: credentials.userId,
+    password: credentials.password,
+  );
+}

--- a/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.g.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'knet_download_client_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+///
+/// 認証情報が未設定の場合は null を返す。
+
+@ProviderFor(knetDownloadClient)
+final knetDownloadClientProvider = KnetDownloadClientProvider._();
+
+/// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+///
+/// 認証情報が未設定の場合は null を返す。
+
+final class KnetDownloadClientProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<KnetDownloadClient?>,
+          KnetDownloadClient?,
+          FutureOr<KnetDownloadClient?>
+        >
+    with
+        $FutureModifier<KnetDownloadClient?>,
+        $FutureProvider<KnetDownloadClient?> {
+  /// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+  ///
+  /// 認証情報が未設定の場合は null を返す。
+  KnetDownloadClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'knetDownloadClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$knetDownloadClientHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<KnetDownloadClient?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<KnetDownloadClient?> create(Ref ref) {
+    return knetDownloadClient(ref);
+  }
+}
+
+String _$knetDownloadClientHash() =>
+    r'1052415c1f1259a1043870504adb764c0ac002a7';

--- a/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
+++ b/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
@@ -1,0 +1,126 @@
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_credentials_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class KnetWaveformPage extends ConsumerWidget {
+  const KnetWaveformPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final credentials = ref.watch(knetCredentialsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('K-NET 強震波形'),
+      ),
+      body: credentials.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('エラー: $e')),
+        data: (data) {
+          if (data == null) {
+            return _UnconfiguredView(
+              onSetup: () =>
+                  const KnetCredentialsSettingsRoute().push<void>(context),
+            );
+          }
+          return _ConfiguredView(userId: data.userId);
+        },
+      ),
+    );
+  }
+}
+
+class _UnconfiguredView extends StatelessWidget {
+  const _UnconfiguredView({required this.onSetup});
+
+  final VoidCallback onSetup;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.lock_outline,
+              size: 64,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'BOSAI 認証情報が未設定です',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '防災科研の強震波形データをダウンロードするには、'
+              ' 事前に NIED のサイトでユーザー登録を行い、'
+              ' 認証情報を設定してください。',
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onSetup,
+              icon: const Icon(Icons.settings),
+              label: const Text('認証情報を設定する'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ConfiguredView extends StatelessWidget {
+  const _ConfiguredView({required this.userId});
+
+  final String userId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sensors,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'K-NET/KiK-net 強震観測網',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'ユーザー: $userId',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '波形データのダウンロード・'
+              '表示機能は準備中です。',
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              onPressed: () =>
+                  const KnetCredentialsSettingsRoute().push<void>(context),
+              icon: const Icon(Icons.settings),
+              label: const Text('認証設定'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart
+++ b/app/lib/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart
@@ -1,0 +1,217 @@
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_credentials_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:knet_api_client/knet_api_client.dart';
+
+class KnetCredentialsSettingsPage extends HookConsumerWidget {
+  const KnetCredentialsSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userIdController = useTextEditingController();
+    final passwordController = useTextEditingController();
+    final isVerifying = useState(false);
+    final verifyResult = useState<bool?>(null);
+
+    final credentials = ref.watch(knetCredentialsProvider);
+
+    useEffect(
+      () {
+        credentials.whenData((data) {
+          if (data != null) {
+            userIdController.text = data.userId;
+            passwordController.text = data.password;
+          }
+        });
+        return null;
+      },
+      [credentials],
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('K-NET 認証設定'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '防災科研 強震観測網 認証情報',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '防災科学技術研究所（NIED）の強震観測網データをダウンロードするために、'
+                    'ユーザー登録済みの BOSAI アカウント情報を入力してください。',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: userIdController,
+            decoration: const InputDecoration(
+              labelText: 'ユーザーID',
+              hintText: 'BOSAI ユーザーID',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.person),
+            ),
+            textInputAction: TextInputAction.next,
+            onChanged: (_) => verifyResult.value = null,
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: passwordController,
+            decoration: const InputDecoration(
+              labelText: 'パスワード',
+              hintText: 'BOSAI パスワード',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.lock),
+            ),
+            obscureText: true,
+            textInputAction: TextInputAction.done,
+            onChanged: (_) => verifyResult.value = null,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonal(
+                  onPressed: isVerifying.value
+                      ? null
+                      : () async {
+                          final userId = userIdController.text.trim();
+                          final password = passwordController.text.trim();
+                          if (userId.isEmpty || password.isEmpty) {
+                            return;
+                          }
+                          isVerifying.value = true;
+                          verifyResult.value = null;
+                          try {
+                            final client = KnetDownloadClient(
+                              userId: userId,
+                              password: password,
+                            );
+                            final ok = await client.verifyAuthentication();
+                            verifyResult.value = ok;
+                          } on Exception catch (_) {
+                            verifyResult.value = false;
+                          } finally {
+                            isVerifying.value = false;
+                          }
+                        },
+                  child: isVerifying.value
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('認証テスト'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: FilledButton(
+                  onPressed: isVerifying.value
+                      ? null
+                      : () async {
+                          final userId = userIdController.text.trim();
+                          final password = passwordController.text.trim();
+                          if (userId.isEmpty || password.isEmpty) {
+                            return;
+                          }
+                          await ref
+                              .read(knetCredentialsProvider.notifier)
+                              .save(userId: userId, password: password);
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('認証情報を保存しました')),
+                            );
+                          }
+                        },
+                  child: const Text('保存'),
+                ),
+              ),
+            ],
+          ),
+          if (verifyResult.value != null) ...[
+            const SizedBox(height: 12),
+            _VerifyResultBanner(success: verifyResult.value!),
+          ],
+          const SizedBox(height: 24),
+          credentials.when(
+            loading: () => const SizedBox.shrink(),
+            error: (_, _) => const SizedBox.shrink(),
+            data: (data) {
+              if (data == null) {
+                return const SizedBox.shrink();
+              }
+              return OutlinedButton.icon(
+                icon: const Icon(Icons.delete_outline),
+                label: const Text('認証情報を削除'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Theme.of(context).colorScheme.error,
+                ),
+                onPressed: () async {
+                  await ref.read(knetCredentialsProvider.notifier).clear();
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+                },
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VerifyResultBanner extends StatelessWidget {
+  const _VerifyResultBanner({required this.success});
+
+  final bool success;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: success
+            ? Theme.of(context).colorScheme.primaryContainer
+            : Theme.of(context).colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            success ? Icons.check_circle_outline : Icons.error_outline,
+            color: success
+                ? Theme.of(context).colorScheme.onPrimaryContainer
+                : Theme.of(context).colorScheme.onErrorContainer,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              success ? '認証に成功しました' : '認証に失敗しました。IDまたはパスワードを確認してください。',
+              style: TextStyle(
+                color: success
+                    ? Theme.of(context).colorScheme.onPrimaryContainer
+                    : Theme.of(context).colorScheme.onErrorContainer,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/nied/ui/nied_page.dart
+++ b/app/lib/feature/nied/ui/nied_page.dart
@@ -24,6 +24,12 @@ class NiedPage extends StatelessWidget {
             leading: const Icon(Icons.sensors),
             onTap: () async => const FnetRoute().push<void>(context),
           ),
+          ListTile(
+            title: const Text('K-NET/KiK-net'),
+            subtitle: const Text('強震観測網 波形データ'),
+            leading: const Icon(Icons.show_chart),
+            onTap: () async => const KnetWaveformRoute().push<void>(context),
+          ),
         ],
       ),
     );

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -112,6 +112,10 @@ dependencies:
   jma_map:
     path: ../packages/jma_map
   json_annotation: ^4.11.0
+  knet_api_client:
+    path: ../packages/knet_api_client
+  knet_waveform_parser:
+    path: ../packages/knet_waveform_parser
   kyoshin_monitor_api:
     path: ../packages/kyoshin_monitor_api
   kyoshin_monitor_image_parser:


### PR DESCRIPTION
## Summary

- `knet_api_client` / `knet_waveform_parser` パッケージを `app/pubspec.yaml` に path 依存として追加
- `KnetCredentialsNotifier`: BOSAI ユーザーID/パスワードを `flutter_secure_storage` で管理する Riverpod 3 Notifier
- `KnetDownloadClientProvider`: 認証情報を watch して `KnetDownloadClient` を生成（未設定時は null）
- `KnetWaveformPage`: 認証未設定時は設定画面へ誘導するガード画面
- `KnetCredentialsSettingsPage`: ID/PW 入力フォーム + 認証テストボタン（保存・削除対応）
- GoRouter に `settings/nied/knet` および `settings/nied/knet/settings` ルートを追加
- NIED ページに "K-NET/KiK-net 強震観測網 波形データ" の ListTile を追加

## セキュリティ注意事項

- BOSAI_ID / BOSAI_PW はアプリに埋め込んでいない
- ユーザーが手動で入力し、SecureStorage に保存する設計

## Base PR

この PR は `feat/knet-waveform-parser` ブランチがベース（パーサー実装 PR #1187 に積み上げ）。

## Test plan

- [ ] NIED ページに K-NET エントリが表示される
- [ ] K-NET ページを開くと「認証情報未設定」のガード画面が表示される
- [ ] 認証設定ページで ID/PW を入力して「保存」すると SecureStorage に保存される
- [ ] 保存後に K-NET ページを開くと設定済み画面になる
- [ ] 「認証テスト」ボタンが正常に動作する（成功/失敗バナーが表示される）
- [ ] 「認証情報を削除」で SecureStorage から削除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)