### PR TITLE
fix: jma_map_utility の minBy() null アサーションによるクラッシュを修正

### DIFF
--- a/app/lib/core/provider/map/jma_map_utility.dart
+++ b/app/lib/core/provider/map/jma_map_utility.dart
@@ -52,7 +52,8 @@ class JmaMapUtility {
       });
 
       // degree 距離で最近傍を選択し、km 距離を返す
-      final nearest = minBy(dataList, (e) => e?.$2)!;
+      final nearest = minBy(dataList, (e) => e?.$2);
+      if (nearest == null) return (item: null, distanceKm: null);
       return (item: nearest.$1, distanceKm: nearest.$3);
     }
 


### PR DESCRIPTION
## Summary

- `JmaMapUtility.findNearestItem()` 内で `minBy(dataList, ...)` の結果を `!` で強制アンラップしており、`mapData.data` が空の場合にクラッシュする問題を修正

## 変更内容

`app/lib/core/provider/map/jma_map_utility.dart:55` の強制アンラップを除去し、`null` の場合は `(item: null, distanceKm: null)` を返すように変更。

```dart
// Before
final nearest = minBy(dataList, (e) => e?.$2)!;

// After
final nearest = minBy(dataList, (e) => e?.$2);
if (nearest == null) return (item: null, distanceKm: null);
```

## Test plan

- [ ] `dart analyze` が警告なしでパスすること
- [ ] `AREA_TSUNAMI` の `data` フィールドが空のレスポンスを受け取った場合にクラッシュしないこと

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)