### PR TITLE
fix(eew): EEW震度予報区域レイヤーの初期フィルターのレース条件を修正

### DIFF
--- a/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
@@ -103,12 +103,20 @@ class EewForecastRegionLayer extends HookConsumerWidget {
             }
             final color = colorModel.fromJmaIntensity(intensity).background;
             final layerId = _intensityLayerId(intensity);
+            final codes = intensityCodes[intensity] ?? const [];
+            final initialFilter = codes.isEmpty
+                ? _emptyFilter
+                : <Object>[
+                    'in',
+                    ['get', 'code'],
+                    ['literal', codes],
+                  ];
             await styleController.addLayer(
               FillStyleLayer(
                 id: layerId,
                 sourceId: _sourceId,
                 sourceLayerId: _sourceLayerId,
-                filter: _emptyFilter,
+                filter: initialFilter,
                 paint: {
                   'fill-color': color.toHexString(),
                   'fill-opacity': 0.7,
@@ -147,13 +155,20 @@ class EewForecastRegionLayer extends HookConsumerWidget {
         var disposed = false;
 
         unawaited(() async {
+          final initialWarningFilter = warningCodes.isEmpty
+              ? _emptyFilter
+              : <Object>[
+                  'in',
+                  ['get', 'code'],
+                  ['literal', warningCodes],
+                ];
           await styleController.addLayer(
-            const FillStyleLayer(
+            FillStyleLayer(
               id: _warningLayerId,
               sourceId: _sourceId,
               sourceLayerId: _sourceLayerId,
-              filter: _emptyFilter,
-              paint: {
+              filter: initialWarningFilter,
+              paint: const {
                 'fill-color': '#FF0000',
                 'fill-opacity': 0.4,
               },


### PR DESCRIPTION
## 概要

`EewForecastRegionLayer` の intensity/warning モード両方で、`addLayer` 完了前にデータが確定している場合にフィルターが永遠に適用されないレース条件を修正。

## 問題

- `addLayer` は非同期（`unawaited`）で実行される
- データ更新用 `useEffect` は `isInitialized.value` を確認するが、`useRef` の値変更はリビルドを起こさないため、初期化完了後にフィルター更新 effect が再実行されない
- EEW が先に到着してから地図レイヤーが初期化される場合（通常の起動フロー）、震度予報区域が永遠に表示されない

## 修正内容

`addLayer` 呼び出し時に、その時点の `intensityCodes` / `warningCodes` から正しい初期フィルターを計算して渡すよう修正。

`eew_estimated_intensity_layer.dart` で `a7e65d83` にて適用済みの同パターンを踏襲。

## テスト

- `dart analyze` パス済み

Closes #1205