### PR TITLE
fix(location): API送信後は成否に関わらずデバッグ通知を表示

### DIFF
--- a/app/lib/feature/location/data/background_location_service.dart
+++ b/app/lib/feature/location/data/background_location_service.dart
@@ -193,8 +193,7 @@ Future<void> _fireDebugNotifications(
       }
     }
 
-    if (debugSettings.notifyApiUpdate &&
-        (didUpdateEew || didUpdateEarthquake || didUpdateShake)) {
+    if (debugSettings.notifyApiUpdate) {
       final eewStatus = eewError != null ? '✗($eewError)' : (didUpdateEew ? '✓' : '-');
       final eqStatus = earthquakeError != null ? '✗($earthquakeError)' : (didUpdateEarthquake ? '✓' : '-');
       final shakeStatus = shakeError != null ? '✗($shakeError)' : (didUpdateShake ? '✓' : '-');


### PR DESCRIPTION
## Summary

- `notifyApiUpdate` が ON の場合、API更新が成功・失敗・変化なしにかかわらず、常にローカル通知を表示するよう修正
- 変更前: `didUpdateEew || didUpdateEarthquake || didUpdateShake` が true の時のみ通知（失敗時・変化なし時はサイレント）
- 変更後: `notifyApiUpdate` が ON であれば常に通知（各項目のステータスに `✓` / `-` / `✗(エラー内容)` を表示）

## Test plan

- [ ] デバッグ設定で `notifyApiUpdate` を ON にした状態でバックグラウンド位置更新を発生させる
- [ ] API更新が成功した場合に通知が表示されることを確認
- [ ] API更新が失敗した場合（ネットワークエラー等）にも通知が表示されることを確認
- [ ] リージョン変化なしの場合（`-` 表示）でも通知が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)