### PR TITLE
feat(debug): 端末シェイク・Shift+D でデバッグページを開けるように

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/core/theme/build_theme.dart';
 import 'package:eqmonitor/core/theme/custom_colors.dart';
 import 'package:eqmonitor/core/theme/theme_provider.dart';
+import 'package:eqmonitor/feature/debug/launcher/debug_launcher.dart';
 import 'package:eqmonitor/feature/start/ui/component/forced_update_dialog.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -60,6 +61,8 @@ class App extends HookConsumerWidget {
           title: 'EQMonitor',
           themeMode: theme.value,
           routerConfig: routerConfig,
+          builder: (context, child) =>
+              DebugLauncher(child: child ?? const SizedBox.shrink()),
           theme: buildTheme(
             colorScheme: lightColorScheme,
             customColors: lightCustomColors,

--- a/app/lib/feature/debug/launcher/debug_launcher.dart
+++ b/app/lib/feature/debug/launcher/debug_launcher.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:eqmonitor/core/provider/environment/environment.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sensors_plus/sensors_plus.dart';
+
+/// 端末シェイクまたは Shift+D でデバッグページを開くラッパー。
+///
+/// kDebugMode / Beta ビルドでのみ有効化することを想定。
+class DebugLauncher extends ConsumerStatefulWidget {
+  const DebugLauncher({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  ConsumerState<DebugLauncher> createState() => _DebugLauncherState();
+}
+
+class _DebugLauncherState extends ConsumerState<DebugLauncher> {
+  static const _shakeGForceThreshold = 2.7;
+  static const _shakeCooldown = Duration(seconds: 1);
+  static const _openCooldown = Duration(milliseconds: 800);
+
+  StreamSubscription<UserAccelerometerEvent>? _accelSubscription;
+  var _lastShake = DateTime.fromMillisecondsSinceEpoch(0);
+  var _lastOpen = DateTime.fromMillisecondsSinceEpoch(0);
+
+  @override
+  void initState() {
+    super.initState();
+    _startShakeListener();
+    HardwareKeyboard.instance.addHandler(_handleKey);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_handleKey);
+    unawaited(_accelSubscription?.cancel());
+    super.dispose();
+  }
+
+  void _startShakeListener() {
+    if (kIsWeb || !(Platform.isAndroid || Platform.isIOS)) {
+      return;
+    }
+    _accelSubscription =
+        userAccelerometerEventStream(
+          samplingPeriod: SensorInterval.gameInterval,
+        ).listen(_onAccel, onError: (_) {});
+  }
+
+  void _onAccel(UserAccelerometerEvent event) {
+    final magnitude = sqrt(
+      event.x * event.x + event.y * event.y + event.z * event.z,
+    );
+    final gForce = magnitude / 9.80665;
+    if (gForce < _shakeGForceThreshold) {
+      return;
+    }
+    final now = DateTime.now();
+    if (now.difference(_lastShake) < _shakeCooldown) {
+      return;
+    }
+    _lastShake = now;
+    _openDebugPage();
+  }
+
+  bool _handleKey(KeyEvent event) {
+    if (event is! KeyDownEvent) {
+      return false;
+    }
+    if (event.logicalKey != LogicalKeyboardKey.keyD) {
+      return false;
+    }
+    final keyboard = HardwareKeyboard.instance;
+    final shiftPressed =
+        keyboard.isLogicalKeyPressed(LogicalKeyboardKey.shiftLeft) ||
+        keyboard.isLogicalKeyPressed(LogicalKeyboardKey.shiftRight);
+    if (!shiftPressed) {
+      return false;
+    }
+    _openDebugPage();
+    return true;
+  }
+
+  void _openDebugPage() {
+    final now = DateTime.now();
+    if (now.difference(_lastOpen) < _openCooldown) {
+      return;
+    }
+    if (!_isLauncherEnabled) {
+      return;
+    }
+    _lastOpen = now;
+    final router = ref.read(goRouterProvider);
+    final currentLocation =
+        router.routerDelegate.currentConfiguration.uri.toString();
+    if (currentLocation.startsWith(const DebugRoute().location)) {
+      return;
+    }
+    unawaited(router.push<void>(const DebugRoute().location));
+  }
+
+  bool get _isLauncherEnabled {
+    if (kDebugMode) {
+      return true;
+    }
+    final buildCfg = ref.read(buildConfigProvider);
+    if (buildCfg.isBetaTesting) {
+      return true;
+    }
+    return ref.read(debugProvider).value ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -139,6 +139,7 @@ dependencies:
   riverpod: ^3.2.1
   riverpod_annotation: ^4.0.0
   screenshot: 3.0.0
+  sensors_plus: ^7.0.0
   share_plus: ^12.0.0
   shared_preferences: ^2.3.3
   shared_preferences_foundation: ^2.5.6

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1813,6 +1813,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  sensors_plus:
+    dependency: transitive
+    description:
+      name: sensors_plus
+      sha256: "56e8cd4260d9ed8e00ecd8da5d9fdc8a1b2ec12345a750dfa51ff83fcf12e3fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  sensors_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: sensors_plus_platform_interface
+      sha256: "58815d2f5e46c0c41c40fb39375d3f127306f7742efe3b891c0b1c87e2b5cd5d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   share_plus:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- closes #1245
- `sensors_plus` (SPM 対応) を追加し、加速度センサーで端末シェイクを検出してデバッグページを開く
- `HardwareKeyboard` で `Shift + D` を検出してデバッグページを開く
- `kDebugMode` / Beta テストビルド / デバッグモード ON のいずれかでのみ有効化（プロダクションでの誤発動を防止）
- `MaterialApp.router` の `builder` に `DebugLauncher` を差し込んでアプリ全体で監視

## 実装メモ
- シェイク判定は `userAccelerometerEventStream` を使い、重力を除いた加速度の大きさが約 2.7G を超えたら発火
- 連続発火を防ぐためシェイク 1 秒・オープン 0.8 秒のクールダウン
- 既にデバッグページ配下にいる場合は再度プッシュしない

## Test plan
- [ ] iOS 実機でアプリを左右に振るとデバッグページが開くこと
- [ ] Android 実機でアプリを左右に振るとデバッグページが開くこと
- [ ] 物理キーボード接続時に `Shift + D` でデバッグページが開くこと
- [ ] Release ビルド (`isBetaTesting=false`, デバッグモード OFF) では発火しないこと
- [ ] デバッグページを開いた状態でさらに振っても多重 push されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)