### PR TITLE
feat: Start API / Changelog API のアプリ側実装

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/core/theme/build_theme.dart';
 import 'package:eqmonitor/core/theme/custom_colors.dart';
 import 'package:eqmonitor/core/theme/theme_provider.dart';
+import 'package:eqmonitor/feature/start/ui/component/forced_update_dialog.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -79,7 +80,7 @@ class App extends HookConsumerWidget {
       },
     );
     final buildCfg = ref.read(buildConfigProvider);
-    Widget result = app;
+    Widget result = ForcedUpdateWrapper(child: app);
 
     if (buildCfg.isBetaTesting) {
       final packageInfo = ref.watch(packageInfoProvider);

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/beta_testing/data/notifier/beta_testing_notifier.dart';
 import 'package:eqmonitor/feature/beta_testing/ui/page/beta_testing_warning_page.dart';
+import 'package:eqmonitor/feature/changelog/ui/page/changelog_page.dart';
 import 'package:eqmonitor/feature/devices/ui/page/debug_device_settings_page.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_details_page.dart';
@@ -296,6 +297,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
     ),
     TypedGoRoute<EarthquakeHistoryConfigRoute>(path: 'earthquake-history'),
     TypedGoRoute<AboutThisAppRoute>(path: 'about-this-app'),
