### PR TITLE
feat(api): RegionSetting に city_code/city_name (#087 P8 client)

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region.dart
@@ -11,6 +11,10 @@ abstract class NotificationRegion with _$NotificationRegion {
     required String? regionName,
     required bool isCurrentLocation,
     required JmaIntensity minJmaIntensity,
+    // 市区町村コード (NULL = region 単位の通知設定)。
+    // EEW 設定では常に NULL (EEW は area_forecast_local_eew コード単位のみ対応)。
+    @Default(null) String? cityCode,
+    @Default(null) String? cityName,
   }) = _NotificationRegion;
 }
 
@@ -18,6 +22,8 @@ extension RegionSettingResponseConverter on api.RegionSettingResponse {
   NotificationRegion get toNotificationRegion => NotificationRegion(
     regionId: regionId.toInt(),
     regionName: regionName,
+    cityCode: cityCode,
+    cityName: cityName,
     isCurrentLocation: isCurrentLocation,
     minJmaIntensity: minJmaIntensity.toJmaIntensity,
   );
@@ -27,7 +33,10 @@ extension NotificationRegionToRequest on NotificationRegion {
   api.RegionSettingRequest get toApiRequest => api.RegionSettingRequest(
     regionId: regionId,
     isCurrentLocation: isCurrentLocation,
-    minJmaIntensity: minJmaIntensity.toApiJmaIntensity ?? api.JmaIntensity.value4,
+    minJmaIntensity:
+        minJmaIntensity.toApiJmaIntensity ?? api.JmaIntensity.value4,
     regionName: regionName,
+    cityCode: cityCode,
+    cityName: cityName,
   );
 }

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_region.freezed.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_region.freezed.dart
@@ -14,7 +14,9 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NotificationRegion {
 
- int get regionId; String? get regionName; bool get isCurrentLocation; JmaIntensity get minJmaIntensity;
+ int get regionId; String? get regionName; bool get isCurrentLocation; JmaIntensity get minJmaIntensity;// 市区町村コード (NULL = region 単位の通知設定)。
+// EEW 設定では常に NULL (EEW は area_forecast_local_eew コード単位のみ対応)。
+ String? get cityCode; String? get cityName;
 /// Create a copy of NotificationRegion
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +27,16 @@ $NotificationRegionCopyWith<NotificationRegion> get copyWith => _$NotificationRe
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationRegion&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationRegion&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,regionId,regionName,isCurrentLocation,minJmaIntensity);
+int get hashCode => Object.hash(runtimeType,regionId,regionName,isCurrentLocation,minJmaIntensity,cityCode,cityName);
 
 @override
 String toString() {
-  return 'NotificationRegion(regionId: $regionId, regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity)';
+  return 'NotificationRegion(regionId: $regionId, regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, cityCode: $cityCode, cityName: $cityName)';
 }
 
 
@@ -45,7 +47,7 @@ abstract mixin class $NotificationRegionCopyWith<$Res>  {
   factory $NotificationRegionCopyWith(NotificationRegion value, $Res Function(NotificationRegion) _then) = _$NotificationRegionCopyWithImpl;
 @useResult
 $Res call({
- int regionId, String? regionName, bool isCurrentLocation, JmaIntensity minJmaIntensity
+ int regionId, String? regionName, bool isCurrentLocation, JmaIntensity minJmaIntensity, String? cityCode, String? cityName
 });
 
 
@@ -62,13 +64,15 @@ class _$NotificationRegionCopyWithImpl<$Res>
 
 /// Create a copy of NotificationRegion
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? regionId = null,Object? regionName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? regionId = null,Object? regionName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? cityCode = freezed,Object? cityName = freezed,}) {
   return _then(_self.copyWith(
 regionId: null == regionId ? _self.regionId : regionId // ignore: cast_nullable_to_non_nullable
 as int,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
 as String?,isCurrentLocation: null == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool,minJmaIntensity: null == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
-as JmaIntensity,
+as JmaIntensity,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -153,10 +157,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int regionId,  String? regionName,  bool isCurrentLocation,  JmaIntensity minJmaIntensity)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int regionId,  String? regionName,  bool isCurrentLocation,  JmaIntensity minJmaIntensity,  String? cityCode,  String? cityName)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NotificationRegion() when $default != null:
-return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
+return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity,_that.cityCode,_that.cityName);case _:
   return orElse();
 
 }
@@ -174,10 +178,10 @@ return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.mi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int regionId,  String? regionName,  bool isCurrentLocation,  JmaIntensity minJmaIntensity)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int regionId,  String? regionName,  bool isCurrentLocation,  JmaIntensity minJmaIntensity,  String? cityCode,  String? cityName)  $default,) {final _that = this;
 switch (_that) {
 case _NotificationRegion():
-return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
+return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity,_that.cityCode,_that.cityName);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -194,10 +198,10 @@ return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.mi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int regionId,  String? regionName,  bool isCurrentLocation,  JmaIntensity minJmaIntensity)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int regionId,  String? regionName,  bool isCurrentLocation,  JmaIntensity minJmaIntensity,  String? cityCode,  String? cityName)?  $default,) {final _that = this;
 switch (_that) {
 case _NotificationRegion() when $default != null:
-return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
+return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity,_that.cityCode,_that.cityName);case _:
   return null;
 
 }
