### PR TITLE
feat(home): 指定地域選択ページを追加し設定画面から導線を整備

### DIFF
--- a/app/lib/feature/home/data/notifier/home_configuration_notifier.dart
+++ b/app/lib/feature/home/data/notifier/home_configuration_notifier.dart
@@ -69,6 +69,17 @@ class HomeConfigurationNotifier extends _$HomeConfigurationNotifier {
     );
   }
 
+  /// 指定地域の設定値だけをクリアする。
+  /// スコープ自体は変更しない（呼び出し側で必要に応じて切り替える）。
+  Future<void> clearCustomEarthquakeHistoryParameter() async {
+    final current = await future;
+    await save(
+      current.copyWith(
+        common: current.common.copyWith(parameter: null),
+      ),
+    );
+  }
+
   Future<void> updateEew(HomeEewSettings eew) async {
     final current = await future;
     await save(current.copyWith(eew: eew));

--- a/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
+++ b/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
@@ -1,16 +1,15 @@
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
-import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_not_found.dart';
-import 'package:eqmonitor/feature/earthquake_history/ui/components/region_picker_map_page.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
 import 'package:eqmonitor/feature/home/data/provider/home_earthquake_history_parameter_provider.dart';
 import 'package:eqmonitor/feature/home/ui/component/sheet/component/home_earthquake_list.dart';
 import 'package:eqmonitor/feature/home/ui/component/sheet/component/home_scope_selector.dart';
 import 'package:eqmonitor/feature/home/ui/component/sheet/component/home_scope_unavailable_body.dart';
+import 'package:eqmonitor/feature/home/ui/page/home_designated_region_picker_page.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:skeletonizer/skeletonizer.dart';
@@ -39,20 +38,19 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
         };
 
         Future<void> openRegionPicker() async {
-          final result = await RegionPickerMapPage.show(
+          final result = await HomeDesignatedRegionPickerPage.show(
             context,
-            selectedType: 'city',
+            initialParameter: home.common.parameter,
           );
-          if (result != null) {
-            await ref
-                .read(homeConfigurationProvider.notifier)
-                .setCustomEarthquakeHistoryParameter(
-                  EarthquakeHistoryParameter(
-                    regionSearchType: RegionSearchType.city,
-                    regionCode: result.code,
-                    regionName: result.name,
-                  ),
-                );
+          if (result == null) {
+            return;
+          }
+          final notifier = ref.read(homeConfigurationProvider.notifier);
+          if (result.regionCode == null) {
+            // クリアされた場合は parameter のみ消し、スコープは保持する
+            await notifier.clearCustomEarthquakeHistoryParameter();
+          } else {
+            await notifier.setCustomEarthquakeHistoryParameter(result);
           }
         }
 
@@ -104,7 +102,8 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                           ? const EarthquakeHistoryNotFound()
                           : HomeEarthquakeList(
                               earthquakes: value.items,
-                              showCurrentLocationIntensity: scope ==
+                              showCurrentLocationIntensity:
+                                  scope ==
                                   HomeEarthquakeHistoryScope.currentLocation,
                             ),
                     AsyncError(:final error) => ErrorCard(

--- a/app/lib/feature/home/ui/page/home_designated_region_picker_page.dart
+++ b/app/lib/feature/home/ui/page/home_designated_region_picker_page.dart
@@ -1,0 +1,196 @@
+import 'package:eqmonitor/core/component/selector/city_selector.dart';
+import 'package:eqmonitor/core/component/selector/prefecture_selector.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/region_picker_map_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// ホーム地震履歴カードの「指定地域」を設定するためのページ。
+///
+/// 都道府県/市区町村のいずれかを、リストもしくは地図から選択して
+/// [EarthquakeHistoryParameter] を返す。
+class HomeDesignatedRegionPickerPage extends HookConsumerWidget {
+  const HomeDesignatedRegionPickerPage({super.key, this.initialParameter});
+
+  final EarthquakeHistoryParameter? initialParameter;
+
+  /// 結果として [EarthquakeHistoryParameter] を返すページを push する。
+  ///
+  /// クリアされた場合は [EarthquakeHistoryParameter] のフィールドが
+  /// すべて未設定のインスタンスを返す。キャンセル時は `null`。
+  static Future<EarthquakeHistoryParameter?> show(
+    BuildContext context, {
+    EarthquakeHistoryParameter? initialParameter,
+  }) {
+    return Navigator.of(context).push<EarthquakeHistoryParameter>(
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => HomeDesignatedRegionPickerPage(
+          initialParameter: initialParameter,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final selectedType = useState<RegionSearchType>(
+      initialParameter?.regionSearchType ?? RegionSearchType.prefecture,
+    );
+    final selectedCode = useState<String?>(initialParameter?.regionCode);
+    final selectedName = useState<String?>(initialParameter?.regionName);
+
+    Future<void> openMap() async {
+      final result = await RegionPickerMapPage.show(
+        context,
+        selectedType: selectedType.value == RegionSearchType.city
+            ? 'city'
+            : 'prefecture',
+      );
+      if (result != null) {
+        selectedCode.value = result.code;
+        selectedName.value = result.name;
+      }
+    }
+
+    final canApply =
+        selectedCode.value != null && selectedCode.value!.isNotEmpty;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('指定地域を選択'),
+        actions: [
+          if (canApply)
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(
+                EarthquakeHistoryParameter(
+                  regionSearchType: selectedType.value,
+                  regionCode: selectedCode.value,
+                  regionName: selectedName.value,
+                ),
+              ),
+              child: const Text('決定'),
+            ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text(
+              'ホーム画面の地震履歴で「指定地域」として表示する都道府県・市区町村を選択します。',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                ChoiceChip(
+                  label: const Text('都道府県'),
+                  selected: selectedType.value == RegionSearchType.prefecture,
+                  onSelected: (s) {
+                    if (s) {
+                      selectedType.value = RegionSearchType.prefecture;
+                      selectedCode.value = null;
+                      selectedName.value = null;
+                    }
+                  },
+                ),
+                const SizedBox(width: 8),
+                ChoiceChip(
+                  label: const Text('市区町村'),
+                  selected: selectedType.value == RegionSearchType.city,
+                  onSelected: (s) {
+                    if (s) {
+                      selectedType.value = RegionSearchType.city;
+                      selectedCode.value = null;
+                      selectedName.value = null;
+                    }
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (selectedType.value == RegionSearchType.prefecture)
+              PrefectureSelector(
+                selectedCode: selectedCode.value,
+                onChanged: (selection) {
+                  if (selection != null) {
+                    selectedCode.value = selection.code;
+                    selectedName.value = selection.name;
+                  } else {
+                    selectedCode.value = null;
+                    selectedName.value = null;
+                  }
+                },
+              )
+            else
+              CitySelector(
+                selectedCode: selectedCode.value,
+                selectedName: selectedName.value,
+                onChanged: (selection) {
+                  if (selection != null) {
+                    selectedCode.value = selection.code;
+                    selectedName.value = selection.name;
+                  } else {
+                    selectedCode.value = null;
+                    selectedName.value = null;
+                  }
+                },
+              ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: openMap,
+              icon: const Icon(Icons.map_outlined),
+              label: const Text('地図から選択'),
+            ),
+            const SizedBox(height: 16),
+            if (selectedName.value != null && selectedName.value!.isNotEmpty)
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.place_outlined),
+                  title: Text(selectedName.value!),
+                  subtitle: Text(
+                    selectedType.value == RegionSearchType.prefecture
+                        ? '都道府県'
+                        : '市区町村',
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.close),
+                    tooltip: '選択を解除',
+                    onPressed: () {
+                      selectedCode.value = null;
+                      selectedName.value = null;
+                    },
+                  ),
+                ),
+              ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: canApply
+                  ? () => Navigator.of(context).pop(
+                      EarthquakeHistoryParameter(
+                        regionSearchType: selectedType.value,
+                        regionCode: selectedCode.value,
+                        regionName: selectedName.value,
+                      ),
+                    )
+                  : null,
+              child: const Text('この地域を設定する'),
+            ),
+            if (initialParameter?.regionCode != null) ...[
+              const SizedBox(height: 8),
+              OutlinedButton(
+                onPressed: () => Navigator.of(context).pop(
+                  const EarthquakeHistoryParameter(),
+                ),
+                child: const Text('設定を解除する'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
+++ b/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
@@ -2,7 +2,10 @@ import 'dart:io';
 
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/home/ui/page/home_designated_region_picker_page.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -18,6 +21,9 @@ class EarthquakeHistoryConfigPage extends StatelessWidget {
       appBar: AppBar(title: const Text('地震履歴設定')),
       body: ListView(
         children: const [
+          SettingsSectionHeader(text: 'ホーム地震履歴カード'),
+          _HomeDesignatedRegionConfigTile(),
+          Divider(),
           SettingsSectionHeader(text: '地震履歴一覧'),
           _EarthquakeHistoryListConfigWidget(),
           Divider(),
@@ -25,6 +31,45 @@ class EarthquakeHistoryConfigPage extends StatelessWidget {
           _EarthquakeHistoryDetailConfigWidget(),
         ],
       ),
+    );
+  }
+}
+
+class _HomeDesignatedRegionConfigTile extends ConsumerWidget {
+  const _HomeDesignatedRegionConfigTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final homeAsync = ref.watch(homeConfigurationProvider);
+    final parameter = homeAsync.value?.common.parameter;
+    final regionName = parameter?.regionName;
+    final searchTypeLabel = switch (parameter?.regionSearchType) {
+      RegionSearchType.prefecture => '都道府県',
+      RegionSearchType.city => '市区町村',
+      null => null,
+    };
+
+    return ListTile(
+      title: const Text('指定地域'),
+      subtitle: regionName != null
+          ? Text('$searchTypeLabel: $regionName')
+          : const Text('未設定（タップして設定）'),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () async {
+        final result = await HomeDesignatedRegionPickerPage.show(
+          context,
+          initialParameter: parameter,
+        );
+        if (result == null) {
+          return;
+        }
+        final notifier = ref.read(homeConfigurationProvider.notifier);
+        if (result.regionCode == null) {
+          await notifier.clearCustomEarthquakeHistoryParameter();
+        } else {
+          await notifier.setCustomEarthquakeHistoryParameter(result);
+        }
+      },
     );
   }
 }
@@ -110,29 +155,30 @@ class _EarthquakeHistoryDetailConfigWidget extends ConsumerWidget {
           title: const Text('アイコンの表示'),
           trailing: Text(state.iconMode.displayName),
           onTap: () async {
-            final result = await showModalBottomSheet<EarthquakeHistoryIconMode>(
-              context: context,
-              clipBehavior: Clip.antiAlias,
-              builder: (context) {
-                return SafeArea(
-                  child: RadioGroup(
-                    onChanged: (value) => Navigator.pop(context, value),
-                    groupValue: state.iconMode,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        sheetBar,
-                        for (final mode in EarthquakeHistoryIconMode.values)
-                          RadioListTile.adaptive(
-                            title: Text(mode.displayName),
-                            value: mode,
-                          ),
-                      ],
-                    ),
-                  ),
+            final result =
+                await showModalBottomSheet<EarthquakeHistoryIconMode>(
+                  context: context,
+                  clipBehavior: Clip.antiAlias,
+                  builder: (context) {
+                    return SafeArea(
+                      child: RadioGroup(
+                        onChanged: (value) => Navigator.pop(context, value),
+                        groupValue: state.iconMode,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            sheetBar,
+                            for (final mode in EarthquakeHistoryIconMode.values)
+                              RadioListTile.adaptive(
+                                title: Text(mode.displayName),
+                                value: mode,
+                              ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
                 );
-              },
-            );
             if (result != null) {
               await saveDetail(state.copyWith(iconMode: result));
             }
@@ -145,28 +191,28 @@ class _EarthquakeHistoryDetailConfigWidget extends ConsumerWidget {
           onTap: () async {
             final result =
                 await showModalBottomSheet<EarthquakeHistoryFillMode>(
-              context: context,
-              clipBehavior: Clip.antiAlias,
-              builder: (context) {
-                return SafeArea(
-                  child: RadioGroup(
-                    onChanged: (value) => Navigator.pop(context, value),
-                    groupValue: state.fillMode,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        sheetBar,
-                        for (final mode in EarthquakeHistoryFillMode.values)
-                          RadioListTile.adaptive(
-                            title: Text(mode.displayName),
-                            value: mode,
-                          ),
-                      ],
-                    ),
-                  ),
+                  context: context,
+                  clipBehavior: Clip.antiAlias,
+                  builder: (context) {
+                    return SafeArea(
+                      child: RadioGroup(
+                        onChanged: (value) => Navigator.pop(context, value),
+                        groupValue: state.fillMode,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            sheetBar,
+                            for (final mode in EarthquakeHistoryFillMode.values)
+                              RadioListTile.adaptive(
+                                title: Text(mode.displayName),
+                                value: mode,
+                              ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
                 );
-              },
-            );
             if (result != null) {
               await saveDetail(state.copyWith(fillMode: result));
             }
@@ -325,8 +371,7 @@ class __IconModeSegmentedControlState
         },
         onValueChanged: (value) async {
           if (value != null) {
-            final full =
-                ref.read(earthquakeHistoryConfigProvider).requireValue;
+            final full = ref.read(earthquakeHistoryConfigProvider).requireValue;
             await ref
                 .read(earthquakeHistoryConfigProvider.notifier)
                 .save(full.copyWith.detail(iconMode: value));
@@ -396,8 +441,7 @@ class __FillModeSegmentedControlState
         },
         onValueChanged: (value) async {
           if (value != null) {
-            final full =
-                ref.read(earthquakeHistoryConfigProvider).requireValue;
+            final full = ref.read(earthquakeHistoryConfigProvider).requireValue;
             await ref
                 .read(earthquakeHistoryConfigProvider.notifier)
                 .save(full.copyWith.detail(fillMode: value));
@@ -432,7 +476,8 @@ class __FillModeSegmentedControlState
 
 enum _IntensityMode {
   intensity('震度'),
-  lpgm('長周期地震動階級');
+  lpgm('長周期地震動階級')
+  ;
 
   const _IntensityMode(this.name);
   final String name;


### PR DESCRIPTION
## Summary

- `HomeDesignatedRegionPickerPage` を新設し、都道府県/市区町村をリスト or 地図から選択できるようにした
- ホーム地震履歴シートと地震履歴設定ページの「指定地域」設定導線を統一
- `HomeConfigurationNotifier.clearCustomEarthquakeHistoryParameter` で、スコープを保持したまま指定地域だけ解除できるようにした

このPRは `docs/todo/075_home_earthquake_history_scope_followups.md` のフォローアップ (1)「指定地域の設定フロー」に対応する。

## Notes / Decisions

- **データ保存先**: 仕様書では `EarthquakeHistoryListConfig.designatedRegion*` への保存と記載されているが、既存のホーム検索パイプライン (`homeEarthquakeHistoryParameterProvider`) は `HomeCommonSettings.parameter` を参照しているため、互換性とパス長最小化の観点から `HomeCommonSettings.parameter` を引き続き source of truth として利用する。設定UIから保存・読み込みされる値はこちらに統一される。
- **文言**: 「指定地域を選択」「この地域を設定する」など仮置き。レビューで調整可。
- **マップピッカー**: 既存の `RegionPickerMapPage` を「地図から選択」サブフローとして再利用。
- フォローアップPR (一覧整合、エラー表示、テスト) は本PRが develop にマージされた後に順次出す予定。

## Test plan

- [ ] ホーム → 地震履歴カード → スコープを「指定地域」に切替えると新ピッカーが開く
- [ ] ピッカーで都道府県・市区町村の双方を選択して「決定」したら、ホームのスコープと表示が更新される
- [ ] 「設定を解除する」を押すと未設定状態に戻る (スコープは custom のまま)
- [ ] 設定 → 地震履歴設定 → 「指定地域」 ListTile から同じピッカーが開き、現在の選択がプリセットされる
- [ ] 地図から選択も従来通り動く