+    TypedGoRoute<ChangelogRoute>(path: 'changelog'),
     TypedGoRoute<DebugRoute>(
       path: 'debug',
       routes: [
@@ -754,6 +756,14 @@ class KyoshinMonitorAboutRoute extends GoRouteData
   Widget build(BuildContext context, GoRouterState state) {
     return const KyoshinMonitorAboutPage();
   }
+}
+
+class ChangelogRoute extends GoRouteData with $ChangelogRoute {
+  const ChangelogRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const ChangelogPage();
 }
 
 class _NavigatorObserver extends NavigatorObserver {

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -452,6 +452,7 @@ RouteBase get $settingsRoute => GoRouteData.$route(
       path: 'about-this-app',
       factory: $AboutThisAppRoute._fromState,
     ),
+    GoRouteData.$route(path: 'changelog', factory: $ChangelogRoute._fromState),
     GoRouteData.$route(
       path: 'debug',
       factory: $DebugRoute._fromState,
@@ -911,6 +912,27 @@ mixin $AboutThisAppRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/settings/about-this-app');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $ChangelogRoute on GoRouteData {
+  static ChangelogRoute _fromState(GoRouterState state) =>
+      const ChangelogRoute();
+
+  @override
+  String get location => GoRouteData.$location('/settings/changelog');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/changelog/data/notifier/changelog_notifier.dart
+++ b/app/lib/feature/changelog/data/notifier/changelog_notifier.dart
@@ -1,0 +1,24 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/changelog/data/repository/changelog_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'changelog_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class ChangelogNotifier extends _$ChangelogNotifier {
+  @override
+  AsyncValue<api.ChangelogResponse?> build() => const AsyncValue.data(null);
+
+  Future<void> fetch() async {
+    state = const AsyncValue<api.ChangelogResponse?>.loading();
+    final repo = await ref.read(changelogRepositoryProvider.future);
+    final result = await repo.fetch();
+    switch (result) {
+      case Success(:final value):
+        state = AsyncValue.data(value);
+      case Failure(:final exception, :final stackTrace):
+        state = AsyncValue.error(exception, stackTrace ?? StackTrace.current);
+    }
+  }
+}

--- a/app/lib/feature/changelog/data/notifier/changelog_notifier.g.dart
+++ b/app/lib/feature/changelog/data/notifier/changelog_notifier.g.dart
@@ -1,0 +1,79 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'changelog_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ChangelogNotifier)
+final changelogProvider = ChangelogNotifierProvider._();
+
+final class ChangelogNotifierProvider
+    extends
+        $NotifierProvider<
+          ChangelogNotifier,
+          AsyncValue<api.ChangelogResponse?>
+        > {
+  ChangelogNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'changelogProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$changelogNotifierHash();
+
+  @$internal
+  @override
+  ChangelogNotifier create() => ChangelogNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<api.ChangelogResponse?> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<api.ChangelogResponse?>>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$changelogNotifierHash() => r'146f55848c7eef545a7cbdf7ac20206dc6ade83b';
+
+abstract class _$ChangelogNotifier
+    extends $Notifier<AsyncValue<api.ChangelogResponse?>> {
+  AsyncValue<api.ChangelogResponse?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<api.ChangelogResponse?>,
+              AsyncValue<api.ChangelogResponse?>
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<api.ChangelogResponse?>,
+                AsyncValue<api.ChangelogResponse?>
+              >,
+              AsyncValue<api.ChangelogResponse?>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/changelog/data/repository/changelog_repository.dart
+++ b/app/lib/feature/changelog/data/repository/changelog_repository.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'changelog_repository.g.dart';
+
+const _kEtagKey = 'changelog_etag';
+const _kBodyKey = 'changelog_body';
+
+@Riverpod(keepAlive: true)
+Future<ChangelogRepository> changelogRepository(Ref ref) async =>
+    ChangelogRepository(
+      await ref.watch(apiClientProvider.future),
+      await SharedPreferences.getInstance(),
+    );
+
+class ChangelogRepository {
+  ChangelogRepository(this._api, this._prefs);
+
+  final api.ApiClient _api;
+  final SharedPreferences _prefs;
+
+  Future<Result<api.ChangelogResponse, Exception>> fetch() async {
+    final cachedEtag = _prefs.getString(_kEtagKey);
+    try {
+      final response = await _api.changelog.getV1Changelog(
+        ifNoneMatch: cachedEtag,
+      );
+      final etag = response.response.headers.value('etag');
+      if (etag != null) {
+        await _prefs.setString(_kEtagKey, etag);
+      }
+      final body = jsonEncode(response.data.toJson());
+      await _prefs.setString(_kBodyKey, body);
+      return Success(response.data);
+    } on DioException catch (e, st) {
+      if (e.response?.statusCode == 304) {
+        final cached = _tryReadCache();
+        if (cached != null) {
+          return Success(cached);
+        }
+      }
+      final cached = _tryReadCache();
+      if (cached != null) {
+        return Success(cached);
+      }
+      return Failure(e, st);
+    } on Exception catch (e, st) {
+      final cached = _tryReadCache();
+      if (cached != null) {
+        return Success(cached);
+      }
+      return Failure(e, st);
+    }
+  }
+
+  api.ChangelogResponse? _tryReadCache() {
+    final body = _prefs.getString(_kBodyKey);
+    if (body == null) {
+      return null;
+    }
+    try {
+      return api.ChangelogResponse.fromJson(
+        jsonDecode(body) as Map<String, Object?>,
+      );
+    } on FormatException {
+      return null;
+    }
+  }
+}

--- a/app/lib/feature/changelog/data/repository/changelog_repository.g.dart
+++ b/app/lib/feature/changelog/data/repository/changelog_repository.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'changelog_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(changelogRepository)
+final changelogRepositoryProvider = ChangelogRepositoryProvider._();
+
+final class ChangelogRepositoryProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<ChangelogRepository>,
+          ChangelogRepository,
+          FutureOr<ChangelogRepository>
+        >
+    with
+        $FutureModifier<ChangelogRepository>,
+        $FutureProvider<ChangelogRepository> {
+  ChangelogRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'changelogRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$changelogRepositoryHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<ChangelogRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<ChangelogRepository> create(Ref ref) {
+    return changelogRepository(ref);
+  }
+}
+
+String _$changelogRepositoryHash() =>
+    r'edcb1620cd2b9eab138cf94a32ac8d2ca3e3bae4';

--- a/app/lib/feature/changelog/ui/page/changelog_page.dart
+++ b/app/lib/feature/changelog/ui/page/changelog_page.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/changelog/data/notifier/changelog_notifier.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+
+class ChangelogPage extends ConsumerStatefulWidget {
+  const ChangelogPage({super.key});
+
+  @override
+  ConsumerState<ChangelogPage> createState() => _ChangelogPageState();
+}
+
+class _ChangelogPageState extends ConsumerState<ChangelogPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(ref.read(changelogProvider.notifier).fetch());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(changelogProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('変更履歴')),
+      body: switch (state) {
+        AsyncLoading() => const Center(child: CircularProgressIndicator.adaptive()),
+        AsyncError(:final error) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, size: 48),
+              const SizedBox(height: 16),
+              const Text('読み込みに失敗しました'),
+              const SizedBox(height: 8),
+              Text(
+                error.toString(),
+                style: Theme.of(context).textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              FilledButton.tonal(
+                onPressed: () =>
+                    ref.read(changelogProvider.notifier).fetch(),
+                child: const Text('再試行'),
+              ),
+            ],
+          ),
+        ),
+        AsyncData(:final value) when value == null => const Center(
+          child: CircularProgressIndicator.adaptive(),
+        ),
+        AsyncData(:final value) => _ChangelogList(entries: value!.entries),
+      },
+    );
+  }
+}
+
+class _ChangelogList extends StatelessWidget {
+  const _ChangelogList({required this.entries});
+
+  final List<api.ChangelogEntry> entries;
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.isEmpty) {
+      return const Center(child: Text('変更履歴はありません'));
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.only(bottom: 32),
+      itemCount: entries.length,
+      itemBuilder: (context, index) => _ChangelogEntryCard(
+        entry: entries[index],
+      ),
+    );
+  }
+}
+
+class _ChangelogEntryCard extends StatelessWidget {
+  const _ChangelogEntryCard({required this.entry});
+
+  final api.ChangelogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateStr = DateFormat('yyyy年MM月dd日').format(entry.date.toLocal());
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'v${entry.version}',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(dateStr, style: theme.textTheme.bodySmall),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (final section in entry.sections)
+            _SectionWidget(section: section),
+          const Divider(),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionWidget extends StatelessWidget {
+  const _SectionWidget({required this.section});
+
+  final api.ChangelogSection section;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final markdownContent =
+        '### ${section.title}\n\n${section.items.map((i) => '- $i').join('\n')}';
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: MarkdownBody(
+        data: markdownContent,
+        styleSheet: MarkdownStyleSheet.fromTheme(theme),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/map/data/notifier/map_configuration_notifier.g.dart
+++ b/app/lib/feature/map/data/notifier/map_configuration_notifier.g.dart
@@ -36,7 +36,7 @@ final class MapConfigurationNotifierProvider
 }
 
 String _$mapConfigurationNotifierHash() =>
-    r'b7f79776643393fbada1a3f90530fb61d0b55277';
+    r'b9df3172b78904e871c2726bb977e12383789137';
 
 abstract class _$MapConfigurationNotifier
     extends $AsyncNotifier<MapConfiguration> {

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -13,6 +13,7 @@ import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier
 import 'package:eqmonitor/feature/settings/children/config/debug/app_check/app_check_debug_provider.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/hypocenter_icon/hypocenter_icon_page.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
+import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -261,6 +262,8 @@ class _DebugWidget extends ConsumerWidget {
           ),
           const _ParameterDebugSection(),
           const Divider(),
+          const _StartApiDebugSection(),
+          const Divider(),
           const _AppCheckSection(),
         ],
       ),
@@ -489,6 +492,94 @@ class _BackgroundLocationDebugSection extends ConsumerWidget {
           value: settings.notifyApiUpdate,
           onChanged: (v) => notifier.setNotifyApiUpdate(value: v),
         ),
+      ],
+    );
+  }
+}
+
+class _StartApiDebugSection extends ConsumerWidget {
+  const _StartApiDebugSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final startAsync = ref.watch(startProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          title: const Text('Start API'),
+          leading: const Icon(Icons.rocket_launch_outlined),
+          subtitle: const Text('アプリ起動フラグ・バージョン情報'),
+          trailing: IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: '強制再取得',
+            onPressed: () =>
+                ref.read(startProvider.notifier).refresh(),
+          ),
+        ),
+        switch (startAsync) {
+          AsyncLoading() => const ListTile(
+            leading: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            title: Text('取得中...'),
+          ),
+          AsyncError(:final error) => ListTile(
+            leading: const Icon(Icons.error_outline),
+            title: const Text('エラー'),
+            subtitle: Text(error.toString()),
+          ),
+          AsyncData(:final value) when value == null => const ListTile(
+            leading: Icon(Icons.hourglass_empty),
+            title: Text('未取得'),
+          ),
+          AsyncData(:final value) => Column(
+            children: [
+              ListTile(
+                dense: true,
+                title: const Text('maintenance.enabled'),
+                trailing: Text(value!.flags.maintenance.enabled.toString()),
+              ),
+              if (value.flags.maintenance.message != null)
+                ListTile(
+                  dense: true,
+                  title: const Text('maintenance.message'),
+                  subtitle: Text(value.flags.maintenance.message!),
+                ),
+              ListTile(
+                dense: true,
+                title: const Text('latest.version'),
+                trailing: Text(
+                  value.app.version.latest?.version ?? '(なし)',
+                ),
+              ),
+              ListTile(
+                dense: true,
+                title: const Text('latest.showWhatsNew'),
+                trailing: Text(
+                  value.app.version.latest?.showWhatsNew.toString() ?? '-',
+                ),
+              ),
+              ListTile(
+                dense: true,
+                title: const Text('requiredVersions'),
+                subtitle: Text(
+                  value.app.version.requiredVersions
+                      .map((r) => r.version)
+                      .join(', ')
+                      .isNotEmpty
+                      ? value.app.version.requiredVersions
+                          .map((r) => r.version)
+                          .join(', ')
+                      : '(なし)',
+                ),
+              ),
+            ],
+          ),
+        },
       ],
     );
   }

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -60,6 +60,11 @@ class SettingsPage extends ConsumerWidget {
           ),
           const SettingsSectionHeader(text: 'アプリの情報と問い合わせ'),
           ListTile(
+            title: const Text('変更履歴'),
+            leading: const Icon(Icons.history_edu_outlined),
+            onTap: () async => const ChangelogRoute().push<void>(context),
+          ),
+          ListTile(
             title: const Text('このアプリケーションについて'),
             subtitle: const Text('利用規約やプライバシーポリシーを確認できます'),
             leading: const Icon(Icons.description),

--- a/app/lib/feature/start/data/notifier/start_notifier.dart
+++ b/app/lib/feature/start/data/notifier/start_notifier.dart
@@ -1,0 +1,34 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/start/data/repository/start_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'start_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class StartNotifier extends _$StartNotifier {
+  @override
+  AsyncValue<api.StartResponse?> build() => const AsyncValue.data(null);
+
+  /// バックグラウンドでStart APIを取得し、stateを更新する。
+  /// エラーは無視し、キャッシュがあればそれを使う。
+  Future<void> fetchInBackground() async {
+    final repo = await ref.read(startRepositoryProvider.future);
+    final result = await repo.fetch();
+    switch (result) {
+      case Success(:final value):
+        state = AsyncValue.data(value);
+      case Failure():
+        // キャッシュも取れなかった場合のみ失敗状態にする
+        if (state.value == null) {
+          state = const AsyncValue.data(null);
+        }
+    }
+  }
+
+  /// 強制的に再取得する（デバッグ用など）。
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    await fetchInBackground();
+  }
+}

