### PR TITLE
fix: 地震履歴詳細の市区町村塗りつぶしをデフォルトで表示するよう修正

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart
@@ -42,7 +42,7 @@ abstract class EarthquakeHistoryDetailConfig
 
     /// 塗りつぶしの表示モード
     @JsonKey(unknownEnumValue: EarthquakeHistoryFillMode.none)
-    @Default(EarthquakeHistoryFillMode.none)
+    @Default(EarthquakeHistoryFillMode.matchIcon)
     EarthquakeHistoryFillMode fillMode,
 
     /// 観測点の表示方法

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart
@@ -806,7 +806,7 @@ return $default(_that.iconMode,_that.fillMode,_that.stationDisplayMode,_that.hyp
 @JsonSerializable()
 
 class _EarthquakeHistoryDetailConfig implements EarthquakeHistoryDetailConfig {
-  const _EarthquakeHistoryDetailConfig({@JsonKey(unknownEnumValue: EarthquakeHistoryIconMode.auto) this.iconMode = EarthquakeHistoryIconMode.auto, @JsonKey(unknownEnumValue: EarthquakeHistoryFillMode.none) this.fillMode = EarthquakeHistoryFillMode.none, this.stationDisplayMode = StationDisplayMode.maxFocused, this.hypocenterDisplayMode = HypocenterDisplayMode.zoomFade, this.showHypocenterError = false, this.showStationLabel = false, this.useEstimatedIntensityWhenAvailable = true, this.showLegend = true, this.showingLpgmIntensity = false, this.showStation = true});
+  const _EarthquakeHistoryDetailConfig({@JsonKey(unknownEnumValue: EarthquakeHistoryIconMode.auto) this.iconMode = EarthquakeHistoryIconMode.auto, @JsonKey(unknownEnumValue: EarthquakeHistoryFillMode.none) this.fillMode = EarthquakeHistoryFillMode.matchIcon, this.stationDisplayMode = StationDisplayMode.maxFocused, this.hypocenterDisplayMode = HypocenterDisplayMode.zoomFade, this.showHypocenterError = false, this.showStationLabel = false, this.useEstimatedIntensityWhenAvailable = true, this.showLegend = true, this.showingLpgmIntensity = false, this.showStation = true});
   factory _EarthquakeHistoryDetailConfig.fromJson(Map<String, dynamic> json) => _$EarthquakeHistoryDetailConfigFromJson(json);
 
 /// アイコンの表示モード

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_map_layer_mode_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_map_layer_mode_test.dart
@@ -23,7 +23,9 @@ void main() {
       final earthquake = testData.earthquake(
         intensity: testData.fullIntensity(),
       );
-      const config = EarthquakeHistoryDetailConfig();
+      const config = EarthquakeHistoryDetailConfig(
+        fillMode: EarthquakeHistoryFillMode.none,
+      );
 
       final mode = resolver.resolveFillLayerMode(
         earthquake: earthquake,
@@ -43,10 +45,7 @@ void main() {
         EarthquakeHistoryIconMode.station,
         EarthquakeHistoryIconMode.auto,
       ]) {
-        final config = EarthquakeHistoryDetailConfig(
-          fillMode: EarthquakeHistoryFillMode.matchIcon,
-          iconMode: iconMode,
-        );
+        final config = EarthquakeHistoryDetailConfig(iconMode: iconMode);
 
         expect(
           resolver.resolveFillLayerMode(
@@ -116,9 +115,7 @@ void main() {
 
     test('intensityがない不正な地震データはnoneを返す', () {
       final earthquake = testData.earthquake();
-      const config = EarthquakeHistoryDetailConfig(
-        fillMode: EarthquakeHistoryFillMode.matchIcon,
-      );
+      const config = EarthquakeHistoryDetailConfig();
 
       expect(
         resolver.resolveMapLayerMode(


### PR DESCRIPTION
## Summary

- `EarthquakeHistoryDetailConfig.fillMode` のデフォルト値が `EarthquakeHistoryFillMode.none` だったため、塗りつぶしが一切表示されない状態だった
- デフォルトを `EarthquakeHistoryFillMode.matchIcon` に変更し、アイコン表示モードに合わせて地域・市区町村の塗りつぶしが出るよう修正
- `resolveFillLayerMode` が `fillMode == none` で即 `none` を返すため、設定を変えない限りフィルレイヤーは描画されていなかった

## Root Cause

`earthquake_history_config_model.dart:45` の `@Default(EarthquakeHistoryFillMode.none)` が原因。生成済み `*.freezed.dart` も同時に更新した。

## Test plan

- [ ] `dart analyze` — issues なし
- [ ] `earthquake_history_map_layer_mode_test.dart` のテストが全件パスすること（`fill無効ならnoneを返す` は明示的に `fillMode: none` を指定するよう更新）
- [ ] 地震履歴詳細画面で細分化地域・市区町村の塗りつぶしが表示されることを実機/シミュレーターで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)