### PR TITLE
feat: K-NET PNG図・MP4動画表示機能

### DIFF
--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.g.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.g.dart
@@ -58,7 +58,7 @@ final class EqMonitorWsStatusProvider
   }
 }
 
-String _$eqMonitorWsStatusHash() => r'82c1a2269e1bb5c0cbf316255b589c6c648930fb';
+String _$eqMonitorWsStatusHash() => r'9d588019d3d23a3ce9b44a03d247dde182feb581';
 
 /// WebSocket の接続状態・ping 情報を保持する keepAlive Notifier。
 ///

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -14,6 +14,8 @@ import 'package:eqmonitor/feature/earthquake_search/data/model/earthquake_search
 import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_page.dart';
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
 import 'package:eqmonitor/feature/home/ui/page/home_map_layer_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/knet_waveform_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_observation_network_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_page.dart';
 import 'package:eqmonitor/feature/nied/ui/aqua/aqua_catalog_page.dart';
@@ -324,6 +326,14 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
               path: 'fnet',
               routes: [
                 TypedGoRoute<FnetCatalogRoute>(path: 'catalog'),
+              ],
+            ),
+            TypedGoRoute<KnetWaveformRoute>(
+              path: 'knet',
+              routes: [
+                TypedGoRoute<KnetCredentialsSettingsRoute>(
+                  path: 'settings',
+                ),
               ],
             ),
           ],
@@ -646,6 +656,23 @@ class FnetCatalogRoute extends GoRouteData with $FnetCatalogRoute {
   Widget build(BuildContext context, GoRouterState state) {
     return const FnetCatalogPage();
   }
+}
+
+class KnetWaveformRoute extends GoRouteData with $KnetWaveformRoute {
+  const KnetWaveformRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const KnetWaveformPage();
+}
+
+class KnetCredentialsSettingsRoute extends GoRouteData
+    with $KnetCredentialsSettingsRoute {
+  const KnetCredentialsSettingsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const KnetCredentialsSettingsPage();
 }
 
 class KyoshinMonitorAboutRoute extends GoRouteData

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -15,6 +15,7 @@ import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
 import 'package:eqmonitor/feature/home/ui/page/home_map_layer_page.dart';
 import 'package:eqmonitor/feature/knet_waveform/ui/knet_waveform_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/media/knet_media_page.dart';
 import 'package:eqmonitor/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_observation_network_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_page.dart';
@@ -108,8 +109,7 @@ class SplashRoute extends GoRouteData with $SplashRoute {
   const SplashRoute();
 
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const SplashPage();
+  Widget build(BuildContext context, GoRouterState state) => const SplashPage();
 }
 
 @TypedGoRoute<OnboardingRoute>(path: '/onboarding')
@@ -333,6 +333,9 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
               routes: [
                 TypedGoRoute<KnetCredentialsSettingsRoute>(
                   path: 'settings',
+                ),
+                TypedGoRoute<KnetMediaRoute>(
+                  path: 'media',
                 ),
               ],
             ),
@@ -673,6 +676,17 @@ class KnetCredentialsSettingsRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const KnetCredentialsSettingsPage();
+}
+
+class KnetMediaRoute extends GoRouteData with $KnetMediaRoute {
+  const KnetMediaRoute({required this.$extra});
+
+  /// 地震発生時刻（JST）
+  final DateTime $extra;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      KnetMediaPage(eventTime: $extra);
 }
 
 class KyoshinMonitorAboutRoute extends GoRouteData

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -532,6 +532,16 @@ RouteBase get $settingsRoute => GoRouteData.$route(
                 ),
               ],
             ),
+            GoRouteData.$route(
+              path: 'knet',
+              factory: $KnetWaveformRoute._fromState,
+              routes: [
+                GoRouteData.$route(
+                  path: 'settings',
+                  factory: $KnetCredentialsSettingsRoute._fromState,
+                ),
+              ],
+            ),
           ],
         ),
       ],