--- a/app/lib/feature/start/data/notifier/start_notifier.g.dart
+++ b/app/lib/feature/start/data/notifier/start_notifier.g.dart
@@ -1,0 +1,75 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'start_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(StartNotifier)
+final startProvider = StartNotifierProvider._();
+
+final class StartNotifierProvider
+    extends $NotifierProvider<StartNotifier, AsyncValue<api.StartResponse?>> {
+  StartNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'startProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$startNotifierHash();
+
+  @$internal
+  @override
+  StartNotifier create() => StartNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<api.StartResponse?> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<api.StartResponse?>>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$startNotifierHash() => r'd698cb59c4574aaabcb76cfa8c4505e1cf0732a9';
+
+abstract class _$StartNotifier
+    extends $Notifier<AsyncValue<api.StartResponse?>> {
+  AsyncValue<api.StartResponse?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<api.StartResponse?>,
+              AsyncValue<api.StartResponse?>
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<api.StartResponse?>,
+                AsyncValue<api.StartResponse?>
+              >,
+              AsyncValue<api.StartResponse?>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/start/data/repository/start_repository.dart
+++ b/app/lib/feature/start/data/repository/start_repository.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'start_repository.g.dart';
+
+const _kEtagKey = 'start_etag';
+const _kBodyKey = 'start_body';
+
+@Riverpod(keepAlive: true)
+Future<StartRepository> startRepository(Ref ref) async =>
+    StartRepository(
+      await ref.watch(apiClientProvider.future),
+      await SharedPreferences.getInstance(),
+    );
+
+class StartRepository {
+  StartRepository(this._api, this._prefs);
+
+  final api.ApiClient _api;
+  final SharedPreferences _prefs;
+
+  /// Start APIを取得し、304なら有効なキャッシュを返す。
+  /// ネットワーク失敗時もキャッシュがあればそれを返す。
+  Future<Result<api.StartResponse, Exception>> fetch() async {
+    final cachedEtag = _prefs.getString(_kEtagKey);
+    try {
+      final response = await _api.start.getV1Start(ifNoneMatch: cachedEtag);
+      final etag = response.response.headers.value('etag');
+      if (etag != null) {
+        await _prefs.setString(_kEtagKey, etag);
+      }
+      final body = jsonEncode(response.data.toJson());
+      await _prefs.setString(_kBodyKey, body);
+      return Success(response.data);
+    } on DioException catch (e, st) {
+      if (e.response?.statusCode == 304) {
+        final cached = _tryReadCache();
+        if (cached != null) {
+          return Success(cached);
+        }
+      }
+      final cached = _tryReadCache();
+      if (cached != null) {
+        return Success(cached);
+      }
+      return Failure(e, st);
+    } on Exception catch (e, st) {
+      final cached = _tryReadCache();
+      if (cached != null) {
+        return Success(cached);
+      }
+      return Failure(e, st);
+    }
+  }
+
+  api.StartResponse? _tryReadCache() {
+    final body = _prefs.getString(_kBodyKey);
+    if (body == null) {
+      return null;
+    }
+    try {
+      return api.StartResponse.fromJson(
+        jsonDecode(body) as Map<String, Object?>,
+      );
+    } on FormatException {
+      return null;
+    }
+  }
+}

--- a/app/lib/feature/start/data/repository/start_repository.g.dart
+++ b/app/lib/feature/start/data/repository/start_repository.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'start_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(startRepository)
+final startRepositoryProvider = StartRepositoryProvider._();
+
+final class StartRepositoryProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<StartRepository>,
+          StartRepository,
+          FutureOr<StartRepository>
+        >
+    with $FutureModifier<StartRepository>, $FutureProvider<StartRepository> {
+  StartRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'startRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$startRepositoryHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<StartRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<StartRepository> create(Ref ref) {
+    return startRepository(ref);
+  }
+}
+
+String _$startRepositoryHash() => r'63b74d41e2a06fe9e535d06c22793a720c0dfa88';

--- a/app/lib/feature/start/ui/component/forced_update_dialog.dart
+++ b/app/lib/feature/start/ui/component/forced_update_dialog.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+import 'package:version/version.dart';
+
+/// 強制アップデートが必要かどうかを監視し、必要なら非解除可能ダイアログを表示するWrapper。
+class ForcedUpdateWrapper extends ConsumerStatefulWidget {
+  const ForcedUpdateWrapper({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  ConsumerState<ForcedUpdateWrapper> createState() =>
+      _ForcedUpdateWrapperState();
+}
+
+class _ForcedUpdateWrapperState extends ConsumerState<ForcedUpdateWrapper> {
+  var _dialogShown = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_checkAndShow());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Start APIが更新されたときにも再チェックする
+    ref.listen(startProvider, (_, next) {
+      if (next.value != null && !_dialogShown) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          unawaited(_checkAndShow());
+        });
+      }
+    });
+    return widget.child;
+  }
+
+  Future<void> _checkAndShow() async {
+    if (_dialogShown || !mounted) {
+      return;
+    }
+
+    final startData = ref.read(startProvider).value;
+    if (startData == null) {
+      return;
+    }
+
+    final requiredVersions = startData.app.version.requiredVersions;
+    if (requiredVersions.isEmpty) {
+      return;
+    }
+
+    final info = await PackageInfo.fromPlatform();
+    Version current;
+    try {
+      current = Version.parse(info.version);
+    } on FormatException {
+      return;
+    }
+
+    for (final req in requiredVersions) {
+      Version required;
+      try {
+        required = Version.parse(req.version);
+      } on FormatException {
+        continue;
+      }
+      if (current < required) {
+        if (!mounted) {
+          return;
+        }
+        setState(() => _dialogShown = true);
+        await _showDialog(context, req: req, storeUrl: startData.app.storeUrl);
+        return;
+      }
+    }
+  }
+
+  Future<void> _showDialog(
+    BuildContext context, {
+    required api.RequiredVersion req,
+    required api.StoreUrl storeUrl,
+  }) {
+    final url = _resolveStoreUrl(storeUrl);
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => PopScope(
+        canPop: false,
+        child: AlertDialog(
+          title: const Text('アップデートが必要です'),
+          content: Text(
+            req.message ??
+                '最新バージョンへのアップデートが必要です。ストアよりアップデートを行ってください。',
+          ),
+          actions: [
+            FilledButton(
+              onPressed: url != null
+                  ? () {
+                      unawaited(
+                        launchUrlString(
+                          url,
+                          mode: LaunchMode.externalApplication,
+                        ),
+                      );
+                    }
+                  : null,
+              child: const Text('アップデートする'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String? _resolveStoreUrl(api.StoreUrl storeUrl) {
+    if (kIsWeb) {
+      return null;
+    }
+    if (Platform.isIOS || Platform.isMacOS) {
+      return storeUrl.ios;
+    }
+    if (Platform.isAndroid) {
+      return storeUrl.android;
+    }
+    return null;
+  }
+}

--- a/app/lib/feature/start/ui/component/maintenance_banner.dart
+++ b/app/lib/feature/start/ui/component/maintenance_banner.dart
@@ -1,0 +1,71 @@
+import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+/// ホームシートに表示するメンテナンス通知バナー。
+/// メンテナンス中の場合のみ表示する。
+class MaintenanceBanner extends ConsumerWidget {
+  const MaintenanceBanner({required this.bottomSpacing, super.key});
+
+  final double bottomSpacing;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final startState = ref.watch(startProvider);
+    final maintenance = startState.value?.flags.maintenance;
+
+    if (maintenance == null || !maintenance.enabled) {
+      return const SizedBox.shrink();
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final message = maintenance.message ?? 'メンテナンス中です。しばらくお待ちください。';
+    final url = maintenance.url;
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottomSpacing),
+      child: Material(
+        color: colorScheme.tertiaryContainer,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: url != null
+              ? () => launchUrlString(
+                    url,
+                    mode: LaunchMode.externalApplication,
+                  )
+              : null,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.build_outlined,
+                  color: colorScheme.onTertiaryContainer,
+                  size: 20,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    message,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onTertiaryContainer,
+                    ),
+                  ),
+                ),
+                if (url != null) ...[
+                  Icon(
+                    Icons.open_in_new,
+                    color: colorScheme.onTertiaryContainer,
+                    size: 16,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/start/ui/component/whats_new_banner.dart
+++ b/app/lib/feature/start/ui/component/whats_new_banner.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _kSeenKey = 'whats_new_seen_version';
+
+/// ホームシートに表示する「What's New」バナー。
+/// 未閲覧の最新バージョンがある場合のみ表示する。
+class WhatsNewBanner extends ConsumerWidget {
+  const WhatsNewBanner({required this.bottomSpacing, super.key});
+
+  final double bottomSpacing;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final startState = ref.watch(startProvider);
+    final latest = startState.value?.app.version.latest;
+
+    if (latest == null || !latest.showWhatsNew) {
+      return const SizedBox.shrink();
+    }
+
+    return _WhatsNewBannerContent(
+      latest: latest,
+      bottomSpacing: bottomSpacing,
+    );
+  }
+}
+
+class _WhatsNewBannerContent extends StatefulWidget {
+  const _WhatsNewBannerContent({
+    required this.latest,
+    required this.bottomSpacing,
+  });
+
+  final api.LatestVersion latest;
+  final double bottomSpacing;
+
+  @override
+  State<_WhatsNewBannerContent> createState() => _WhatsNewBannerContentState();
+}
+
+class _WhatsNewBannerContentState extends State<_WhatsNewBannerContent> {
+  var _dismissed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_checkSeen());
+  }
+
+  Future<void> _checkSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    final seen = prefs.getString(_kSeenKey);
+    if (seen == widget.latest.version && mounted) {
+      setState(() => _dismissed = true);
+    }
+  }
+
+  Future<void> _markSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kSeenKey, widget.latest.version);
+    if (mounted) {
+      setState(() => _dismissed = true);
+    }
+  }
+
+  void _showDetail(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (ctx) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.6,
+        maxChildSize: 0.95,
+        minChildSize: 0.3,
+        builder: (_, controller) => _WhatsNewSheet(
+          latest: widget.latest,
+          whatsNew: widget.latest.whatsNew,
+          scrollController: controller,
+          onClose: () {
+            Navigator.of(ctx).pop();
+            unawaited(_markSeen());
+          },
+        ),
+      ),
+    ).ignore();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed) {
+      return const SizedBox.shrink();
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: EdgeInsets.only(bottom: widget.bottomSpacing),
+      child: Material(
+        color: colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () => _showDetail(context),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.new_releases_outlined,
+                  color: colorScheme.onPrimaryContainer,
+                  size: 20,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'v${widget.latest.version} にアップデートしました',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  color: colorScheme.onPrimaryContainer,
+                  size: 20,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WhatsNewSheet extends StatelessWidget {
+  const _WhatsNewSheet({
+    required this.latest,
+    required this.whatsNew,
+    required this.scrollController,
+    required this.onClose,
+  });
+
+  final api.LatestVersion latest;
+  final api.WhatsNew? whatsNew;
+  final ScrollController scrollController;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final title = whatsNew?.title ?? 'v${latest.version} の新機能';
+    final content = whatsNew?.content ?? '';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: onClose,
+        ),
+      ),
+      body: SingleChildScrollView(
+        controller: scrollController,
+        padding: const EdgeInsets.all(16),
+        child: content.isNotEmpty
+            ? MarkdownBody(
+                data: content,
+                styleSheet: MarkdownStyleSheet.fromTheme(theme),
+              )
+            : Text(
+                'このバージョンの更新内容はありません。',
+                style: theme.textTheme.bodyMedium,
+              ),
+      ),
+    );
+  }
+}

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -15,6 +15,8 @@ import 'package:eqmonitor/feature/home/ui/component/sheet/home_earthquake_histor
 import 'package:eqmonitor/feature/location/data/background_location_permission_provider.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_settings_notifier.dart';
 import 'package:eqmonitor/feature/shake_detection/data/provider/shake_detection_merge_provider.dart';
