### PR TITLE
fix(home): スコープ未解決時の「さらに表示」を無効化し一覧と整合させる

### DIFF
--- a/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
+++ b/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
@@ -104,7 +104,8 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                           ? const EarthquakeHistoryNotFound()
                           : HomeEarthquakeList(
                               earthquakes: value.items,
-                              showCurrentLocationIntensity: scope ==
+                              showCurrentLocationIntensity:
+                                  scope ==
                                   HomeEarthquakeHistoryScope.currentLocation,
                             ),
                     AsyncError(:final error) => ErrorCard(
@@ -139,9 +140,15 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                 child: Align(
                   alignment: Alignment.centerRight,
                   child: TextButton(
-                    onPressed: () async => EarthquakeHistoryRoute(
-                      $extra: paramAsync.value,
-                    ).push<void>(context),
+                    // スコープに対応する検索パラメータが解決できないときは
+                    // 「全国」が開いてしまい一覧の表示条件と一致しないため、
+                    // 一覧ボタン自体を無効化する（未設定/未解決の案内は
+                    // 上の HomeScopeUnavailableBody が担当する）。
+                    onPressed: paramAsync.value == null
+                        ? null
+                        : () async => EarthquakeHistoryRoute(
+                            $extra: paramAsync.value,
+                          ).push<void>(context),
                     child: const Text('さらに表示'),
                   ),
                 ),


### PR DESCRIPTION
## Summary

ホーム地震履歴シートの「さらに表示」が、`homeEarthquakeHistoryParameterProvider` の値が `null` の状態（現在地が未取得・指定地域が未設定など）でも押下できてしまい、`EarthquakeHistoryPage` 側で空のパラメータが適用されて「全国」一覧が開いていた。スコープと一覧の検索条件が一致しないため、ボタン自体を無効化して動作を揃える。

`docs/todo/075_home_earthquake_history_scope_followups.md` のフォローアップ (2)「『さらに表示』と地震履歴一覧の整合」に対応する。

## Notes

- `EarthquakeHistoryParameter` は既に `$extra` 経由で `EarthquakeHistoryPage` の `initialParameter` に渡っており、`EarthquakeHistoryParameterPersistentDelegate` が parameter のフィールドを直接フィルタチップに反映するため、解決済みのスコープであれば一覧側でも条件が正しく見える。
- 未設定/未解決時の案内・再試行UIは `HomeScopeUnavailableBody` が担当しているので、ボタンの無効化のみで UX 上のギャップは埋まる。

## Test plan

- [ ] 全国スコープ → 「さらに表示」で全国一覧が開く
- [ ] 現在地スコープで位置情報が解決済み → 該当市区町村で絞り込まれた一覧が開く
- [ ] 現在地スコープで位置情報未取得 → ボタンが無効化されており、`HomeScopeUnavailableBody` の再試行から取得できる
- [ ] 指定地域スコープで未設定 → ボタンが無効化されており、シートから設定ピッカーに進める
- [ ] 指定地域スコープで設定済み → その地域で絞り込まれた一覧が開く