### PR TITLE
fix(eqmonitor_api): @Default(ja) のビルドエラーで CD が落ちていたのを修正

### DIFF
--- a/app/lib/feature/devices/data/model/registered_device.dart
+++ b/app/lib/feature/devices/data/model/registered_device.dart
@@ -36,12 +36,12 @@ extension DevicePlatformDisplay on DevicePlatform {
 extension DeviceApiExtension on api.DeviceMeResponse {
   RegisteredDevice get toRegisteredDevice => RegisteredDevice(
     id: id,
-    platform: type?.toString() == 'ANDROID' ? .android : .ios,
+    platform: type == api.DeviceType.android ? .android : .ios,
     userId: userId,
-    locale: switch (locale?.toString()) {
-      'en' => DeviceLocale.en,
-      'zh' => DeviceLocale.zh,
-      _ => DeviceLocale.ja,
+    locale: switch (locale) {
+      api.DeviceLocale.en => DeviceLocale.en,
+      api.DeviceLocale.zh => DeviceLocale.zh,
+      api.DeviceLocale.ja => DeviceLocale.ja,
     },
     createdAtIso: createdAt.toIso8601String(),
     updatedAtIso: updatedAt.toIso8601String(),

--- a/app/lib/feature/devices/data/repository/device_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.dart
@@ -34,8 +34,8 @@ class DeviceRepository {
   }) => Result.capture(() async {
     await _api.device.postV2Device(
       body: api.DeviceRegisterBody(
-        type: devicePlatform.toDeviceType.toJson(),
-        locale: deviceLocale.toDeviceLocale.toJson(),
+        type: devicePlatform.toDeviceType,
+        locale: deviceLocale.toDeviceLocale,
       ),
     );
     final getResponse = await _api.device.getV2DeviceMe();

--- a/packages/eqmonitor_api/lib/src/models/device_me_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_me_response.dart
@@ -4,6 +4,9 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'device_locale.dart';
+import 'device_type.dart';
+
 part 'device_me_response.freezed.dart';
 part 'device_me_response.g.dart';
 
@@ -11,15 +14,15 @@ part 'device_me_response.g.dart';
 abstract class DeviceMeResponse with _$DeviceMeResponse {
   const factory DeviceMeResponse({
     required String id,
-    required dynamic type,
-    required dynamic registrationType,
+    required DeviceType type,
+    required String registrationType,
     @JsonKey(includeIfNull: true)
     required String? userId,
     required DateTime createdAt,
     required DateTime updatedAt,
     @JsonKey(includeIfNull: true)
-    @Default(ja)
-    dynamic locale,
+    @Default(DeviceLocale.ja)
+    DeviceLocale locale,
   }) = _DeviceMeResponse;
   
   factory DeviceMeResponse.fromJson(Map<String, Object?> json) => _$DeviceMeResponseFromJson(json);

--- a/packages/eqmonitor_api/lib/src/models/device_me_response.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_me_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$DeviceMeResponse {
 
- String get id; dynamic get type; dynamic get registrationType;@JsonKey(includeIfNull: true) String? get userId; DateTime get createdAt; DateTime get updatedAt;@JsonKey(includeIfNull: true) dynamic get locale;
+ String get id; DeviceType get type; String get registrationType;@JsonKey(includeIfNull: true) String? get userId; DateTime get createdAt; DateTime get updatedAt;@JsonKey(includeIfNull: true) DeviceLocale get locale;
 /// Create a copy of DeviceMeResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,12 +28,12 @@ $DeviceMeResponseCopyWith<DeviceMeResponse> get copyWith => _$DeviceMeResponseCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeviceMeResponse&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.type, type)&&const DeepCollectionEquality().equals(other.registrationType, registrationType)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other.locale, locale));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeviceMeResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.registrationType, registrationType) || other.registrationType == registrationType)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.locale, locale) || other.locale == locale));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(type),const DeepCollectionEquality().hash(registrationType),userId,createdAt,updatedAt,const DeepCollectionEquality().hash(locale));
+int get hashCode => Object.hash(runtimeType,id,type,registrationType,userId,createdAt,updatedAt,locale);
 
 @override
 String toString() {
@@ -48,7 +48,7 @@ abstract mixin class $DeviceMeResponseCopyWith<$Res>  {
   factory $DeviceMeResponseCopyWith(DeviceMeResponse value, $Res Function(DeviceMeResponse) _then) = _$DeviceMeResponseCopyWithImpl;
 @useResult
 $Res call({
- String id, dynamic type, dynamic registrationType,@JsonKey(includeIfNull: true) String? userId, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: true) dynamic locale
+ String id, DeviceType type, String registrationType,@JsonKey(includeIfNull: true) String? userId, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: true) DeviceLocale locale
 });
 
 
@@ -65,16 +65,16 @@ class _$DeviceMeResponseCopyWithImpl<$Res>
 
 /// Create a copy of DeviceMeResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = freezed,Object? registrationType = freezed,Object? userId = freezed,Object? createdAt = null,Object? updatedAt = null,Object? locale = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? type = null,Object? registrationType = null,Object? userId = freezed,Object? createdAt = null,Object? updatedAt = null,Object? locale = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as dynamic,registrationType: freezed == registrationType ? _self.registrationType : registrationType // ignore: cast_nullable_to_non_nullable
-as dynamic,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as DeviceType,registrationType: null == registrationType ? _self.registrationType : registrationType // ignore: cast_nullable_to_non_nullable
+as String,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
 as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
-as DateTime,locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
-as dynamic,
+as DateTime,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as DeviceLocale,
   ));
 }
 
@@ -159,7 +159,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  dynamic type,  dynamic registrationType, @JsonKey(includeIfNull: true)  String? userId,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: true)  dynamic locale)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  DeviceType type,  String registrationType, @JsonKey(includeIfNull: true)  String? userId,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: true)  DeviceLocale locale)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _DeviceMeResponse() when $default != null:
 return $default(_that.id,_that.type,_that.registrationType,_that.userId,_that.createdAt,_that.updatedAt,_that.locale);case _:
