### PR TITLE
test(ads): add unit tests for AdsOptOutNotifier

### DIFF
--- a/app/test/feature/ads/data/notifier/ads_opt_out_notifier_test.dart
+++ b/app/test/feature/ads/data/notifier/ads_opt_out_notifier_test.dart
@@ -1,0 +1,95 @@
+import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
+import 'package:eqmonitor/feature/ads/data/notifier/ads_opt_out_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<ProviderContainer> _container({Map<String, Object> initial = const {}}) async {
+  SharedPreferences.setMockInitialValues(initial);
+  final prefs = await SharedPreferences.getInstance();
+  return ProviderContainer(
+    overrides: [
+      app_prefs.sharedPreferencesProvider.overrideWithValue(
+        app_prefs.SharedPreferencesAsync(prefs),
+      ),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AdsOptOutNotifier', () {
+    test('初期値は false（SharedPreferences 未設定時）', () async {
+      final container = await _container();
+      addTearDown(container.dispose);
+
+      expect(container.read(adsOptOutProvider), isFalse);
+    });
+
+    test('SharedPreferences に true が入っていれば true を返す', () async {
+      final container = await _container(initial: {'ads_opt_out': true});
+      addTearDown(container.dispose);
+
+      expect(container.read(adsOptOutProvider), isTrue);
+    });
+
+    test('toggle で値が反転する', () async {
+      final container = await _container();
+      addTearDown(container.dispose);
+
+      expect(container.read(adsOptOutProvider), isFalse);
+
+      await container.read(adsOptOutProvider.notifier).toggle();
+      expect(container.read(adsOptOutProvider), isTrue);
+
+      await container.read(adsOptOutProvider.notifier).toggle();
+      expect(container.read(adsOptOutProvider), isFalse);
+    });
+
+    test('setOptOut(value: true) で true 固定にできる', () async {
+      final container = await _container();
+      addTearDown(container.dispose);
+
+      await container
+          .read(adsOptOutProvider.notifier)
+          .setOptOut(value: true);
+      expect(container.read(adsOptOutProvider), isTrue);
+
+      // 冪等性: 再度 true でもクラッシュしない
+      await container
+          .read(adsOptOutProvider.notifier)
+          .setOptOut(value: true);
+      expect(container.read(adsOptOutProvider), isTrue);
+    });
+
+    test('setOptOut(value: false) で false に戻せる', () async {
+      final container = await _container(initial: {'ads_opt_out': true});
+      addTearDown(container.dispose);
+
+      await container
+          .read(adsOptOutProvider.notifier)
+          .setOptOut(value: false);
+      expect(container.read(adsOptOutProvider), isFalse);
+    });
+
+    test('変更後の値が SharedPreferences に永続化される', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          app_prefs.sharedPreferencesProvider.overrideWithValue(
+            app_prefs.SharedPreferencesAsync(prefs),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(adsOptOutProvider.notifier)
+          .setOptOut(value: true);
+
+      expect(prefs.getBool('ads_opt_out'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`feature/ads/data/notifier/ads_opt_out_notifier.dart` の挙動を `shared_preferences` mock で網羅。

## Cases

- 初期値: SharedPreferences 未設定時は false
- 初期値: SharedPreferences に true があれば true
- `toggle()` で値が反転（false→true→false）
- `setOptOut(value: true)` で true 固定 + 冪等性
- `setOptOut(value: false)` で false に戻せる
- 変更が SharedPreferences に永続化される

## Test plan

- [x] `mise exec -- flutter test app/test/feature/ads/data/notifier/ads_opt_out_notifier_test.dart` → 6/6 pass