### PR TITLE
feat(home): スコープ未解決時の案内を権限状態に応じて細かく分岐

### DIFF
--- a/app/lib/feature/home/ui/component/sheet/component/home_scope_unavailable_body.dart
+++ b/app/lib/feature/home/ui/component/sheet/component/home_scope_unavailable_body.dart
@@ -1,8 +1,15 @@
+import 'dart:async';
+
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 
+/// スコープに対する検索パラメータが取れない（未設定 / 未解決）ときに
+/// シート上に表示する案内ブロック。
+///
+/// 文言と再試行導線をスコープごとに切り替える。
+/// 位置情報がらみのケースでは権限状態に応じてさらに細かく分岐する。
 class HomeScopeUnavailableBody extends StatelessWidget {
   const HomeScopeUnavailableBody({
     required this.scope,
@@ -17,20 +24,36 @@ class HomeScopeUnavailableBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return switch (scope) {
+      HomeEarthquakeHistoryScope.nationwide => const SizedBox.shrink(),
+      HomeEarthquakeHistoryScope.currentLocation => _CurrentLocationUnavailable(
+        onRetry: onRetry,
+      ),
+      HomeEarthquakeHistoryScope.custom => _CustomUnavailable(
+        onConfigureRegion: onConfigureRegion,
+      ),
+    };
+  }
+}
+
+class _UnavailableContainer extends StatelessWidget {
+  const _UnavailableContainer({
+    required this.icon,
+    required this.message,
+    this.actions = const [],
+  });
+
+  final IconData icon;
+  final String message;
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
     final designSystem = context.designSystem;
     final color = designSystem.color;
     final spacing = designSystem.spacing;
     final shape = designSystem.shape;
     final typography = designSystem.typography;
-    final message = switch (scope) {
-      .currentLocation => '現在地の市区町村を特定できません。位置情報の利用を許可してください。',
-      .custom => '指定地域が設定されていません。',
-      .nationwide => '',
-    };
-
-    if (message.isEmpty) {
-      return const SizedBox.shrink();
-    }
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -49,44 +72,135 @@ class HomeScopeUnavailableBody extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              scope == HomeEarthquakeHistoryScope.currentLocation
-                  ? Icons.location_off_outlined
-                  : Icons.tune_outlined,
-              color: designSystem.textColor.secondary,
-            ),
+            Icon(icon, color: designSystem.textColor.secondary),
             SizedBox(height: spacing.sm),
             Text(
               message,
               style: typography.bodyMedium,
               textAlign: TextAlign.center,
             ),
-            if (scope == HomeEarthquakeHistoryScope.currentLocation) ...[
+            if (actions.isNotEmpty) ...[
               SizedBox(height: spacing.md),
-              FilledButton.tonal(
-                onPressed: () async {
-                  final status = await Geolocator.checkPermission();
-                  if (status == LocationPermission.denied) {
-                    await Geolocator.requestPermission();
-                  } else if (status == LocationPermission.deniedForever) {
-                    await Geolocator.openAppSettings();
-                  }
-                  onRetry();
-                },
-                child: const Text('位置情報の取得を許可する'),
-              ),
-            ],
-            if (scope == HomeEarthquakeHistoryScope.custom &&
-                onConfigureRegion != null) ...[
-              SizedBox(height: spacing.md),
-              FilledButton.tonal(
-                onPressed: onConfigureRegion,
-                child: const Text('地域を設定する'),
+              Wrap(
+                spacing: spacing.sm,
+                runSpacing: spacing.sm,
+                alignment: WrapAlignment.center,
+                children: actions,
               ),
             ],
           ],
         ),
       ),
