### PR TITLE
chore: Flutter 3.44.0 へアップグレード & 依存パッケージのメジャーバージョンアップ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Managed by `mise.toml`:
 
 | Tool    | Version     |
 |---------|-------------|
-| Flutter | 3.41.4      |
+| Flutter | 3.44.0      |
 | Dart    | ^3.11.0     |
 | Java    | 17          |
 | Node    | LTS         |

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -6,7 +6,7 @@ version: 3.0.0
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 
@@ -56,7 +56,7 @@ dependencies:
   core:
     path: ../packages/core
   crypto: ^3.0.6
-  cue: ^0.2.1
+  cue: ^0.3.1
   dart_azarashi:
     path: ../packages/dart_azarashi
   device_info_plus: ^12.1.0

--- a/mise.lock
+++ b/mise.lock
@@ -89,6 +89,7 @@ url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/linux-arm64-musl/claude"
 
 [tools.claude."platforms.linux-x64"]
+checksum = "blake3:5615771a35e3fb5634db3f4d92650a5ad038f8957e1d30064e1c3dd0ed932305"
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-musl"]
@@ -125,7 +126,7 @@ checksum = "sha256:423c18774488ad5476cefef2a36b91014672ab81e4bead8d7d623f519ffac
 url = "https://github.com/firebase/firebase-tools/releases/download/v15.18.0/firebase-tools-win.exe"
 
 [[tools.flutter]]
-version = "3.41.9-stable"
+version = "3.44.0-stable"
 backend = "asdf:flutter"
 
 [[tools.gcloud]]

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ experimental_monorepo_root = true
 
 [tools]
 "aqua:suzuki-shunsuke/tfcmt" = "latest"
-flutter = "3.41.9-stable"
+flutter = "3.44.0-stable"
 java = "17"
 node = "lts"
 "pipx:codemagic-cli-tools" = "latest"

--- a/packages/_base/pubspec.yaml
+++ b/packages/_base/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/packages/background_location_tracker/pubspec.yaml
+++ b/packages/background_location_tracker/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/packages/earthquake_replay/pubspec.yaml
+++ b/packages/earthquake_replay/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/packages/eqmonitor_lints/lib/analysis_options.yaml
+++ b/packages/eqmonitor_lints/lib/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:yumemi_lints/flutter/3.41/recommended.yaml
+include: package:yumemi_lints/flutter/3.44/recommended.yaml
 
 formatter:
   trailing_commas: preserve

--- a/packages/eqmonitor_lints/pubspec.yaml
+++ b/packages/eqmonitor_lints/pubspec.yaml
@@ -2,7 +2,7 @@ name: eqmonitor_lints
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/packages/kyoshin_monitor_api/pubspec.yaml
+++ b/packages/kyoshin_monitor_api/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/packages/kyoshin_monitor_image_parser/pubspec.yaml
+++ b/packages/kyoshin_monitor_image_parser/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/packages/live_activity_util/pubspec.yaml
+++ b/packages/live_activity_util/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 
 resolution: workspace
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: cue
-      sha256: "4afd93d6a1d352d6509816cd0a45d71a06be3107b84c3f85259e73afde3cff2c"
+      sha256: c98b4a3fffcc1726113d0b4d94d70fa2f9c8061382bddb2e456726392053eb4c
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.3.1"
   dart_style:
     dependency: transitive
     description:
@@ -1163,10 +1163,10 @@ packages:
     dependency: transitive
     description:
       name: in_app_review
-      sha256: ab26ac54dbd802896af78c670b265eaeab7ecddd6af4d0751e9604b60574817f
+      sha256: "364db0c160b37fe7fad9cdaa18f968473924b17368869010af902760421b6bf8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.12"
   in_app_review_platform_interface:
     dependency: transitive
     description:
@@ -1385,10 +1385,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2023,10 +2023,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: f8a08a13fb8f0f8c590df89d745000bed44a673ed94bac846739e1a016875c21
+      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.7"
+    version: "2.5.8"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -2143,26 +2143,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   theme_tailor:
     dependency: transitive
     description:
@@ -2215,10 +2215,10 @@ packages:
     dependency: transitive
     description:
       name: upgrader
-      sha256: a9ab8cabe01c98c12b3c381a3bc8693413cb64a2a3ec7395ce0f53844ef30a2f
+      sha256: e05ddce3799a73b76470d8d239951038f5759f116e89fe0c909e30ac2856310b
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.0"
+    version: "13.3.0"
   url_launcher:
     dependency: transitive
     description:
@@ -2231,10 +2231,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.29"
+    version: "6.3.30"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -2311,10 +2311,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "98e7e94de127b46a86ef46197fff84ff99f3d3b80a708390d717ad731efef598"
+      sha256: b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   vector_math:
     dependency: transitive
     description:
@@ -2351,10 +2351,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: a39d6f28f8069564d8cc17396472f958dd9eaddf2d5c8e90aad4d793ac369bf3
+      sha256: "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.6"
+    version: "2.9.7"
   video_player_platform_interface:
     dependency: transitive
     description:
@@ -2525,4 +2525,4 @@ packages:
     version: "4.4.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0 <4.0.0"
+  flutter: ">=3.44.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: eqmonitor_workspace
 description: The workspace for the EQMonitor project.
 environment:
   sdk: ^3.11.0
-  flutter: ^3.41.0
+  flutter: ^3.44.0
 workspace:
   - app
   # ignore: path_does_not_exist
@@ -18,7 +18,7 @@ melos:
       runPubGetInParallel: false
       environment:
         sdk: ^3.11.0
-        flutter: ^3.41.0
+        flutter: ^3.44.0
   scripts:
     analyze:
       run: |


### PR DESCRIPTION
## Summary

- `mise.toml`: Flutter `3.41.9-stable` → `3.44.0-stable`
- 全 `pubspec.yaml`: Flutter SDK 制約 `^3.41.0` → `^3.44.0`
- `analysis_options.yaml`: `yumemi_lints/flutter/3.41` → `yumemi_lints/flutter/3.44`
- `dart pub upgrade --major-versions` による依存パッケージの更新（`cue` 0.2→0.3 等）

## Test plan

- [ ] CI の `dart analyze` が通ること
- [ ] CI の unit tests が通ること
- [ ] `flutter pub get` がエラーなく完了すること