### PR TITLE
feat(subscription): paywall / management / promo sheet UI scaffold

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -59,6 +59,8 @@ import 'package:eqmonitor/feature/settings/settings_page.dart';
 import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
 import 'package:eqmonitor/feature/shake_detection/ui/shake_detection_history_details_page.dart';
 import 'package:eqmonitor/feature/shake_detection/ui/shake_detection_history_page.dart';
+import 'package:eqmonitor/feature/subscription/ui/page/paywall_page.dart';
+import 'package:eqmonitor/feature/subscription/ui/page/subscription_settings_page.dart';
 import 'package:eqmonitor/feature/telegram_list/ui/telegram_list_by_event_id_page.dart';
 import 'package:eqmonitor/page/home_page.dart';
 import 'package:eqmonitor/page/splash_page.dart';
@@ -764,6 +766,25 @@ class ChangelogRoute extends GoRouteData with $ChangelogRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const ChangelogPage();
+}
+
+@TypedGoRoute<PaywallRoute>(path: '/subscription/paywall')
+class PaywallRoute extends GoRouteData with $PaywallRoute {
+  const PaywallRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const PaywallPage();
+}
+
+@TypedGoRoute<SubscriptionSettingsRoute>(path: '/subscription/settings')
+class SubscriptionSettingsRoute extends GoRouteData
+    with $SubscriptionSettingsRoute {
+  const SubscriptionSettingsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const SubscriptionSettingsPage();
 }
 
 class _NavigatorObserver extends NavigatorObserver {

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -21,6 +21,8 @@ List<RouteBase> get $appRoutes => [
   $homeRoute,
   $talkerRoute,
   $settingsRoute,
+  $paywallRoute,
+  $subscriptionSettingsRoute,
 ];
 
 RouteBase get $splashRoute =>
@@ -1534,6 +1536,57 @@ bool _$boolConverter(String value) {
     default:
       throw UnsupportedError('Cannot convert "$value" into a bool.');
   }
+}
+
+RouteBase get $paywallRoute => GoRouteData.$route(
+  path: '/subscription/paywall',
+  factory: $PaywallRoute._fromState,
+);
+
+mixin $PaywallRoute on GoRouteData {
+  static PaywallRoute _fromState(GoRouterState state) => const PaywallRoute();
+
+  @override
+  String get location => GoRouteData.$location('/subscription/paywall');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $subscriptionSettingsRoute => GoRouteData.$route(
+  path: '/subscription/settings',
+  factory: $SubscriptionSettingsRoute._fromState,
+);
+
+mixin $SubscriptionSettingsRoute on GoRouteData {
+  static SubscriptionSettingsRoute _fromState(GoRouterState state) =>
+      const SubscriptionSettingsRoute();
+
+  @override
+  String get location => GoRouteData.$location('/subscription/settings');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
 }
 
 // **************************************************************************

--- a/app/lib/feature/ads/data/flow/ads_opt_out_flow.dart
+++ b/app/lib/feature/ads/data/flow/ads_opt_out_flow.dart
@@ -1,0 +1,39 @@
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/ads/data/notifier/ads_opt_out_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ads_opt_out_flow.g.dart';
+
+@riverpod
+AdsOptOutFlow adsOptOutFlow(Ref ref) => AdsOptOutFlow();
+
+/// 広告 opt-out / Paywall 導線をまとめた Flow。
+class AdsOptOutFlow {
+  /// 「EQMonitor Pro を見る」を選んだとき。
+  /// ボトムシートを閉じてから Paywall へ遷移する。
+  Future<void> showPaywall(WidgetRef ref, BuildContext context) async {
+    Navigator.of(context).pop();
+    if (!context.mounted) {
+      return;
+    }
+    await const PaywallRoute().push<void>(context);
+  }
+
+  /// 「広告なしで続ける（無料）」を選んだとき。
+  /// opt-out フラグを true にしてシートを閉じる。
+  Future<void> continueWithoutAds(
+    WidgetRef ref,
+    BuildContext context,
+  ) async {
+    await ref.read(adsOptOutProvider.notifier).setOptOut(value: true);
+    if (!context.mounted) {
+      return;
+    }
+    Navigator.of(context).pop();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('広告を非表示にしました')),
+    );
+  }
+}

--- a/app/lib/feature/ads/data/flow/ads_opt_out_flow.g.dart
+++ b/app/lib/feature/ads/data/flow/ads_opt_out_flow.g.dart
@@ -1,0 +1,53 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'ads_opt_out_flow.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(adsOptOutFlow)
+final adsOptOutFlowProvider = AdsOptOutFlowProvider._();
+
+final class AdsOptOutFlowProvider
+    extends $FunctionalProvider<AdsOptOutFlow, AdsOptOutFlow, AdsOptOutFlow>
+    with $Provider<AdsOptOutFlow> {
+  AdsOptOutFlowProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'adsOptOutFlowProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$adsOptOutFlowHash();
+
+  @$internal
+  @override
+  $ProviderElement<AdsOptOutFlow> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AdsOptOutFlow create(Ref ref) {
+    return adsOptOutFlow(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AdsOptOutFlow value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AdsOptOutFlow>(value),
+    );
+  }
+}
+
+String _$adsOptOutFlowHash() => r'e4fc4ed9cb28ce6fb2583eefcb9ada13c16c878f';

--- a/app/lib/feature/ads/data/notifier/ads_opt_out_notifier.dart
+++ b/app/lib/feature/ads/data/notifier/ads_opt_out_notifier.dart
@@ -20,4 +20,10 @@ class AdsOptOutNotifier extends _$AdsOptOutNotifier {
     await prefs.setBool(_key.key, next);
     state = next;
   }
+
+  Future<void> setOptOut({required bool value}) async {
+    final prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setBool(_key.key, value);
+    state = value;
+  }
 }

--- a/app/lib/feature/ads/data/notifier/ads_opt_out_notifier.g.dart
+++ b/app/lib/feature/ads/data/notifier/ads_opt_out_notifier.g.dart
@@ -43,7 +43,7 @@ final class AdsOptOutNotifierProvider
   }
 }
 