+    );
+  }
+}
+
+class _CurrentLocationUnavailable extends StatefulWidget {
+  const _CurrentLocationUnavailable({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  State<_CurrentLocationUnavailable> createState() =>
+      _CurrentLocationUnavailableState();
+}
+
+class _CurrentLocationUnavailableState
+    extends State<_CurrentLocationUnavailable> {
+  LocationPermission? _permission;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_refreshPermission());
+  }
+
+  Future<void> _refreshPermission() async {
+    final p = await Geolocator.checkPermission();
+    if (mounted) {
+      setState(() => _permission = p);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final permission = _permission;
+
+    // 権限取得中はスケルトンを避けて軽量プレースホルダ
+    if (permission == null) {
+      return const _UnavailableContainer(
+        icon: Icons.location_searching_outlined,
+        message: '現在地を取得しています…',
+      );
+    }
+
+    // 権限がない / 永続拒否 / それでも取れない、それぞれに合わせて文言と
+    // アクションを切り替える。
+    return switch (permission) {
+      LocationPermission.denied => _UnavailableContainer(
+        icon: Icons.location_off_outlined,
+        message: '位置情報の利用が許可されていません。許可すると現在地周辺の地震を表示できます。',
+        actions: [
+          FilledButton.tonal(
+            onPressed: () async {
+              await Geolocator.requestPermission();
+              await _refreshPermission();
+              widget.onRetry();
+            },
+            child: const Text('位置情報を許可する'),
+          ),
+        ],
+      ),
+      LocationPermission.deniedForever => _UnavailableContainer(
+        icon: Icons.location_disabled_outlined,
+        message: '位置情報の利用が拒否されています。アプリの設定から許可してください。',
+        actions: [
+          FilledButton.tonal(
+            onPressed: () async {
+              await Geolocator.openAppSettings();
+              await _refreshPermission();
+              widget.onRetry();
+            },
+            child: const Text('設定を開く'),
+          ),
+        ],
+      ),
+      _ => _UnavailableContainer(
+        // 権限はあるが位置・市区町村の解決に失敗しているケース。
+        icon: Icons.gps_not_fixed_outlined,
+        message: '現在地から地震情報を取得できませんでした。電波状況などをご確認のうえ再試行してください。',
+        actions: [
+          OutlinedButton.icon(
+            onPressed: () {
+              widget.onRetry();
+              unawaited(_refreshPermission());
+            },
+            icon: const Icon(Icons.refresh),
+            label: const Text('再試行'),
+          ),
+        ],
+      ),
+    };
+  }
+}
+
+class _CustomUnavailable extends StatelessWidget {
+  const _CustomUnavailable({this.onConfigureRegion});
+
+  final VoidCallback? onConfigureRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    return _UnavailableContainer(
+      icon: Icons.tune_outlined,
+      message: '指定地域が未設定です。表示したい都道府県・市区町村を選んでください。',
+      actions: [
+        if (onConfigureRegion != null)
+          FilledButton.tonal(
+            onPressed: onConfigureRegion,
+            child: const Text('地域を設定する'),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary

ホーム地震履歴シートでスコープに対応するパラメータが取得できないときに表示される `HomeScopeUnavailableBody` を、状態ごとに案内文言と導線が違うように改修した。

`docs/todo/075_home_earthquake_history_scope_followups.md` のフォローアップ (3)「読み込み・エラー・未設定時の表示」に対応する。

## Changes

- 現在地スコープ:
  - `LocationPermission.denied` → 権限リクエスト導線
  - `LocationPermission.deniedForever` → 設定を開く導線
  - 取得失敗（権限あり） → 再試行ボタン
- 指定地域スコープの未設定時メッセージを「未設定です」から「表示したい都道府県・市区町村を選んでください」へ。`HomeDesignatedRegionPickerPage`（別 PR）への導線と整合。
- 共通レイアウトを `_UnavailableContainer` に切り出し、アクションを `Wrap` で並べて狭い端末でも overflow しないようにする。

## Notes

- JMA mapping 失敗 / API エラーをさらに区別するには provider 側で結果を richer な型にする必要があり、本 PR のスコープからは外している（コメントで明示）。
- 文言は仮置き。レビューで調整可。

## Test plan

- [ ] 現在地スコープで位置情報を一度も許可していない状態 → 「位置情報を許可する」ボタン表示
- [ ] 設定で位置情報を「拒否」した後にアプリ起動 → 「設定を開く」ボタン表示
- [ ] 位置情報許可済みだが圏外などで取得できないとき → 「再試行」ボタン表示
- [ ] 指定地域スコープ・未設定 → 「地域を設定する」ボタン表示
- [ ] 各 Container が iPhone SE 幅でも overflow しない