@@ -180,7 +180,7 @@ return $default(_that.id,_that.type,_that.registrationType,_that.userId,_that.cr
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  dynamic type,  dynamic registrationType, @JsonKey(includeIfNull: true)  String? userId,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: true)  dynamic locale)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  DeviceType type,  String registrationType, @JsonKey(includeIfNull: true)  String? userId,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: true)  DeviceLocale locale)  $default,) {final _that = this;
 switch (_that) {
 case _DeviceMeResponse():
 return $default(_that.id,_that.type,_that.registrationType,_that.userId,_that.createdAt,_that.updatedAt,_that.locale);case _:
@@ -200,7 +200,7 @@ return $default(_that.id,_that.type,_that.registrationType,_that.userId,_that.cr
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  dynamic type,  dynamic registrationType, @JsonKey(includeIfNull: true)  String? userId,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: true)  dynamic locale)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  DeviceType type,  String registrationType, @JsonKey(includeIfNull: true)  String? userId,  DateTime createdAt,  DateTime updatedAt, @JsonKey(includeIfNull: true)  DeviceLocale locale)?  $default,) {final _that = this;
 switch (_that) {
 case _DeviceMeResponse() when $default != null:
 return $default(_that.id,_that.type,_that.registrationType,_that.userId,_that.createdAt,_that.updatedAt,_that.locale);case _:
@@ -215,16 +215,16 @@ return $default(_that.id,_that.type,_that.registrationType,_that.userId,_that.cr
 @JsonSerializable()
 
 class _DeviceMeResponse implements DeviceMeResponse {
-  const _DeviceMeResponse({required this.id, required this.type, required this.registrationType, @JsonKey(includeIfNull: true) required this.userId, required this.createdAt, required this.updatedAt, @JsonKey(includeIfNull: true) this.locale = ja});
+  const _DeviceMeResponse({required this.id, required this.type, required this.registrationType, @JsonKey(includeIfNull: true) required this.userId, required this.createdAt, required this.updatedAt, @JsonKey(includeIfNull: true) this.locale = DeviceLocale.ja});
   factory _DeviceMeResponse.fromJson(Map<String, dynamic> json) => _$DeviceMeResponseFromJson(json);
 
 @override final  String id;
-@override final  dynamic type;
-@override final  dynamic registrationType;
+@override final  DeviceType type;
+@override final  String registrationType;
 @override@JsonKey(includeIfNull: true) final  String? userId;
 @override final  DateTime createdAt;
 @override final  DateTime updatedAt;
-@override@JsonKey(includeIfNull: true) final  dynamic locale;
+@override@JsonKey(includeIfNull: true) final  DeviceLocale locale;
 
 /// Create a copy of DeviceMeResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -239,12 +239,12 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DeviceMeResponse&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.type, type)&&const DeepCollectionEquality().equals(other.registrationType, registrationType)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&const DeepCollectionEquality().equals(other.locale, locale));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DeviceMeResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.type, type) || other.type == type)&&(identical(other.registrationType, registrationType) || other.registrationType == registrationType)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.locale, locale) || other.locale == locale));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(type),const DeepCollectionEquality().hash(registrationType),userId,createdAt,updatedAt,const DeepCollectionEquality().hash(locale));
+int get hashCode => Object.hash(runtimeType,id,type,registrationType,userId,createdAt,updatedAt,locale);
 
 @override
 String toString() {
@@ -259,7 +259,7 @@ abstract mixin class _$DeviceMeResponseCopyWith<$Res> implements $DeviceMeRespon
   factory _$DeviceMeResponseCopyWith(_DeviceMeResponse value, $Res Function(_DeviceMeResponse) _then) = __$DeviceMeResponseCopyWithImpl;
 @override @useResult
 $Res call({
- String id, dynamic type, dynamic registrationType,@JsonKey(includeIfNull: true) String? userId, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: true) dynamic locale
+ String id, DeviceType type, String registrationType,@JsonKey(includeIfNull: true) String? userId, DateTime createdAt, DateTime updatedAt,@JsonKey(includeIfNull: true) DeviceLocale locale
 });
 
 
@@ -276,16 +276,16 @@ class __$DeviceMeResponseCopyWithImpl<$Res>
 
 /// Create a copy of DeviceMeResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? type = freezed,Object? registrationType = freezed,Object? userId = freezed,Object? createdAt = null,Object? updatedAt = null,Object? locale = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? type = null,Object? registrationType = null,Object? userId = freezed,Object? createdAt = null,Object? updatedAt = null,Object? locale = null,}) {
   return _then(_DeviceMeResponse(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as dynamic,registrationType: freezed == registrationType ? _self.registrationType : registrationType // ignore: cast_nullable_to_non_nullable
-as dynamic,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as DeviceType,registrationType: null == registrationType ? _self.registrationType : registrationType // ignore: cast_nullable_to_non_nullable
+as String,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
 as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
-as DateTime,locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
-as dynamic,
+as DateTime,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as DeviceLocale,
   ));
 }
 

--- a/packages/eqmonitor_api/lib/src/models/device_me_response.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_me_response.g.dart
@@ -13,12 +13,15 @@ _DeviceMeResponse _$DeviceMeResponseFromJson(
 ) => $checkedCreate('_DeviceMeResponse', json, ($checkedConvert) {
   final val = _DeviceMeResponse(
     id: $checkedConvert('id', (v) => v as String),
-    type: $checkedConvert('type', (v) => v),
-    registrationType: $checkedConvert('registrationType', (v) => v),
+    type: $checkedConvert('type', (v) => $enumDecode(_$DeviceTypeEnumMap, v)),
+    registrationType: $checkedConvert('registrationType', (v) => v as String),
     userId: $checkedConvert('userId', (v) => v as String?),
     createdAt: $checkedConvert('createdAt', (v) => DateTime.parse(v as String)),
     updatedAt: $checkedConvert('updatedAt', (v) => DateTime.parse(v as String)),
-    locale: $checkedConvert('locale', (v) => v ?? ja),
+    locale: $checkedConvert(
+      'locale',
+      (v) => $enumDecodeNullable(_$DeviceLocaleEnumMap, v) ?? DeviceLocale.ja,
+    ),
   );
   return val;
 });
@@ -33,3 +36,14 @@ Map<String, dynamic> _$DeviceMeResponseToJson(_DeviceMeResponse instance) =>
       'updatedAt': instance.updatedAt.toIso8601String(),
       'locale': instance.locale,
     };
+
+const _$DeviceTypeEnumMap = {
+  DeviceType.ios: 'IOS',
+  DeviceType.android: 'ANDROID',
+};
+
+const _$DeviceLocaleEnumMap = {
+  DeviceLocale.ja: 'ja',
+  DeviceLocale.en: 'en',
+  DeviceLocale.zh: 'zh',
+};

--- a/packages/eqmonitor_api/lib/src/models/device_register_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_register_body.dart
@@ -4,16 +4,19 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'device_locale.dart';
+import 'device_type.dart';
+
 part 'device_register_body.freezed.dart';
 part 'device_register_body.g.dart';
 
 @Freezed()
 abstract class DeviceRegisterBody with _$DeviceRegisterBody {
   const factory DeviceRegisterBody({
-    required dynamic type,
+    required DeviceType type,
     @JsonKey(includeIfNull: true)
-    @Default(ja)
-    dynamic locale,
+    @Default(DeviceLocale.ja)
+    DeviceLocale locale,
   }) = _DeviceRegisterBody;
   
   factory DeviceRegisterBody.fromJson(Map<String, Object?> json) => _$DeviceRegisterBodyFromJson(json);

--- a/packages/eqmonitor_api/lib/src/models/device_register_body.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_register_body.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$DeviceRegisterBody {
 
- dynamic get type;@JsonKey(includeIfNull: true) dynamic get locale;
+ DeviceType get type;@JsonKey(includeIfNull: true) DeviceLocale get locale;
 /// Create a copy of DeviceRegisterBody
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,12 +28,12 @@ $DeviceRegisterBodyCopyWith<DeviceRegisterBody> get copyWith => _$DeviceRegister
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeviceRegisterBody&&const DeepCollectionEquality().equals(other.type, type)&&const DeepCollectionEquality().equals(other.locale, locale));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeviceRegisterBody&&(identical(other.type, type) || other.type == type)&&(identical(other.locale, locale) || other.locale == locale));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(type),const DeepCollectionEquality().hash(locale));
+int get hashCode => Object.hash(runtimeType,type,locale);
 
 @override
 String toString() {
@@ -48,7 +48,7 @@ abstract mixin class $DeviceRegisterBodyCopyWith<$Res>  {
   factory $DeviceRegisterBodyCopyWith(DeviceRegisterBody value, $Res Function(DeviceRegisterBody) _then) = _$DeviceRegisterBodyCopyWithImpl;
 @useResult
 $Res call({
- dynamic type,@JsonKey(includeIfNull: true) dynamic locale
+ DeviceType type,@JsonKey(includeIfNull: true) DeviceLocale locale
 });
 
 
@@ -65,11 +65,11 @@ class _$DeviceRegisterBodyCopyWithImpl<$Res>
 
 /// Create a copy of DeviceRegisterBody
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? type = freezed,Object? locale = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? locale = null,}) {
   return _then(_self.copyWith(
-type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as dynamic,locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
-as dynamic,
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as DeviceType,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as DeviceLocale,
   ));
 }
 
@@ -154,7 +154,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( dynamic type, @JsonKey(includeIfNull: true)  dynamic locale)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DeviceType type, @JsonKey(includeIfNull: true)  DeviceLocale locale)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _DeviceRegisterBody() when $default != null:
 return $default(_that.type,_that.locale);case _:
@@ -175,7 +175,7 @@ return $default(_that.type,_that.locale);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( dynamic type, @JsonKey(includeIfNull: true)  dynamic locale)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DeviceType type, @JsonKey(includeIfNull: true)  DeviceLocale locale)  $default,) {final _that = this;
 switch (_that) {
 case _DeviceRegisterBody():
 return $default(_that.type,_that.locale);case _:
@@ -195,7 +195,7 @@ return $default(_that.type,_that.locale);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( dynamic type, @JsonKey(includeIfNull: true)  dynamic locale)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DeviceType type, @JsonKey(includeIfNull: true)  DeviceLocale locale)?  $default,) {final _that = this;
 switch (_that) {
 case _DeviceRegisterBody() when $default != null:
 return $default(_that.type,_that.locale);case _:
@@ -210,11 +210,11 @@ return $default(_that.type,_that.locale);case _:
 @JsonSerializable()
 
 class _DeviceRegisterBody implements DeviceRegisterBody {
-  const _DeviceRegisterBody({required this.type, @JsonKey(includeIfNull: true) this.locale = ja});
+  const _DeviceRegisterBody({required this.type, @JsonKey(includeIfNull: true) this.locale = DeviceLocale.ja});
   factory _DeviceRegisterBody.fromJson(Map<String, dynamic> json) => _$DeviceRegisterBodyFromJson(json);
 
-@override final  dynamic type;
-@override@JsonKey(includeIfNull: true) final  dynamic locale;
+@override final  DeviceType type;
+@override@JsonKey(includeIfNull: true) final  DeviceLocale locale;
 
 /// Create a copy of DeviceRegisterBody
 /// with the given fields replaced by the non-null parameter values.
@@ -229,12 +229,12 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DeviceRegisterBody&&const DeepCollectionEquality().equals(other.type, type)&&const DeepCollectionEquality().equals(other.locale, locale));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DeviceRegisterBody&&(identical(other.type, type) || other.type == type)&&(identical(other.locale, locale) || other.locale == locale));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(type),const DeepCollectionEquality().hash(locale));
+int get hashCode => Object.hash(runtimeType,type,locale);
 
 @override
 String toString() {
@@ -249,7 +249,7 @@ abstract mixin class _$DeviceRegisterBodyCopyWith<$Res> implements $DeviceRegist
   factory _$DeviceRegisterBodyCopyWith(_DeviceRegisterBody value, $Res Function(_DeviceRegisterBody) _then) = __$DeviceRegisterBodyCopyWithImpl;
 @override @useResult
 $Res call({
- dynamic type,@JsonKey(includeIfNull: true) dynamic locale
+ DeviceType type,@JsonKey(includeIfNull: true) DeviceLocale locale
 });
 
 
@@ -266,11 +266,11 @@ class __$DeviceRegisterBodyCopyWithImpl<$Res>
 
 /// Create a copy of DeviceRegisterBody
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? type = freezed,Object? locale = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? locale = null,}) {
   return _then(_DeviceRegisterBody(
-type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as dynamic,locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
-as dynamic,
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as DeviceType,locale: null == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
+as DeviceLocale,
   ));
 }
 