@@ -209,13 +213,17 @@ return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.mi
 
 
 class _NotificationRegion implements NotificationRegion {
-  const _NotificationRegion({required this.regionId, required this.regionName, required this.isCurrentLocation, required this.minJmaIntensity});
+  const _NotificationRegion({required this.regionId, required this.regionName, required this.isCurrentLocation, required this.minJmaIntensity, this.cityCode = null, this.cityName = null});
   
 
 @override final  int regionId;
 @override final  String? regionName;
 @override final  bool isCurrentLocation;
 @override final  JmaIntensity minJmaIntensity;
+// 市区町村コード (NULL = region 単位の通知設定)。
+// EEW 設定では常に NULL (EEW は area_forecast_local_eew コード単位のみ対応)。
+@override@JsonKey() final  String? cityCode;
+@override@JsonKey() final  String? cityName;
 
 /// Create a copy of NotificationRegion
 /// with the given fields replaced by the non-null parameter values.
@@ -227,16 +235,16 @@ _$NotificationRegionCopyWith<_NotificationRegion> get copyWith => __$Notificatio
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationRegion&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationRegion&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,regionId,regionName,isCurrentLocation,minJmaIntensity);
+int get hashCode => Object.hash(runtimeType,regionId,regionName,isCurrentLocation,minJmaIntensity,cityCode,cityName);
 
 @override
 String toString() {
-  return 'NotificationRegion(regionId: $regionId, regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity)';
+  return 'NotificationRegion(regionId: $regionId, regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, cityCode: $cityCode, cityName: $cityName)';
 }
 
 
@@ -247,7 +255,7 @@ abstract mixin class _$NotificationRegionCopyWith<$Res> implements $Notification
   factory _$NotificationRegionCopyWith(_NotificationRegion value, $Res Function(_NotificationRegion) _then) = __$NotificationRegionCopyWithImpl;
 @override @useResult
 $Res call({
- int regionId, String? regionName, bool isCurrentLocation, JmaIntensity minJmaIntensity
+ int regionId, String? regionName, bool isCurrentLocation, JmaIntensity minJmaIntensity, String? cityCode, String? cityName
 });
 
 
