### PR TITLE
fix(android): Kotlin バージョン宣言を復元 — プラグイン向け 2.2.21 を維持

### DIFF
--- a/app/android/settings.gradle.kts
+++ b/app/android/settings.gradle.kts
@@ -19,6 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.13.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
     id("com.google.gms.google-services") version("4.3.15") apply false
 }
 


### PR DESCRIPTION
## 問題

前の KGP 完全削除 (#1260) により Flutter 3.44 のビルトイン Kotlin (2.0.0) が使われるようになり、Kotlin 2.2.0 でコンパイルされたプラグイン (`app_settings 7.0.0` 等) がビルドエラーになった。

```
Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin.
The actual metadata version is 2.2.0, but the compiler version 2.0.0 can read versions up to 2.1.0.
```

## 修正

`settings.gradle.kts` に `org.jetbrains.kotlin.android version 2.2.21` を復元。

- `app/build.gradle.kts` の `id("kotlin-android")` は削除のまま維持（Flutter 3.44 Built-in Kotlin 移行）
- `settings.gradle.kts` の KGP バージョン宣言は復元（プラグイン向けに 2.2.x コンパイラを提供）

この組み合わせにより：
- アプリ自身は Flutter 3.44 のビルトイン Kotlin を使用
- 各プラグインは 2.2.21 コンパイラを使用でき、2.2.0 メタデータと互換性を持つ

## Test plan

- [ ] CI の Deploy App (Android AAB) が成功すること