--- a/packages/eqmonitor_api/lib/src/models/device_register_body.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_register_body.g.dart
@@ -11,11 +11,29 @@ part of 'device_register_body.dart';
 _DeviceRegisterBody _$DeviceRegisterBodyFromJson(Map<String, dynamic> json) =>
     $checkedCreate('_DeviceRegisterBody', json, ($checkedConvert) {
       final val = _DeviceRegisterBody(
-        type: $checkedConvert('type', (v) => v),
-        locale: $checkedConvert('locale', (v) => v ?? ja),
+        type: $checkedConvert(
+          'type',
+          (v) => $enumDecode(_$DeviceTypeEnumMap, v),
+        ),
+        locale: $checkedConvert(
+          'locale',
+          (v) =>
+              $enumDecodeNullable(_$DeviceLocaleEnumMap, v) ?? DeviceLocale.ja,
+        ),
       );
       return val;
     });
 
 Map<String, dynamic> _$DeviceRegisterBodyToJson(_DeviceRegisterBody instance) =>
     <String, dynamic>{'type': instance.type, 'locale': instance.locale};
+
+const _$DeviceTypeEnumMap = {
+  DeviceType.ios: 'IOS',
+  DeviceType.android: 'ANDROID',
+};
+
+const _$DeviceLocaleEnumMap = {
+  DeviceLocale.ja: 'ja',
+  DeviceLocale.en: 'en',
+  DeviceLocale.zh: 'zh',
+};


### PR DESCRIPTION
## Summary

- OpenAPI 生成された `device_register_body.dart` / `device_me_response.dart` で `@Default(ja)` が `DeviceLocale` を import しておらず参照解決できず、Android Release ビルド (CD) が `Undefined name 'ja'` で落ちていた。
- 応急対応として生成済みコードを手で直し、関連する `device_repository.dart` / `registered_device.dart` の dynamic 由来の余計な `.toJson()` / `?.` を整理。
- ローカルで `dart analyze lib` → No issues。`packages/eqmonitor_api` も clean。

## Root cause

`packages/eqmonitor_api` の OpenAPI -> Dart codegen で、enum の default 値が namespace なしで出力されている（`@Default(ja)` のような裸参照）。`device_locale.dart` の import も伴っていないため未解決識別子になっている。

本 PR は CD blocker のホットフィックスで、根本対応はジェネレータテンプレート（または backend `openapi.json` の `default` フィールド出力）の修正で別途必要。

## Test plan

- [x] `cd packages/eqmonitor_api && dart run build_runner build` 通過（freezed/g.dart 再生成）
- [x] `cd app && dart analyze lib` → No issues
- [ ] CI で `flutter build appbundle --release` がパスすること