@@ -264,13 +272,15 @@ class __$NotificationRegionCopyWithImpl<$Res>
 
 /// Create a copy of NotificationRegion
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? regionId = null,Object? regionName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? regionId = null,Object? regionName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? cityCode = freezed,Object? cityName = freezed,}) {
   return _then(_NotificationRegion(
 regionId: null == regionId ? _self.regionId : regionId // ignore: cast_nullable_to_non_nullable
 as int,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
 as String?,isCurrentLocation: null == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool,minJmaIntensity: null == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
-as JmaIntensity,
+as JmaIntensity,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.dart
@@ -14,6 +14,10 @@ abstract class RegionSettingPatchRequest with _$RegionSettingPatchRequest {
   const factory RegionSettingPatchRequest({
     @JsonKey(includeIfNull: false,name: 'region_name')
     String? regionName,
+    @JsonKey(includeIfNull: false,name: 'city_code')
+    String? cityCode,
+    @JsonKey(includeIfNull: false,name: 'city_name')
+    String? cityName,
     @JsonKey(includeIfNull: false,name: 'is_current_location')
     bool? isCurrentLocation,
     @JsonKey(includeIfNull: false,name: 'min_jma_intensity')

--- a/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RegionSettingPatchRequest {
 
-@JsonKey(includeIfNull: false, name: 'region_name') String? get regionName;@JsonKey(includeIfNull: false, name: 'is_current_location') bool? get isCurrentLocation;@JsonKey(includeIfNull: false, name: 'min_jma_intensity') JmaIntensity? get minJmaIntensity;
+@JsonKey(includeIfNull: false, name: 'region_name') String? get regionName;@JsonKey(includeIfNull: false, name: 'city_code') String? get cityCode;@JsonKey(includeIfNull: false, name: 'city_name') String? get cityName;@JsonKey(includeIfNull: false, name: 'is_current_location') bool? get isCurrentLocation;@JsonKey(includeIfNull: false, name: 'min_jma_intensity') JmaIntensity? get minJmaIntensity;
 /// Create a copy of RegionSettingPatchRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $RegionSettingPatchRequestCopyWith<RegionSettingPatchRequest> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegionSettingPatchRequest&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegionSettingPatchRequest&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionName,isCurrentLocation,minJmaIntensity);
+int get hashCode => Object.hash(runtimeType,regionName,cityCode,cityName,isCurrentLocation,minJmaIntensity);
 
 @override
 String toString() {
-  return 'RegionSettingPatchRequest(regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity)';
+  return 'RegionSettingPatchRequest(regionName: $regionName, cityCode: $cityCode, cityName: $cityName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $RegionSettingPatchRequestCopyWith<$Res>  {
   factory $RegionSettingPatchRequestCopyWith(RegionSettingPatchRequest value, $Res Function(RegionSettingPatchRequest) _then) = _$RegionSettingPatchRequestCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(includeIfNull: false, name: 'region_name') String? regionName,@JsonKey(includeIfNull: false, name: 'is_current_location') bool? isCurrentLocation,@JsonKey(includeIfNull: false, name: 'min_jma_intensity') JmaIntensity? minJmaIntensity
+@JsonKey(includeIfNull: false, name: 'region_name') String? regionName,@JsonKey(includeIfNull: false, name: 'city_code') String? cityCode,@JsonKey(includeIfNull: false, name: 'city_name') String? cityName,@JsonKey(includeIfNull: false, name: 'is_current_location') bool? isCurrentLocation,@JsonKey(includeIfNull: false, name: 'min_jma_intensity') JmaIntensity? minJmaIntensity
 });
 
 
@@ -65,9 +65,11 @@ class _$RegionSettingPatchRequestCopyWithImpl<$Res>
 
 /// Create a copy of RegionSettingPatchRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? regionName = freezed,Object? isCurrentLocation = freezed,Object? minJmaIntensity = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? regionName = freezed,Object? cityCode = freezed,Object? cityName = freezed,Object? isCurrentLocation = freezed,Object? minJmaIntensity = freezed,}) {
   return _then(_self.copyWith(
 regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
 as String?,isCurrentLocation: freezed == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool?,minJmaIntensity: freezed == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity?,
@@ -155,10 +157,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'is_current_location')  bool? isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity')  JmaIntensity? minJmaIntensity)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: false, name: 'city_name')  String? cityName, @JsonKey(includeIfNull: false, name: 'is_current_location')  bool? isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity')  JmaIntensity? minJmaIntensity)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _RegionSettingPatchRequest() when $default != null:
-return $default(_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
+return $default(_that.regionName,_that.cityCode,_that.cityName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
   return orElse();
 
 }
@@ -176,10 +178,10 @@ return $default(_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'is_current_location')  bool? isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity')  JmaIntensity? minJmaIntensity)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: false, name: 'city_name')  String? cityName, @JsonKey(includeIfNull: false, name: 'is_current_location')  bool? isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity')  JmaIntensity? minJmaIntensity)  $default,) {final _that = this;
 switch (_that) {
 case _RegionSettingPatchRequest():
-return $default(_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
+return $default(_that.regionName,_that.cityCode,_that.cityName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +198,10 @@ return $default(_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'is_current_location')  bool? isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity')  JmaIntensity? minJmaIntensity)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: false, name: 'city_name')  String? cityName, @JsonKey(includeIfNull: false, name: 'is_current_location')  bool? isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity')  JmaIntensity? minJmaIntensity)?  $default,) {final _that = this;
 switch (_that) {
 case _RegionSettingPatchRequest() when $default != null:
-return $default(_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
+return $default(_that.regionName,_that.cityCode,_that.cityName,_that.isCurrentLocation,_that.minJmaIntensity);case _:
   return null;
 
 }
@@ -211,10 +213,12 @@ return $default(_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity);
 @JsonSerializable()
 
 class _RegionSettingPatchRequest implements RegionSettingPatchRequest {
-  const _RegionSettingPatchRequest({@JsonKey(includeIfNull: false, name: 'region_name') this.regionName, @JsonKey(includeIfNull: false, name: 'is_current_location') this.isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity') this.minJmaIntensity});
+  const _RegionSettingPatchRequest({@JsonKey(includeIfNull: false, name: 'region_name') this.regionName, @JsonKey(includeIfNull: false, name: 'city_code') this.cityCode, @JsonKey(includeIfNull: false, name: 'city_name') this.cityName, @JsonKey(includeIfNull: false, name: 'is_current_location') this.isCurrentLocation, @JsonKey(includeIfNull: false, name: 'min_jma_intensity') this.minJmaIntensity});
   factory _RegionSettingPatchRequest.fromJson(Map<String, dynamic> json) => _$RegionSettingPatchRequestFromJson(json);
 
 @override@JsonKey(includeIfNull: false, name: 'region_name') final  String? regionName;
+@override@JsonKey(includeIfNull: false, name: 'city_code') final  String? cityCode;
+@override@JsonKey(includeIfNull: false, name: 'city_name') final  String? cityName;
 @override@JsonKey(includeIfNull: false, name: 'is_current_location') final  bool? isCurrentLocation;
 @override@JsonKey(includeIfNull: false, name: 'min_jma_intensity') final  JmaIntensity? minJmaIntensity;
 
@@ -231,16 +235,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegionSettingPatchRequest&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegionSettingPatchRequest&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionName,isCurrentLocation,minJmaIntensity);
+int get hashCode => Object.hash(runtimeType,regionName,cityCode,cityName,isCurrentLocation,minJmaIntensity);
 
 @override
 String toString() {
-  return 'RegionSettingPatchRequest(regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity)';
+  return 'RegionSettingPatchRequest(regionName: $regionName, cityCode: $cityCode, cityName: $cityName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity)';
 }
 
 
@@ -251,7 +255,7 @@ abstract mixin class _$RegionSettingPatchRequestCopyWith<$Res> implements $Regio
   factory _$RegionSettingPatchRequestCopyWith(_RegionSettingPatchRequest value, $Res Function(_RegionSettingPatchRequest) _then) = __$RegionSettingPatchRequestCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(includeIfNull: false, name: 'region_name') String? regionName,@JsonKey(includeIfNull: false, name: 'is_current_location') bool? isCurrentLocation,@JsonKey(includeIfNull: false, name: 'min_jma_intensity') JmaIntensity? minJmaIntensity
+@JsonKey(includeIfNull: false, name: 'region_name') String? regionName,@JsonKey(includeIfNull: false, name: 'city_code') String? cityCode,@JsonKey(includeIfNull: false, name: 'city_name') String? cityName,@JsonKey(includeIfNull: false, name: 'is_current_location') bool? isCurrentLocation,@JsonKey(includeIfNull: false, name: 'min_jma_intensity') JmaIntensity? minJmaIntensity
 });
 
 
@@ -268,9 +272,11 @@ class __$RegionSettingPatchRequestCopyWithImpl<$Res>
 
 /// Create a copy of RegionSettingPatchRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? regionName = freezed,Object? isCurrentLocation = freezed,Object? minJmaIntensity = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? regionName = freezed,Object? cityCode = freezed,Object? cityName = freezed,Object? isCurrentLocation = freezed,Object? minJmaIntensity = freezed,}) {
   return _then(_RegionSettingPatchRequest(
 regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
 as String?,isCurrentLocation: freezed == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool?,minJmaIntensity: freezed == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity?,

--- a/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.g.dart
@@ -16,6 +16,8 @@ _RegionSettingPatchRequest _$RegionSettingPatchRequestFromJson(
   ($checkedConvert) {
     final val = _RegionSettingPatchRequest(
       regionName: $checkedConvert('region_name', (v) => v as String?),
+      cityCode: $checkedConvert('city_code', (v) => v as String?),
+      cityName: $checkedConvert('city_name', (v) => v as String?),
       isCurrentLocation: $checkedConvert(
         'is_current_location',
         (v) => v as bool?,
@@ -29,6 +31,8 @@ _RegionSettingPatchRequest _$RegionSettingPatchRequestFromJson(
   },
   fieldKeyMap: const {
     'regionName': 'region_name',
+    'cityCode': 'city_code',
+    'cityName': 'city_name',
     'isCurrentLocation': 'is_current_location',
     'minJmaIntensity': 'min_jma_intensity',
   },
@@ -38,6 +42,8 @@ Map<String, dynamic> _$RegionSettingPatchRequestToJson(
   _RegionSettingPatchRequest instance,
 ) => <String, dynamic>{
   'region_name': ?instance.regionName,
+  'city_code': ?instance.cityCode,
+  'city_name': ?instance.cityName,
   'is_current_location': ?instance.isCurrentLocation,
   'min_jma_intensity': ?instance.minJmaIntensity,
 };

--- a/packages/eqmonitor_api/lib/src/models/region_setting_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_request.dart
@@ -20,6 +20,10 @@ abstract class RegionSettingRequest with _$RegionSettingRequest {
     required JmaIntensity minJmaIntensity,
     @JsonKey(includeIfNull: false,name: 'region_name')
     String? regionName,
+    @JsonKey(includeIfNull: false,name: 'city_code')
+    String? cityCode,
+    @JsonKey(includeIfNull: false,name: 'city_name')
+    String? cityName,
   }) = _RegionSettingRequest;
   
   factory RegionSettingRequest.fromJson(Map<String, Object?> json) => _$RegionSettingRequestFromJson(json);

--- a/packages/eqmonitor_api/lib/src/models/region_setting_request.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RegionSettingRequest {
 
-@JsonKey(name: 'region_id') num get regionId;@JsonKey(name: 'is_current_location') bool get isCurrentLocation;@JsonKey(name: 'min_jma_intensity') JmaIntensity get minJmaIntensity;@JsonKey(includeIfNull: false, name: 'region_name') String? get regionName;
+@JsonKey(name: 'region_id') num get regionId;@JsonKey(name: 'is_current_location') bool get isCurrentLocation;@JsonKey(name: 'min_jma_intensity') JmaIntensity get minJmaIntensity;@JsonKey(includeIfNull: false, name: 'region_name') String? get regionName;@JsonKey(includeIfNull: false, name: 'city_code') String? get cityCode;@JsonKey(includeIfNull: false, name: 'city_name') String? get cityName;
 /// Create a copy of RegionSettingRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $RegionSettingRequestCopyWith<RegionSettingRequest> get copyWith => _$RegionSett
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegionSettingRequest&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.regionName, regionName) || other.regionName == regionName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegionSettingRequest&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionId,isCurrentLocation,minJmaIntensity,regionName);
+int get hashCode => Object.hash(runtimeType,regionId,isCurrentLocation,minJmaIntensity,regionName,cityCode,cityName);
 
 @override
 String toString() {
-  return 'RegionSettingRequest(regionId: $regionId, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, regionName: $regionName)';
+  return 'RegionSettingRequest(regionId: $regionId, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, regionName: $regionName, cityCode: $cityCode, cityName: $cityName)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $RegionSettingRequestCopyWith<$Res>  {
   factory $RegionSettingRequestCopyWith(RegionSettingRequest value, $Res Function(RegionSettingRequest) _then) = _$RegionSettingRequestCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'region_id') num regionId,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(includeIfNull: false, name: 'region_name') String? regionName
+@JsonKey(name: 'region_id') num regionId,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(includeIfNull: false, name: 'region_name') String? regionName,@JsonKey(includeIfNull: false, name: 'city_code') String? cityCode,@JsonKey(includeIfNull: false, name: 'city_name') String? cityName
 });
 
 
@@ -65,12 +65,14 @@ class _$RegionSettingRequestCopyWithImpl<$Res>
 
 /// Create a copy of RegionSettingRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? regionId = null,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? regionName = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? regionId = null,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? regionName = freezed,Object? cityCode = freezed,Object? cityName = freezed,}) {
   return _then(_self.copyWith(
 regionId: null == regionId ? _self.regionId : regionId // ignore: cast_nullable_to_non_nullable
 as num,isCurrentLocation: null == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool,minJmaIntensity: null == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -156,10 +158,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name')  String? regionName)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: false, name: 'city_name')  String? cityName)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _RegionSettingRequest() when $default != null:
-return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_that.regionName);case _:
+return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_that.regionName,_that.cityCode,_that.cityName);case _:
   return orElse();
 
 }
@@ -177,10 +179,10 @@ return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name')  String? regionName)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: false, name: 'city_name')  String? cityName)  $default,) {final _that = this;
 switch (_that) {
 case _RegionSettingRequest():
-return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_that.regionName);case _:
+return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_that.regionName,_that.cityCode,_that.cityName);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -197,10 +199,10 @@ return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name')  String? regionName)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: false, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: false, name: 'city_name')  String? cityName)?  $default,) {final _that = this;
 switch (_that) {
 case _RegionSettingRequest() when $default != null:
-return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_that.regionName);case _:
+return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_that.regionName,_that.cityCode,_that.cityName);case _:
   return null;
 
 }
@@ -212,13 +214,15 @@ return $default(_that.regionId,_that.isCurrentLocation,_that.minJmaIntensity,_th
 @JsonSerializable()
 
 class _RegionSettingRequest implements RegionSettingRequest {
-  const _RegionSettingRequest({@JsonKey(name: 'region_id') required this.regionId, @JsonKey(name: 'is_current_location') required this.isCurrentLocation, @JsonKey(name: 'min_jma_intensity') required this.minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name') this.regionName});
+  const _RegionSettingRequest({@JsonKey(name: 'region_id') required this.regionId, @JsonKey(name: 'is_current_location') required this.isCurrentLocation, @JsonKey(name: 'min_jma_intensity') required this.minJmaIntensity, @JsonKey(includeIfNull: false, name: 'region_name') this.regionName, @JsonKey(includeIfNull: false, name: 'city_code') this.cityCode, @JsonKey(includeIfNull: false, name: 'city_name') this.cityName});
   factory _RegionSettingRequest.fromJson(Map<String, dynamic> json) => _$RegionSettingRequestFromJson(json);
 
 @override@JsonKey(name: 'region_id') final  num regionId;
 @override@JsonKey(name: 'is_current_location') final  bool isCurrentLocation;
 @override@JsonKey(name: 'min_jma_intensity') final  JmaIntensity minJmaIntensity;
 @override@JsonKey(includeIfNull: false, name: 'region_name') final  String? regionName;
+@override@JsonKey(includeIfNull: false, name: 'city_code') final  String? cityCode;
+@override@JsonKey(includeIfNull: false, name: 'city_name') final  String? cityName;
 
 /// Create a copy of RegionSettingRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -233,16 +237,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegionSettingRequest&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.regionName, regionName) || other.regionName == regionName));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegionSettingRequest&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionId,isCurrentLocation,minJmaIntensity,regionName);
+int get hashCode => Object.hash(runtimeType,regionId,isCurrentLocation,minJmaIntensity,regionName,cityCode,cityName);
 
 @override
 String toString() {
-  return 'RegionSettingRequest(regionId: $regionId, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, regionName: $regionName)';
+  return 'RegionSettingRequest(regionId: $regionId, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, regionName: $regionName, cityCode: $cityCode, cityName: $cityName)';
 }
 
 
@@ -253,7 +257,7 @@ abstract mixin class _$RegionSettingRequestCopyWith<$Res> implements $RegionSett
   factory _$RegionSettingRequestCopyWith(_RegionSettingRequest value, $Res Function(_RegionSettingRequest) _then) = __$RegionSettingRequestCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'region_id') num regionId,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(includeIfNull: false, name: 'region_name') String? regionName
+@JsonKey(name: 'region_id') num regionId,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(includeIfNull: false, name: 'region_name') String? regionName,@JsonKey(includeIfNull: false, name: 'city_code') String? cityCode,@JsonKey(includeIfNull: false, name: 'city_name') String? cityName
 });
 
 
@@ -270,12 +274,14 @@ class __$RegionSettingRequestCopyWithImpl<$Res>
 
 /// Create a copy of RegionSettingRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? regionId = null,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? regionName = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? regionId = null,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? regionName = freezed,Object? cityCode = freezed,Object? cityName = freezed,}) {
   return _then(_RegionSettingRequest(
 regionId: null == regionId ? _self.regionId : regionId // ignore: cast_nullable_to_non_nullable
 as num,isCurrentLocation: null == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool,minJmaIntensity: null == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/packages/eqmonitor_api/lib/src/models/region_setting_request.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_request.g.dart
@@ -25,6 +25,8 @@ _RegionSettingRequest _$RegionSettingRequestFromJson(
         (v) => $enumDecode(_$JmaIntensityEnumMap, v),
       ),
       regionName: $checkedConvert('region_name', (v) => v as String?),
+      cityCode: $checkedConvert('city_code', (v) => v as String?),
+      cityName: $checkedConvert('city_name', (v) => v as String?),
     );
     return val;
   },
@@ -33,6 +35,8 @@ _RegionSettingRequest _$RegionSettingRequestFromJson(
     'isCurrentLocation': 'is_current_location',
     'minJmaIntensity': 'min_jma_intensity',
     'regionName': 'region_name',
+    'cityCode': 'city_code',
+    'cityName': 'city_name',
   },
 );
 
@@ -43,6 +47,8 @@ Map<String, dynamic> _$RegionSettingRequestToJson(
   'is_current_location': instance.isCurrentLocation,
   'min_jma_intensity': instance.minJmaIntensity,
   'region_name': ?instance.regionName,
+  'city_code': ?instance.cityCode,
+  'city_name': ?instance.cityName,
 };
 
 const _$JmaIntensityEnumMap = {

--- a/packages/eqmonitor_api/lib/src/models/region_setting_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_response.dart
@@ -16,6 +16,10 @@ abstract class RegionSettingResponse with _$RegionSettingResponse {
     required num regionId,
     @JsonKey(includeIfNull: true,name: 'region_name')
     required String? regionName,
+    @JsonKey(includeIfNull: true,name: 'city_code')
+    required String? cityCode,
+    @JsonKey(includeIfNull: true,name: 'city_name')
+    required String? cityName,
     @JsonKey(name: 'is_current_location')
     required bool isCurrentLocation,
     @JsonKey(name: 'min_jma_intensity')

--- a/packages/eqmonitor_api/lib/src/models/region_setting_response.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RegionSettingResponse {
 
-@JsonKey(name: 'region_id') num get regionId;@JsonKey(includeIfNull: true, name: 'region_name') String? get regionName;@JsonKey(name: 'is_current_location') bool get isCurrentLocation;@JsonKey(name: 'min_jma_intensity') JmaIntensity get minJmaIntensity;@JsonKey(name: 'created_at') String get createdAt;@JsonKey(name: 'updated_at') String get updatedAt;
+@JsonKey(name: 'region_id') num get regionId;@JsonKey(includeIfNull: true, name: 'region_name') String? get regionName;@JsonKey(includeIfNull: true, name: 'city_code') String? get cityCode;@JsonKey(includeIfNull: true, name: 'city_name') String? get cityName;@JsonKey(name: 'is_current_location') bool get isCurrentLocation;@JsonKey(name: 'min_jma_intensity') JmaIntensity get minJmaIntensity;@JsonKey(name: 'created_at') String get createdAt;@JsonKey(name: 'updated_at') String get updatedAt;
 /// Create a copy of RegionSettingResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $RegionSettingResponseCopyWith<RegionSettingResponse> get copyWith => _$RegionSe
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegionSettingResponse&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegionSettingResponse&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionId,regionName,isCurrentLocation,minJmaIntensity,createdAt,updatedAt);
+int get hashCode => Object.hash(runtimeType,regionId,regionName,cityCode,cityName,isCurrentLocation,minJmaIntensity,createdAt,updatedAt);
 
 @override
 String toString() {
-  return 'RegionSettingResponse(regionId: $regionId, regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, createdAt: $createdAt, updatedAt: $updatedAt)';
+  return 'RegionSettingResponse(regionId: $regionId, regionName: $regionName, cityCode: $cityCode, cityName: $cityName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, createdAt: $createdAt, updatedAt: $updatedAt)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $RegionSettingResponseCopyWith<$Res>  {
   factory $RegionSettingResponseCopyWith(RegionSettingResponse value, $Res Function(RegionSettingResponse) _then) = _$RegionSettingResponseCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'region_id') num regionId,@JsonKey(includeIfNull: true, name: 'region_name') String? regionName,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(name: 'created_at') String createdAt,@JsonKey(name: 'updated_at') String updatedAt
+@JsonKey(name: 'region_id') num regionId,@JsonKey(includeIfNull: true, name: 'region_name') String? regionName,@JsonKey(includeIfNull: true, name: 'city_code') String? cityCode,@JsonKey(includeIfNull: true, name: 'city_name') String? cityName,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(name: 'created_at') String createdAt,@JsonKey(name: 'updated_at') String updatedAt
 });
 
 
@@ -65,10 +65,12 @@ class _$RegionSettingResponseCopyWithImpl<$Res>
 
 /// Create a copy of RegionSettingResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? regionId = null,Object? regionName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? createdAt = null,Object? updatedAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? regionId = null,Object? regionName = freezed,Object? cityCode = freezed,Object? cityName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? createdAt = null,Object? updatedAt = null,}) {
   return _then(_self.copyWith(
 regionId: null == regionId ? _self.regionId : regionId // ignore: cast_nullable_to_non_nullable
 as num,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
 as String?,isCurrentLocation: null == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool,minJmaIntensity: null == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
@@ -158,10 +160,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(includeIfNull: true, name: 'region_name')  String? regionName, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(name: 'created_at')  String createdAt, @JsonKey(name: 'updated_at')  String updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(includeIfNull: true, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: true, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: true, name: 'city_name')  String? cityName, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(name: 'created_at')  String createdAt, @JsonKey(name: 'updated_at')  String updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _RegionSettingResponse() when $default != null:
-return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity,_that.createdAt,_that.updatedAt);case _:
+return $default(_that.regionId,_that.regionName,_that.cityCode,_that.cityName,_that.isCurrentLocation,_that.minJmaIntensity,_that.createdAt,_that.updatedAt);case _:
   return orElse();
 
 }
@@ -179,10 +181,10 @@ return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.mi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(includeIfNull: true, name: 'region_name')  String? regionName, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(name: 'created_at')  String createdAt, @JsonKey(name: 'updated_at')  String updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(includeIfNull: true, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: true, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: true, name: 'city_name')  String? cityName, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(name: 'created_at')  String createdAt, @JsonKey(name: 'updated_at')  String updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _RegionSettingResponse():
-return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity,_that.createdAt,_that.updatedAt);case _:
+return $default(_that.regionId,_that.regionName,_that.cityCode,_that.cityName,_that.isCurrentLocation,_that.minJmaIntensity,_that.createdAt,_that.updatedAt);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +201,10 @@ return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.mi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(includeIfNull: true, name: 'region_name')  String? regionName, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(name: 'created_at')  String createdAt, @JsonKey(name: 'updated_at')  String updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'region_id')  num regionId, @JsonKey(includeIfNull: true, name: 'region_name')  String? regionName, @JsonKey(includeIfNull: true, name: 'city_code')  String? cityCode, @JsonKey(includeIfNull: true, name: 'city_name')  String? cityName, @JsonKey(name: 'is_current_location')  bool isCurrentLocation, @JsonKey(name: 'min_jma_intensity')  JmaIntensity minJmaIntensity, @JsonKey(name: 'created_at')  String createdAt, @JsonKey(name: 'updated_at')  String updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _RegionSettingResponse() when $default != null:
-return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.minJmaIntensity,_that.createdAt,_that.updatedAt);case _:
+return $default(_that.regionId,_that.regionName,_that.cityCode,_that.cityName,_that.isCurrentLocation,_that.minJmaIntensity,_that.createdAt,_that.updatedAt);case _:
   return null;
 
 }
