### PR TITLE
feat(map): ホーム設定の maxZoom・方位ロックを全マップで共通化

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -20,6 +20,9 @@ import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history
 import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_intensity_icon_layer.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/layer/model/earthquake_history_map_layer_mode.dart';
+import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/home_map_options.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:eqmonitor/feature/map/ui/maplibre_event_provider.dart';
 import 'package:flutter/foundation.dart';
@@ -78,6 +81,11 @@ class _MapContent extends HookConsumerWidget {
       earthquakeHistoryConfigProvider.select((v) => v.requireValue.detail),
     );
     final jmaMap = ref.watch(jmaMapProvider).requireValue;
+    final mapSettings = ref.watch(
+      homeConfigurationProvider.select(
+        (v) => v.value?.map ?? const HomeMapSettings(),
+      ),
+    );
 
     ref.listen(earthquakeHistoryMapFocusProvider(earthquake.eventId), (
       _,
@@ -110,10 +118,13 @@ class _MapContent extends HookConsumerWidget {
 
     final center = initialGeographicForEarthquake(earthquake);
     final zoom = initialZoomForEarthquake(earthquake);
+    final (:maxZoom, :gestures) = sharedMapOptionsFromSettings(mapSettings);
     final mapOptions = MapOptions(
       initCenter: center,
       initZoom: zoom,
       initStyle: styleString,
+      maxZoom: maxZoom,
+      gestures: gestures,
     );
     final hypocenterLayer = EarthquakeHistoryHypocenterLayer(
       earthquake: earthquake,

--- a/app/lib/feature/earthquake_replay/ui/earthquake_replay_page.dart
+++ b/app/lib/feature/earthquake_replay/ui/earthquake_replay_page.dart
@@ -3,6 +3,9 @@ import 'package:eqmonitor/feature/earthquake_replay/data/notifier/replay_notifie
 import 'package:eqmonitor/feature/earthquake_replay/ui/components/replay_controls.dart';
 import 'package:eqmonitor/feature/earthquake_replay/ui/components/replay_data_overlay.dart';
 import 'package:eqmonitor/feature/earthquake_replay/ui/components/replay_map_layer.dart';
+import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/home_map_options.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -191,11 +194,19 @@ class _MapContent extends HookConsumerWidget {
     final replayState = ref.watch(replayProvider);
     final showOverlay = replayState?.showDataOverlay ?? false;
     final recentEvents = replayState?.recentEvents ?? [];
+    final mapSettings = ref.watch(
+      homeConfigurationProvider.select(
+        (v) => v.value?.map ?? const HomeMapSettings(),
+      ),
+    );
+    final (:maxZoom, :gestures) = sharedMapOptionsFromSettings(mapSettings);
 
     final mapOptions = MapOptions(
       initCenter: const Geographic(lon: 138, lat: 36.5),
       initZoom: 4.5,
       initStyle: styleString,
+      maxZoom: maxZoom,
+      gestures: gestures,
     );
 
     return Stack(

--- a/app/lib/feature/eew/ui/components/eew_details_map_view.dart
+++ b/app/lib/feature/eew/ui/components/eew_details_map_view.dart
@@ -3,6 +3,9 @@ import 'package:eqmonitor/feature/eew/data/model/eew_display_mode.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/eew/ui/components/eew_forecast_region_layer.dart';
 import 'package:eqmonitor/feature/eew/ui/components/eew_static_ps_wave_layer.dart';
+import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/home_map_options.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:flutter/material.dart';
@@ -41,7 +44,7 @@ class EewDetailsMapView extends HookConsumerWidget {
   }
 }
 
-class _MapContent extends StatelessWidget {
+class _MapContent extends ConsumerWidget {
   const _MapContent({
     required this.styleString,
     required this.selectedEew,
@@ -57,11 +60,19 @@ class _MapContent extends StatelessWidget {
   final EewDisplayMode displayMode;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mapSettings = ref.watch(
+      homeConfigurationProvider.select(
+        (v) => v.value?.map ?? const HomeMapSettings(),
+      ),
+    );
+    final (:maxZoom, :gestures) = sharedMapOptionsFromSettings(mapSettings);
     final mapOptions = MapOptions(
       initCenter: initialCenter,
       initZoom: initZoom,
       initStyle: styleString,
+      maxZoom: maxZoom,
+      gestures: gestures,
     );
 
     return MapLibreMap(

--- a/app/lib/feature/home/ui/component/map/home_map_options.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_options.dart
@@ -6,6 +6,14 @@ import 'package:eqmonitor/feature/map/utils/map_zoom_calculator.dart';
 import 'package:flutter/material.dart';
 import 'package:maplibre/maplibre.dart';
 
+/// ホーム設定から全マップ共通の maxZoom と gestures を取り出す
+({double maxZoom, MapGestures gestures}) sharedMapOptionsFromSettings(
+  HomeMapSettings map,
+) {
+  final maxZ = (map.maxZoom ?? 22).clamp(0.0, 24.0);
+  return (maxZoom: maxZ, gestures: MapGestures.all(rotate: !map.lockBearing));
+}
+
 /// ホーム設定に基づく初期 [MapOptions]（最大ズーム・方位ロック・表示範囲プリセット）
 MapOptions homeMapOptionsFromSettings({
   required BuildContext context,

--- a/app/lib/feature/shake_detection/ui/shake_detection_history_details_page.dart
+++ b/app/lib/feature/shake_detection/ui/shake_detection_history_details_page.dart
@@ -4,6 +4,9 @@ import 'dart:convert';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/home_map_options.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';
@@ -101,11 +104,19 @@ class _PageContent extends HookConsumerWidget {
       lat: (event.minLat + event.maxLat) / 2,
       lon: (event.minLng + event.maxLng) / 2,
     );
+    final mapSettings = ref.watch(
+      homeConfigurationProvider.select(
+        (v) => v.value?.map ?? const HomeMapSettings(),
+      ),
+    );
+    final (:maxZoom, :gestures) = sharedMapOptionsFromSettings(mapSettings);
 
     final mapOptions = MapOptions(
       initCenter: center,
       initZoom: 5,
       initStyle: styleString,
+      maxZoom: maxZoom,
+      gestures: gestures,
     );
 
     final isInitialized = useRef(false);


### PR DESCRIPTION
## Summary

- `HomeMapSettings` の `maxZoom`（最大ズーム制限）と `lockBearing`（方位ロック）をホームマップ以外にも適用する
- `sharedMapOptionsFromSettings` ヘルパー関数を `home_map_options.dart` に追加し、各マップで共通利用できるようにした
- 対象マップ：地震詳細・EEW詳細・揺れ検知詳細・リプレイ

## Changes

- `home_map_options.dart`: `sharedMapOptionsFromSettings` ヘルパー追加（maxZoom・gestures を返す）
- `eew_details_map_view.dart`: `_MapContent` を `ConsumerWidget` 化、設定を適用
- `earthquake_history_details_map_view.dart`: `homeConfigurationProvider` を watch、設定を適用
- `shake_detection_history_details_page.dart`: `homeConfigurationProvider` を watch、設定を適用
- `earthquake_replay_page.dart`: `homeConfigurationProvider` を watch、設定を適用

> `defaultBounds` / `customBounds` はホーム初期表示専用のため対象外。  
> `home_map_bounds_selector_page.dart` / `region_picker_map_page.dart` は設定用UIのため除外。

## Test plan

- [ ] ホームのマップ設定で「方位ロック」ON → 地震詳細・EEW詳細マップで地図が回転しないことを確認
- [ ] ホームのマップ設定で「最大ズーム」設定 → 各マップでその制限が効くことを確認
- [ ] 設定を変更していない状態でのデフォルト動作に変化がないことを確認
- [ ] `dart analyze` が No issues であることを確認

Closes #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)