-String _$adsOptOutNotifierHash() => r'8231988f9135986be75bed81d96b2a288b0d9a2b';
+String _$adsOptOutNotifierHash() => r'878e447190e717cc4a5c20a0e7de5d10817ef474';
 
 abstract class _$AdsOptOutNotifier extends $Notifier<bool> {
   bool build();

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -40,6 +40,14 @@ class SettingsPage extends ConsumerWidget {
             ),
           ),
           const _AppVersionInformation(),
+          const SettingsSectionHeader(text: 'EQMonitor Pro'),
+          ListTile(
+            title: const Text('EQMonitor Pro'),
+            subtitle: const Text('プラン確認・アップグレード・購入の復元'),
+            leading: const Icon(Icons.workspace_premium_outlined),
+            onTap: () async =>
+                const SubscriptionSettingsRoute().push<void>(context),
+          ),
           const SettingsSectionHeader(text: '各種設定'),
           ListTile(
             title: const Text('通知設定'),

--- a/app/lib/feature/subscription/data/flow/paywall_flow.dart
+++ b/app/lib/feature/subscription/data/flow/paywall_flow.dart
@@ -1,0 +1,92 @@
+import 'dart:io' show Platform;
+
+import 'package:eqmonitor/feature/subscription/data/model/purchase_result.dart';
+import 'package:eqmonitor/feature/subscription/data/notifier/subscription_notifier.dart';
+import 'package:eqmonitor/feature/subscription/ui/component/thank_you_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+part 'paywall_flow.g.dart';
+
+@riverpod
+PaywallFlow paywallFlow(Ref ref) => PaywallFlow();
+
+/// Paywall / SubscriptionSettings から呼ばれる購入・復元・外部リンクの Flow。
+class PaywallFlow {
+  /// 月額プランの購入フロー。結果に応じてダイアログ / SnackBar を出す。
+  Future<void> purchaseMonthly(WidgetRef ref, BuildContext context) async {
+    final result = await ref
+        .read(subscriptionProvider.notifier)
+        .purchaseMonthly();
+    if (!context.mounted) {
+      return;
+    }
+    await handlePurchaseResult(
+      context,
+      result: result,
+      popOnSuccess: true,
+    );
+  }
+
+  /// 購入を復元する。
+  Future<void> restorePurchases(WidgetRef ref, BuildContext context) async {
+    final result = await ref
+        .read(subscriptionProvider.notifier)
+        .restorePurchases();
+    if (!context.mounted) {
+      return;
+    }
+    await handlePurchaseResult(
+      context,
+      result: result,
+      popOnSuccess: false,
+    );
+  }
+
+  Future<void> handlePurchaseResult(
+    BuildContext context, {
+    required PurchaseResult result,
+    required bool popOnSuccess,
+  }) async {
+    switch (result) {
+      case PurchaseResultSuccess():
+        await showDialog<void>(
+          context: context,
+          builder: (context) => const ThankYouDialog(),
+        );
+        if (!context.mounted) {
+          return;
+        }
+        if (popOnSuccess && Navigator.of(context).canPop()) {
+          Navigator.of(context).pop();
+        }
+      case PurchaseResultCancelled():
+        return;
+      case PurchaseResultFailed(:final message):
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('購入に失敗しました: $message')),
+        );
+      case PurchaseResultUnavailable():
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('アップグレード機能は近日公開予定です'),
+          ),
+        );
+    }
+  }
+
+  /// 利用規約 / プライバシーポリシー / 特商法のページを外部ブラウザで開く。
+  Future<void> openExternalUrl(String url) async {
+    await launchUrlString(url, mode: LaunchMode.externalApplication);
+  }
+
+  /// App Store / Play Store のサブスクリプション管理画面を開く。
+  Future<void> openStoreSubscriptionManagement() async {
+    final url = Platform.isIOS
+        ? 'https://apps.apple.com/account/subscriptions'
+        : 'https://play.google.com/store/account/subscriptions';
+    await launchUrlString(url, mode: LaunchMode.externalApplication);
+  }
+}

--- a/app/lib/feature/subscription/data/flow/paywall_flow.g.dart
+++ b/app/lib/feature/subscription/data/flow/paywall_flow.g.dart
@@ -1,0 +1,53 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'paywall_flow.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(paywallFlow)
+final paywallFlowProvider = PaywallFlowProvider._();
+
+final class PaywallFlowProvider
+    extends $FunctionalProvider<PaywallFlow, PaywallFlow, PaywallFlow>
+    with $Provider<PaywallFlow> {
+  PaywallFlowProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'paywallFlowProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$paywallFlowHash();
+
+  @$internal
+  @override
+  $ProviderElement<PaywallFlow> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  PaywallFlow create(Ref ref) {
+    return paywallFlow(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PaywallFlow value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PaywallFlow>(value),
+    );
+  }
+}
+
+String _$paywallFlowHash() => r'913a679cdd55bd6a49432c98235c911eeac17365';

--- a/app/lib/feature/subscription/data/model/purchase_result.dart
+++ b/app/lib/feature/subscription/data/model/purchase_result.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'purchase_result.freezed.dart';
+
+/// 課金フローの結果。UI 側のスナックバー / ダイアログ分岐に使う。
+///
+/// 本実装は別 PR (#12) で `purchases_flutter` 統合とあわせて差し替えられる。
+@Freezed()
+sealed class PurchaseResult with _$PurchaseResult {
+  const factory PurchaseResult.success() = PurchaseResultSuccess;
+  const factory PurchaseResult.cancelled() = PurchaseResultCancelled;
+  const factory PurchaseResult.failed(String message) = PurchaseResultFailed;
+  const factory PurchaseResult.unavailable(String reason) =
+      PurchaseResultUnavailable;
+}

