### PR TITLE
fix: 複数箇所の強制アンラップによるクラッシュリスクを解消

### DIFF
--- a/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
+++ b/app/lib/feature/eew/ui/page/eew_details_by_event_id_page.dart
@@ -46,10 +46,10 @@ class EewDetailsByEventIdPage extends HookConsumerWidget {
             (a, b) => a.serialNo.compareTo(b.serialNo),
           );
 
+          final idx = selectedIndex.value;
           final selectedEew =
-              selectedIndex.value != null &&
-                  selectedIndex.value! < sortedEews.length
-              ? sortedEews[selectedIndex.value!]
+              (idx != null && idx < sortedEews.length)
+              ? sortedEews[idx]
               : null;
 
           return _ResponsiveLayout(

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_picker.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_region_picker.dart
@@ -117,13 +117,20 @@ class _RegionPickerDialog extends HookConsumerWidget {
         ),
         FilledButton(
           onPressed: canSubmit
-              ? () => Navigator.of(context).pop(
+              ? () {
+                  final code = selectedCode.value;
+                  final name = selectedName.value;
+                  if (!isAllMode && code == null) {
+                    return;
+                  }
+                  Navigator.of(context).pop(
                     (
-                      regionId: isAllMode ? 0 : int.parse(selectedCode.value!),
-                      regionName: isAllMode ? '全国' : selectedName.value!,
+                      regionId: isAllMode ? 0 : int.parse(code!),
+                      regionName: isAllMode ? '全国' : (name ?? ''),
                       minIntensity: intensity.value,
                     ),
-                  )
+                  );
+                }
               : null,
           child: const Text('追加'),
         ),

--- a/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
+++ b/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
@@ -49,10 +49,10 @@ class TelegramListByEventIdPage extends HookConsumerWidget {
             isLoading: asyncState.isLoading,
             scrollController: scrollController,
           ),
-          AsyncError(:final error) when asyncState.hasValue =>
+          AsyncError(:final error, :final value?) =>
             _TelegramListView(
-              items: asyncState.value!.items,
-              hasNext: asyncState.value!.hasNext,
+              items: value.items,
+              hasNext: value.hasNext,
               isLoading: false,
               scrollController: scrollController,
               error: error,


### PR DESCRIPTION
## Summary

- `AsyncValue.value!` をパターンマッチング (`AsyncError(:final error, :final value?)`) に置き換え、`hasValue` ガード不要で安全に値を取得
- `useState.value!` をローカル変数への代入に置き換え、クロージャ内での null 参照リスクを排除
- `notification_region_picker.dart` では early-return ガードを追加し、`selectedCode.value!` を安全化

## Affected files

| ファイル | 修正内容 |
|---|---|
| `telegram_list_by_event_id_page.dart` | `AsyncError` パターンマッチングで value を安全に抽出 |
| `eew_details_by_event_id_page.dart` | `selectedIndex.value` をローカル変数 `idx` に代入 |
| `notification_region_picker.dart` | `code`/`name` をローカル変数に取り出し early-return で null ガード |

## Test plan

- [ ] dart analyze がエラーなしで通ること
- [ ] 電文一覧画面でエラー発生時に前回データが正常表示されること
- [ ] EEW 詳細画面で選択インデックスが変更されてもクラッシュしないこと
- [ ] 通知地域追加ダイアログで「追加」ボタン押下時にクラッシュしないこと

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)