@@ -214,11 +216,13 @@ return $default(_that.regionId,_that.regionName,_that.isCurrentLocation,_that.mi
 @JsonSerializable()
 
 class _RegionSettingResponse implements RegionSettingResponse {
-  const _RegionSettingResponse({@JsonKey(name: 'region_id') required this.regionId, @JsonKey(includeIfNull: true, name: 'region_name') required this.regionName, @JsonKey(name: 'is_current_location') required this.isCurrentLocation, @JsonKey(name: 'min_jma_intensity') required this.minJmaIntensity, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt});
+  const _RegionSettingResponse({@JsonKey(name: 'region_id') required this.regionId, @JsonKey(includeIfNull: true, name: 'region_name') required this.regionName, @JsonKey(includeIfNull: true, name: 'city_code') required this.cityCode, @JsonKey(includeIfNull: true, name: 'city_name') required this.cityName, @JsonKey(name: 'is_current_location') required this.isCurrentLocation, @JsonKey(name: 'min_jma_intensity') required this.minJmaIntensity, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt});
   factory _RegionSettingResponse.fromJson(Map<String, dynamic> json) => _$RegionSettingResponseFromJson(json);
 
 @override@JsonKey(name: 'region_id') final  num regionId;
 @override@JsonKey(includeIfNull: true, name: 'region_name') final  String? regionName;
+@override@JsonKey(includeIfNull: true, name: 'city_code') final  String? cityCode;
+@override@JsonKey(includeIfNull: true, name: 'city_name') final  String? cityName;
 @override@JsonKey(name: 'is_current_location') final  bool isCurrentLocation;
 @override@JsonKey(name: 'min_jma_intensity') final  JmaIntensity minJmaIntensity;
 @override@JsonKey(name: 'created_at') final  String createdAt;
@@ -237,16 +241,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegionSettingResponse&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegionSettingResponse&&(identical(other.regionId, regionId) || other.regionId == regionId)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.cityName, cityName) || other.cityName == cityName)&&(identical(other.isCurrentLocation, isCurrentLocation) || other.isCurrentLocation == isCurrentLocation)&&(identical(other.minJmaIntensity, minJmaIntensity) || other.minJmaIntensity == minJmaIntensity)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionId,regionName,isCurrentLocation,minJmaIntensity,createdAt,updatedAt);
+int get hashCode => Object.hash(runtimeType,regionId,regionName,cityCode,cityName,isCurrentLocation,minJmaIntensity,createdAt,updatedAt);
 
 @override
 String toString() {
-  return 'RegionSettingResponse(regionId: $regionId, regionName: $regionName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, createdAt: $createdAt, updatedAt: $updatedAt)';
+  return 'RegionSettingResponse(regionId: $regionId, regionName: $regionName, cityCode: $cityCode, cityName: $cityName, isCurrentLocation: $isCurrentLocation, minJmaIntensity: $minJmaIntensity, createdAt: $createdAt, updatedAt: $updatedAt)';
 }
 
 