@@ -1284,6 +1294,49 @@ mixin $FnetCatalogRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/settings/debug/nied/fnet/catalog');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetWaveformRoute on GoRouteData {
+  static KnetWaveformRoute _fromState(GoRouterState state) =>
+      const KnetWaveformRoute();
+
+  @override
+  String get location => GoRouteData.$location('/settings/debug/nied/knet');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetCredentialsSettingsRoute on GoRouteData {
+  static KnetCredentialsSettingsRoute _fromState(GoRouterState state) =>
+      const KnetCredentialsSettingsRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/nied/knet/settings');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -540,6 +540,10 @@ RouteBase get $settingsRoute => GoRouteData.$route(
                   path: 'settings',
                   factory: $KnetCredentialsSettingsRoute._fromState,
                 ),
+                GoRouteData.$route(
+                  path: 'media',
+                  factory: $KnetMediaRoute._fromState,
+                ),
               ],
             ),
           ],
@@ -1350,6 +1354,32 @@ mixin $KnetCredentialsSettingsRoute on GoRouteData {
 
   @override
   void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetMediaRoute on GoRouteData {
+  static KnetMediaRoute _fromState(GoRouterState state) =>
+      KnetMediaRoute($extra: state.extra as DateTime);
+
+  KnetMediaRoute get _self => this as KnetMediaRoute;
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/nied/knet/media');
+
+  @override
+  void go(BuildContext context) => context.go(location, extra: _self.$extra);
+
+  @override
+  Future<T?> push<T>(BuildContext context) =>
+      context.push<T>(location, extra: _self.$extra);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location, extra: _self.$extra);
+
+  @override
+  void replace(BuildContext context) =>
+      context.replace(location, extra: _self.$extra);
 }
 
 T? _$convertMapValue<T>(

--- a/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart
@@ -1,0 +1,47 @@
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'knet_credentials_provider.g.dart';
+
+const _knetUserIdKey = 'knet_bosai_user_id';
+const _knetPasswordKey = 'knet_bosai_password';
+
+/// BOSAI 認証情報（ユーザーID + パスワード）
+class KnetCredentials {
+  const KnetCredentials({required this.userId, required this.password});
+
+  final String userId;
+  final String password;
+}
+
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+@Riverpod(keepAlive: true)
+class KnetCredentialsNotifier extends _$KnetCredentialsNotifier {
+  @override
+  Future<KnetCredentials?> build() async {
+    final storage = await ref.watch(secureStorageProvider.future);
+    final userId = await storage.read(key: _knetUserIdKey);
+    final password = await storage.read(key: _knetPasswordKey);
+    if (userId == null || password == null) {
+      return null;
+    }
+    return KnetCredentials(userId: userId, password: password);
+  }
+
+  Future<void> save({
+    required String userId,
+    required String password,
+  }) async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.write(key: _knetUserIdKey, value: userId);
+    await storage.write(key: _knetPasswordKey, value: password);
+    state = AsyncData(KnetCredentials(userId: userId, password: password));
+  }
+
+  Future<void> clear() async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.delete(key: _knetUserIdKey);
+    await storage.delete(key: _knetPasswordKey);
+    state = const AsyncData(null);
+  }
+}

