### PR TITLE
feat: K-NET 強震波形ビューワー（地震選択・観測点一覧・波形グラフ・ヘッダ編集）

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -14,8 +14,12 @@ import 'package:eqmonitor/feature/earthquake_search/data/model/earthquake_search
 import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_page.dart';
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
 import 'package:eqmonitor/feature/home/ui/page/home_map_layer_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/earthquake/knet_earthquake_list_page.dart';
 import 'package:eqmonitor/feature/knet_waveform/ui/knet_waveform_page.dart';
 import 'package:eqmonitor/feature/knet_waveform/ui/settings/knet_credentials_settings_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/station/knet_header_edit_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/station/knet_station_detail_page.dart';
+import 'package:eqmonitor/feature/knet_waveform/ui/station/knet_station_list_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_observation_network_page.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/kyoshin_monitor_about_page.dart';
 import 'package:eqmonitor/feature/nied/ui/aqua/aqua_catalog_page.dart';
@@ -108,8 +112,7 @@ class SplashRoute extends GoRouteData with $SplashRoute {
   const SplashRoute();
 
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const SplashPage();
+  Widget build(BuildContext context, GoRouterState state) => const SplashPage();
 }
 
 @TypedGoRoute<OnboardingRoute>(path: '/onboarding')
@@ -333,6 +336,24 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
               routes: [
                 TypedGoRoute<KnetCredentialsSettingsRoute>(
                   path: 'settings',
+                ),
+                TypedGoRoute<KnetEarthquakeListRoute>(
+                  path: 'earthquakes',
+                  routes: [
+                    TypedGoRoute<KnetStationListRoute>(
+                      path: ':eventTimeMs/stations',
+                      routes: [
+                        TypedGoRoute<KnetStationDetailRoute>(
+                          path: ':stationCode',
+                          routes: [
+                            TypedGoRoute<KnetHeaderEditRoute>(
+                              path: 'edit',
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -673,6 +694,58 @@ class KnetCredentialsSettingsRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const KnetCredentialsSettingsPage();
+}
+
+class KnetEarthquakeListRoute extends GoRouteData
+    with $KnetEarthquakeListRoute {
+  const KnetEarthquakeListRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const KnetEarthquakeListPage();
+}
+
+class KnetStationListRoute extends GoRouteData with $KnetStationListRoute {
+  const KnetStationListRoute({required this.eventTimeMs});
+
+  final int eventTimeMs;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      KnetStationListPage(eventTimeMs: eventTimeMs);
+}
+
+class KnetStationDetailRoute extends GoRouteData with $KnetStationDetailRoute {
+  const KnetStationDetailRoute({
+    required this.eventTimeMs,
+    required this.stationCode,
+  });
+
+  final int eventTimeMs;
+  final String stationCode;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      KnetStationDetailPage(
+        eventTimeMs: eventTimeMs,
+        stationCode: stationCode,
+      );
+}
+
+class KnetHeaderEditRoute extends GoRouteData with $KnetHeaderEditRoute {
+  const KnetHeaderEditRoute({
+    required this.eventTimeMs,
+    required this.stationCode,
+  });
+
+  final int eventTimeMs;
+  final String stationCode;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => KnetHeaderEditPage(
+    eventTimeMs: eventTimeMs,
+    stationCode: stationCode,
+  );
 }
 
 class KyoshinMonitorAboutRoute extends GoRouteData

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -540,6 +540,28 @@ RouteBase get $settingsRoute => GoRouteData.$route(
                   path: 'settings',
                   factory: $KnetCredentialsSettingsRoute._fromState,
                 ),
+                GoRouteData.$route(
+                  path: 'earthquakes',
+                  factory: $KnetEarthquakeListRoute._fromState,
+                  routes: [
+                    GoRouteData.$route(
+                      path: ':eventTimeMs/stations',
+                      factory: $KnetStationListRoute._fromState,
+                      routes: [
+                        GoRouteData.$route(
+                          path: ':stationCode',
+                          factory: $KnetStationDetailRoute._fromState,
+                          routes: [
+                            GoRouteData.$route(
+                              path: 'edit',
+                              factory: $KnetHeaderEditRoute._fromState,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ],
             ),
           ],
@@ -1337,6 +1359,111 @@ mixin $KnetCredentialsSettingsRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/settings/debug/nied/knet/settings');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetEarthquakeListRoute on GoRouteData {
+  static KnetEarthquakeListRoute _fromState(GoRouterState state) =>
+      const KnetEarthquakeListRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/nied/knet/earthquakes');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetStationListRoute on GoRouteData {
+  static KnetStationListRoute _fromState(GoRouterState state) =>
+      KnetStationListRoute(
+        eventTimeMs: int.parse(state.pathParameters['eventTimeMs']!),
+      );
+
+  KnetStationListRoute get _self => this as KnetStationListRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/settings/debug/nied/knet/earthquakes/${Uri.encodeComponent(_self.eventTimeMs.toString())}/stations',
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetStationDetailRoute on GoRouteData {
+  static KnetStationDetailRoute _fromState(GoRouterState state) =>
+      KnetStationDetailRoute(
+        eventTimeMs: int.parse(state.pathParameters['eventTimeMs']!),
+        stationCode: state.pathParameters['stationCode']!,
+      );
+
+  KnetStationDetailRoute get _self => this as KnetStationDetailRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/settings/debug/nied/knet/earthquakes/${Uri.encodeComponent(_self.eventTimeMs.toString())}/stations/${Uri.encodeComponent(_self.stationCode)}',
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $KnetHeaderEditRoute on GoRouteData {
+  static KnetHeaderEditRoute _fromState(GoRouterState state) =>
+      KnetHeaderEditRoute(
+        eventTimeMs: int.parse(state.pathParameters['eventTimeMs']!),
+        stationCode: state.pathParameters['stationCode']!,
+      );
+
+  KnetHeaderEditRoute get _self => this as KnetHeaderEditRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/settings/debug/nied/knet/earthquakes/${Uri.encodeComponent(_self.eventTimeMs.toString())}/stations/${Uri.encodeComponent(_self.stationCode)}/edit',
+  );
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_download_client_provider.dart';
+import 'package:knet_api_client/knet_api_client.dart';
+import 'package:knet_waveform_parser/knet_waveform_parser.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'knet_waveform_download_provider.g.dart';
+
+/// 観測点コードでグループ化した K-NET 強震記録マップ
+///
+/// key: 観測点コード (e.g. "IBR011")
+/// value: チャンネル方向別の KnetRecord
+typedef KnetStationRecords = Map<String, Map<KnetChannelDirection, KnetRecord>>;
+
+/// 指定した地震発生時刻の ZIP をダウンロード・解凍・パースし、
+/// 観測点コードでグループ化した記録マップを返す @riverpod provider
+///
+/// [eventTimeMs] は DateTime.millisecondsSinceEpoch（URL パラメータとして使用）
+@riverpod
+Future<KnetStationRecords> knetWaveformDownload(
+  Ref ref,
+  int eventTimeMs,
+) async {
+  final client = await ref.watch(knetDownloadClientProvider.future);
+  if (client == null) {
+    throw const KnetWaveformDownloadException(
+      '認証情報が未設定です。設定画面から BOSAI 認証情報を入力してください。',
+    );
+  }
+
+  final eventTime = DateTime.fromMillisecondsSinceEpoch(eventTimeMs);
+  final zipUrl = knetAllZipUrl(eventTime);
+
+  final bytes = await client.fetchBytes(zipUrl);
+  final archive = ZipDecoder().decodeBytes(bytes);
+
+  const parser = KnetAsciiParser();
+  final result = <String, Map<KnetChannelDirection, KnetRecord>>{};
+
+  for (final file in archive.files) {
+    if (file.isDirectory) {
+      continue;
+    }
+    // K-NET ASCII ファイルは .NS / .EW / .UD の拡張子を持つ
+    final name = file.name;
+    final dot = name.lastIndexOf('.');
+    if (dot < 0) {
+      continue;
+    }
+    final ext = name.substring(dot + 1).toUpperCase();
+    if (ext != 'NS' && ext != 'EW' && ext != 'UD') {
+      continue;
+    }
+
+    final content = file.content;
+    if (content.isEmpty) {
+      continue;
+    }
+
+    final text = utf8.decode(content, allowMalformed: true);
+
+    try {
+      final record = parser.parse(text);
+      final stationCode = record.stationInfo.stationCode;
+      result.putIfAbsent(stationCode, () => {})[record.direction] = record;
+    } on KnetParseException {
+      // パース失敗はスキップ
+    }
+  }
+
+  if (result.isEmpty) {
+    throw const KnetWaveformDownloadException(
+      'ZIPファイルに有効な波形データが含まれていませんでした。',
+    );
+  }
+
+  return result;
+}
+
+/// K-NET 波形ダウンロード・パースエラー
+class KnetWaveformDownloadException implements Exception {
+  const KnetWaveformDownloadException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'KnetWaveformDownloadException: $message';
+}

--- a/app/lib/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:isolate';
 
 import 'package:archive/archive.dart';
 import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_download_client_provider.dart';
@@ -17,7 +18,8 @@ typedef KnetStationRecords = Map<String, Map<KnetChannelDirection, KnetRecord>>;
 /// 指定した地震発生時刻の ZIP をダウンロード・解凍・パースし、
 /// 観測点コードでグループ化した記録マップを返す @riverpod provider
 ///
-/// [eventTimeMs] は DateTime.millisecondsSinceEpoch（URL パラメータとして使用）
+/// [eventTimeMs] は DateTime.millisecondsSinceEpoch（UTC 基準）。
+/// knetAllZipUrl は JST の年月日時分秒を期待するため、UTC+9h に変換して渡す。
 @riverpod
 Future<KnetStationRecords> knetWaveformDownload(
   Ref ref,
@@ -30,12 +32,35 @@ Future<KnetStationRecords> knetWaveformDownload(
     );
   }
 
-  final eventTime = DateTime.fromMillisecondsSinceEpoch(eventTimeMs);
+  // knetAllZipUrl の _format* ヘルパーは DateTime の各フィールド (year/month/day/hour 等)
+  // を直接読むため、JST (UTC+9) の DateTime として渡す必要がある。
+  // isUtc: true で UTC として解釈したうえで +9h することで、
+  // 端末ロケールによらず JST の年月日時分秒が得られる。
+  final eventTime = DateTime.fromMillisecondsSinceEpoch(
+    eventTimeMs,
+    isUtc: true,
+  ).add(const Duration(hours: 9));
   final zipUrl = knetAllZipUrl(eventTime);
 
   final bytes = await client.fetchBytes(zipUrl);
-  final archive = ZipDecoder().decodeBytes(bytes);
 
+  // ZIP 解凍 + パースは重い処理のため Isolate で実行する
+  final result = await Isolate.run(() => _parseZipBytes(bytes));
+
+  if (result.isEmpty) {
+    throw const KnetWaveformDownloadException(
+      'ZIPファイルに有効な波形データが含まれていませんでした。',
+    );
+  }
+
+  return result;
+}
+
+/// ZIP バイト列を解凍・パースして観測点レコードマップを返す純粋関数。
+///
+/// UI isolate をブロックしないよう [Isolate.run] から呼び出す。
+KnetStationRecords _parseZipBytes(List<int> bytes) {
+  final archive = ZipDecoder().decodeBytes(bytes);
   const parser = KnetAsciiParser();
   final result = <String, Map<KnetChannelDirection, KnetRecord>>{};
 
@@ -54,7 +79,7 @@ Future<KnetStationRecords> knetWaveformDownload(
       continue;
     }
 
-    final content = file.content;
+    final content = file.content as List<int>;
     if (content.isEmpty) {
       continue;
     }
@@ -68,12 +93,6 @@ Future<KnetStationRecords> knetWaveformDownload(
     } on KnetParseException {
       // パース失敗はスキップ
     }
-  }
-
-  if (result.isEmpty) {
-    throw const KnetWaveformDownloadException(
-      'ZIPファイルに有効な波形データが含まれていませんでした。',
-    );
   }
 
   return result;

--- a/app/lib/feature/knet_waveform/data/provider/knet_waveform_download_provider.g.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_waveform_download_provider.g.dart
@@ -1,0 +1,113 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'knet_waveform_download_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 指定した地震発生時刻の ZIP をダウンロード・解凍・パースし、
+/// 観測点コードでグループ化した記録マップを返す @riverpod provider
+///
+/// [eventTimeMs] は DateTime.millisecondsSinceEpoch（URL パラメータとして使用）
+
+@ProviderFor(knetWaveformDownload)
+final knetWaveformDownloadProvider = KnetWaveformDownloadFamily._();
+
+/// 指定した地震発生時刻の ZIP をダウンロード・解凍・パースし、
+/// 観測点コードでグループ化した記録マップを返す @riverpod provider
+///
+/// [eventTimeMs] は DateTime.millisecondsSinceEpoch（URL パラメータとして使用）
+
+final class KnetWaveformDownloadProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<KnetStationRecords>,
+          KnetStationRecords,
+          FutureOr<KnetStationRecords>
+        >
+    with
+        $FutureModifier<KnetStationRecords>,
+        $FutureProvider<KnetStationRecords> {
+  /// 指定した地震発生時刻の ZIP をダウンロード・解凍・パースし、
+  /// 観測点コードでグループ化した記録マップを返す @riverpod provider
+  ///
+  /// [eventTimeMs] は DateTime.millisecondsSinceEpoch（URL パラメータとして使用）
+  KnetWaveformDownloadProvider._({
+    required KnetWaveformDownloadFamily super.from,
+    required int super.argument,
+  }) : super(
+         retry: null,
+         name: r'knetWaveformDownloadProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$knetWaveformDownloadHash();
+
+  @override
+  String toString() {
+    return r'knetWaveformDownloadProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<KnetStationRecords> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<KnetStationRecords> create(Ref ref) {
+    final argument = this.argument as int;
+    return knetWaveformDownload(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is KnetWaveformDownloadProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$knetWaveformDownloadHash() =>
+    r'ceb3d7e987e3c9aa5e6c9aae2eff2a2747da49b9';
+
+/// 指定した地震発生時刻の ZIP をダウンロード・解凍・パースし、
+/// 観測点コードでグループ化した記録マップを返す @riverpod provider
+///
+/// [eventTimeMs] は DateTime.millisecondsSinceEpoch（URL パラメータとして使用）
+
+final class KnetWaveformDownloadFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<KnetStationRecords>, int> {
+  KnetWaveformDownloadFamily._()
+    : super(
+        retry: null,
+        name: r'knetWaveformDownloadProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// 指定した地震発生時刻の ZIP をダウンロード・解凍・パースし、
+  /// 観測点コードでグループ化した記録マップを返す @riverpod provider
+  ///
+  /// [eventTimeMs] は DateTime.millisecondsSinceEpoch（URL パラメータとして使用）
+
+  KnetWaveformDownloadProvider call(int eventTimeMs) =>
+      KnetWaveformDownloadProvider._(argument: eventTimeMs, from: this);
+
+  @override
+  String toString() => r'knetWaveformDownloadProvider';
+}

--- a/app/lib/feature/knet_waveform/ui/earthquake/knet_earthquake_list_page.dart
+++ b/app/lib/feature/knet_waveform/ui/earthquake/knet_earthquake_list_page.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+
+/// サンプル地震イベント（発生日時 JST）
+final _sampleEvents = <_EqEvent>[
+  _EqEvent(
+    dateTime: DateTime(2011, 3, 11, 14, 46, 18),
+    description: '東北地方太平洋沖地震 M9.0',
+  ),
+  _EqEvent(
+    dateTime: DateTime(2016, 4, 16, 1, 25, 5),
+    description: '熊本地震（本震）M7.3',
+  ),
+  _EqEvent(
+    dateTime: DateTime(2024, 1, 1, 16, 10, 9),
+    description: '令和6年能登半島地震 M7.6',
+  ),
+];
+
+class _EqEvent {
+  const _EqEvent({required this.dateTime, required this.description});
+  final DateTime dateTime;
+  final String description;
+}
+
+/// 地震イベント一覧画面
+///
+/// ユーザーが地震を選択すると観測点一覧画面へ遷移する。
+class KnetEarthquakeListPage extends ConsumerWidget {
+  const KnetEarthquakeListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fmt = DateFormat('yyyy/MM/dd HH:mm:ss');
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('地震イベント選択'),
+      ),
+      body: ListView.separated(
+        itemCount: _sampleEvents.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final event = _sampleEvents[index];
+          return ListTile(
+            leading: const Icon(Icons.vibration),
+            title: Text(event.description),
+            subtitle: Text(fmt.format(event.dateTime)),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => unawaited(
+              KnetStationListRoute(
+                eventTimeMs: event.dateTime.millisecondsSinceEpoch,
+              ).push<void>(context),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/earthquake/knet_earthquake_list_page.dart
+++ b/app/lib/feature/knet_waveform/ui/earthquake/knet_earthquake_list_page.dart
@@ -5,18 +5,18 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 
-/// サンプル地震イベント（発生日時 JST）
+/// サンプル地震イベント（UTC で定義。download_provider が UTC+9h = JST に変換する）
 final _sampleEvents = <_EqEvent>[
   _EqEvent(
-    dateTime: DateTime(2011, 3, 11, 14, 46, 18),
+    dateTime: DateTime.utc(2011, 3, 11, 5, 46, 18),
     description: '東北地方太平洋沖地震 M9.0',
   ),
   _EqEvent(
-    dateTime: DateTime(2016, 4, 16, 1, 25, 5),
+    dateTime: DateTime.utc(2016, 4, 15, 16, 25, 5),
     description: '熊本地震（本震）M7.3',
   ),
   _EqEvent(
-    dateTime: DateTime(2024, 1, 1, 16, 10, 9),
+    dateTime: DateTime.utc(2024, 1, 1, 7, 10, 9),
     description: '令和6年能登半島地震 M7.6',
   ),
 ];

--- a/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
+++ b/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
@@ -24,7 +24,10 @@ class KnetWaveformPage extends ConsumerWidget {
                   const KnetCredentialsSettingsRoute().push<void>(context),
             );
           }
-          return _ConfiguredView(userId: data.userId);
+          return _ConfiguredView(
+            userId: data.userId,
+            onBrowse: () => const KnetEarthquakeListRoute().push<void>(context),
+          );
         },
       ),
     );
@@ -77,9 +80,13 @@ class _UnconfiguredView extends StatelessWidget {
 }
 
 class _ConfiguredView extends StatelessWidget {
-  const _ConfiguredView({required this.userId});
+  const _ConfiguredView({
+    required this.userId,
+    required this.onBrowse,
+  });
 
   final String userId;
+  final VoidCallback onBrowse;
 
   @override
   Widget build(BuildContext context) {
@@ -104,14 +111,13 @@ class _ConfiguredView extends StatelessWidget {
               'ユーザー: $userId',
               style: Theme.of(context).textTheme.bodySmall,
             ),
-            const SizedBox(height: 8),
-            Text(
-              '波形データのダウンロード・'
-              '表示機能は準備中です。',
-              style: Theme.of(context).textTheme.bodySmall,
-              textAlign: TextAlign.center,
-            ),
             const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onBrowse,
+              icon: const Icon(Icons.list_alt),
+              label: const Text('地震データを閲覧'),
+            ),
+            const SizedBox(height: 12),
             OutlinedButton.icon(
               onPressed: () =>
                   const KnetCredentialsSettingsRoute().push<void>(context),

--- a/app/lib/feature/knet_waveform/ui/station/knet_header_edit_page.dart
+++ b/app/lib/feature/knet_waveform/ui/station/knet_header_edit_page.dart
@@ -28,7 +28,13 @@ class KnetHeaderEditPage extends HookConsumerWidget {
       ),
       body: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('エラー: $e')),
+        error: (e, st) {
+          final msg = e is KnetWaveformDownloadException
+              ? e.message
+              : 'データの取得に失敗しました';
+          debugPrint('K-NET header edit error: $e\n$st');
+          return Center(child: Text(msg));
+        },
         data: (stationMap) {
           final records = stationMap[stationCode];
           if (records == null) {
@@ -69,11 +75,14 @@ class _EditForm extends HookWidget {
 
     void onSave() {
       if (formKey.currentState?.validate() ?? false) {
-        // 現時点ではメモリ内保持のみ。
-        // 将来的に SharedPreferences や Hive への永続化を実装する想定。
+        // TODO(#1201): 編集内容の永続化は未実装。
+        // 将来的に StateProvider<Map<String, KnetHeaderOverride>> などで
+        // セッション内保持 → SharedPreferences/Hive への永続化を実装する。
         isSaved.value = true;
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('保存しました（セッション内一時保存）')),
+          const SnackBar(
+            content: Text('入力内容を確認しました（保存機能は未実装です）'),
+          ),
         );
       }
     }
@@ -85,25 +94,25 @@ class _EditForm extends HookWidget {
         children: [
           if (isSaved.value)
             Card(
-              color: Theme.of(context).colorScheme.primaryContainer,
+              color: Theme.of(context).colorScheme.secondaryContainer,
               child: Padding(
                 padding: const EdgeInsets.all(12),
                 child: Row(
                   children: [
                     Icon(
                       Icons.info_outline,
-                      color: Theme.of(context).colorScheme.onPrimaryContainer,
+                      color: Theme.of(context).colorScheme.onSecondaryContainer,
                       size: 18,
                     ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
-                        'セッション内一時保存済み。アプリ再起動時はリセットされます。',
+                        '保存機能は未実装です。入力内容はアプリ再起動時にリセットされます。',
                         style: TextStyle(
                           fontSize: 12,
                           color: Theme.of(
                             context,
-                          ).colorScheme.onPrimaryContainer,
+                          ).colorScheme.onSecondaryContainer,
                         ),
                       ),
                     ),
@@ -151,7 +160,7 @@ class _EditForm extends HookWidget {
           FilledButton.icon(
             onPressed: onSave,
             icon: const Icon(Icons.save),
-            label: const Text('保存'),
+            label: const Text('確認（保存は次回実装）'),
           ),
         ],
       ),

--- a/app/lib/feature/knet_waveform/ui/station/knet_header_edit_page.dart
+++ b/app/lib/feature/knet_waveform/ui/station/knet_header_edit_page.dart
@@ -1,0 +1,187 @@
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:knet_waveform_parser/knet_waveform_parser.dart';
+
+/// K-NET 観測点ヘッダ情報編集画面
+///
+/// 観測点の基本情報を編集・確認できる。
+/// 変更内容はセッション内メモリに保持する（今後永続化対応予定）。
+class KnetHeaderEditPage extends HookConsumerWidget {
+  const KnetHeaderEditPage({
+    required this.eventTimeMs,
+    required this.stationCode,
+    super.key,
+  });
+
+  final int eventTimeMs;
+  final String stationCode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(knetWaveformDownloadProvider(eventTimeMs));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('ヘッダ編集: $stationCode'),
+      ),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('エラー: $e')),
+        data: (stationMap) {
+          final records = stationMap[stationCode];
+          if (records == null) {
+            return const Center(child: Text('観測点データが見つかりません'));
+          }
+
+          final representative =
+              records[KnetChannelDirection.ns] ?? records.values.first;
+          return _EditForm(record: representative);
+        },
+      ),
+    );
+  }
+}
+
+class _EditForm extends HookWidget {
+  const _EditForm({required this.record});
+
+  final KnetRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final info = record.stationInfo;
+    final stationCodeCtrl = useTextEditingController(text: info.stationCode);
+    final latCtrl = useTextEditingController(
+      text: info.latitude.toStringAsFixed(4),
+    );
+    final lonCtrl = useTextEditingController(
+      text: info.longitude.toStringAsFixed(4),
+    );
+    final heightCtrl = useTextEditingController(
+      text: info.heightM.toStringAsFixed(1),
+    );
+    final memoCtrl = useTextEditingController(text: record.memo);
+
+    final formKey = useMemoized(GlobalKey<FormState>.new);
+    final isSaved = useState(false);
+
+    void onSave() {
+      if (formKey.currentState?.validate() ?? false) {
+        // 現時点ではメモリ内保持のみ。
+        // 将来的に SharedPreferences や Hive への永続化を実装する想定。
+        isSaved.value = true;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('保存しました（セッション内一時保存）')),
+        );
+      }
+    }
+
+    return Form(
+      key: formKey,
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (isSaved.value)
+            Card(
+              color: Theme.of(context).colorScheme.primaryContainer,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.info_outline,
+                      color: Theme.of(context).colorScheme.onPrimaryContainer,
+                      size: 18,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'セッション内一時保存済み。アプリ再起動時はリセットされます。',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          const SizedBox(height: 8),
+          _buildField(
+            controller: stationCodeCtrl,
+            label: '観測点コード',
+            keyboardType: TextInputType.text,
+          ),
+          const SizedBox(height: 12),
+          _buildField(
+            controller: latCtrl,
+            label: '緯度 (度)',
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            validator: _validateDouble,
+          ),
+          const SizedBox(height: 12),
+          _buildField(
+            controller: lonCtrl,
+            label: '経度 (度)',
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            validator: _validateDouble,
+          ),
+          const SizedBox(height: 12),
+          _buildField(
+            controller: heightCtrl,
+            label: '標高 (m)',
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            validator: _validateDouble,
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: memoCtrl,
+            decoration: const InputDecoration(
+              labelText: 'メモ',
+              border: OutlineInputBorder(),
+            ),
+            maxLines: 3,
+          ),
+          const SizedBox(height: 24),
+          FilledButton.icon(
+            onPressed: onSave,
+            icon: const Icon(Icons.save),
+            label: const Text('保存'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildField({
+    required TextEditingController controller,
+    required String label,
+    TextInputType? keyboardType,
+    String? Function(String?)? validator,
+  }) {
+    return TextFormField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+      ),
+      keyboardType: keyboardType,
+      validator: validator,
+    );
+  }
+
+  String? _validateDouble(String? value) {
+    if (value == null || value.isEmpty) {
+      return '値を入力してください';
+    }
+    if (double.tryParse(value) == null) {
+      return '数値を入力してください';
+    }
+    return null;
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/station/knet_station_detail_page.dart
+++ b/app/lib/feature/knet_waveform/ui/station/knet_station_detail_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart';
@@ -53,7 +54,13 @@ class KnetStationDetailPage extends HookConsumerWidget {
       ),
       body: async.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('エラー: $e')),
+        error: (e, st) {
+          final msg = e is KnetWaveformDownloadException
+              ? e.message
+              : 'データの取得に失敗しました';
+          debugPrint('K-NET station detail error: $e\n$st');
+          return Center(child: Text(msg));
+        },
         data: (stationMap) {
           final records = stationMap[stationCode];
           if (records == null) {
@@ -225,10 +232,10 @@ class _WaveformChart extends StatelessWidget {
 
     // データ点が多い場合は間引く（最大 2000 点）
     const maxPoints = 2000;
-    final step = acc.length > maxPoints ? acc.length ~/ maxPoints : 1;
+    final step = math.max(1, (acc.length / maxPoints).ceil());
 
     final spots = <FlSpot>[];
-    for (var i = 0; i < acc.length; i += step) {
+    for (var i = 0; i < acc.length && spots.length < maxPoints; i += step) {
       spots.add(FlSpot(i * dt, acc[i]));
     }
 
@@ -237,7 +244,8 @@ class _WaveformChart extends StatelessWidget {
     }
 
     final maxY = acc.reduce((a, b) => a.abs() > b.abs() ? a : b).abs();
-    final yLimit = maxY * 1.1;
+    // maxY が 0 の場合は 1.0 をデフォルト値として使用し、ゼロ除算・ゼロスケールを防ぐ
+    final yLimit = maxY == 0 ? 1.0 : maxY * 1.1;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(8, 16, 16, 8),

--- a/app/lib/feature/knet_waveform/ui/station/knet_station_detail_page.dart
+++ b/app/lib/feature/knet_waveform/ui/station/knet_station_detail_page.dart
@@ -1,0 +1,325 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:knet_waveform_parser/knet_waveform_parser.dart';
+
+/// K-NET 観測点詳細画面
+///
+/// 観測点の加速度波形グラフ (NS / EW / UD) とヘッダ情報を表示する。
+class KnetStationDetailPage extends HookConsumerWidget {
+  const KnetStationDetailPage({
+    required this.eventTimeMs,
+    required this.stationCode,
+    super.key,
+  });
+
+  final int eventTimeMs;
+  final String stationCode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(knetWaveformDownloadProvider(eventTimeMs));
+    final tabController = useTabController(initialLength: 3);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(stationCode),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: 'ヘッダ編集',
+            onPressed: () => unawaited(
+              KnetHeaderEditRoute(
+                eventTimeMs: eventTimeMs,
+                stationCode: stationCode,
+              ).push<void>(context),
+            ),
+          ),
+        ],
+        bottom: TabBar(
+          controller: tabController,
+          tabs: const [
+            Tab(text: 'N-S'),
+            Tab(text: 'E-W'),
+            Tab(text: 'U-D'),
+          ],
+        ),
+      ),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('エラー: $e')),
+        data: (stationMap) {
+          final records = stationMap[stationCode];
+          if (records == null) {
+            return const Center(child: Text('観測点データが見つかりません'));
+          }
+
+          final representative =
+              records[KnetChannelDirection.ns] ?? records.values.first;
+          final info = representative.stationInfo;
+          final eqInfo = representative.earthquakeInfo;
+
+          return Column(
+            children: [
+              _HeaderInfoCard(
+                stationInfo: info,
+                earthquakeInfo: eqInfo,
+                record: representative,
+              ),
+              Expanded(
+                child: TabBarView(
+                  controller: tabController,
+                  children:
+                      [
+                        KnetChannelDirection.ns,
+                        KnetChannelDirection.ew,
+                        KnetChannelDirection.ud,
+                      ].map((dir) {
+                        final record = records[dir];
+                        if (record == null) {
+                          return Center(
+                            child: Text(
+                              '${dir.label} チャンネルのデータがありません',
+                            ),
+                          );
+                        }
+                        return _WaveformChart(record: record);
+                      }).toList(),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// ヘッダ情報カード
+class _HeaderInfoCard extends StatelessWidget {
+  const _HeaderInfoCard({
+    required this.stationInfo,
+    required this.earthquakeInfo,
+    required this.record,
+  });
+
+  final KnetStationInfo stationInfo;
+  final KnetEarthquakeInfo? earthquakeInfo;
+  final KnetRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final fmt = DateFormat('yyyy/MM/dd HH:mm:ss');
+
+    return Card(
+      margin: const EdgeInsets.all(8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('観測点情報', style: textTheme.titleSmall),
+            const SizedBox(height: 4),
+            _InfoRow(
+              label: '観測点コード',
+              value: stationInfo.stationCode,
+            ),
+            _InfoRow(
+              label: '緯度 / 経度',
+              value:
+                  '${stationInfo.latitude.toStringAsFixed(4)}°N  '
+                  '${stationInfo.longitude.toStringAsFixed(4)}°E',
+            ),
+            _InfoRow(
+              label: '標高',
+              value: '${stationInfo.heightM.toStringAsFixed(1)} m',
+            ),
+            _InfoRow(
+              label: 'サンプリング周波数',
+              value: '${record.samplingFrequencyHz.toStringAsFixed(0)} Hz',
+            ),
+            _InfoRow(
+              label: '計測時間',
+              value: '${record.durationTimeSec.toStringAsFixed(1)} 秒',
+            ),
+            _InfoRow(
+              label: '記録開始時刻',
+              value: fmt.format(record.recordTime),
+            ),
+            if (earthquakeInfo != null) ...[
+              const Divider(),
+              Text('地震情報', style: textTheme.titleSmall),
+              const SizedBox(height: 4),
+              _InfoRow(
+                label: '発生時刻',
+                value: fmt.format(earthquakeInfo!.originTime),
+              ),
+              _InfoRow(
+                label: '震源',
+                value:
+                    '${earthquakeInfo!.latitude.toStringAsFixed(2)}°N  '
+                    '${earthquakeInfo!.longitude.toStringAsFixed(2)}°E  '
+                    '深さ ${earthquakeInfo!.depthKm.toStringAsFixed(0)} km',
+              ),
+              _InfoRow(
+                label: 'マグニチュード',
+                value: 'M${earthquakeInfo!.magnitude.toStringAsFixed(1)}',
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 140,
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.outline,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(value, style: Theme.of(context).textTheme.bodySmall),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 加速度波形グラフ (fl_chart)
+class _WaveformChart extends StatelessWidget {
+  const _WaveformChart({required this.record});
+
+  final KnetRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final acc = record.accelerationGal;
+    final dt = 1.0 / record.samplingFrequencyHz;
+
+    // データ点が多い場合は間引く（最大 2000 点）
+    const maxPoints = 2000;
+    final step = acc.length > maxPoints ? acc.length ~/ maxPoints : 1;
+
+    final spots = <FlSpot>[];
+    for (var i = 0; i < acc.length; i += step) {
+      spots.add(FlSpot(i * dt, acc[i]));
+    }
+
+    if (spots.isEmpty) {
+      return const Center(child: Text('データなし'));
+    }
+
+    final maxY = acc.reduce((a, b) => a.abs() > b.abs() ? a : b).abs();
+    final yLimit = maxY * 1.1;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 16, 16, 8),
+      child: Column(
+        children: [
+          Expanded(
+            child: LineChart(
+              LineChartData(
+                minY: -yLimit,
+                maxY: yLimit,
+                clipData: const FlClipData.all(),
+                gridData: FlGridData(
+                  horizontalInterval: yLimit / 4,
+                  getDrawingHorizontalLine: (_) => FlLine(
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.5),
+                    strokeWidth: 0.5,
+                  ),
+                  getDrawingVerticalLine: (_) => FlLine(
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.5),
+                    strokeWidth: 0.5,
+                  ),
+                ),
+                titlesData: FlTitlesData(
+                  bottomTitles: AxisTitles(
+                    axisNameWidget: const Text(
+                      '時刻 (秒)',
+                      style: TextStyle(fontSize: 10),
+                    ),
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      reservedSize: 28,
+                      getTitlesWidget: (value, meta) => Text(
+                        value.toStringAsFixed(0),
+                        style: const TextStyle(fontSize: 9),
+                      ),
+                    ),
+                  ),
+                  leftTitles: AxisTitles(
+                    axisNameWidget: const Text(
+                      '加速度 (gal)',
+                      style: TextStyle(fontSize: 10),
+                    ),
+                    axisNameSize: 20,
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      reservedSize: 48,
+                      getTitlesWidget: (value, meta) => Text(
+                        value.toStringAsFixed(0),
+                        style: const TextStyle(fontSize: 9),
+                      ),
+                    ),
+                  ),
+                  topTitles: const AxisTitles(),
+                  rightTitles: const AxisTitles(),
+                ),
+                borderData: FlBorderData(
+                  show: true,
+                  border: Border.all(
+                    color: colorScheme.outlineVariant,
+                  ),
+                ),
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: spots,
+                    color: colorScheme.primary,
+                    barWidth: 1,
+                    dotData: const FlDotData(show: false),
+                    belowBarData: BarAreaData(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              '最大加速度: ${record.maxAccelerationGal.toStringAsFixed(2)} gal',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/station/knet_station_list_page.dart
+++ b/app/lib/feature/knet_waveform/ui/station/knet_station_list_page.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_waveform_download_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:knet_waveform_parser/knet_waveform_parser.dart';
+
+/// K-NET 観測点一覧画面
+///
+/// 指定した地震の ZIP をダウンロード・解凍・パースし、
+/// 観測点コード・緯度経度・最大加速度を一覧表示する。
+class KnetStationListPage extends ConsumerWidget {
+  const KnetStationListPage({required this.eventTimeMs, super.key});
+
+  final int eventTimeMs;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(knetWaveformDownloadProvider(eventTimeMs));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('観測点一覧'),
+      ),
+      body: async.when(
+        loading: () => const Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('波形データをダウンロード中...'),
+            ],
+          ),
+        ),
+        error: (e, _) => _ErrorView(
+          message: e.toString(),
+          onRetry: () => ref.invalidate(
+            knetWaveformDownloadProvider(eventTimeMs),
+          ),
+        ),
+        data: (stationMap) => _StationListView(
+          stationMap: stationMap,
+          eventTimeMs: eventTimeMs,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'データの取得に失敗しました',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('再試行'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StationListView extends StatelessWidget {
+  const _StationListView({
+    required this.stationMap,
+    required this.eventTimeMs,
+  });
+
+  final KnetStationRecords stationMap;
+  final int eventTimeMs;
+
+  @override
+  Widget build(BuildContext context) {
+    final stations = stationMap.entries.toList()
+      ..sort((a, b) => _maxAcc(b.value).compareTo(_maxAcc(a.value)));
+
+    return ListView.separated(
+      itemCount: stations.length,
+      separatorBuilder: (_, _) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final entry = stations[index];
+        final stationCode = entry.key;
+        final records = entry.value;
+
+        // 代表レコード（NS 優先、無ければ最初の成分）
+        final representative =
+            records[KnetChannelDirection.ns] ?? records.values.first;
+        final info = representative.stationInfo;
+        final maxAcc = _maxAcc(records);
+
+        return ListTile(
+          leading: const Icon(Icons.sensors),
+          title: Text(stationCode),
+          subtitle: Text(
+            '${info.latitude.toStringAsFixed(4)}°N  '
+            '${info.longitude.toStringAsFixed(4)}°E\n'
+            '最大加速度: ${maxAcc.toStringAsFixed(1)} gal',
+          ),
+          isThreeLine: true,
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () => unawaited(
+            KnetStationDetailRoute(
+              eventTimeMs: eventTimeMs,
+              stationCode: stationCode,
+            ).push<void>(context),
+          ),
+        );
+      },
+    );
+  }
+
+  double _maxAcc(Map<KnetChannelDirection, KnetRecord> records) {
+    if (records.isEmpty) {
+      return 0;
+    }
+    return records.values
+        .map((r) => r.maxAccelerationGal)
+        .reduce((a, b) => a > b ? a : b);
+  }
+}

--- a/app/lib/feature/knet_waveform/ui/station/knet_station_list_page.dart
+++ b/app/lib/feature/knet_waveform/ui/station/knet_station_list_page.dart
@@ -6,6 +6,16 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:knet_waveform_parser/knet_waveform_parser.dart';
 
+/// 観測点の各チャンネルを横断した最大加速度 (gal) を返す。
+double _maxAcceleration(Map<KnetChannelDirection, KnetRecord> records) {
+  if (records.isEmpty) {
+    return 0;
+  }
+  return records.values
+      .map((r) => r.maxAccelerationGal)
+      .reduce((a, b) => a > b ? a : b);
+}
+
 /// K-NET 観測点一覧画面
 ///
 /// 指定した地震の ZIP をダウンロード・解凍・パースし、
@@ -34,12 +44,18 @@ class KnetStationListPage extends ConsumerWidget {
             ],
           ),
         ),
-        error: (e, _) => _ErrorView(
-          message: e.toString(),
-          onRetry: () => ref.invalidate(
-            knetWaveformDownloadProvider(eventTimeMs),
-          ),
-        ),
+        error: (e, st) {
+          final msg = e is KnetWaveformDownloadException
+              ? e.message
+              : 'データの取得に失敗しました';
+          debugPrint('K-NET waveform download error: $e\n$st');
+          return _ErrorView(
+            message: msg,
+            onRetry: () => ref.invalidate(
+              knetWaveformDownloadProvider(eventTimeMs),
+            ),
+          );
+        },
         data: (stationMap) => _StationListView(
           stationMap: stationMap,
           eventTimeMs: eventTimeMs,
@@ -103,22 +119,32 @@ class _StationListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final stations = stationMap.entries.toList()
-      ..sort((a, b) => _maxAcc(b.value).compareTo(_maxAcc(a.value)));
+    // maxAcc をソート前に一度だけ計算してキャッシュする
+    final sorted =
+        stationMap.entries
+            .map(
+              (e) => (
+                stationCode: e.key,
+                records: e.value,
+                maxAcc: _maxAcceleration(e.value),
+              ),
+            )
+            .toList()
+          ..sort((a, b) => b.maxAcc.compareTo(a.maxAcc));
 
     return ListView.separated(
-      itemCount: stations.length,
+      itemCount: sorted.length,
       separatorBuilder: (_, _) => const Divider(height: 1),
       itemBuilder: (context, index) {
-        final entry = stations[index];
-        final stationCode = entry.key;
-        final records = entry.value;
+        final entry = sorted[index];
+        final stationCode = entry.stationCode;
+        final records = entry.records;
+        final maxAcc = entry.maxAcc;
 
         // 代表レコード（NS 優先、無ければ最初の成分）
         final representative =
             records[KnetChannelDirection.ns] ?? records.values.first;
         final info = representative.stationInfo;
-        final maxAcc = _maxAcc(records);
 
         return ListTile(
           leading: const Icon(Icons.sensors),
@@ -139,14 +165,5 @@ class _StationListView extends StatelessWidget {
         );
       },
     );
-  }
-
-  double _maxAcc(Map<KnetChannelDirection, KnetRecord> records) {
-    if (records.isEmpty) {
-      return 0;
-    }
-    return records.values
-        .map((r) => r.maxAccelerationGal)
-        .reduce((a, b) => a > b ? a : b);
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -46,6 +46,7 @@ dependency_overrides:
       path: packages/maplibre_webview
 
 dependencies:
+  archive: ^4.0.7
   app_settings: ^7.0.0
   background_location_tracker:
     path: ../packages/background_location_tracker
@@ -71,6 +72,7 @@ dependencies:
   extensions:
     path: ../packages/extensions
   file_picker: ^11.0.2
+  fl_chart: ^0.70.2
   firebase_analytics: ^12.0.0
   firebase_app_check: ^0.4.2
   firebase_app_installations: ^0.4.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -617,6 +617,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: transitive
+    description:
+      name: fl_chart
+      sha256: "5276944c6ffc975ae796569a826c38a62d2abcf264e26b88fa6f482e107f4237"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.70.2"
   flutter:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

- `archive ^4.0.7` + `fl_chart ^0.70.2` を `app/pubspec.yaml` に追加し、K-NET ZIP ダウンロード→解凍→パース→グラフ表示の一連パイプラインを実装
- `knetWaveformDownloadProvider`（Riverpod）で認証済みクライアント経由の ZIP 取得 → `ZipDecoder` 解凍 → `KnetAsciiParser` パースを行い、観測点コードごとに成分別 `KnetRecord` をキャッシュ
- 地震選択画面 → 観測点一覧 → 波形グラフ → ヘッダ編集 の 4 画面を追加
- `go_router` + `TypedGoRoute` によるタイプセーフルーティングを `router.dart` へ追加
- `KnetWaveformPage` の「準備中」プレースホルダを「地震データを閲覧」ボタンに置換
- `dart analyze lib` ゼロエラー・`dart format` 適用済み

## 実装詳細

### 新規ファイル
| ファイル | 概要 |
|---|---|
| `data/provider/knet_waveform_download_provider.dart` | Riverpod provider・ZIP DL・パース |
| `ui/earthquake/knet_earthquake_list_page.dart` | 地震選択画面（3件ハードコード） |
| `ui/station/knet_station_list_page.dart` | 観測点一覧（最大加速度降順ソート） |
| `ui/station/knet_station_detail_page.dart` | NS/EW/UD タブ波形グラフ + ヘッダ情報 |
| `ui/station/knet_header_edit_page.dart` | ヘッダ情報編集（セッション内一時保存） |

### ルート構成
```
KnetWaveformRoute
└── KnetEarthquakeListRoute (earthquakes)
    └── KnetStationListRoute (:eventTimeMs/stations)
        └── KnetStationDetailRoute (:stationCode)
            └── KnetHeaderEditRoute (edit)
```

## Test plan
- [ ] K-NET 認証情報を設定済みの状態で「地震データを閲覧」をタップし地震リストが表示されることを確認
- [ ] 地震を選択すると ZIP ダウンロードが走り観測点一覧が最大加速度降順で表示されることを確認
- [ ] 観測点をタップすると NS / EW / UD タブで加速度波形グラフが表示されることを確認
- [ ] グラフのY軸(gal)・X軸(秒)ラベルが正しく表示されることを確認
- [ ] ヘッダ編集ボタンから緯度・経度・標高・メモを編集し「保存」でスナックバーが出ることを確認
- [ ] 認証情報未設定時は設定ページへの導線が表示されることを確認

> **注意**: NIED の実 ZIP が `.tar.gz` をネストして配布するケースがあるため、実認証情報を用いた結合テストが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)