### PR TITLE
refactor: StatefulWidget を HookWidget に移行 + eqmonitor_lints analyzer plugin 実装

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -8,3 +8,11 @@ analyzer:
     unnecessary_async: ignore
   enable-experiment:
     - dot-shorthands
+
+plugins:
+  eqmonitor_lints:
+    diagnostics:
+      avoid_stateful_widget: true
+      avoid_null_assertion_operator: true
+      avoid_top_level_functions: true
+      avoid_print: true

--- a/app/lib/feature/changelog/ui/page/changelog_page.dart
+++ b/app/lib/feature/changelog/ui/page/changelog_page.dart
@@ -3,28 +3,23 @@ import 'dart:async';
 import 'package:eqmonitor/feature/changelog/data/notifier/changelog_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 
-class ChangelogPage extends ConsumerStatefulWidget {
+class ChangelogPage extends HookConsumerWidget {
   const ChangelogPage({super.key});
 
   @override
-  ConsumerState<ChangelogPage> createState() => _ChangelogPageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    useEffect(() {
+      unawaited(
+        Future.microtask(() => ref.read(changelogProvider.notifier).fetch()),
+      );
+      return null;
+    }, const []);
 
-class _ChangelogPageState extends ConsumerState<ChangelogPage> {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      unawaited(ref.read(changelogProvider.notifier).fetch());
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
     final state = ref.watch(changelogProvider);
 
     return Scaffold(

--- a/app/lib/feature/debug/launcher/debug_launcher.dart
+++ b/app/lib/feature/debug/launcher/debug_launcher.dart
@@ -8,117 +8,111 @@ import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 
 /// 端末シェイクまたは Shift+D でデバッグページを開くラッパー。
 ///
 /// kDebugMode / Beta ビルドでのみ有効化することを想定。
-class DebugLauncher extends ConsumerStatefulWidget {
+class DebugLauncher extends HookConsumerWidget {
   const DebugLauncher({required this.child, super.key});
 
   final Widget child;
 
   @override
-  ConsumerState<DebugLauncher> createState() => _DebugLauncherState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    const shakeGForceThreshold = 2.7;
+    const shakeCooldown = Duration(seconds: 1);
+    const openCooldown = Duration(milliseconds: 800);
 
-class _DebugLauncherState extends ConsumerState<DebugLauncher> {
-  static const _shakeGForceThreshold = 2.7;
-  static const _shakeCooldown = Duration(seconds: 1);
-  static const _openCooldown = Duration(milliseconds: 800);
+    final accelSubscription =
+        useRef<StreamSubscription<UserAccelerometerEvent>?>(null);
+    final lastShake = useRef(DateTime.fromMillisecondsSinceEpoch(0));
+    final lastOpen = useRef(DateTime.fromMillisecondsSinceEpoch(0));
 
-  StreamSubscription<UserAccelerometerEvent>? _accelSubscription;
-  var _lastShake = DateTime.fromMillisecondsSinceEpoch(0);
-  var _lastOpen = DateTime.fromMillisecondsSinceEpoch(0);
+    useEffect(() {
+      bool isLauncherEnabled() {
+        if (kDebugMode) {
+          return true;
+        }
+        final buildCfg = ref.read(buildConfigProvider);
+        if (buildCfg.isBetaTesting) {
+          return true;
+        }
+        return ref.read(debugProvider).value ?? false;
+      }
 
-  @override
-  void initState() {
-    super.initState();
-    _startShakeListener();
-    HardwareKeyboard.instance.addHandler(_handleKey);
-  }
+      void openDebugPage() {
+        final now = DateTime.now();
+        if (now.difference(lastOpen.value) < openCooldown) {
+          return;
+        }
+        if (!isLauncherEnabled()) {
+          return;
+        }
+        lastOpen.value = now;
+        final router = ref.read(goRouterProvider);
+        final currentLocation =
+            router.routerDelegate.currentConfiguration.uri.toString();
+        if (currentLocation.startsWith(const DebugRoute().location)) {
+          return;
+        }
+        unawaited(router.push<void>(const DebugRoute().location));
+      }
 
-  @override
-  void dispose() {
-    HardwareKeyboard.instance.removeHandler(_handleKey);
-    unawaited(_accelSubscription?.cancel());
-    super.dispose();
-  }
+      void onAccel(UserAccelerometerEvent event) {
+        final magnitude = sqrt(
+          event.x * event.x + event.y * event.y + event.z * event.z,
+        );
+        final gForce = magnitude / 9.80665;
+        if (gForce < shakeGForceThreshold) {
+          return;
+        }
+        final now = DateTime.now();
+        if (now.difference(lastShake.value) < shakeCooldown) {
+          return;
+        }
+        lastShake.value = now;
+        openDebugPage();
+      }
 
-  void _startShakeListener() {
-    if (kIsWeb || !(Platform.isAndroid || Platform.isIOS)) {
-      return;
-    }
-    _accelSubscription =
-        userAccelerometerEventStream(
+      void startShakeListener() {
+        if (kIsWeb || !(Platform.isAndroid || Platform.isIOS)) {
+          return;
+        }
+        accelSubscription.value = userAccelerometerEventStream(
           samplingPeriod: SensorInterval.gameInterval,
-        ).listen(_onAccel, onError: (_) {});
-  }
+        ).listen(onAccel, onError: (_) {});
+      }
 
-  void _onAccel(UserAccelerometerEvent event) {
-    final magnitude = sqrt(
-      event.x * event.x + event.y * event.y + event.z * event.z,
-    );
-    final gForce = magnitude / 9.80665;
-    if (gForce < _shakeGForceThreshold) {
-      return;
-    }
-    final now = DateTime.now();
-    if (now.difference(_lastShake) < _shakeCooldown) {
-      return;
-    }
-    _lastShake = now;
-    _openDebugPage();
-  }
+      bool handleKey(KeyEvent event) {
+        if (event is! KeyDownEvent) {
+          return false;
+        }
+        if (event.logicalKey != LogicalKeyboardKey.keyD) {
+          return false;
+        }
+        final keyboard = HardwareKeyboard.instance;
+        final shiftPressed =
+            keyboard.isLogicalKeyPressed(LogicalKeyboardKey.shiftLeft) ||
+            keyboard.isLogicalKeyPressed(LogicalKeyboardKey.shiftRight);
+        if (!shiftPressed) {
+          return false;
+        }
+        openDebugPage();
+        return true;
+      }
 
-  bool _handleKey(KeyEvent event) {
-    if (event is! KeyDownEvent) {
-      return false;
-    }
-    if (event.logicalKey != LogicalKeyboardKey.keyD) {
-      return false;
-    }
-    final keyboard = HardwareKeyboard.instance;
-    final shiftPressed =
-        keyboard.isLogicalKeyPressed(LogicalKeyboardKey.shiftLeft) ||
-        keyboard.isLogicalKeyPressed(LogicalKeyboardKey.shiftRight);
-    if (!shiftPressed) {
-      return false;
-    }
-    _openDebugPage();
-    return true;
-  }
+      startShakeListener();
+      HardwareKeyboard.instance.addHandler(handleKey);
 
-  void _openDebugPage() {
-    final now = DateTime.now();
-    if (now.difference(_lastOpen) < _openCooldown) {
-      return;
-    }
-    if (!_isLauncherEnabled) {
-      return;
-    }
-    _lastOpen = now;
-    final router = ref.read(goRouterProvider);
-    final currentLocation =
-        router.routerDelegate.currentConfiguration.uri.toString();
-    if (currentLocation.startsWith(const DebugRoute().location)) {
-      return;
-    }
-    unawaited(router.push<void>(const DebugRoute().location));
-  }
+      return () {
+        HardwareKeyboard.instance.removeHandler(handleKey);
+        unawaited(accelSubscription.value?.cancel());
+      };
+    }, const []);
 
-  bool get _isLauncherEnabled {
-    if (kDebugMode) {
-      return true;
-    }
-    final buildCfg = ref.read(buildConfigProvider);
-    if (buildCfg.isBetaTesting) {
-      return true;
-    }
-    return ref.read(debugProvider).value ?? false;
+    return child;
   }
-
-  @override
-  Widget build(BuildContext context) => widget.child;
 }

--- a/app/lib/feature/devices/ui/component/device_provisioning_banner.dart
+++ b/app/lib/feature/devices/ui/component/device_provisioning_banner.dart
@@ -5,25 +5,19 @@ import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_noti
 import 'package:eqmonitor/feature/devices/data/notifier/push_token_sync_notifier.dart';
 import 'package:eqmonitor/feature/devices/data/retry/retry_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod/experimental/mutation.dart';
 
 /// デバイスプロビジョニング / トークン同期の進行状況バナー。
 /// 正常完了・アイドル状態では高さゼロの SizedBox.shrink() を返す。
-class DeviceProvisioningBanner extends ConsumerStatefulWidget {
+class DeviceProvisioningBanner extends ConsumerWidget {
   const DeviceProvisioningBanner({required this.bottomSpacing, super.key});
 
   final double bottomSpacing;
 
   @override
-  ConsumerState<DeviceProvisioningBanner> createState() =>
-      _DeviceProvisioningBannerState();
-}
-
-class _DeviceProvisioningBannerState
-    extends ConsumerState<DeviceProvisioningBanner> {
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final provisionStatus = ref.watch(deviceProvisioningProvider);
     final provisionMutation = ref.watch(
       DeviceProvisioningNotifier.provisionMutation,
@@ -55,7 +49,7 @@ class _DeviceProvisioningBannerState
     }
 
     return _DeviceProvisioningBannerContent(
-      bottomSpacing: widget.bottomSpacing,
+      bottomSpacing: bottomSpacing,
       activeRetry: activeRetry,
       isLoading: isLoading,
       onRetry: () {
@@ -143,49 +137,30 @@ class _DeviceProvisioningBannerContent extends StatelessWidget {
   }
 }
 
-class _WaitingBanner extends StatefulWidget {
+class _WaitingBanner extends HookWidget {
   const _WaitingBanner({required this.resumeAt, required this.error});
 
   final DateTime resumeAt;
   final DeviceProvisioningException error;
 
   @override
-  State<_WaitingBanner> createState() => _WaitingBannerState();
-}
-
-class _WaitingBannerState extends State<_WaitingBanner> {
-  Timer? _timer;
-  Duration _remaining = Duration.zero;
-
-  @override
-  void initState() {
-    super.initState();
-    final now = DateTime.now();
-    _remaining = widget.resumeAt.isAfter(now)
-        ? widget.resumeAt.difference(now)
-        : Duration.zero;
-    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (mounted) {
-        final now = DateTime.now();
-        setState(() {
-          _remaining = widget.resumeAt.isAfter(now)
-              ? widget.resumeAt.difference(now)
-              : Duration.zero;
-        });
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    Duration calcRemaining() {
+      final now = DateTime.now();
+      return resumeAt.isAfter(now) ? resumeAt.difference(now) : Duration.zero;
+    }
+
+    final remaining = useState(calcRemaining());
+
+    useEffect(() {
+      final timer = Timer.periodic(const Duration(seconds: 1), (_) {
+        remaining.value = calcRemaining();
+      });
+      return timer.cancel;
+    }, [resumeAt]);
+
     final colorScheme = Theme.of(context).colorScheme;
-    final seconds = _remaining.inSeconds;
+    final seconds = remaining.value.inSeconds;
     return _BannerTile(
       icon: Icons.schedule,
       backgroundColor: colorScheme.tertiaryContainer,

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -76,54 +76,33 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
 
 // ── プロビジョニング起動状態セクション ──────────────────────────────────────
 
-class _ProvisioningStartupSection extends ConsumerStatefulWidget {
+class _ProvisioningStartupSection extends HookConsumerWidget {
   const _ProvisioningStartupSection({required this.deviceIdAsync});
 
   final AsyncValue<String> deviceIdAsync;
 
   @override
-  ConsumerState<_ProvisioningStartupSection> createState() =>
-      _ProvisioningStartupSectionState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final retryState = useState<RetryControllerState>(const RetryIdle());
+    final waitRemaining = useState(Duration.zero);
 
-class _ProvisioningStartupSectionState
-    extends ConsumerState<_ProvisioningStartupSection> {
-  Timer? _timer;
-  RetryControllerState _retryState = const RetryIdle();
-  Duration _waitRemaining = Duration.zero;
-
-  @override
-  void initState() {
-    super.initState();
-    _tick();
-    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (mounted) {
-        _tick();
-      }
-    });
-  }
-
-  void _tick() {
-    final rs = ref.read(deviceProvisioningProvider.notifier).retryState;
-    setState(() {
-      _retryState = rs;
+    void tick() {
+      final rs = ref.read(deviceProvisioningProvider.notifier).retryState;
+      retryState.value = rs;
       if (rs is RetryWaiting) {
         final diff = rs.resumeAt.difference(DateTime.now());
-        _waitRemaining = diff.isNegative ? Duration.zero : diff;
+        waitRemaining.value = diff.isNegative ? Duration.zero : diff;
       } else {
-        _waitRemaining = Duration.zero;
+        waitRemaining.value = Duration.zero;
       }
-    });
-  }
+    }
 
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
+    useEffect(() {
+      tick();
+      final timer = Timer.periodic(const Duration(seconds: 1), (_) => tick());
+      return timer.cancel;
+    }, const []);
 
-  @override
-  Widget build(BuildContext context) {
     final provisionStatus = ref.watch(deviceProvisioningProvider);
     final provisionMutation =
         ref.watch(DeviceProvisioningNotifier.provisionMutation);
@@ -140,7 +119,7 @@ class _ProvisioningStartupSectionState
       _ => '取得中…',
     };
 
-    final retryChip = switch (_retryState) {
+    final retryChip = switch (retryState.value) {
       RetryIdle() => _StatusChip(
         label: 'アイドル',
         color: scheme.secondaryContainer,
@@ -153,7 +132,7 @@ class _ProvisioningStartupSectionState
         icon: Icons.sync,
       ),
       RetryWaiting(:final attempt) => _StatusChip(
-        label: '待機中 (試行 ${attempt + 1}, ${_waitRemaining.inSeconds}s後)',
+        label: '待機中 (試行 ${attempt + 1}, ${waitRemaining.value.inSeconds}s後)',
         color: scheme.secondaryContainer,
         textColor: scheme.onSecondaryContainer,
         icon: Icons.schedule,
@@ -168,7 +147,7 @@ class _ProvisioningStartupSectionState
 
     final needsProvision =
         provisionStatus.value == DeviceProvisioningStatus.required ||
-        _retryState is RetryExhausted;
+        retryState.value is RetryExhausted;
 
     return _SectionCard(
       title: '起動時プロビジョニング',
@@ -177,7 +156,7 @@ class _ProvisioningStartupSectionState
         children: [
           _KeyValueRow(
             label: 'Device ID',
-            value: widget.deviceIdAsync.value ?? '…',
+            value: deviceIdAsync.value ?? '…',
           ),
           _KeyValueRow(
             label: '保存済みフラグ',
@@ -201,10 +180,10 @@ class _ProvisioningStartupSectionState
               retryChip,
             ],
           ),
-          if (_retryState is RetryWaiting) ...[
+          if (retryState.value is RetryWaiting) ...[
             const SizedBox(height: 4),
             Text(
-              (_retryState as RetryWaiting).lastError.userMessage,
+              (retryState.value as RetryWaiting).lastError.userMessage,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: scheme.onSurfaceVariant,
               ),

--- a/app/lib/feature/earthquake_history/ui/components/region_picker_map_page.dart
+++ b/app/lib/feature/earthquake_history/ui/components/region_picker_map_page.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
 import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lat_lng/lat_lng.dart';
 import 'package:maplibre/maplibre.dart';
@@ -12,7 +13,7 @@ import 'package:maplibre/maplibre.dart';
 typedef RegionPickerResult = ({String code, String name});
 
 /// 地図をタップして都道府県・市区町村を選択するページ。
-class RegionPickerMapPage extends ConsumerStatefulWidget {
+class RegionPickerMapPage extends HookConsumerWidget {
   const RegionPickerMapPage({required this.selectedType, super.key});
 
   final String selectedType;
@@ -28,70 +29,57 @@ class RegionPickerMapPage extends ConsumerStatefulWidget {
   );
 
   @override
-  ConsumerState<RegionPickerMapPage> createState() => _RegionPickerMapPageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final resolvedCode = useState<String?>(null);
+    final resolvedName = useState<String?>(null);
+    final isResolving = useState(false);
 
-class _RegionPickerMapPageState extends ConsumerState<RegionPickerMapPage> {
-  String? _resolvedCode;
-  String? _resolvedName;
-  var _isResolving = false;
-
-  Future<void> _resolveLocation(double lat, double lon) async {
-    setState(() {
-      _isResolving = true;
-      _resolvedCode = null;
-      _resolvedName = null;
-    });
-    try {
-      final latLng = LatLng(lat, lon);
-      if (widget.selectedType == 'city') {
-        final city = await ref.read(
-          jmaMapAreaInformationCityInsideProvider(latLng).future,
-        );
-        if (city?.property != null) {
-          setState(() {
-            _resolvedCode = city!.property!.code;
-            _resolvedName = city.property!.name;
-          });
-        }
-      } else {
-        final city = await ref.read(
-          jmaMapAreaInformationCityInsideProvider(latLng).future,
-        );
-        if (city?.property != null) {
-          final cityCode = city!.property!.code;
-          final prefix =
-              cityCode.length >= 2 ? cityCode.substring(0, 2) : cityCode;
-          final jmaCodeTable = ref.read(jmaCodeTableProvider).value;
-          final prefecture = jmaCodeTable
-              ?.codeTables
-              .areaInformationPrefectureEarthquake
-              .firstWhereOrNull(
-                (p) => p.code.startsWith(prefix),
-              );
-          if (prefecture != null) {
-            setState(() {
-              _resolvedCode = prefecture.code;
-              _resolvedName = prefecture.name.ja;
-            });
+    Future<void> resolveLocation(double lat, double lon) async {
+      isResolving.value = true;
+      resolvedCode.value = null;
+      resolvedName.value = null;
+      try {
+        final latLng = LatLng(lat, lon);
+        if (selectedType == 'city') {
+          final city = await ref.read(
+            jmaMapAreaInformationCityInsideProvider(latLng).future,
+          );
+          if (city?.property != null) {
+            resolvedCode.value = city!.property!.code;
+            resolvedName.value = city.property!.name;
+          }
+        } else {
+          final city = await ref.read(
+            jmaMapAreaInformationCityInsideProvider(latLng).future,
+          );
+          if (city?.property != null) {
+            final cityCode = city!.property!.code;
+            final prefix =
+                cityCode.length >= 2 ? cityCode.substring(0, 2) : cityCode;
+            final jmaCodeTable = ref.read(jmaCodeTableProvider).value;
+            final prefecture = jmaCodeTable
+                ?.codeTables
+                .areaInformationPrefectureEarthquake
+                .firstWhereOrNull(
+                  (p) => p.code.startsWith(prefix),
+                );
+            if (prefecture != null) {
+              resolvedCode.value = prefecture.code;
+              resolvedName.value = prefecture.name.ja;
+            }
           }
         }
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _isResolving = false);
+      } finally {
+        isResolving.value = false;
       }
     }
-  }
 
-  @override
-  Widget build(BuildContext context) {
     final mapConfigAsync = ref.watch(mapConfigurationProvider);
     final styleString = mapConfigAsync.value?.styleString;
     final title =
-        widget.selectedType == 'prefecture' ? '都道府県を地図から選択' : '市区町村を地図から選択';
+        selectedType == 'prefecture' ? '都道府県を地図から選択' : '市区町村を地図から選択';
     final hint =
-        widget.selectedType == 'prefecture' ? '地図をタップして都道府県を選択' : '地図をタップして市区町村を選択';
+        selectedType == 'prefecture' ? '地図をタップして都道府県を選択' : '地図をタップして市区町村を選択';
 
     if (styleString == null) {
       return Scaffold(
@@ -104,11 +92,11 @@ class _RegionPickerMapPageState extends ConsumerState<RegionPickerMapPage> {
       appBar: AppBar(
         title: Text(title),
         actions: [
-          if (_resolvedCode != null)
+          if (resolvedCode.value != null)
             TextButton(
               onPressed: () => Navigator.of(context).pop((
-                code: _resolvedCode!,
-                name: _resolvedName!,
+                code: resolvedCode.value!,
+                name: resolvedName.value!,
               )),
               child: const Text('決定'),
             ),
@@ -119,14 +107,14 @@ class _RegionPickerMapPageState extends ConsumerState<RegionPickerMapPage> {
           MapLibreMap(
             options: MapOptions(initStyle: styleString),
             onEvent: (event) {
-              if (event is MapEventClick && !_isResolving) {
-                _resolveLocation(event.point.lat, event.point.lon).ignore();
+              if (event is MapEventClick && !isResolving.value) {
+                resolveLocation(event.point.lat, event.point.lon).ignore();
               }
             },
           ),
-          if (_isResolving)
+          if (isResolving.value)
             const Center(child: CircularProgressIndicator.adaptive()),
-          if (_resolvedCode == null && !_isResolving)
+          if (resolvedCode.value == null && !isResolving.value)
             Positioned(
               bottom: 32,
               left: 16,
@@ -142,7 +130,7 @@ class _RegionPickerMapPageState extends ConsumerState<RegionPickerMapPage> {
                 ),
               ),
             ),
-          if (_resolvedName != null && !_isResolving)
+          if (resolvedName.value != null && !isResolving.value)
             Positioned(
               bottom: 32,
               left: 16,
@@ -159,14 +147,14 @@ class _RegionPickerMapPageState extends ConsumerState<RegionPickerMapPage> {
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
-                          _resolvedName!,
+                          resolvedName.value!,
                           style: Theme.of(context).textTheme.titleMedium,
                         ),
                       ),
                       TextButton(
                         onPressed: () => Navigator.of(context).pop((
-                          code: _resolvedCode!,
-                          name: _resolvedName!,
+                          code: resolvedCode.value!,
+                          name: resolvedName.value!,
                         )),
                         child: const Text('決定'),
                       ),

--- a/app/lib/feature/home/ui/component/sheet/component/home_scope_unavailable_body.dart
+++ b/app/lib/feature/home/ui/component/sheet/component/home_scope_unavailable_body.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:geolocator/geolocator.dart';
 
 /// スコープに対する検索パラメータが取れない（未設定 / 未解決）ときに
@@ -95,39 +96,27 @@ class _UnavailableContainer extends StatelessWidget {
   }
 }
 
-class _CurrentLocationUnavailable extends StatefulWidget {
+class _CurrentLocationUnavailable extends HookWidget {
   const _CurrentLocationUnavailable({required this.onRetry});
 
   final VoidCallback onRetry;
 
   @override
-  State<_CurrentLocationUnavailable> createState() =>
-      _CurrentLocationUnavailableState();
-}
-
-class _CurrentLocationUnavailableState
-    extends State<_CurrentLocationUnavailable> {
-  LocationPermission? _permission;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_refreshPermission());
-  }
-
-  Future<void> _refreshPermission() async {
-    final p = await Geolocator.checkPermission();
-    if (mounted) {
-      setState(() => _permission = p);
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final permission = _permission;
+    final permission = useState<LocationPermission?>(null);
+
+    Future<void> refreshPermission() async {
+      final p = await Geolocator.checkPermission();
+      permission.value = p;
+    }
+
+    useEffect(() {
+      unawaited(Future.microtask(refreshPermission));
+      return null;
+    }, const []);
 
     // 権限取得中はスケルトンを避けて軽量プレースホルダ
-    if (permission == null) {
+    if (permission.value == null) {
       return const _UnavailableContainer(
         icon: Icons.location_searching_outlined,
         message: '現在地を取得しています…',
@@ -136,7 +125,7 @@ class _CurrentLocationUnavailableState
 
     // 権限がない / 永続拒否 / それでも取れない、それぞれに合わせて文言と
     // アクションを切り替える。
-    return switch (permission) {
+    return switch (permission.value!) {
       LocationPermission.denied => _UnavailableContainer(
         icon: Icons.location_off_outlined,
         message: '位置情報の利用が許可されていません。許可すると現在地周辺の地震を表示できます。',
@@ -144,8 +133,8 @@ class _CurrentLocationUnavailableState
           FilledButton.tonal(
             onPressed: () async {
               await Geolocator.requestPermission();
-              await _refreshPermission();
-              widget.onRetry();
+              await refreshPermission();
+              onRetry();
             },
             child: const Text('位置情報を許可する'),
           ),
@@ -158,8 +147,8 @@ class _CurrentLocationUnavailableState
           FilledButton.tonal(
             onPressed: () async {
               await Geolocator.openAppSettings();
-              await _refreshPermission();
-              widget.onRetry();
+              await refreshPermission();
+              onRetry();
             },
             child: const Text('設定を開く'),
           ),
@@ -172,8 +161,8 @@ class _CurrentLocationUnavailableState
         actions: [
           OutlinedButton.icon(
             onPressed: () {
-              widget.onRetry();
-              unawaited(_refreshPermission());
+              onRetry();
+              unawaited(Future.microtask(refreshPermission));
             },
             icon: const Icon(Icons.refresh),
             label: const Text('再試行'),

--- a/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
+++ b/app/lib/feature/knet_waveform/ui/knet_waveform_page.dart
@@ -2,6 +2,7 @@ import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_credentials_provider.dart';
 import 'package:eqmonitor/feature/knet_waveform/data/provider/knet_directory_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 
@@ -284,27 +285,19 @@ class _MonthPickerDialog extends ConsumerWidget {
 // Record picker dialog (searchable)
 // ---------------------------------------------------------------------------
 
-class _RecordPickerDialog extends ConsumerStatefulWidget {
+class _RecordPickerDialog extends HookConsumerWidget {
   const _RecordPickerDialog({required this.year, required this.month});
 
   final int year;
   final int month;
 
   @override
-  ConsumerState<_RecordPickerDialog> createState() =>
-      _RecordPickerDialogState();
-}
-
-class _RecordPickerDialogState extends ConsumerState<_RecordPickerDialog> {
-  final _formatter = DateFormat('MM/dd HH:mm:ss');
-  var _query = '';
-
-  @override
-  Widget build(BuildContext context) {
-    final recordsAsync =
-        ref.watch(knetRecordsProvider(widget.year, widget.month));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final query = useState('');
+    final formatter = useMemoized(() => DateFormat('MM/dd HH:mm:ss'));
+    final recordsAsync = ref.watch(knetRecordsProvider(year, month));
     return AlertDialog(
-      title: Text('${widget.year}年${widget.month}月 — 記録を選択'),
+      title: Text('$year年$month月 — 記録を選択'),
       contentPadding: const EdgeInsets.only(top: 8),
       content: SizedBox(
         width: double.maxFinite,
@@ -313,10 +306,10 @@ class _RecordPickerDialogState extends ConsumerState<_RecordPickerDialog> {
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (e, _) => Center(child: Text('エラー: $e')),
           data: (records) {
-            final filtered = _query.isEmpty
+            final filtered = query.value.isEmpty
                 ? records
                 : records.where((dt) {
-                    return _formatter.format(dt).contains(_query);
+                    return formatter.format(dt).contains(query.value);
                   }).toList();
             return Column(
               children: [
@@ -328,7 +321,7 @@ class _RecordPickerDialogState extends ConsumerState<_RecordPickerDialog> {
                       prefixIcon: Icon(Icons.search),
                       isDense: true,
                     ),
-                    onChanged: (v) => setState(() => _query = v),
+                    onChanged: (v) => query.value = v,
                   ),
                 ),
                 Expanded(
@@ -338,7 +331,7 @@ class _RecordPickerDialogState extends ConsumerState<_RecordPickerDialog> {
                       final dt = filtered[i];
                       return ListTile(
                         dense: true,
-                        title: Text(_formatter.format(dt)),
+                        title: Text(formatter.format(dt)),
                         onTap: () => Navigator.of(context).pop(dt),
                       );
                     },

--- a/app/lib/feature/knet_waveform/ui/record/knet_station_waveform_page.dart
+++ b/app/lib/feature/knet_waveform/ui/record/knet_station_waveform_page.dart
@@ -457,23 +457,17 @@ class _SpectrumView extends StatelessWidget {
   }
 }
 
-class _SpectrumChart extends StatefulWidget {
+class _SpectrumChart extends HookWidget {
   const _SpectrumChart({required this.spectrum});
 
   final ResponseSpectrumResult spectrum;
 
   @override
-  State<_SpectrumChart> createState() => _SpectrumChartState();
-}
-
-class _SpectrumChartState extends State<_SpectrumChart> {
-  var _selected = 0; // 0=Sa 1=Sv 2=Sd
-
-  @override
   Widget build(BuildContext context) {
+    final selected = useState(0); // 0=Sa 1=Sv 2=Sd
     final cs = Theme.of(context).colorScheme;
-    final sp = widget.spectrum;
-    final (vals, unit, label) = switch (_selected) {
+    final sp = spectrum;
+    final (vals, unit, label) = switch (selected.value) {
       1 => (sp.sv, 'cm/s', '速度応答スペクトル Sv (h=5%)'),
       2 => (sp.sd, 'cm', '変位応答スペクトル Sd (h=5%)'),
       _ => (sp.sa, 'gal', '加速度応答スペクトル Sa (h=5%)'),
@@ -502,8 +496,8 @@ class _SpectrumChartState extends State<_SpectrumChart> {
               ButtonSegment(value: 1, label: Text('Sv (cm/s)')),
               ButtonSegment(value: 2, label: Text('Sd (cm)')),
             ],
-            selected: {_selected},
-            onSelectionChanged: (s) => setState(() => _selected = s.first),
+            selected: {selected.value},
+            onSelectionChanged: (s) => selected.value = s.first,
             style: const ButtonStyle(visualDensity: VisualDensity.compact),
           ),
         ),

--- a/app/lib/feature/map/ui/maplibre_event_provider.dart
+++ b/app/lib/feature/map/ui/maplibre_event_provider.dart
@@ -1,10 +1,11 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:maplibre/maplibre.dart';
 
-/// MapLibreのイベントストリームをグローバルに提供するInheritedWidget
-class MapLibreEventProvider extends StatefulWidget {
+/// MapLibre の map イベントを子ウィジェットツリーに提供する InheritedWidget。
+///
+/// StatelessWidget + InheritedWidget パターン。
+/// StreamController は公開しない。emit のみを提供する。
+class MapLibreEventProvider extends StatelessWidget {
   const MapLibreEventProvider({
     required this.child,
     super.key,
@@ -12,54 +13,39 @@ class MapLibreEventProvider extends StatefulWidget {
 
   final Widget child;
 
-  static MapLibreEventProviderState of(BuildContext context) =>
+  static MapLibreEventController of(BuildContext context) =>
       maybeOf(context) ?? (throw Exception('MapLibreEventProvider not found'));
 
-  static MapLibreEventProviderState? maybeOf(BuildContext context) => context
+  static MapLibreEventController? maybeOf(BuildContext context) => context
       .dependOnInheritedWidgetOfExactType<_InheritedMapLibreEventProvider>()
-      ?.state;
-
-  @override
-  State<MapLibreEventProvider> createState() => MapLibreEventProviderState();
-}
-
-class MapLibreEventProviderState extends State<MapLibreEventProvider> {
-  final _eventStreamController = StreamController<MapEvent>.broadcast();
-
-  /// イベントストリームを取得
-  Stream<MapEvent> get eventStream => _eventStreamController.stream;
-
-  @override
-  void dispose() {
-    unawaited(_eventStreamController.close());
-    super.dispose();
-  }
-
-  void emit(MapEvent event) {
-    if (!_eventStreamController.isClosed) {
-      _eventStreamController.add(event);
-    }
-  }
+      ?.controller;
 
   @override
   Widget build(BuildContext context) {
     return _InheritedMapLibreEventProvider(
-      state: this,
-      child: widget.child,
+      controller: const MapLibreEventController(),
+      child: child,
     );
   }
 }
 
+/// MapLibre イベントを受け取るコントローラ。
+///
+/// emit は現在 no-op。将来的にイベントをリスナーへ転送する実装に拡張可能。
+class MapLibreEventController {
+  const MapLibreEventController();
+
+  void emit(MapEvent event) {}
+}
+
 class _InheritedMapLibreEventProvider extends InheritedWidget {
   const _InheritedMapLibreEventProvider({
-    required this.state,
+    required this.controller,
     required super.child,
   });
 
-  final MapLibreEventProviderState state;
+  final MapLibreEventController controller;
 
   @override
-  bool updateShouldNotify(_InheritedMapLibreEventProvider oldWidget) {
-    return oldWidget.state != state;
-  }
+  bool updateShouldNotify(_InheritedMapLibreEventProvider oldWidget) => false;
 }

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -18,6 +18,7 @@ import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class DebugPage extends ConsumerWidget {
@@ -368,20 +369,12 @@ class _AppCheckSection extends ConsumerWidget {
   }
 }
 
-class _ParameterDebugSection extends ConsumerStatefulWidget {
+class _ParameterDebugSection extends HookConsumerWidget {
   const _ParameterDebugSection();
 
   @override
-  ConsumerState<_ParameterDebugSection> createState() =>
-      _ParameterDebugSectionState();
-}
-
-class _ParameterDebugSectionState
-    extends ConsumerState<_ParameterDebugSection> {
-  var _isRefreshing = false;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isRefreshing = useState(false);
     final paramAsync = ref.watch(parameterSetProvider);
 
     return Column(
@@ -390,7 +383,7 @@ class _ParameterDebugSectionState
         ListTile(
           title: const Text('パラメータ'),
           leading: const Icon(Icons.data_object),
-          trailing: _isRefreshing
+          trailing: isRefreshing.value
               ? const SizedBox(
                   width: 24,
                   height: 24,
@@ -400,7 +393,7 @@ class _ParameterDebugSectionState
                   icon: const Icon(Icons.refresh),
                   tooltip: '強制再取得',
                   onPressed: () async {
-                    setState(() => _isRefreshing = true);
+                    isRefreshing.value = true;
                     final messenger = ScaffoldMessenger.of(context);
                     try {
                       final updated = await ref
@@ -418,9 +411,7 @@ class _ParameterDebugSectionState
                         SnackBar(content: Text('エラー: $e')),
                       );
                     } finally {
-                      if (mounted) {
-                        setState(() => _isRefreshing = false);
-                      }
+                      isRefreshing.value = false;
                     }
                   },
                 ),

--- a/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
+++ b/app/lib/feature/settings/children/config/earthquake_history/earthquake_history_config_page.dart
@@ -334,18 +334,11 @@ class _EarthquakeHistoryDetailConfigBody extends HookConsumerWidget {
   }
 }
 
-class _IconModeSegmentedControl extends ConsumerStatefulWidget {
+class _IconModeSegmentedControl extends ConsumerWidget {
   const _IconModeSegmentedControl();
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      __IconModeSegmentedControlState();
-}
-
-class __IconModeSegmentedControlState
-    extends ConsumerState<_IconModeSegmentedControl> {
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(
       earthquakeHistoryConfigProvider.select(
         (value) => value.requireValue.detail,
@@ -407,18 +400,11 @@ class __IconModeSegmentedControlState
   }
 }
 
-class _FillModeSegmentedControl extends ConsumerStatefulWidget {
+class _FillModeSegmentedControl extends ConsumerWidget {
   const _FillModeSegmentedControl();
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() =>
-      __FillModeSegmentedControlState();
-}
-
-class __FillModeSegmentedControlState
-    extends ConsumerState<_FillModeSegmentedControl> {
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(
       earthquakeHistoryConfigProvider.select(
         (value) => value.requireValue.detail,

--- a/app/lib/feature/start/ui/component/whats_new_banner.dart
+++ b/app/lib/feature/start/ui/component/whats_new_banner.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -32,7 +33,7 @@ class WhatsNewBanner extends ConsumerWidget {
   }
 }
 
-class _WhatsNewBannerContent extends StatefulWidget {
+class _WhatsNewBannerContent extends HookWidget {
   const _WhatsNewBannerContent({
     required this.latest,
     required this.bottomSpacing,
@@ -42,71 +43,61 @@ class _WhatsNewBannerContent extends StatefulWidget {
   final double bottomSpacing;
 
   @override
-  State<_WhatsNewBannerContent> createState() => _WhatsNewBannerContentState();
-}
-
-class _WhatsNewBannerContentState extends State<_WhatsNewBannerContent> {
-  var _dismissed = false;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_checkSeen());
-  }
-
-  Future<void> _checkSeen() async {
-    final prefs = await SharedPreferences.getInstance();
-    final seen = prefs.getString(_kSeenKey);
-    if (seen == widget.latest.version && mounted) {
-      setState(() => _dismissed = true);
-    }
-  }
-
-  Future<void> _markSeen() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_kSeenKey, widget.latest.version);
-    if (mounted) {
-      setState(() => _dismissed = true);
-    }
-  }
-
-  void _showDetail(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (ctx) => DraggableScrollableSheet(
-        expand: false,
-        initialChildSize: 0.6,
-        maxChildSize: 0.95,
-        minChildSize: 0.3,
-        builder: (_, controller) => _WhatsNewSheet(
-          latest: widget.latest,
-          whatsNew: widget.latest.whatsNew,
-          scrollController: controller,
-          onClose: () {
-            Navigator.of(ctx).pop();
-            unawaited(_markSeen());
-          },
-        ),
-      ),
-    ).ignore();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (_dismissed) {
+    final dismissed = useState(false);
+
+    useEffect(() {
+      unawaited(Future.microtask(() async {
+        final prefs = await SharedPreferences.getInstance();
+        final seen = prefs.getString(_kSeenKey);
+        if (seen == latest.version) {
+          dismissed.value = true;
+        }
+      }));
+      return null;
+    }, const []);
+
+    Future<void> markSeen() async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_kSeenKey, latest.version);
+      dismissed.value = true;
+    }
+
+    void showDetail(BuildContext context) {
+      showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        builder: (ctx) => DraggableScrollableSheet(
+          expand: false,
+          initialChildSize: 0.6,
+          maxChildSize: 0.95,
+          minChildSize: 0.3,
+          builder: (_, controller) => _WhatsNewSheet(
+            latest: latest,
+            whatsNew: latest.whatsNew,
+            scrollController: controller,
+            onClose: () {
+              Navigator.of(ctx).pop();
+              unawaited(markSeen());
+            },
+          ),
+        ),
+      ).ignore();
+    }
+
+    if (dismissed.value) {
       return const SizedBox.shrink();
     }
 
     final colorScheme = Theme.of(context).colorScheme;
     return Padding(
-      padding: EdgeInsets.only(bottom: widget.bottomSpacing),
+      padding: EdgeInsets.only(bottom: bottomSpacing),
       child: Material(
         color: colorScheme.primaryContainer,
         borderRadius: BorderRadius.circular(12),
         child: InkWell(
           borderRadius: BorderRadius.circular(12),
-          onTap: () => _showDetail(context),
+          onTap: () => showDetail(context),
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: Row(
@@ -119,7 +110,7 @@ class _WhatsNewBannerContentState extends State<_WhatsNewBannerContent> {
                 const SizedBox(width: 12),
                 Expanded(
                   child: Text(
-                    'v${widget.latest.version} にアップデートしました',
+                    'v${latest.version} にアップデートしました',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: colorScheme.onPrimaryContainer,
                     ),

--- a/packages/eqmonitor_lints/lib/main.dart
+++ b/packages/eqmonitor_lints/lib/main.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+
+import 'package:analysis_server_plugin/plugin.dart';
+import 'package:analysis_server_plugin/registry.dart';
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:eqmonitor_lints/src/rules/avoid_null_assertion_operator.dart';
+import 'package:eqmonitor_lints/src/rules/avoid_print_call.dart';
+import 'package:eqmonitor_lints/src/rules/avoid_stateful_widget.dart';
+import 'package:eqmonitor_lints/src/rules/avoid_top_level_functions.dart';
+
+final plugin = _EqmonitorLintsPlugin();
+
+class _EqmonitorLintsPlugin extends Plugin {
+  @override
+  String get name => 'eqmonitor_lints';
+
+  @override
+  Future<void> register(PluginRegistry registry) async {
+    <AnalysisRule>[
+      AvoidStatefulWidget(),
+      AvoidNullAssertionOperator(),
+      AvoidTopLevelFunctions(),
+      AvoidPrintCall(),
+    ].forEach(registry.registerLintRule);
+  }
+}

--- a/packages/eqmonitor_lints/lib/src/rules/avoid_null_assertion_operator.dart
+++ b/packages/eqmonitor_lints/lib/src/rules/avoid_null_assertion_operator.dart
@@ -1,0 +1,49 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+class AvoidNullAssertionOperator extends AnalysisRule {
+  AvoidNullAssertionOperator()
+    : super(
+        name: _code.name,
+        description: _code.problemMessage,
+      );
+
+  static const _code = LintCode(
+    'avoid_null_assertion_operator',
+    'null アサーション演算子 (!) の使用は禁止です。'
+        ' ? 演算子とフロー解析 (if (x != null)) で安全に扱ってください。',
+    correctionMessage:
+        '! を削除し、null チェックを使用してください。'
+        ' 例: if (x != null) { ... } または x?.method()',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => _code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addPostfixExpression(this, _Visitor(this));
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final AnalysisRule rule;
+
+  @override
+  void visitPostfixExpression(PostfixExpression node) {
+    if (node.operator.type == TokenType.BANG) {
+      rule.reportAtToken(node.operator);
+    }
+  }
+}

--- a/packages/eqmonitor_lints/lib/src/rules/avoid_print_call.dart
+++ b/packages/eqmonitor_lints/lib/src/rules/avoid_print_call.dart
@@ -1,0 +1,63 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/error/error.dart';
+
+class AvoidPrintCall extends AnalysisRule {
+  AvoidPrintCall()
+    : super(
+        name: _code.name,
+        description: _code.problemMessage,
+      );
+
+  static const _code = LintCode(
+    'avoid_print',
+    '{0} の使用は禁止です。talker または dart:developer の log() を使用してください。',
+    correctionMessage:
+        'talker.log() / talker.error() または'
+        ' dart:developer の log() に置き換えてください。',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => _code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final AnalysisRule rule;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.target != null) {
+      return;
+    }
+
+    final name = node.methodName.name;
+    final element = node.methodName.element;
+    if (element is! TopLevelFunctionElement) {
+      return;
+    }
+
+    final libraryUri = element.library.uri.toString();
+    final isPrint = name == 'print' && libraryUri == 'dart:core';
+    final isDebugPrint =
+        name == 'debugPrint' && libraryUri.contains('package:flutter/');
+
+    if (isPrint || isDebugPrint) {
+      rule.reportAtNode(node, arguments: [name]);
+    }
+  }
+}

--- a/packages/eqmonitor_lints/lib/src/rules/avoid_stateful_widget.dart
+++ b/packages/eqmonitor_lints/lib/src/rules/avoid_stateful_widget.dart
@@ -1,0 +1,55 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+class AvoidStatefulWidget extends AnalysisRule {
+  AvoidStatefulWidget()
+    : super(
+        name: _code.name,
+        description: _code.problemMessage,
+      );
+
+  static const _code = LintCode(
+    'avoid_stateful_widget',
+    'StatefulWidget と ConsumerStatefulWidget の利用は禁止です。'
+        ' HookWidget または HookConsumerWidget を使用してください。',
+    correctionMessage:
+        'HookWidget または HookConsumerWidget に変換し、'
+        ' useState / useEffect で状態管理してください。',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => _code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addClassDeclaration(this, _Visitor(this));
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final AnalysisRule rule;
+
+  static const _forbidden = {'StatefulWidget', 'ConsumerStatefulWidget'};
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    final extendsClause = node.extendsClause;
+    if (extendsClause == null) {
+      return;
+    }
+    final superName = extendsClause.superclass.name.lexeme;
+    if (_forbidden.contains(superName)) {
+      rule.reportAtNode(extendsClause);
+    }
+  }
+}

--- a/packages/eqmonitor_lints/lib/src/rules/avoid_top_level_functions.dart
+++ b/packages/eqmonitor_lints/lib/src/rules/avoid_top_level_functions.dart
@@ -1,0 +1,49 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+class AvoidTopLevelFunctions extends AnalysisRule {
+  AvoidTopLevelFunctions()
+    : super(
+        name: _code.name,
+        description: _code.problemMessage,
+      );
+
+  static const _code = LintCode(
+    'avoid_top_level_functions',
+    'トップレベル関数の定義は禁止です。'
+        ' プライベートなトップレベル関数 (_xxx) も禁止です。'
+        ' 処理を専用クラスに切り出し、Riverpod で DI してください。',
+    correctionMessage:
+        '専用クラスを作成し、そのメソッドとして実装してください。'
+        ' 例: @riverpod MyClass myClass(Ref ref) => MyClass();',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => _code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addFunctionDeclaration(this, _Visitor(this));
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final AnalysisRule rule;
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    if (node.parent is CompilationUnit) {
+      rule.reportAtToken(node.name);
+    }
+  }
+}

--- a/packages/eqmonitor_lints/pubspec.yaml
+++ b/packages/eqmonitor_lints/pubspec.yaml
@@ -8,6 +8,9 @@ resolution: workspace
 
 dependencies:
   altive_lints: ^2.1.0
+  analysis_server_plugin: ^0.3.4
+  analyzer: ^9.0.0
+  analyzer_plugin: ^0.13.11
   flutter:
     sdk: flutter
   yumemi_lints: ^4.1.1


### PR DESCRIPTION
## Summary

- `ConsumerStatefulWidget` / `StatefulWidget` を使用していた 11 ファイルを flutter-rules に従い `HookConsumerWidget` / `HookWidget` / `ConsumerWidget` に変換
- `maplibre_event_provider` の `StatefulWidget` + `StreamController` antipattern を廃止し、`StatelessWidget` + `InheritedWidget` パターンに刷新
- `eqmonitor_lints` パッケージに `analysis_server_plugin` ベースの Dart Analyzer Plugin を新規実装（4 つのカスタム lint ルール）

## 変更詳細

### StatefulWidget → HookWidget 移行

| ファイル | 変更前 | 変更後 |
|---------|--------|--------|
| `changelog_page.dart` | `ConsumerStatefulWidget` | `HookConsumerWidget` + `useEffect` |
| `debug_launcher.dart` | `ConsumerStatefulWidget` | `HookConsumerWidget` + `useEffect` / `useRef` |
| `whats_new_banner.dart` `_WhatsNewBannerContent` | `StatefulWidget` | `HookWidget` + `useState` / `useEffect` |
| `device_provisioning_banner.dart` `DeviceProvisioningBanner` | `ConsumerStatefulWidget` (state なし) | `ConsumerWidget` |
| `device_provisioning_banner.dart` `_WaitingBanner` | `StatefulWidget` (Timer) | `HookWidget` + `useState` / `useEffect` |
| `region_picker_map_page.dart` | `ConsumerStatefulWidget` | `HookConsumerWidget` + `useState` |
| `knet_waveform_page.dart` `_RecordPickerDialog` | `ConsumerStatefulWidget` | `HookConsumerWidget` + `useState` |
| `knet_station_waveform_page.dart` `_SpectrumChart` | `StatefulWidget` | `HookWidget` + `useState` |
| `debug_page.dart` `_ParameterDebugSection` | `ConsumerStatefulWidget` | `HookConsumerWidget` + `useState` |
| `earthquake_history_config_page.dart` `_IconMode/_FillMode` | `ConsumerStatefulWidget` (state なし) | `ConsumerWidget` |
| `home_scope_unavailable_body.dart` `_CurrentLocationUnavailable` | `StatefulWidget` | `HookWidget` + `useState` / `useEffect` |
| `debug_device_settings_page.dart` `_ProvisioningStartupSection` | `ConsumerStatefulWidget` (Timer) | `HookConsumerWidget` + `useState` / `useEffect` |

### maplibre_event_provider リファクタリング

- `StatefulWidget` → `StatelessWidget` + `InheritedWidget`
- 未使用だった `StreamController` / `eventStream` を削除
- `MapLibreEventController` クラスに `emit` のみを提供（呼び出し元 API 互換）

### eqmonitor_lints Analyzer Plugin

`analysis_server_plugin` パッケージを使用して実装（`altive_lints` と同じ API）。

| ルール | 検出対象 | Severity |
|-------|---------|---------|
| `avoid_stateful_widget` | `extends StatefulWidget` / `ConsumerStatefulWidget` | warning |
| `avoid_null_assertion_operator` | `expr!` (null assertion 演算子) | warning |
| `avoid_top_level_functions` | top-level 関数定義（private 含む） | warning |
| `avoid_print` | `print()` / `debugPrint()` 呼び出し | warning |

`app/analysis_options.yaml` の `plugins:` セクションで有効化済み。IDE の Dart Analysis Server 再起動で有効になります。

## Test plan

- [ ] `dart analyze app/lib/` がエラーなしで通過することを確認
- [ ] `dart analyze packages/eqmonitor_lints/lib/` がエラーなしで通過することを確認
- [ ] IDE で `StatefulWidget` を書くと `avoid_stateful_widget` 警告が表示されることを確認（Analysis Server 再起動後）
- [ ] `print()` を書くと `avoid_print` 警告が表示されることを確認
- [ ] ホーム画面・地震履歴・K-NET 波形など各画面が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)