--- a/app/lib/feature/subscription/data/model/purchase_result.freezed.dart
+++ b/app/lib/feature/subscription/data/model/purchase_result.freezed.dart
@@ -1,0 +1,382 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'purchase_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$PurchaseResult {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PurchaseResult);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PurchaseResult()';
+}
+
+
+}
+
+/// @nodoc
+class $PurchaseResultCopyWith<$Res>  {
+$PurchaseResultCopyWith(PurchaseResult _, $Res Function(PurchaseResult) __);
+}
+
+
+/// Adds pattern-matching-related methods to [PurchaseResult].
+extension PurchaseResultPatterns on PurchaseResult {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( PurchaseResultSuccess value)?  success,TResult Function( PurchaseResultCancelled value)?  cancelled,TResult Function( PurchaseResultFailed value)?  failed,TResult Function( PurchaseResultUnavailable value)?  unavailable,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case PurchaseResultSuccess() when success != null:
+return success(_that);case PurchaseResultCancelled() when cancelled != null:
+return cancelled(_that);case PurchaseResultFailed() when failed != null:
+return failed(_that);case PurchaseResultUnavailable() when unavailable != null:
+return unavailable(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( PurchaseResultSuccess value)  success,required TResult Function( PurchaseResultCancelled value)  cancelled,required TResult Function( PurchaseResultFailed value)  failed,required TResult Function( PurchaseResultUnavailable value)  unavailable,}){
+final _that = this;
+switch (_that) {
+case PurchaseResultSuccess():
+return success(_that);case PurchaseResultCancelled():
+return cancelled(_that);case PurchaseResultFailed():
+return failed(_that);case PurchaseResultUnavailable():
+return unavailable(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( PurchaseResultSuccess value)?  success,TResult? Function( PurchaseResultCancelled value)?  cancelled,TResult? Function( PurchaseResultFailed value)?  failed,TResult? Function( PurchaseResultUnavailable value)?  unavailable,}){
+final _that = this;
+switch (_that) {
+case PurchaseResultSuccess() when success != null:
+return success(_that);case PurchaseResultCancelled() when cancelled != null:
+return cancelled(_that);case PurchaseResultFailed() when failed != null:
+return failed(_that);case PurchaseResultUnavailable() when unavailable != null:
+return unavailable(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  success,TResult Function()?  cancelled,TResult Function( String message)?  failed,TResult Function( String reason)?  unavailable,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case PurchaseResultSuccess() when success != null:
+return success();case PurchaseResultCancelled() when cancelled != null:
+return cancelled();case PurchaseResultFailed() when failed != null:
+return failed(_that.message);case PurchaseResultUnavailable() when unavailable != null:
+return unavailable(_that.reason);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  success,required TResult Function()  cancelled,required TResult Function( String message)  failed,required TResult Function( String reason)  unavailable,}) {final _that = this;
+switch (_that) {
+case PurchaseResultSuccess():
+return success();case PurchaseResultCancelled():
+return cancelled();case PurchaseResultFailed():
+return failed(_that.message);case PurchaseResultUnavailable():
+return unavailable(_that.reason);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  success,TResult? Function()?  cancelled,TResult? Function( String message)?  failed,TResult? Function( String reason)?  unavailable,}) {final _that = this;
+switch (_that) {
+case PurchaseResultSuccess() when success != null:
+return success();case PurchaseResultCancelled() when cancelled != null:
+return cancelled();case PurchaseResultFailed() when failed != null:
+return failed(_that.message);case PurchaseResultUnavailable() when unavailable != null:
+return unavailable(_that.reason);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class PurchaseResultSuccess implements PurchaseResult {
+  const PurchaseResultSuccess();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PurchaseResultSuccess);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PurchaseResult.success()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PurchaseResultCancelled implements PurchaseResult {
+  const PurchaseResultCancelled();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PurchaseResultCancelled);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PurchaseResult.cancelled()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PurchaseResultFailed implements PurchaseResult {
+  const PurchaseResultFailed(this.message);
+  
+
+ final  String message;
+
+/// Create a copy of PurchaseResult
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PurchaseResultFailedCopyWith<PurchaseResultFailed> get copyWith => _$PurchaseResultFailedCopyWithImpl<PurchaseResultFailed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PurchaseResultFailed&&(identical(other.message, message) || other.message == message));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'PurchaseResult.failed(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PurchaseResultFailedCopyWith<$Res> implements $PurchaseResultCopyWith<$Res> {
+  factory $PurchaseResultFailedCopyWith(PurchaseResultFailed value, $Res Function(PurchaseResultFailed) _then) = _$PurchaseResultFailedCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$PurchaseResultFailedCopyWithImpl<$Res>
+    implements $PurchaseResultFailedCopyWith<$Res> {
+  _$PurchaseResultFailedCopyWithImpl(this._self, this._then);
+
+  final PurchaseResultFailed _self;
+  final $Res Function(PurchaseResultFailed) _then;
+
+/// Create a copy of PurchaseResult
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(PurchaseResultFailed(
+null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class PurchaseResultUnavailable implements PurchaseResult {
+  const PurchaseResultUnavailable(this.reason);
+  
+
+ final  String reason;
+
+/// Create a copy of PurchaseResult
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PurchaseResultUnavailableCopyWith<PurchaseResultUnavailable> get copyWith => _$PurchaseResultUnavailableCopyWithImpl<PurchaseResultUnavailable>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PurchaseResultUnavailable&&(identical(other.reason, reason) || other.reason == reason));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,reason);
+
+@override
+String toString() {
+  return 'PurchaseResult.unavailable(reason: $reason)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PurchaseResultUnavailableCopyWith<$Res> implements $PurchaseResultCopyWith<$Res> {
+  factory $PurchaseResultUnavailableCopyWith(PurchaseResultUnavailable value, $Res Function(PurchaseResultUnavailable) _then) = _$PurchaseResultUnavailableCopyWithImpl;
+@useResult
+$Res call({
+ String reason
+});
+
+
+
+
+}
+/// @nodoc
+class _$PurchaseResultUnavailableCopyWithImpl<$Res>
+    implements $PurchaseResultUnavailableCopyWith<$Res> {
+  _$PurchaseResultUnavailableCopyWithImpl(this._self, this._then);
+
+  final PurchaseResultUnavailable _self;
+  final $Res Function(PurchaseResultUnavailable) _then;
+
+/// Create a copy of PurchaseResult
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? reason = null,}) {
+  return _then(PurchaseResultUnavailable(
+null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/subscription/data/model/subscription_status.dart
+++ b/app/lib/feature/subscription/data/model/subscription_status.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'subscription_status.freezed.dart';
+
+/// サブスクリプションの状態を表すモデル。
+///
+/// 本実装は別 PR (#12) で `purchases_flutter` 統合とあわせて差し替えられる。
+/// UI 側はこの型に依存する。
+@Freezed()
+sealed class SubscriptionStatus with _$SubscriptionStatus {
+  const factory SubscriptionStatus.active({
+    required String productId,
+    DateTime? expiresAt,
+    @Default(true) bool willRenew,
+  }) = SubscriptionStatusActive;
+
+  const factory SubscriptionStatus.inactive() = SubscriptionStatusInactive;
+}

--- a/app/lib/feature/subscription/data/model/subscription_status.freezed.dart
+++ b/app/lib/feature/subscription/data/model/subscription_status.freezed.dart
@@ -1,0 +1,276 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'subscription_status.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$SubscriptionStatus {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SubscriptionStatus);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'SubscriptionStatus()';
+}
+
+
+}
+
+/// @nodoc
+class $SubscriptionStatusCopyWith<$Res>  {
+$SubscriptionStatusCopyWith(SubscriptionStatus _, $Res Function(SubscriptionStatus) __);
+}
+
+
+/// Adds pattern-matching-related methods to [SubscriptionStatus].
+extension SubscriptionStatusPatterns on SubscriptionStatus {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( SubscriptionStatusActive value)?  active,TResult Function( SubscriptionStatusInactive value)?  inactive,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case SubscriptionStatusActive() when active != null:
+return active(_that);case SubscriptionStatusInactive() when inactive != null:
+return inactive(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( SubscriptionStatusActive value)  active,required TResult Function( SubscriptionStatusInactive value)  inactive,}){
+final _that = this;
+switch (_that) {
+case SubscriptionStatusActive():
+return active(_that);case SubscriptionStatusInactive():
+return inactive(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( SubscriptionStatusActive value)?  active,TResult? Function( SubscriptionStatusInactive value)?  inactive,}){
+final _that = this;
+switch (_that) {
+case SubscriptionStatusActive() when active != null:
+return active(_that);case SubscriptionStatusInactive() when inactive != null:
+return inactive(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String productId,  DateTime? expiresAt,  bool willRenew)?  active,TResult Function()?  inactive,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case SubscriptionStatusActive() when active != null:
+return active(_that.productId,_that.expiresAt,_that.willRenew);case SubscriptionStatusInactive() when inactive != null:
+return inactive();case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String productId,  DateTime? expiresAt,  bool willRenew)  active,required TResult Function()  inactive,}) {final _that = this;
+switch (_that) {
+case SubscriptionStatusActive():
+return active(_that.productId,_that.expiresAt,_that.willRenew);case SubscriptionStatusInactive():
+return inactive();}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String productId,  DateTime? expiresAt,  bool willRenew)?  active,TResult? Function()?  inactive,}) {final _that = this;
+switch (_that) {
+case SubscriptionStatusActive() when active != null:
+return active(_that.productId,_that.expiresAt,_that.willRenew);case SubscriptionStatusInactive() when inactive != null:
+return inactive();case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class SubscriptionStatusActive implements SubscriptionStatus {
+  const SubscriptionStatusActive({required this.productId, this.expiresAt, this.willRenew = true});
+  
+
+ final  String productId;
+ final  DateTime? expiresAt;
+@JsonKey() final  bool willRenew;
+
+/// Create a copy of SubscriptionStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SubscriptionStatusActiveCopyWith<SubscriptionStatusActive> get copyWith => _$SubscriptionStatusActiveCopyWithImpl<SubscriptionStatusActive>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SubscriptionStatusActive&&(identical(other.productId, productId) || other.productId == productId)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.willRenew, willRenew) || other.willRenew == willRenew));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,productId,expiresAt,willRenew);
+
+@override
+String toString() {
+  return 'SubscriptionStatus.active(productId: $productId, expiresAt: $expiresAt, willRenew: $willRenew)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SubscriptionStatusActiveCopyWith<$Res> implements $SubscriptionStatusCopyWith<$Res> {
+  factory $SubscriptionStatusActiveCopyWith(SubscriptionStatusActive value, $Res Function(SubscriptionStatusActive) _then) = _$SubscriptionStatusActiveCopyWithImpl;
+@useResult
+$Res call({
+ String productId, DateTime? expiresAt, bool willRenew
+});
+
+
+
+
+}
+/// @nodoc
+class _$SubscriptionStatusActiveCopyWithImpl<$Res>
+    implements $SubscriptionStatusActiveCopyWith<$Res> {
+  _$SubscriptionStatusActiveCopyWithImpl(this._self, this._then);
+
+  final SubscriptionStatusActive _self;
+  final $Res Function(SubscriptionStatusActive) _then;
+
+/// Create a copy of SubscriptionStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? productId = null,Object? expiresAt = freezed,Object? willRenew = null,}) {
+  return _then(SubscriptionStatusActive(
+productId: null == productId ? _self.productId : productId // ignore: cast_nullable_to_non_nullable
+as String,expiresAt: freezed == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,willRenew: null == willRenew ? _self.willRenew : willRenew // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class SubscriptionStatusInactive implements SubscriptionStatus {
+  const SubscriptionStatusInactive();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SubscriptionStatusInactive);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'SubscriptionStatus.inactive()';
+}
+
+
+}
+
+
+
+
+// dart format on

--- a/app/lib/feature/subscription/data/notifier/subscription_notifier.dart
+++ b/app/lib/feature/subscription/data/notifier/subscription_notifier.dart
@@ -1,0 +1,44 @@
+import 'package:eqmonitor/feature/subscription/data/model/purchase_result.dart';
+import 'package:eqmonitor/feature/subscription/data/model/subscription_status.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'subscription_notifier.g.dart';
+
+/// サブスクリプション状態を保持する AsyncNotifier の **スタブ**。
+///
+/// 後続 PR (#12) で RevenueCat (`purchases_flutter`) 統合により
+/// 本実装に差し替えられる。差し替え時にはこの signature を維持し、
+/// UI 側 (`PaywallPage` / `SubscriptionSettingsPage` / `isProProvider`) を
+/// 変更しなくて済むようにする。
+///
+/// 現状の挙動:
+/// - `build()` は常に [SubscriptionStatus.inactive] を返す
+/// - [refresh] は no-op
+/// - [purchaseMonthly] は [PurchaseResult.unavailable] を返す
+/// - [restorePurchases] は [PurchaseResult.unavailable] を返す
+@Riverpod(keepAlive: true)
+class SubscriptionNotifier extends _$SubscriptionNotifier {
+  @override
+  Future<SubscriptionStatus> build() async {
+    // TODO(#12): RevenueCat の `Purchases.getCustomerInfo()` を呼んで
+    // active なエンタイトルメントから [SubscriptionStatus] を組み立てる。
+    return const SubscriptionStatus.inactive();
+  }
+
+  /// サブスク状態を再取得する。stub では何もしない。
+  Future<void> refresh() async {
+    // TODO(#12): RevenueCat から再取得し state を更新する。
+  }
+
+  /// 月額プラン購入フローを開始する。stub では常に unavailable を返す。
+  Future<PurchaseResult> purchaseMonthly() async {
+    // TODO(#12): RevenueCat の `Purchases.purchasePackage(...)` を呼ぶ。
+    return const PurchaseResult.unavailable('SDK 未統合');
+  }
+
+  /// 購入を復元する。stub では unavailable を返す。
+  Future<PurchaseResult> restorePurchases() async {
+    // TODO(#12): RevenueCat の `Purchases.restorePurchases()` を呼ぶ。
+    return const PurchaseResult.unavailable('SDK 未統合');
+  }
+}

--- a/app/lib/feature/subscription/data/notifier/subscription_notifier.g.dart
+++ b/app/lib/feature/subscription/data/notifier/subscription_notifier.g.dart
@@ -1,0 +1,108 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'subscription_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// サブスクリプション状態を保持する AsyncNotifier の **スタブ**。
+///
+/// 後続 PR (#12) で RevenueCat (`purchases_flutter`) 統合により
+/// 本実装に差し替えられる。差し替え時にはこの signature を維持し、
+/// UI 側 (`PaywallPage` / `SubscriptionSettingsPage` / `isProProvider`) を
+/// 変更しなくて済むようにする。
+///
+/// 現状の挙動:
+/// - `build()` は常に [SubscriptionStatus.inactive] を返す
+/// - [refresh] は no-op
+/// - [purchaseMonthly] は [PurchaseResult.unavailable] を返す
+/// - [restorePurchases] は [PurchaseResult.unavailable] を返す
+
+@ProviderFor(SubscriptionNotifier)
+final subscriptionProvider = SubscriptionNotifierProvider._();
+
+/// サブスクリプション状態を保持する AsyncNotifier の **スタブ**。
+///
+/// 後続 PR (#12) で RevenueCat (`purchases_flutter`) 統合により
+/// 本実装に差し替えられる。差し替え時にはこの signature を維持し、
+/// UI 側 (`PaywallPage` / `SubscriptionSettingsPage` / `isProProvider`) を
+/// 変更しなくて済むようにする。
+///
+/// 現状の挙動:
+/// - `build()` は常に [SubscriptionStatus.inactive] を返す
+/// - [refresh] は no-op
+/// - [purchaseMonthly] は [PurchaseResult.unavailable] を返す
+/// - [restorePurchases] は [PurchaseResult.unavailable] を返す
+final class SubscriptionNotifierProvider
+    extends $AsyncNotifierProvider<SubscriptionNotifier, SubscriptionStatus> {
+  /// サブスクリプション状態を保持する AsyncNotifier の **スタブ**。
+  ///
+  /// 後続 PR (#12) で RevenueCat (`purchases_flutter`) 統合により
+  /// 本実装に差し替えられる。差し替え時にはこの signature を維持し、
+  /// UI 側 (`PaywallPage` / `SubscriptionSettingsPage` / `isProProvider`) を
+  /// 変更しなくて済むようにする。
+  ///
+  /// 現状の挙動:
+  /// - `build()` は常に [SubscriptionStatus.inactive] を返す
+  /// - [refresh] は no-op
+  /// - [purchaseMonthly] は [PurchaseResult.unavailable] を返す
+  /// - [restorePurchases] は [PurchaseResult.unavailable] を返す
+  SubscriptionNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'subscriptionProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$subscriptionNotifierHash();
+
+  @$internal
+  @override
+  SubscriptionNotifier create() => SubscriptionNotifier();
+}
+
+String _$subscriptionNotifierHash() =>
+    r'b58bb9c060cf5eac765ed860c5440852a76b64ad';
+
+/// サブスクリプション状態を保持する AsyncNotifier の **スタブ**。
+///
+/// 後続 PR (#12) で RevenueCat (`purchases_flutter`) 統合により
+/// 本実装に差し替えられる。差し替え時にはこの signature を維持し、
+/// UI 側 (`PaywallPage` / `SubscriptionSettingsPage` / `isProProvider`) を
+/// 変更しなくて済むようにする。
+///
+/// 現状の挙動:
+/// - `build()` は常に [SubscriptionStatus.inactive] を返す
+/// - [refresh] は no-op
+/// - [purchaseMonthly] は [PurchaseResult.unavailable] を返す
+/// - [restorePurchases] は [PurchaseResult.unavailable] を返す
+
+abstract class _$SubscriptionNotifier
+    extends $AsyncNotifier<SubscriptionStatus> {
+  FutureOr<SubscriptionStatus> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<SubscriptionStatus>, SubscriptionStatus>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<SubscriptionStatus>, SubscriptionStatus>,
+              AsyncValue<SubscriptionStatus>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/subscription/data/provider/is_pro_provider.dart
+++ b/app/lib/feature/subscription/data/provider/is_pro_provider.dart
@@ -1,7 +1,22 @@
+import 'package:eqmonitor/feature/subscription/data/model/subscription_status.dart';
+import 'package:eqmonitor/feature/subscription/data/notifier/subscription_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'is_pro_provider.g.dart';
 
-/// P5実装前のスタブ。RevenueCat連携後にProユーザー判定に置き換える。
+/// Pro ユーザーかどうかを返す。
+///
+/// [subscriptionProvider] を watch し、active なら true。
+/// SDK 未統合段階では Stub の Notifier が常に [SubscriptionStatus.inactive] を
+/// 返すため false。後続 PR (#12) で RevenueCat 統合後は実際の購読状態を反映する。
 @Riverpod(keepAlive: true)
-bool isPro(Ref ref) => false;
+bool isPro(Ref ref) {
+  final status = ref.watch(subscriptionProvider);
+  return switch (status) {
+    AsyncData(:final value) => switch (value) {
+      SubscriptionStatusActive() => true,
+      SubscriptionStatusInactive() => false,
+    },
+    _ => false,
+  };
+}

--- a/app/lib/feature/subscription/data/provider/is_pro_provider.g.dart
+++ b/app/lib/feature/subscription/data/provider/is_pro_provider.g.dart
@@ -10,16 +10,28 @@ part of 'is_pro_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// P5実装前のスタブ。RevenueCat連携後にProユーザー判定に置き換える。
+/// Pro ユーザーかどうかを返す。
+///
+/// [subscriptionNotifierProvider] を watch し、active なら true。
+/// SDK 未統合段階では Stub の Notifier が常に [SubscriptionStatus.inactive] を
+/// 返すため false。後続 PR (#12) で RevenueCat 統合後は実際の購読状態を反映する。
 
 @ProviderFor(isPro)
 final isProProvider = IsProProvider._();
 
-/// P5実装前のスタブ。RevenueCat連携後にProユーザー判定に置き換える。
+/// Pro ユーザーかどうかを返す。
+///
+/// [subscriptionNotifierProvider] を watch し、active なら true。
+/// SDK 未統合段階では Stub の Notifier が常に [SubscriptionStatus.inactive] を
+/// 返すため false。後続 PR (#12) で RevenueCat 統合後は実際の購読状態を反映する。
 
 final class IsProProvider extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
-  /// P5実装前のスタブ。RevenueCat連携後にProユーザー判定に置き換える。
+  /// Pro ユーザーかどうかを返す。
+  ///
+  /// [subscriptionNotifierProvider] を watch し、active なら true。
+  /// SDK 未統合段階では Stub の Notifier が常に [SubscriptionStatus.inactive] を
+  /// 返すため false。後続 PR (#12) で RevenueCat 統合後は実際の購読状態を反映する。
   IsProProvider._()
     : super(
         from: null,
@@ -53,4 +65,4 @@ final class IsProProvider extends $FunctionalProvider<bool, bool, bool>
   }
 }
 
-String _$isProHash() => r'9126025efc06867fc0949744acfb88c941280888';
+String _$isProHash() => r'd800ad9f47e825157685189e98050df7d0cee142';

--- a/app/lib/feature/subscription/ui/component/ads_opt_out_promo_sheet.dart
+++ b/app/lib/feature/subscription/ui/component/ads_opt_out_promo_sheet.dart
@@ -1,0 +1,95 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/feature/ads/data/flow/ads_opt_out_flow.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 広告 opt-out 前に Pro へ誘導する販促ボトムシート。
+///
+/// `AdsOptOutPromoSheet.show(context)` で表示する。
+class AdsOptOutPromoSheet extends ConsumerWidget {
+  const AdsOptOutPromoSheet({super.key});
+
+  static Future<void> show(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => const AdsOptOutPromoSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final color = context.designSystem.color;
+    final flow = ref.watch(adsOptOutFlowProvider);
+
+    return SafeArea(
+      top: false,
+      child: Container(
+        decoration: BoxDecoration(
+          color: color.surfaceDefault,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: Container(
+                width: 36,
+                height: 4,
+                margin: const EdgeInsets.only(bottom: 16),
+                decoration: BoxDecoration(
+                  color: color.outlineSoft,
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              ),
+            ),
+            Text(
+              'EQMonitor の運営を支援する',
+              style: textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'EQMonitor は、サーバー代と開発費を広告収入でまかなっています。 '
+              'EQMonitor Pro なら広告非表示に加えて、通知地点の拡張などの特典も '
+              'ご利用いただけます。\n'
+              '広告なしのまま無料で続けることも可能です。',
+              style: textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 20),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(52),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ),
+              onPressed: () async => flow.showPaywall(ref, context),
+              child: const Text('EQMonitor Pro を見る'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size.fromHeight(52),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ),
+              onPressed: () async => flow.continueWithoutAds(ref, context),
+              child: const Text('広告なしで続ける（無料）'),
+            ),
+            const SizedBox(height: 4),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('キャンセル'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/subscription/ui/component/thank_you_dialog.dart
+++ b/app/lib/feature/subscription/ui/component/thank_you_dialog.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class ThankYouDialog extends StatelessWidget {
+  const ThankYouDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      icon: Icon(
+        Icons.favorite_rounded,
+        color: theme.colorScheme.primary,
+        size: 36,
+      ),
+      title: const Text('ありがとうございます'),
+      content: const Text(
+        'EQMonitor Pro へようこそ。\n'
+        'いただいたご支援は、開発・運営費用に充てさせていただきます。',
+      ),
+      actions: [
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/feature/subscription/ui/page/paywall_page.dart
+++ b/app/lib/feature/subscription/ui/page/paywall_page.dart
@@ -1,0 +1,299 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/feature/subscription/data/flow/paywall_flow.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// EQMonitor Pro へアップグレードするための Paywall 画面。
+class PaywallPage extends ConsumerWidget {
+  const PaywallPage({super.key});
+
+  static const _termsUrl = 'https://eqmonitor.app/terms';
+  static const _privacyUrl = 'https://eqmonitor.app/privacy';
+  static const _tokushohoUrl = 'https://eqmonitor.app/tokushoho';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final flow = ref.watch(paywallFlowProvider);
+    final color = context.designSystem.color;
+
+    return Scaffold(
+      backgroundColor: color.backgroundDefault,
+      appBar: AppBar(
+        title: const Text('EQMonitor Pro'),
+        backgroundColor: color.backgroundDefault,
+        elevation: 0,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 8, 20, 32),
+        children: [
+          const _PaywallHero(),
+          const SizedBox(height: 28),
+          const _BenefitsSection(),
+          const SizedBox(height: 24),
+          const _PlanCard(),
+          const SizedBox(height: 24),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(56),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+            ),
+            onPressed: () async => flow.purchaseMonthly(ref, context),
+            child: const Text('Pro にアップグレード'),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: () async => flow.restorePurchases(ref, context),
+            child: const Text('購入を復元する'),
+          ),
+          const SizedBox(height: 16),
+          _LegalLinksRow(
+            onTerms: () async => flow.openExternalUrl(_termsUrl),
+            onPrivacy: () async => flow.openExternalUrl(_privacyUrl),
+            onTokushoho: () async => flow.openExternalUrl(_tokushohoUrl),
+          ),
+          const SizedBox(height: 16),
+          const _AutoRenewNotice(),
+        ],
+      ),
+    );
+  }
+}
+
+class _PaywallHero extends StatelessWidget {
+  const _PaywallHero();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final color = context.designSystem.color;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: color.surfaceEmphasis,
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Text(
+            'EQMonitor Pro',
+            style: textTheme.labelMedium,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'すべての通知、\nすべての安心。',
+          style: textTheme.displayMedium,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'EQMonitor Pro は、開発・運営を支援していただく方向けの月額プランです。 '
+          'いただいた支援は、サーバー代と開発費に充てられます。',
+          style: textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}
+
+class _Benefit {
+  const _Benefit({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+
+class _BenefitsSection extends StatelessWidget {
+  const _BenefitsSection();
+
+  static const _benefits = <_Benefit>[
+    _Benefit(
+      icon: Icons.block_rounded,
+      title: '広告を非表示',
+      description: 'すべての画面で広告を非表示にします。',
+    ),
+    _Benefit(
+      icon: Icons.notifications_active_outlined,
+      title: '通知地点を最大 5 つに拡張',
+      description: '気になる地域をまとめて見守れます。',
+    ),
+    _Benefit(
+      icon: Icons.vibration_rounded,
+      title: '揺れ検知を 3 地点に拡張',
+      description: '複数地点の揺れをまとめて受信できます。',
+    ),
+    _Benefit(
+      icon: Icons.favorite_outline,
+      title: '開発・運営を支援',
+      description: 'いただいた支援は EQMonitor の運営に充てられます。',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final color = context.designSystem.color;
+    return Container(
+      decoration: BoxDecoration(
+        color: color.surfaceCard,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: color.outlineSoft),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        children: [
+          for (final benefit in _benefits) _BenefitRow(benefit: benefit),
+        ],
+      ),
+    );
+  }
+}
+
+class _BenefitRow extends StatelessWidget {
+  const _BenefitRow({required this.benefit});
+
+  final _Benefit benefit;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(benefit.icon, color: theme.colorScheme.primary, size: 24),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(benefit.title, style: textTheme.titleSmall),
+                const SizedBox(height: 4),
+                Text(benefit.description, style: textTheme.bodySmall),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlanCard extends StatelessWidget {
+  const _PlanCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final color = context.designSystem.color;
+    return Container(
+      decoration: BoxDecoration(
+        color: color.surfaceEmphasis,
+        borderRadius: BorderRadius.circular(28),
+        border: Border.all(color: theme.colorScheme.primary, width: 1.5),
+      ),
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text('月額プラン', style: textTheme.titleMedium),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary,
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  'おすすめ',
+                  style: textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text('¥300', style: textTheme.headlineLarge),
+              const SizedBox(width: 6),
+              Text('/ 月（税込）', style: textTheme.bodyMedium),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'いつでも解約可能。期間中は Pro 特典をすべてご利用いただけます。',
+            style: textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LegalLinksRow extends StatelessWidget {
+  const _LegalLinksRow({
+    required this.onTerms,
+    required this.onPrivacy,
+    required this.onTokushoho,
+  });
+
+  final Future<void> Function() onTerms;
+  final Future<void> Function() onPrivacy;
+  final Future<void> Function() onTokushoho;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      alignment: WrapAlignment.center,
+      spacing: 4,
+      children: [
+        TextButton(onPressed: () async => onTerms(), child: const Text('利用規約')),
+        TextButton(
+          onPressed: () async => onPrivacy(),
+          child: const Text('プライバシーポリシー'),
+        ),
+        TextButton(
+          onPressed: () async => onTokushoho(),
+          child: const Text('特定商取引法に基づく表記'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AutoRenewNotice extends StatelessWidget {
+  const _AutoRenewNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      '自動更新サブスクリプションです。期間終了の 24 時間前までに解約しないと、 '
+      '自動的に更新されます。解約は App Store / Google Play の '
+      'サブスクリプション管理画面からいつでも行えます。',
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: context.designSystem.color.outlineStrong,
+      ),
+      textAlign: TextAlign.center,
+    );
+  }
+}

--- a/app/lib/feature/subscription/ui/page/subscription_settings_page.dart
+++ b/app/lib/feature/subscription/ui/page/subscription_settings_page.dart
@@ -1,0 +1,167 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/subscription/data/flow/paywall_flow.dart';
+import 'package:eqmonitor/feature/subscription/data/model/subscription_status.dart';
+import 'package:eqmonitor/feature/subscription/data/notifier/subscription_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// サブスクリプションの状態確認 / 管理画面。
+class SubscriptionSettingsPage extends ConsumerWidget {
+  const SubscriptionSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final statusAsync = ref.watch(subscriptionProvider);
+    final color = context.designSystem.color;
+    return Scaffold(
+      backgroundColor: color.backgroundDefault,
+      appBar: AppBar(title: const Text('EQMonitor Pro')),
+      body: statusAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text('サブスクリプション情報の取得に失敗しました: $error'),
+          ),
+        ),
+        data: (status) => switch (status) {
+          SubscriptionStatusActive() => _ActiveSection(status: status),
+          SubscriptionStatusInactive() => const _InactiveSection(),
+        },
+      ),
+    );
+  }
+}
+
+class _ActiveSection extends ConsumerWidget {
+  const _ActiveSection({required this.status});
+
+  final SubscriptionStatusActive status;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final color = context.designSystem.color;
+    final flow = ref.watch(paywallFlowProvider);
+
+    final expiresAt = status.expiresAt;
+    final expiresLabel = expiresAt == null
+        ? null
+        : '${expiresAt.year.toString().padLeft(4, '0')}/'
+              '${expiresAt.month.toString().padLeft(2, '0')}/'
+              '${expiresAt.day.toString().padLeft(2, '0')}';
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            color: color.surfaceCard,
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(color: color.outlineSoft),
+          ),
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.workspace_premium_rounded,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Text('現在のプラン', style: textTheme.labelMedium),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text('EQMonitor Pro 月額', style: textTheme.titleLarge),
+              const SizedBox(height: 12),
+              if (expiresLabel != null)
+                Text(
+                  status.willRenew
+                      ? '次回更新: $expiresLabel'
+                      : '有効期限: $expiresLabel（自動更新オフ）',
+                  style: textTheme.bodyMedium,
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+        FilledButton.tonal(
+          style: FilledButton.styleFrom(
+            minimumSize: const Size.fromHeight(52),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+          ),
+          onPressed: () async => flow.openStoreSubscriptionManagement(),
+          child: const Text('サブスクリプションを管理'),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () async => flow.restorePurchases(ref, context),
+          child: const Text('購入を復元'),
+        ),
+      ],
+    );
+  }
+}
+
+class _InactiveSection extends ConsumerWidget {
+  const _InactiveSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final color = context.designSystem.color;
+    final flow = ref.watch(paywallFlowProvider);
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            color: color.surfaceCard,
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(color: color.outlineSoft),
+          ),
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('現在のプラン', style: textTheme.labelMedium),
+              const SizedBox(height: 8),
+              Text('Free', style: textTheme.titleLarge),
+              const SizedBox(height: 12),
+              Text(
+                'EQMonitor Pro にアップグレードすると、通知地点の拡張・広告非表示などの '
+                '特典をご利用いただけます。',
+                style: textTheme.bodyMedium,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          style: FilledButton.styleFrom(
+            minimumSize: const Size.fromHeight(56),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+          ),
+          onPressed: () async => const PaywallRoute().push<void>(context),
+          child: const Text('EQMonitor Pro にアップグレード'),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () async => flow.restorePurchases(ref, context),
+          child: const Text('購入を復元'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

EQMonitor Pro 月額プラン向けの UI 群を追加します。SDK (RevenueCat / `purchases_flutter`) の実統合は別 PR (#12 を想定) で行うため、本 PR では UI と画面遷移、`SubscriptionNotifier` の stub に絞っています。

- Paywall ページ（ヒーロー / 特典カード / プラン選択 / CTA / 復元 / 規約リンク / 自動更新説明）
- サブスク管理ページ（active / inactive 切替表示、ストア管理画面導線、購入復元）
- 広告 opt-out の販促ボトムシート（Pro 訴求 → Paywall / 広告非表示で続行 / キャンセル）
- ThankYou ダイアログ
- `SubscriptionStatus` / `PurchaseResult` の Freezed sealed union 定義
- `SubscriptionNotifier` の stub 実装（常に `inactive` を返し、`purchaseMonthly()` は `unavailable` を返す）
- `isProProvider` を stub から `subscriptionProvider` を watch する派生 provider に置換
- `AdsOptOutNotifier` に `setOptOut({required bool value})` を追加（既存の `toggle()` は維持）
- `PaywallFlow` / `AdsOptOutFlow` Action class（flutter-rules の `data/flow/` 規約に従い `WidgetRef` / `BuildContext` をメソッド引数で受け取る）
- ルート追加: `/subscription/paywall`, `/subscription/settings`
- 設定画面 root に「EQMonitor Pro」セクション 1 件追加

## 触ったファイル

新規:
- `app/lib/feature/subscription/data/model/subscription_status.dart` (+ freezed)
- `app/lib/feature/subscription/data/model/purchase_result.dart` (+ freezed)
- `app/lib/feature/subscription/data/notifier/subscription_notifier.dart` (stub)
- `app/lib/feature/subscription/data/flow/paywall_flow.dart`
- `app/lib/feature/subscription/ui/page/paywall_page.dart`
- `app/lib/feature/subscription/ui/page/subscription_settings_page.dart`
- `app/lib/feature/subscription/ui/component/thank_you_dialog.dart`
- `app/lib/feature/subscription/ui/component/ads_opt_out_promo_sheet.dart`
- `app/lib/feature/ads/data/flow/ads_opt_out_flow.dart`

編集:
- `app/lib/feature/subscription/data/provider/is_pro_provider.dart` （stub `false` → `subscriptionProvider` watch）
- `app/lib/feature/ads/data/notifier/ads_opt_out_notifier.dart` （`setOptOut` 追加）
- `app/lib/core/router/router.dart` （PaywallRoute / SubscriptionSettingsRoute 追加）
- `app/lib/feature/settings/settings_page.dart` （Pro セクション追加）

## Stub の置き換え予定箇所（後続 PR #12 想定）

- `SubscriptionNotifier.build()` — `Purchases.getCustomerInfo()` から `SubscriptionStatus` を組み立てる
- `SubscriptionNotifier.purchaseMonthly()` — `Purchases.purchasePackage(...)` を呼ぶ
- `SubscriptionNotifier.restorePurchases()` — `Purchases.restorePurchases()` を呼ぶ
- `SubscriptionNotifier.refresh()` — RC から再取得
- 上記置き換え時、UI / `isProProvider` / Flow 側に変更は不要（型シグネチャ維持）

## 暫定 URL 一覧（後で本物に差し替え予定）

- 利用規約: `https://eqmonitor.app/terms`
- プライバシーポリシー: `https://eqmonitor.app/privacy`
- 特定商取引法に基づく表記: `https://eqmonitor.app/tokushoho`
- ストア管理: iOS `https://apps.apple.com/account/subscriptions`, Android `https://play.google.com/store/account/subscriptions`

## 商品 ID

- iOS: `net.yumnumm.eqmontior.pro.monthly`
- Android: `eqmonitor.pro.monthly:eqmonitor-pro-monthly`
- 価格: ¥300/月 (税込)

## 未解決・要相談

- 特商法 URL（実 URL に差し替え必要）
- 文言確定（Pro 特典の最終文言、ヒーローコピー、販促文）
- ThankYou ダイアログ文言
- スクリーンショット未撮影
- 通知地点上限 5 / 揺れ検知 3 など Pro 特典数値は仮置き

## Test plan

- [ ] 設定画面に「EQMonitor Pro」セクションが表示される
- [ ] そこから `/subscription/settings` に遷移し、Free 表示で「アップグレード」 CTA が見える
- [ ] 「アップグレード」で `/subscription/paywall` に遷移する
- [ ] Paywall の「Pro にアップグレード」を押すと `アップグレード機能は近日公開予定です` SnackBar
- [ ] 「購入を復元する」でも同 SnackBar
- [ ] 利用規約・プライバシーポリシー・特商法リンクで外部ブラウザが開く
- [ ] `AdsOptOutPromoSheet.show()` 経由でボトムシートが表示され、各ボタンが期待通り動作
- [ ] `dart analyze lib` がクリーン (確認済み)