### PR TITLE
feat(android): HCPP (Hybrid Composition Plus Plus) を有効化

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -72,6 +72,10 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-3081840463138357~7301133452" />
+
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableHCPP"
+            android:value="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
## Summary

- `AndroidManifest.xml` に `io.flutter.embedding.android.EnableHCPP` メタデータを追加し、Android の PlatformView で HCPP レンダリングモードを有効化

## 変更内容

MapLibre などの PlatformView に対して **Hybrid Composition Plus Plus (HCPP)** を有効にします。

HCPP は従来の Hybrid Composition の改善版で、以下のメリットがあります：
- Flutter フレームとネイティブビューの合成タイミングが改善され、チラつきが軽減
- スクロール・アニメーション時のパフォーマンス向上
- メモリコピーを削減し、より効率的なレンダリング

Flutter 3.27+ でサポートされており、現在使用中の Flutter 3.41.9 で利用可能です。

## 参照

- https://docs.flutter.dev/platform-integration/android/platform-views#hcpp

## Test plan

- [ ] Android 実機で地図ビュー（ホーム画面・地震履歴・EEW詳細）が正常に描画されることを確認
- [ ] 地図のスクロール・ズーム操作時にチラつきや描画崩れがないことを確認