### PR TITLE
fix(android): Flutter 3.44 Built-in Kotlin 移行 — KGP 宣言を削除

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -4,7 +4,6 @@ import java.io.FileInputStream
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 

--- a/app/android/settings.gradle.kts
+++ b/app/android/settings.gradle.kts
@@ -19,7 +19,6 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.13.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
     id("com.google.gms.google-services") version("4.3.15") apply false
 }
 


### PR DESCRIPTION
## 問題

Flutter 3.44 へのアップグレード後、Android ビルドが以下のエラーで失敗するようになった。

```
Execution failed for task ':google_api_availability_android:extractReleaseAnnotations'.
> Could not generate a decorated class for type AndroidLintWorkAction.
```

## 原因

Flutter 3.44 から `dev.flutter.flutter-gradle-plugin` が Kotlin Gradle Plugin (KGP) を自動管理する **Built-in Kotlin** が導入された。アプリ側で重複して KGP を宣言していると AGP の Lint クラスローダが競合してビルドが壊れる。

## 修正

- `app/android/app/build.gradle.kts`: `id("kotlin-android")` を削除
- `app/android/settings.gradle.kts`: `id("org.jetbrains.kotlin.android") version "2.2.21" apply false` を削除

Ref: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers

## Test plan

- [ ] CI の Deploy App (Android) が成功すること