--- a/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.g.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'knet_credentials_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+
+@ProviderFor(KnetCredentialsNotifier)
+final knetCredentialsProvider = KnetCredentialsNotifierProvider._();
+
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+final class KnetCredentialsNotifierProvider
+    extends $AsyncNotifierProvider<KnetCredentialsNotifier, KnetCredentials?> {
+  /// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+  KnetCredentialsNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'knetCredentialsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$knetCredentialsNotifierHash();
+
+  @$internal
+  @override
+  KnetCredentialsNotifier create() => KnetCredentialsNotifier();
+}
+
+String _$knetCredentialsNotifierHash() =>
+    r'e4c92ecfcaed3bfd9ffc32046c86869dc38a4a59';
+
+/// SecureStorage から BOSAI 認証情報を読み書きする Notifier
+
+abstract class _$KnetCredentialsNotifier
+    extends $AsyncNotifier<KnetCredentials?> {
+  FutureOr<KnetCredentials?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<KnetCredentials?>, KnetCredentials?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<KnetCredentials?>, KnetCredentials?>,
+              AsyncValue<KnetCredentials?>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.dart
@@ -1,0 +1,20 @@
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_credentials_provider.dart';
+import 'package:knet_api_client/knet_api_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'knet_download_client_provider.g.dart';
+
+/// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+///
+/// 認証情報が未設定の場合は null を返す。
+@Riverpod(keepAlive: true)
+Future<KnetDownloadClient?> knetDownloadClient(Ref ref) async {
+  final credentials = await ref.watch(knetCredentialsProvider.future);
+  if (credentials == null) {
+    return null;
+  }
+  return KnetDownloadClient(
+    userId: credentials.userId,
+    password: credentials.password,
+  );
+}

--- a/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.g.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_download_client_provider.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'knet_download_client_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+///
+/// 認証情報が未設定の場合は null を返す。
+
+@ProviderFor(knetDownloadClient)
+final knetDownloadClientProvider = KnetDownloadClientProvider._();
+
+/// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+///
+/// 認証情報が未設定の場合は null を返す。
+
+final class KnetDownloadClientProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<KnetDownloadClient?>,
+          KnetDownloadClient?,
+          FutureOr<KnetDownloadClient?>
+        >
+    with
+        $FutureModifier<KnetDownloadClient?>,
+        $FutureProvider<KnetDownloadClient?> {
+  /// 認証情報を基に [KnetDownloadClient] を生成するプロバイダ
+  ///
+  /// 認証情報が未設定の場合は null を返す。
+  KnetDownloadClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'knetDownloadClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$knetDownloadClientHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<KnetDownloadClient?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<KnetDownloadClient?> create(Ref ref) {
+    return knetDownloadClient(ref);
+  }
+}
+
+String _$knetDownloadClientHash() =>
+    r'1052415c1f1259a1043870504adb764c0ac002a7';

