### PR TITLE
fix: 地震履歴詳細画面の市区町村塗りつぶしをデフォルトで有効化

### DIFF
--- a/app/lib/core/gen/assets.gen.dart
+++ b/app/lib/core/gen/assets.gen.dart
@@ -34,10 +34,6 @@ class $AssetsDocsGen {
   List<String> get values => [aboutThisApp, privacyPolicy, termOfService];
 }
 
-class $AssetsFontsGen {
-  const $AssetsFontsGen();
-}
-
 class $AssetsImagesGen {
   const $AssetsImagesGen();
 
@@ -351,7 +347,6 @@ class Assets {
       'assets/KyoshinShindoColorMap.json';
   static const $AssetsDebugGen debug = $AssetsDebugGen();
   static const $AssetsDocsGen docs = $AssetsDocsGen();
-  static const $AssetsFontsGen fonts = $AssetsFontsGen();
   static const AssetGenImage header = AssetGenImage('assets/header.png');
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const String jmaCodeTable = 'assets/jma_code_table.pb';

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.dart
@@ -42,7 +42,7 @@ abstract class EarthquakeHistoryDetailConfig
 
     /// 塗りつぶしの表示モード
     @JsonKey(unknownEnumValue: EarthquakeHistoryFillMode.none)
-    @Default(EarthquakeHistoryFillMode.none)
+    @Default(EarthquakeHistoryFillMode.matchIcon)
     EarthquakeHistoryFillMode fillMode,
 
     /// 観測点の表示方法

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.freezed.dart
@@ -806,7 +806,7 @@ return $default(_that.iconMode,_that.fillMode,_that.stationDisplayMode,_that.hyp
 @JsonSerializable()
 
 class _EarthquakeHistoryDetailConfig implements EarthquakeHistoryDetailConfig {
-  const _EarthquakeHistoryDetailConfig({@JsonKey(unknownEnumValue: EarthquakeHistoryIconMode.auto) this.iconMode = EarthquakeHistoryIconMode.auto, @JsonKey(unknownEnumValue: EarthquakeHistoryFillMode.none) this.fillMode = EarthquakeHistoryFillMode.none, this.stationDisplayMode = StationDisplayMode.maxFocused, this.hypocenterDisplayMode = HypocenterDisplayMode.zoomFade, this.showHypocenterError = false, this.showStationLabel = false, this.useEstimatedIntensityWhenAvailable = true, this.showLegend = true, this.showingLpgmIntensity = false, this.showStation = true});
+  const _EarthquakeHistoryDetailConfig({@JsonKey(unknownEnumValue: EarthquakeHistoryIconMode.auto) this.iconMode = EarthquakeHistoryIconMode.auto, @JsonKey(unknownEnumValue: EarthquakeHistoryFillMode.none) this.fillMode = EarthquakeHistoryFillMode.matchIcon, this.stationDisplayMode = StationDisplayMode.maxFocused, this.hypocenterDisplayMode = HypocenterDisplayMode.zoomFade, this.showHypocenterError = false, this.showStationLabel = false, this.useEstimatedIntensityWhenAvailable = true, this.showLegend = true, this.showingLpgmIntensity = false, this.showStation = true});
   factory _EarthquakeHistoryDetailConfig.fromJson(Map<String, dynamic> json) => _$EarthquakeHistoryDetailConfigFromJson(json);
 
 /// アイコンの表示モード

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_config_model.g.dart
@@ -102,7 +102,7 @@ _EarthquakeHistoryDetailConfig _$EarthquakeHistoryDetailConfigFromJson(
               v,
               unknownValue: EarthquakeHistoryFillMode.none,
             ) ??
-            EarthquakeHistoryFillMode.none,
+            EarthquakeHistoryFillMode.matchIcon,
       ),
       stationDisplayMode: $checkedConvert(
         'station_display_mode',

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_map_layer_mode_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_map_layer_mode_test.dart
@@ -23,7 +23,9 @@ void main() {
       final earthquake = testData.earthquake(
         intensity: testData.fullIntensity(),
       );
-      const config = EarthquakeHistoryDetailConfig();
+      const config = EarthquakeHistoryDetailConfig(
+        fillMode: EarthquakeHistoryFillMode.none,
+      );
 
       final mode = resolver.resolveFillLayerMode(
         earthquake: earthquake,
@@ -43,10 +45,7 @@ void main() {
         EarthquakeHistoryIconMode.station,
         EarthquakeHistoryIconMode.auto,
       ]) {
-        final config = EarthquakeHistoryDetailConfig(
-          fillMode: EarthquakeHistoryFillMode.matchIcon,
-          iconMode: iconMode,
-        );
+        final config = EarthquakeHistoryDetailConfig(iconMode: iconMode);
 
         expect(
           resolver.resolveFillLayerMode(
@@ -116,9 +115,7 @@ void main() {
 
     test('intensityがない不正な地震データはnoneを返す', () {
       final earthquake = testData.earthquake();
-      const config = EarthquakeHistoryDetailConfig(
-        fillMode: EarthquakeHistoryFillMode.matchIcon,
-      );
+      const config = EarthquakeHistoryDetailConfig();
 
       expect(
         resolver.resolveMapLayerMode(


### PR DESCRIPTION
## 概要

地震履歴詳細画面の市区町村塗りつぶしが表示されない問題を修正します。

## 原因

`EarthquakeHistoryDetailConfig` の `fillMode` デフォルト値が `EarthquakeHistoryFillMode.none` になっていたため、設定を手動で変更しない限り塗りつぶしが表示されなかった。

一方 `iconMode` のデフォルトは `auto` で統一されており、`fillMode` だけが `none` になっていたのは意図しない状態と考えられる。

## 修正内容

- `fillMode` のデフォルトを `none` → `matchIcon` に変更
- `matchIcon` は `iconMode` に追従するため、`iconMode: auto`（デフォルト）のときはズームに応じて地域・市区町村の塗りつぶしが自動表示される
- テストを修正（明示的に `fillMode: none` が必要なテストに `none` を追加、不要な `matchIcon` 指定を削除）

## テスト計画

- [ ] `dart analyze` パス (No issues found)
- [ ] `flutter test test/feature/earthquake_history/` 全17件パス
- [ ] 地震履歴詳細画面で市区町村塗りつぶしが初期状態で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)