+import 'package:eqmonitor/feature/start/ui/component/maintenance_banner.dart';
+import 'package:eqmonitor/feature/start/ui/component/whats_new_banner.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -152,6 +154,8 @@ class _SheetBody extends ConsumerWidget {
                 children: [
                   SizedBox(height: spacing.xs),
                   if (state.isNotEmpty) eewCards,
+                  MaintenanceBanner(bottomSpacing: spacing.md),
+                  WhatsNewBanner(bottomSpacing: spacing.md),
                   DeviceProvisioningBanner(bottomSpacing: spacing.md),
                   if (showPermissionBanner) ...[
                     _BackgroundLocationPermissionBanner(

--- a/app/lib/page/splash_page.dart
+++ b/app/lib/page/splash_page.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshin_observation_points_provider.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
+import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -31,6 +34,10 @@ class SplashPage extends HookConsumerWidget {
     useEffect(
       () {
         if (allLoaded) {
+          // バックグラウンドで Start API を取得（ブロックしない）
+          unawaited(
+            ref.read(startProvider.notifier).fetchInBackground(),
+          );
           WidgetsBinding.instance.addPostFrameCallback((_) {
             context.go(const HomeRoute().location);
           });


### PR DESCRIPTION
## Summary

- **Start Repository**: ETag + SharedPreferences キャッシュ、DioException での 304 フォールバック
- **Changelog Repository**: 同上
- **StartNotifier / ChangelogNotifier**: `keepAlive: true` の Riverpod providers
- **What's New バナー**: HomeSheet に追加。タップで BottomSheet 詳細表示（flutter_markdown）、閉じると SharedPrefs に既読保存
- **メンテナンスバナー**: HomeSheet に追加。`flags.maintenance.enabled` が true の場合のみ表示
- **強制アップデートダイアログ**: `PopScope(canPop: false)` で解除不可の AlertDialog。`required_versions` と現在バージョンを比較して表示判定
- **変更履歴ページ**: `ChangelogPage` を設定画面から遷移。flutter_markdown でセクション・items を表示
- **設定ページ**: 「変更履歴」ListTile を追加
- **ルーター**: `ChangelogRoute` を `/settings/changelog` に追加
- **スプラッシュページ**: ホーム遷移時にバックグラウンドで Start API を取得（ブロックしない）
- **デバッグページ**: Start API 状態確認・強制再取得セクションを追加

## Test plan

- [ ] スプラッシュ → ホームの遷移が従来通り完了すること
- [ ] Start API に接続できる環境でバナーが表示されること（メンテナンス、What's New）
- [ ] What's New バナーをタップ → BottomSheet が開き、閉じると次回から非表示になること
- [ ] 設定画面 → 変更履歴 → 一覧が表示されること
- [ ] デバッグ画面の Start API セクションでデータが確認・再取得できること
- [ ] `dart analyze` がエラー・警告なしで通ること