### PR TITLE
test(ads): add unit tests for shouldShowAdsProvider

### DIFF
--- a/app/test/feature/ads/data/provider/should_show_ads_provider_test.dart
+++ b/app/test/feature/ads/data/provider/should_show_ads_provider_test.dart
@@ -1,0 +1,119 @@
+import 'package:eqmonitor/feature/ads/data/notifier/ads_opt_out_notifier.dart';
+import 'package:eqmonitor/feature/ads/data/provider/ads_server_flag_provider.dart';
+import 'package:eqmonitor/feature/ads/data/provider/should_show_ads_provider.dart';
+import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/subscription/data/provider/is_pro_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// `shouldShowAdsProvider` の依存を上書きするためのスタブ群。
+class _StubEewAliveTelegram extends EewAliveTelegram {
+  _StubEewAliveTelegram(this._value);
+
+  final List<EewTelegramItem>? _value;
+
+  @override
+  List<EewTelegramItem>? build() => _value;
+}
+
+class _StubAdsOptOut extends AdsOptOutNotifier {
+  _StubAdsOptOut({required bool initial}) : _initial = initial;
+
+  final bool _initial;
+
+  @override
+  bool build() => _initial;
+}
+
+ProviderContainer _container({
+  required bool isPro,
+  required bool adsServerFlag,
+  required List<EewTelegramItem>? eewAlive,
+  required bool adsOptOut,
+}) {
+  return ProviderContainer(
+    overrides: [
+      isProProvider.overrideWith((ref) => isPro),
+      adsServerFlagProvider.overrideWith((ref) => adsServerFlag),
+      eewAliveTelegramProvider.overrideWith(() => _StubEewAliveTelegram(eewAlive)),
+      adsOptOutProvider.overrideWith(() => _StubAdsOptOut(initial: adsOptOut)),
+    ],
+  );
+}
+
+void main() {
+  group('shouldShowAdsProvider', () {
+    test('全条件 OK のとき true (広告表示)', () {
+      final container = _container(
+        isPro: false,
+        adsServerFlag: true,
+        eewAlive: const [],
+        adsOptOut: false,
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(shouldShowAdsProvider), isTrue);
+    });
+
+    test('Pro ユーザーは false', () {
+      final container = _container(
+        isPro: true,
+        adsServerFlag: true,
+        eewAlive: const [],
+        adsOptOut: false,
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(shouldShowAdsProvider), isFalse);
+    });
+
+    test('サーバフラグが false のとき false', () {
+      final container = _container(
+        isPro: false,
+        adsServerFlag: false,
+        eewAlive: const [],
+        adsOptOut: false,
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(shouldShowAdsProvider), isFalse);
+    });
+
+    test('オプトアウト済みのとき false', () {
+      final container = _container(
+        isPro: false,
+        adsServerFlag: true,
+        eewAlive: const [],
+        adsOptOut: true,
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(shouldShowAdsProvider), isFalse);
+    });
+
+    test('EEW Alive が null のときは表示可 (true)', () {
+      final container = _container(
+        isPro: false,
+        adsServerFlag: true,
+        eewAlive: null,
+        adsOptOut: false,
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(shouldShowAdsProvider), isTrue);
+    });
+
+    test('Pro が最優先 (他条件すべて NG でも Pro なら false)', () {
+      final container = _container(
+        isPro: true,
+        adsServerFlag: false,
+        eewAlive: null,
+        adsOptOut: true,
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(shouldShowAdsProvider), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`feature/ads/data/provider/should_show_ads_provider.dart` の分岐ロジックを単体テストで網羅。

## Cases

- 全条件 OK → true
- Pro ユーザー → false
- サーバフラグ false → false
- オプトアウト済み → false
- EEW Alive が null → true（list 不在は EEW 未発報扱い）
- Pro 最優先（他条件すべて NG でも Pro なら false）

## Notes

EEW non-empty list ケースは `EewTelegramItem` の dummy 生成コストの観点から省略しています。`eewAlive != null && eewAlive.isNotEmpty` 分岐の半分は本 PR でカバー済み、残りは将来 fixture を整える PR で追加可能です。

## Test plan

- [x] `mise exec -- flutter test app/test/feature/ads/data/provider/should_show_ads_provider_test.dart` → 6/6 pass