--- a/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
+++ b/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
@@ -1,0 +1,126 @@
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_credentials_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class KnetWaveformPage extends ConsumerWidget {
+  const KnetWaveformPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final credentials = ref.watch(knetCredentialsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('K-NET 強震波形'),
+      ),
+      body: credentials.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('エラー: $e')),
+        data: (data) {
+          if (data == null) {
+            return _UnconfiguredView(
+              onSetup: () =>
+                  const KnetCredentialsSettingsRoute().push<void>(context),
+            );
+          }
+          return _ConfiguredView(userId: data.userId);
+        },
+      ),
+    );
+  }
+}
+
+class _UnconfiguredView extends StatelessWidget {
+  const _UnconfiguredView({required this.onSetup});
+
+  final VoidCallback onSetup;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.lock_outline,
+              size: 64,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'BOSAI 認証情報が未設定です',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '防災科研の強震波形データをダウンロードするには、'
+              ' 事前に NIED のサイトでユーザー登録を行い、'
+              ' 認証情報を設定してください。',
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onSetup,
+              icon: const Icon(Icons.settings),
+              label: const Text('認証情報を設定する'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ConfiguredView extends StatelessWidget {
+  const _ConfiguredView({required this.userId});
+
+  final String userId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sensors,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'K-NET/KiK-net 強震観測網',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'ユーザー: $userId',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '波形データのダウンロード・'
+              '表示機能は準備中です。',
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            OutlinedButton.icon(
+              onPressed: () =>
+                  const KnetCredentialsSettingsRoute().push<void>(context),
+              icon: const Icon(Icons.settings),
+              label: const Text('認証設定'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
+++ b/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
@@ -81,6 +81,38 @@ class _ConfiguredView extends StatelessWidget {
 
   final String userId;
 
+  Future<void> _openMediaPage(BuildContext context) async {
+    // Step 1: pick date
+    final now = DateTime.now();
+    final date = await showDatePicker(
+      context: context,
+      initialDate: now,
+      firstDate: DateTime(2000),
+      lastDate: now,
+      helpText: '地震発生日を選択',
+    );
+    if (date == null || !context.mounted) {
+      return;
+    }
+    // Step 2: pick time
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+      helpText: '地震発生時刻を選択',
+    );
+    if (time == null || !context.mounted) {
+      return;
+    }
+    final eventTime = DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute,
+    );
+    await KnetMediaRoute($extra: eventTime).push<void>(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Center(
@@ -104,14 +136,13 @@ class _ConfiguredView extends StatelessWidget {
               'ユーザー: $userId',
               style: Theme.of(context).textTheme.bodySmall,
             ),
-            const SizedBox(height: 8),
-            Text(
-              '波形データのダウンロード・'
-              '表示機能は準備中です。',
-              style: Theme.of(context).textTheme.bodySmall,
-              textAlign: TextAlign.center,
-            ),
             const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: () => _openMediaPage(context),
+              icon: const Icon(Icons.image_search),
+              label: const Text('PNG図・MP4動画を表示'),
+            ),
+            const SizedBox(height: 12),
             OutlinedButton.icon(
               onPressed: () =>
                   const KnetCredentialsSettingsRoute().push<void>(context),

--- a/app/lib/feature/knet_waveform/ui/media/knet_fig_view.dart
+++ b/app/lib/feature/knet_waveform/ui/media/knet_fig_view.dart
@@ -1,0 +1,216 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_download_client_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:knet_api_client/knet_api_client.dart';
+
+/// K-NET all/fig PNG 図を表示するビュー
+class KnetFigView extends HookConsumerWidget {
+  const KnetFigView({required this.eventTime, super.key});
+
+  final DateTime eventTime;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clientAsync = ref.watch(knetDownloadClientProvider);
+
+    return clientAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => _ErrorView(
+        message: 'クライアント初期化エラー: $e',
+        onRetry: () => ref.invalidate(knetDownloadClientProvider),
+      ),
+      data: (client) {
+        if (client == null) {
+          return const Center(
+            child: Text('認証情報が設定されていません'),
+          );
+        }
+        return _FigContent(eventTime: eventTime, client: client);
+      },
+    );
+  }
+}
+
+class _FigContent extends HookWidget {
+  const _FigContent({required this.eventTime, required this.client});
+
+  final DateTime eventTime;
+  final KnetDownloadClient client;
+
+  static const _stationTypes = [
+    _StationType('all', 'ALL'),
+    _StationType('knet', 'K-NET'),
+    _StationType('kik', 'KiK-net'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedType = useState(_stationTypes[0]);
+    final imageBytes = useState<Uint8List?>(null);
+    final isLoading = useState(false);
+    final errorMessage = useState<String?>(null);
+
+    Future<void> loadImage() async {
+      isLoading.value = true;
+      errorMessage.value = null;
+      imageBytes.value = null;
+      try {
+        final url = knetAllFigUrl(eventTime, selectedType.value.key);
+        final bytes = await client.fetchBytes(url);
+        imageBytes.value = Uint8List.fromList(bytes);
+      } on Exception catch (e) {
+        errorMessage.value = e.toString();
+      } finally {
+        isLoading.value = false;
+      }
+    }
+
+    useEffect(
+      () {
+        unawaited(loadImage());
+        return null;
+      },
+      [selectedType.value, eventTime],
+    );
+
+    return Column(
+      children: [
+        _StationTypeSelector(
+          stationTypes: _stationTypes,
+          selected: selectedType.value,
+          onChanged: (type) => selectedType.value = type,
+        ),
+        Expanded(
+          child: _ImageArea(
+            isLoading: isLoading.value,
+            errorMessage: errorMessage.value,
+            imageBytes: imageBytes.value,
+            onRetry: loadImage,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StationTypeSelector extends StatelessWidget {
+  const _StationTypeSelector({
+    required this.stationTypes,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final List<_StationType> stationTypes;
+  final _StationType selected;
+  final ValueChanged<_StationType> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: SegmentedButton<_StationType>(
+        segments: stationTypes
+            .map(
+              (t) => ButtonSegment(
+                value: t,
+                label: Text(t.label),
+              ),
+            )
+            .toList(),
+        selected: {selected},
+        onSelectionChanged: (set) {
+          if (set.isNotEmpty) {
+            onChanged(set.first);
+          }
+        },
+      ),
+    );
+  }
+}
+
+class _ImageArea extends StatelessWidget {
+  const _ImageArea({
+    required this.isLoading,
+    required this.onRetry,
+    this.errorMessage,
+    this.imageBytes,
+  });
+
+  final bool isLoading;
+  final String? errorMessage;
+  final Uint8List? imageBytes;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (errorMessage != null) {
+      return _ErrorView(message: errorMessage!, onRetry: onRetry);
+    }
+
+    if (imageBytes == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return InteractiveViewer(
+      minScale: 0.5,
+      maxScale: 5,
+      child: Center(
+        child: Image.memory(
+          imageBytes!,
+          fit: BoxFit.contain,
+          errorBuilder: (context, error, _) =>
+              _ErrorView(message: error.toString(), onRetry: onRetry),
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('再試行'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StationType {
+  const _StationType(this.key, this.label);
+
+  final String key;
+  final String label;
+}

--- a/app/lib/feature/knet_waveform/ui/media/knet_media_page.dart
+++ b/app/lib/feature/knet_waveform/ui/media/knet_media_page.dart
@@ -1,0 +1,40 @@
+import 'package:eqmonitor/feature/knet_waveform/ui/media/knet_fig_view.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/media/knet_movie_view.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+/// K-NET all/fig PNG・all/movie MP4 を表示するページ
+class KnetMediaPage extends StatelessWidget {
+  const KnetMediaPage({required this.eventTime, super.key});
+
+  /// 地震発生時刻（JST）
+  final DateTime eventTime;
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            '強震記録 ${formatter.format(eventTime)}',
+            overflow: TextOverflow.ellipsis,
+          ),
+          bottom: const TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.image), text: 'PNG図'),
+              Tab(icon: Icon(Icons.movie), text: 'MP4動画'),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            KnetFigView(eventTime: eventTime),
+            KnetMovieView(eventTime: eventTime),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/media/knet_movie_view.dart
+++ b/app/lib/feature/knet_waveform/ui/media/knet_movie_view.dart
@@ -1,0 +1,319 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_download_client_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:knet_api_client/knet_api_client.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:video_player/video_player.dart';
+
+/// K-NET all/movie MP4 をダウンロード・再生するビュー
+class KnetMovieView extends HookConsumerWidget {
+  const KnetMovieView({required this.eventTime, super.key});
+
+  final DateTime eventTime;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clientAsync = ref.watch(knetDownloadClientProvider);
+
+    return clientAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => _ErrorView(
+        message: 'クライアント初期化エラー: $e',
+        onRetry: () => ref.invalidate(knetDownloadClientProvider),
+      ),
+      data: (client) {
+        if (client == null) {
+          return const Center(
+            child: Text('認証情報が設定されていません'),
+          );
+        }
+        return _MovieContent(eventTime: eventTime, client: client);
+      },
+    );
+  }
+}
+
+enum _DownloadState { idle, downloading, ready, error }
+
+class _MovieContent extends HookWidget {
+  const _MovieContent({required this.eventTime, required this.client});
+
+  final DateTime eventTime;
+  final KnetDownloadClient client;
+
+  @override
+  Widget build(BuildContext context) {
+    final downloadState = useState(_DownloadState.idle);
+    final downloadProgress = useState<double>(0);
+    final errorMessage = useState<String?>(null);
+    final localFile = useState<File?>(null);
+    final controller = useState<VideoPlayerController?>(null);
+    final isControllerInit = useState(false);
+
+    Future<void> download() async {
+      downloadState.value = _DownloadState.downloading;
+      downloadProgress.value = 0;
+      errorMessage.value = null;
+      localFile.value = null;
+
+      // Dispose old controller if any
+      final oldCtrl = controller.value;
+      controller.value = null;
+      isControllerInit.value = false;
+      await oldCtrl?.dispose();
+
+      try {
+        final url = knetAllMovieUrl(eventTime);
+        final bytes = await client.fetchBytes(url);
+        final dir = await getTemporaryDirectory();
+        final fileName = '${eventTime.millisecondsSinceEpoch}_knet.mp4';
+        final file = File('${dir.path}/$fileName');
+        await file.writeAsBytes(bytes);
+        localFile.value = file;
+        downloadState.value = _DownloadState.ready;
+      } on Exception catch (e) {
+        errorMessage.value = e.toString();
+        downloadState.value = _DownloadState.error;
+      }
+    }
+
+    // Initialize video controller when file is ready
+    useEffect(
+      () {
+        final file = localFile.value;
+        if (file == null) {
+          return null;
+        }
+        final ctrl = VideoPlayerController.file(file);
+        controller.value = ctrl;
+        isControllerInit.value = false;
+
+        unawaited(
+          ctrl.initialize().then((_) {
+            isControllerInit.value = true;
+          }),
+        );
+
+        return ctrl.dispose;
+      },
+      [localFile.value],
+    );
+
+    return switch (downloadState.value) {
+      _DownloadState.idle => Center(
+        child: FilledButton.icon(
+          onPressed: download,
+          icon: const Icon(Icons.download),
+          label: const Text('MP4 をダウンロード'),
+        ),
+      ),
+      _DownloadState.downloading => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const CircularProgressIndicator(),
+              const SizedBox(height: 16),
+              Text(
+                'ダウンロード中...',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              if (downloadProgress.value > 0) ...[
+                const SizedBox(height: 8),
+                LinearProgressIndicator(value: downloadProgress.value),
+              ],
+            ],
+          ),
+        ),
+      ),
+      _DownloadState.error => _ErrorView(
+        message: errorMessage.value ?? '不明なエラー',
+        onRetry: download,
+      ),
+      _DownloadState.ready => _VideoArea(
+        controller: controller.value,
+        isInitialized: isControllerInit.value,
+        onRedownload: download,
+      ),
+    };
+  }
+}
+
+class _VideoArea extends HookWidget {
+  const _VideoArea({
+    required this.controller,
+    required this.isInitialized,
+    required this.onRedownload,
+  });
+
+  final VideoPlayerController? controller;
+  final bool isInitialized;
+  final VoidCallback onRedownload;
+
+  @override
+  Widget build(BuildContext context) {
+    final ctrl = controller;
+
+    if (ctrl == null || !isInitialized) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    // Rebuild when playback state changes
+    useListenable(ctrl);
+
+    final isPlaying = ctrl.value.isPlaying;
+    final duration = ctrl.value.duration;
+    final position = ctrl.value.position;
+    final hasError = ctrl.value.hasError;
+
+    if (hasError) {
+      return _ErrorView(
+        message: ctrl.value.errorDescription ?? '再生エラー',
+        onRetry: onRedownload,
+      );
+    }
+
+    return Column(
+      children: [
+        Expanded(
+          child: Center(
+            child: AspectRatio(
+              aspectRatio: ctrl.value.aspectRatio,
+              child: VideoPlayer(ctrl),
+            ),
+          ),
+        ),
+        _VideoControls(
+          controller: ctrl,
+          isPlaying: isPlaying,
+          duration: duration,
+          position: position,
+          onRedownload: onRedownload,
+        ),
+      ],
+    );
+  }
+}
+
+class _VideoControls extends StatelessWidget {
+  const _VideoControls({
+    required this.controller,
+    required this.isPlaying,
+    required this.duration,
+    required this.position,
+    required this.onRedownload,
+  });
+
+  final VideoPlayerController controller;
+  final bool isPlaying;
+  final Duration duration;
+  final Duration position;
+  final VoidCallback onRedownload;
+
+  String _formatDuration(Duration d) {
+    final minutes = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final total = duration.inMilliseconds;
+    final current = position.inMilliseconds;
+    final sliderValue = total > 0 ? (current / total).clamp(0.0, 1.0) : 0.0;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Text(_formatDuration(position)),
+                Expanded(
+                  child: Slider(
+                    value: sliderValue,
+                    onChanged: (v) {
+                      final seekTo = Duration(
+                        milliseconds: (total * v).toInt(),
+                      );
+                      unawaited(controller.seekTo(seekTo));
+                    },
+                  ),
+                ),
+                Text(_formatDuration(duration)),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                IconButton(
+                  onPressed: () => unawaited(controller.seekTo(Duration.zero)),
+                  icon: const Icon(Icons.skip_previous),
+                  tooltip: '先頭に戻る',
+                ),
+                IconButton.filled(
+                  onPressed: () {
+                    if (isPlaying) {
+                      unawaited(controller.pause());
+                    } else {
+                      unawaited(controller.play());
+                    }
+                  },
+                  icon: Icon(isPlaying ? Icons.pause : Icons.play_arrow),
+                  iconSize: 36,
+                  tooltip: isPlaying ? '一時停止' : '再生',
+                ),
+                IconButton(
+                  onPressed: onRedownload,
+                  icon: const Icon(Icons.refresh),
+                  tooltip: '再ダウンロード',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('再試行'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart
+++ b/app/lib/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart
@@ -1,0 +1,217 @@
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_credentials_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:knet_api_client/knet_api_client.dart';
+
+class KnetCredentialsSettingsPage extends HookConsumerWidget {
+  const KnetCredentialsSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userIdController = useTextEditingController();
+    final passwordController = useTextEditingController();
+    final isVerifying = useState(false);
+    final verifyResult = useState<bool?>(null);
+
+    final credentials = ref.watch(knetCredentialsProvider);
+
+    useEffect(
+      () {
+        credentials.whenData((data) {
+          if (data != null) {
+            userIdController.text = data.userId;
+            passwordController.text = data.password;
+          }
+        });
+        return null;
+      },
+      [credentials],
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('K-NET 認証設定'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '防災科研 強震観測網 認証情報',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '防災科学技術研究所（NIED）の強震観測網データをダウンロードするために、'
+                    'ユーザー登録済みの BOSAI アカウント情報を入力してください。',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: userIdController,
+            decoration: const InputDecoration(
+              labelText: 'ユーザーID',
+              hintText: 'BOSAI ユーザーID',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.person),
+            ),
+            textInputAction: TextInputAction.next,
+            onChanged: (_) => verifyResult.value = null,
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: passwordController,
+            decoration: const InputDecoration(
+              labelText: 'パスワード',
+              hintText: 'BOSAI パスワード',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.lock),
+            ),
+            obscureText: true,
+            textInputAction: TextInputAction.done,
+            onChanged: (_) => verifyResult.value = null,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonal(
+                  onPressed: isVerifying.value
+                      ? null
+                      : () async {
+                          final userId = userIdController.text.trim();
+                          final password = passwordController.text.trim();
+                          if (userId.isEmpty || password.isEmpty) {
+                            return;
+                          }
+                          isVerifying.value = true;
+                          verifyResult.value = null;
+                          try {
+                            final client = KnetDownloadClient(
+                              userId: userId,
+                              password: password,
+                            );
+                            final ok = await client.verifyAuthentication();
+                            verifyResult.value = ok;
+                          } on Exception catch (_) {
+                            verifyResult.value = false;
+                          } finally {
+                            isVerifying.value = false;
+                          }
+                        },
+                  child: isVerifying.value
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('認証テスト'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: FilledButton(
+                  onPressed: isVerifying.value
+                      ? null
+                      : () async {
+                          final userId = userIdController.text.trim();
+                          final password = passwordController.text.trim();
+                          if (userId.isEmpty || password.isEmpty) {
+                            return;
+                          }
+                          await ref
+                              .read(knetCredentialsProvider.notifier)
+                              .save(userId: userId, password: password);
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('認証情報を保存しました')),
+                            );
+                          }
+                        },
+                  child: const Text('保存'),
+                ),
+              ),
+            ],
+          ),
+          if (verifyResult.value != null) ...[
+            const SizedBox(height: 12),
+            _VerifyResultBanner(success: verifyResult.value!),
+          ],
+          const SizedBox(height: 24),
+          credentials.when(
+            loading: () => const SizedBox.shrink(),
+            error: (_, _) => const SizedBox.shrink(),
+            data: (data) {
+              if (data == null) {
+                return const SizedBox.shrink();
+              }
+              return OutlinedButton.icon(
+                icon: const Icon(Icons.delete_outline),
+                label: const Text('認証情報を削除'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Theme.of(context).colorScheme.error,
+                ),
+                onPressed: () async {
+                  await ref.read(knetCredentialsProvider.notifier).clear();
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+                },
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VerifyResultBanner extends StatelessWidget {
+  const _VerifyResultBanner({required this.success});
+
+  final bool success;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: success
+            ? Theme.of(context).colorScheme.primaryContainer
+            : Theme.of(context).colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            success ? Icons.check_circle_outline : Icons.error_outline,
+            color: success
+                ? Theme.of(context).colorScheme.onPrimaryContainer
+                : Theme.of(context).colorScheme.onErrorContainer,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              success ? '認証に成功しました' : '認証に失敗しました。IDまたはパスワードを確認してください。',
+              style: TextStyle(
+                color: success
+                    ? Theme.of(context).colorScheme.onPrimaryContainer
+                    : Theme.of(context).colorScheme.onErrorContainer,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/nied/ui/nied_page.dart
+++ b/app/lib/feature/nied/ui/nied_page.dart
@@ -24,6 +24,12 @@ class NiedPage extends StatelessWidget {
             leading: const Icon(Icons.sensors),
             onTap: () async => const FnetRoute().push<void>(context),
           ),
+          ListTile(
+            title: const Text('K-NET/KiK-net'),
+            subtitle: const Text('強震観測網 波形データ'),
+            leading: const Icon(Icons.show_chart),
+            onTap: () async => const KnetWaveformRoute().push<void>(context),
+          ),
         ],
       ),
     );

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -157,6 +157,7 @@ dependencies:
   url_launcher: ^6.3.1
   uuid: ^4.5.1
   version: ^3.0.2
+  video_player: ^2.11.1
   web_socket: ^1.0.1
   web_socket_client: ^0.2.1
   workflows:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -112,6 +112,10 @@ dependencies:
   jma_map:
     path: ../packages/jma_map
   json_annotation: ^4.11.0
+  knet_api_client:
+    path: ../packages/knet_api_client
+  knet_waveform_parser:
+    path: ../packages/knet_waveform_parser
   kyoshin_monitor_api:
     path: ../packages/kyoshin_monitor_api
   kyoshin_monitor_image_parser:

--- a/packages/knet_api_client/lib/src/knet_download_client.dart
+++ b/packages/knet_api_client/lib/src/knet_download_client.dart
@@ -57,7 +57,7 @@ class KnetDownloadClient {
   Future<bool> verifyAuthentication() async {
     try {
       final response = await _dio.get<dynamic>(
-        '/knet/',
+        'knet/',
         options: Options(responseType: ResponseType.stream),
       );
       return response.statusCode == 200;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2307,6 +2307,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  video_player:
+    dependency: transitive
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.5"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: a39d6f28f8069564d8cc17396472f958dd9eaddf2d5c8e90aad4d793ac369bf3
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.6"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "16eaed5268c571c31840dc58ef8da5f0cd4db2a98490c3b8f1cf70122546c6e0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.7.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- `KnetMediaPage` を追加。タブ形式で **PNG図**（`all/fig`）と **MP4動画**（`all/movie`）を切り替え表示する
- `KnetFigView`: `KnetDownloadClient` で Basic 認証付きダウンロード → `Image.memory` で表示。観測網種別（K-NET / KiK-net / ALL）を `SegmentedButton` で選択可能
- `KnetMovieView`: MP4 をダウンロード後テンポラリディレクトリに保存し `video_player` でローカル再生。スライダー・再生/一時停止コントロール付き
- `KnetWaveformRoute` のサブルート `KnetMediaRoute(path: 'media')` を追加。`$extra: DateTime` で地震発生時刻を渡す
- `KnetWaveformPage` の認証済みビューに日時ピッカー経由でメディアページへ遷移するボタンを追加
- `video_player` パッケージを `app/pubspec.yaml` に追加

## Test plan

- [ ] `dart analyze lib` → No issues found
- [ ] `build_runner build` 成功・`router.g.dart` に `$KnetMediaRoute` が生成される
- [ ] K-NET 認証設定済み状態で「PNG図・MP4動画を表示」ボタンから日時ピッカー経由でメディアページに遷移できる
- [ ] PNG 図タブ: 観測網種別（ALL / K-NET / KiK-net）を切り替えると画像が再取得・表示される
- [ ] MP4 動画タブ: ダウンロード→再生→スライダー操作が正常に動作する
- [ ] 認証情報未設定時・ファイル取得失敗時にエラーメッセージと再試行ボタンが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)