@@ -257,7 +261,7 @@ abstract mixin class _$RegionSettingResponseCopyWith<$Res> implements $RegionSet
   factory _$RegionSettingResponseCopyWith(_RegionSettingResponse value, $Res Function(_RegionSettingResponse) _then) = __$RegionSettingResponseCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'region_id') num regionId,@JsonKey(includeIfNull: true, name: 'region_name') String? regionName,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(name: 'created_at') String createdAt,@JsonKey(name: 'updated_at') String updatedAt
+@JsonKey(name: 'region_id') num regionId,@JsonKey(includeIfNull: true, name: 'region_name') String? regionName,@JsonKey(includeIfNull: true, name: 'city_code') String? cityCode,@JsonKey(includeIfNull: true, name: 'city_name') String? cityName,@JsonKey(name: 'is_current_location') bool isCurrentLocation,@JsonKey(name: 'min_jma_intensity') JmaIntensity minJmaIntensity,@JsonKey(name: 'created_at') String createdAt,@JsonKey(name: 'updated_at') String updatedAt
 });
 
 
@@ -274,10 +278,12 @@ class __$RegionSettingResponseCopyWithImpl<$Res>
 
 /// Create a copy of RegionSettingResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? regionId = null,Object? regionName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? createdAt = null,Object? updatedAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? regionId = null,Object? regionName = freezed,Object? cityCode = freezed,Object? cityName = freezed,Object? isCurrentLocation = null,Object? minJmaIntensity = null,Object? createdAt = null,Object? updatedAt = null,}) {
   return _then(_RegionSettingResponse(
 regionId: null == regionId ? _self.regionId : regionId // ignore: cast_nullable_to_non_nullable
 as num,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,cityName: freezed == cityName ? _self.cityName : cityName // ignore: cast_nullable_to_non_nullable
 as String?,isCurrentLocation: null == isCurrentLocation ? _self.isCurrentLocation : isCurrentLocation // ignore: cast_nullable_to_non_nullable
 as bool,minJmaIntensity: null == minJmaIntensity ? _self.minJmaIntensity : minJmaIntensity // ignore: cast_nullable_to_non_nullable
 as JmaIntensity,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable

--- a/packages/eqmonitor_api/lib/src/models/region_setting_response.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_response.g.dart
@@ -17,6 +17,8 @@ _RegionSettingResponse _$RegionSettingResponseFromJson(
     final val = _RegionSettingResponse(
       regionId: $checkedConvert('region_id', (v) => v as num),
       regionName: $checkedConvert('region_name', (v) => v as String?),
+      cityCode: $checkedConvert('city_code', (v) => v as String?),
+      cityName: $checkedConvert('city_name', (v) => v as String?),
       isCurrentLocation: $checkedConvert(
         'is_current_location',
         (v) => v as bool,
@@ -33,6 +35,8 @@ _RegionSettingResponse _$RegionSettingResponseFromJson(
   fieldKeyMap: const {
     'regionId': 'region_id',
     'regionName': 'region_name',
+    'cityCode': 'city_code',
+    'cityName': 'city_name',
     'isCurrentLocation': 'is_current_location',
     'minJmaIntensity': 'min_jma_intensity',
     'createdAt': 'created_at',
@@ -45,6 +49,8 @@ Map<String, dynamic> _$RegionSettingResponseToJson(
 ) => <String, dynamic>{
   'region_id': instance.regionId,
   'region_name': instance.regionName,
+  'city_code': instance.cityCode,
+  'city_name': instance.cityName,
   'is_current_location': instance.isCurrentLocation,
   'min_jma_intensity': instance.minJmaIntensity,
   'created_at': instance.createdAt,


### PR DESCRIPTION
## Summary

通知配信ルーティング v2 (#087) のフェーズ P8 (アプリ側)。
バックエンドの API スキーマ変更 (YumNumm/eqmonitor-backend#357) に追随し、地震通知設定で市区町村粒度の指定を可能にする。

- `packages/eqmonitor_api`
  - `RegionSettingRequest` / `RegionSettingResponse` / `RegionSettingPatchRequest` に `cityCode` (nullable) / `cityName` (nullable) を追加
  - 既存生成済みコードを直接編集し、build_runner で `.freezed.dart` / `.g.dart` を再生成
  - 差分は city_code / city_name 関連に限定 (他の API は触らない)
- `app/lib/feature/settings/features/notification_settings/data/model/notification_region.dart`
  - `NotificationRegion` に `cityCode` / `cityName` を追加 (デフォルト null)
  - `RegionSettingResponseConverter` / `NotificationRegionToRequest` が city フィールドを通すよう対応

## 依存関係

- 先行: YumNumm/eqmonitor-backend#357 (バックエンド P8 schema)
- 後続: P7 (picker UI) で実際に cityCode をセットする画面を追加

EEW 設定では `cityCode` は常に null (EEW は `area_forecast_local_eew` コード単位のみ対応)。

## Test plan

- [x] `dart analyze` で issue なし
- [x] `flutter test` 全 182 件 pass
- [x] 既存 NotificationRegion 利用箇所が city フィールド無しでも動作 (デフォルト null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)