### PR TITLE
feat(ai-chat): GenUI/A2UI ベースの AI チャットを試験導入 (デバッグメニュー専用)

### DIFF
--- a/app/lib/core/provider/telegram_url/provider/telegram_url_provider.g.dart
+++ b/app/lib/core/provider/telegram_url/provider/telegram_url_provider.g.dart
@@ -35,7 +35,7 @@ final class TelegramUrlProvider
   TelegramUrl create() => TelegramUrl();
 }
 
-String _$telegramUrlHash() => r'259150017f138297d0eb2334a4fd2dee3fab802a';
+String _$telegramUrlHash() => r'66332136514094a5ff7a5aee0f0e82e299971941';
 
 abstract class _$TelegramUrl extends $AsyncNotifier<TelegramUrlModel> {
   FutureOr<TelegramUrlModel> build();

--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_payload_stream.g.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_payload_stream.g.dart
@@ -44,4 +44,4 @@ final class EqmonitorWsPayloadStreamProvider
 }
 
 String _$eqmonitorWsPayloadStreamHash() =>
-    r'd711623abbc83ab007a21570ab66e995bddeb93b';
+    r'c07fd8248ba4802579008f116a5a963f9fe138e3';

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:eqmonitor/app.dart';
 import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/feature/ai_chat/ui/ai_chat_page.dart';
+import 'package:eqmonitor/feature/ai_chat/ui/ai_chat_settings_page.dart';
 import 'package:eqmonitor/feature/beta_testing/data/notifier/beta_testing_notifier.dart';
 import 'package:eqmonitor/feature/beta_testing/ui/page/beta_testing_warning_page.dart';
 import 'package:eqmonitor/feature/changelog/ui/page/changelog_page.dart';
@@ -328,6 +330,8 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
         TypedGoRoute<DebugAppGroupRoute>(path: 'app-group'),
         TypedGoRoute<DebugLiveActivityTestRoute>(path: 'live-activity-test'),
         TypedGoRoute<DebugIntensityIconRoute>(path: 'intensity-icon'),
+        TypedGoRoute<AiChatRoute>(path: 'ai-chat'),
+        TypedGoRoute<AiChatSettingsRoute>(path: 'ai-chat/settings'),
         TypedGoRoute<NiedRoute>(
           path: 'nied',
           routes: [
@@ -657,12 +661,37 @@ class DebugLiveActivityTestRoute extends GoRouteData
   }
 }
 
-class DebugIntensityIconRoute extends GoRouteData with $DebugIntensityIconRoute {
+class DebugIntensityIconRoute extends GoRouteData
+    with $DebugIntensityIconRoute {
   const DebugIntensityIconRoute();
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const IntensityIconDebugPage();
+  }
+}
+
+class AiChatRoute extends GoRouteData with $AiChatRoute {
+  const AiChatRoute({this.eventId, this.epicenterName});
+
+  final String? eventId;
+  final String? epicenterName;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return AiChatPage(
+      eventId: eventId,
+      epicenterName: epicenterName,
+    );
+  }
+}
+
+class AiChatSettingsRoute extends GoRouteData with $AiChatSettingsRoute {
+  const AiChatSettingsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const AiChatSettingsPage();
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -523,6 +523,11 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           path: 'intensity-icon',
           factory: $DebugIntensityIconRoute._fromState,
         ),
+        GoRouteData.$route(path: 'ai-chat', factory: $AiChatRoute._fromState),
+        GoRouteData.$route(
+          path: 'ai-chat/settings',
+          factory: $AiChatSettingsRoute._fromState,
+        ),
         GoRouteData.$route(
           path: 'nied',
           factory: $NiedRoute._fromState,
@@ -1304,6 +1309,59 @@ mixin $DebugIntensityIconRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/settings/debug/intensity-icon');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $AiChatRoute on GoRouteData {
+  static AiChatRoute _fromState(GoRouterState state) => AiChatRoute(
+    eventId: state.uri.queryParameters['event-id'],
+    epicenterName: state.uri.queryParameters['epicenter-name'],
+  );
+
+  AiChatRoute get _self => this as AiChatRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/settings/debug/ai-chat',
+    queryParams: {
+      if (_self.eventId != null) 'event-id': _self.eventId,
+      if (_self.epicenterName != null) 'epicenter-name': _self.epicenterName,
+    },
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $AiChatSettingsRoute on GoRouteData {
+  static AiChatSettingsRoute _fromState(GoRouterState state) =>
+      const AiChatSettingsRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/ai-chat/settings');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/ai_chat/data/ai_chat_session.dart
+++ b/app/lib/feature/ai_chat/data/ai_chat_session.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/ai_chat/data/llm/genkit_client.dart';
+import 'package:eqmonitor/feature/ai_chat/data/model/chat_turn.dart';
+import 'package:eqmonitor/feature/ai_chat/data/model/token_usage.dart';
+import 'package:flutter/foundation.dart';
+import 'package:genkit/genkit.dart' as gk;
+import 'package:genui/genui.dart';
+
+/// AI チャット 1 セッション分の状態をまとめて保持する。
+///
+/// GenUI の [Conversation] / [SurfaceController] / [A2uiTransportAdapter] を
+/// Genkit の `generateStream` と接続して、ユーザー入力 → LLM → A2UI 命令 → サーフェス描画
+/// の一連を駆動する。
+class AiChatSession with ChangeNotifier {
+  AiChatSession({
+    required this.client,
+    required Catalog catalog,
+    String? initialMessage,
+    String? extraSystemPrompt,
+  }) : _catalog = catalog {
+    _surfaceController = SurfaceController(catalogs: [_catalog]);
+    _promptBuilder = PromptBuilder.chat(
+      catalog: _catalog,
+      systemPromptFragments: [
+        ?extraSystemPrompt,
+        ..._defaultSystemPromptFragments,
+      ],
+    );
+    _adapter = A2uiTransportAdapter(onSend: _onSendToLlm);
+    _conversation = Conversation(
+      controller: _surfaceController,
+      transport: _adapter,
+    );
+    _eventSub = _conversation.events.listen(_handleConversationEvent);
+    _conversation.state.addListener(_handleStateChange);
+
+    if (initialMessage != null && initialMessage.isNotEmpty) {
+      // 自動送信は呼び出し側に任せる: 初期メッセージはターン履歴にだけ追加。
+      _turns.value = [..._turns.value, ChatTurn.user(initialMessage)];
+    }
+  }
+
+  final GenkitClient client;
+  final Catalog _catalog;
+
+  late final SurfaceController _surfaceController;
+  late final A2uiTransportAdapter _adapter;
+  late final Conversation _conversation;
+  late final PromptBuilder _promptBuilder;
+  StreamSubscription<ConversationEvent>? _eventSub;
+
+  final List<gk.Message> _llmHistory = [];
+
+  final ValueNotifier<List<ChatTurn>> _turns = ValueNotifier(const []);
+  final ValueNotifier<TokenUsage> _usage = ValueNotifier(const TokenUsage());
+  final ValueNotifier<bool> _isWaiting = ValueNotifier(false);
+  final ValueNotifier<String?> _lastError = ValueNotifier(null);
+
+  ValueListenable<List<ChatTurn>> get turns => _turns;
+  ValueListenable<TokenUsage> get usage => _usage;
+  ValueListenable<bool> get isWaiting => _isWaiting;
+  ValueListenable<String?> get lastError => _lastError;
+
+  SurfaceController get surfaceController => _surfaceController;
+
+  /// テキストを送信する。
+  Future<void> sendText(String text) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+    _turns.value = [..._turns.value, ChatTurn.user(trimmed)];
+    _lastError.value = null;
+    await _conversation.sendRequest(ChatMessage.user(trimmed));
+  }
+
+  Future<void> _onSendToLlm(ChatMessage userMessage) async {
+    // GenUI ChatMessage から最新ユーザ発話のテキストを抽出。
+    final text = _extractText(userMessage);
+    if (text.isEmpty) {
+      return;
+    }
+    _llmHistory.add(
+      gk.Message(
+        role: gk.Role.user,
+        content: [gk.TextPart(text: text)],
+      ),
+    );
+
+    final systemPrompt = _promptBuilder.systemPromptJoined();
+    final messages = <gk.Message>[
+      gk.Message(
+        role: gk.Role.system,
+        content: [gk.TextPart(text: systemPrompt)],
+      ),
+      ..._llmHistory,
+    ];
+
+    try {
+      final stream = client.genkit.generateStream<Object?, void>(
+        model: client.model,
+        messages: messages,
+        toolNames: client.toolNames,
+        maxTurns: 8,
+      );
+
+      await for (final chunk in stream) {
+        final chunkText = chunk.text;
+        if (chunkText.isNotEmpty) {
+          _adapter.addChunk(chunkText);
+        }
+      }
+      await _adapter.flush();
+      final response = await stream.onResult;
+      final assistantText = response.text;
+      if (assistantText.isNotEmpty) {
+        _llmHistory.add(
+          gk.Message(
+            role: gk.Role.model,
+            content: [gk.TextPart(text: assistantText)],
+          ),
+        );
+        // A2UI コマンドだけだったケース以外はテキストもチャット欄に残す。
+        if (!_looksLikeOnlyA2ui(assistantText)) {
+          _turns.value = [
+            ..._turns.value,
+            ChatTurn.assistantText(_stripA2uiBlocks(assistantText)),
+          ];
+        }
+      }
+      _updateUsage(response.usage);
+    } on Exception catch (e) {
+      _lastError.value = e.toString();
+      _turns.value = [..._turns.value, ChatTurn.error(e.toString())];
+      rethrow;
+    }
+  }
+
+  void _handleConversationEvent(ConversationEvent event) {
+    switch (event) {
+      case ConversationSurfaceAdded(:final surfaceId):
+        _turns.value = [
+          ..._turns.value,
+          ChatTurn.assistantSurface(surfaceId),
+        ];
+      case ConversationError(:final error):
+        _lastError.value = error.toString();
+        _turns.value = [
+          ..._turns.value,
+          ChatTurn.error(error.toString()),
+        ];
+      case ConversationContentReceived():
+      case ConversationWaiting():
+      case ConversationComponentsUpdated():
+      case ConversationSurfaceRemoved():
+        // 必要に応じて UI 更新ロジックを追加する余地。
+        break;
+    }
+  }
+
+  void _handleStateChange() {
+    _isWaiting.value = _conversation.state.value.isWaiting;
+  }
+
+  void _updateUsage(gk.GenerationUsage? usage) {
+    if (usage == null) {
+      return;
+    }
+    _usage.value = _usage.value.add(
+      input: usage.inputTokens?.toInt(),
+      output: usage.outputTokens?.toInt(),
+      total: usage.totalTokens?.toInt(),
+    );
+  }
+
+  String _extractText(ChatMessage msg) =>
+      msg.parts.whereType<TextPart>().map((p) => p.text).join();
+
+  /// 応答テキストが A2UI JSON ブロックのみで構成されているか。
+  bool _looksLikeOnlyA2ui(String text) {
+    final stripped = _stripA2uiBlocks(text).trim();
+    return stripped.isEmpty;
+  }
+
+  String _stripA2uiBlocks(String text) {
+    // ```json ... ``` のフェンスを除去（PromptBuilder は a2ui を fenced JSON で出させる）
+    return text.replaceAll(
+      RegExp(r'```(?:json|a2ui)?\s*\{[\s\S]*?\}\s*```', multiLine: true),
+      '',
+    );
+  }
+
+  @override
+  void dispose() {
+    unawaited(_eventSub?.cancel());
+    _conversation.state.removeListener(_handleStateChange);
+    _conversation.dispose();
+    _adapter.dispose();
+    _turns.dispose();
+    _usage.dispose();
+    _isWaiting.dispose();
+    _lastError.dispose();
+    super.dispose();
+  }
+
+  static const _defaultSystemPromptFragments = <String>[
+    'あなたは日本の地震モニタリングアプリ EQMonitor のアシスタントです。',
+    'ユーザの自然言語の問い合わせに応じて、提供されたツール (search_earthquakes / get_earthquake_detail / search_by_epicenter) を用いて地震情報を取得し、結果は A2UI の createSurface + updateComponents を用いて、Card / Column / Text 等で読みやすく整形して提示してください。',
+    '地震の詳細を提示するとき、hypocenter.code がある場合は「同じ震央の過去地震を見る」誘導文を Text として添えてください。',
+    'ツールの結果に originTime が含まれる場合は、JST にフォーマットして読みやすく表示してください。',
+    'マグニチュード・震度・震源名 (hypocenter.name) は強調されるように表示してください。',
+  ];
+}

--- a/app/lib/feature/ai_chat/data/llm/genkit_client.dart
+++ b/app/lib/feature/ai_chat/data/llm/genkit_client.dart
@@ -1,0 +1,171 @@
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_credentials.dart';
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_provider.dart';
+import 'package:eqmonitor/feature/ai_chat/data/tool/eq_tool_runner.dart';
+import 'package:genkit/genkit.dart';
+import 'package:genkit/plugin.dart' show GenkitPlugin;
+import 'package:genkit_anthropic/genkit_anthropic.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+import 'package:genkit_openai/genkit_openai.dart';
+import 'package:schemantic/schemantic.dart';
+
+/// 1 つのプロバイダー + モデル + ツール定義をまとめた Genkit 実体。
+class GenkitClient {
+  GenkitClient({
+    required this.genkit,
+    required this.model,
+    required this.toolNames,
+  });
+
+  final Genkit genkit;
+  final ModelRef<Object?> model;
+  final List<String> toolNames;
+}
+
+/// 認証情報からプロバイダーごとの Genkit インスタンスを構築する。
+GenkitClient createGenkitClient({
+  required AiCredentials credentials,
+  required EqToolRunner toolRunner,
+}) {
+  final genkit = Genkit(
+    plugins: [_buildPlugin(credentials)],
+  );
+  _registerEqTools(genkit, toolRunner);
+  return GenkitClient(
+    genkit: genkit,
+    model: _resolveModel(credentials),
+    toolNames: _eqToolNames,
+  );
+}
+
+GenkitPlugin _buildPlugin(AiCredentials credentials) {
+  return switch (credentials.provider) {
+    AiProvider.anthropic => anthropic(apiKey: credentials.apiKey),
+    AiProvider.gemini => googleAI(apiKey: credentials.apiKey),
+    AiProvider.openai => openAI(apiKey: credentials.apiKey),
+  };
+}
+
+ModelRef<Object?> _resolveModel(AiCredentials credentials) {
+  return switch (credentials.provider) {
+    AiProvider.anthropic => anthropic.model(credentials.model),
+    AiProvider.gemini => googleAI.gemini(credentials.model),
+    AiProvider.openai => openAI.model(credentials.model),
+  };
+}
+
+const _eqToolNames = <String>[
+  'search_earthquakes',
+  'get_earthquake_detail',
+  'search_by_epicenter',
+];
+
+void _registerEqTools(Genkit ai, EqToolRunner runner) {
+  ai.defineTool<Map<String, Object?>, Map<String, Object?>>(
+    name: 'search_earthquakes',
+    description:
+        '気象庁が発表した日本の地震情報を絞り込み検索する。'
+        'マグニチュード、震度、深さなどの条件で過去の地震を見つけたいときに使う。'
+        'パラメータはすべて任意。返却は新しい順、最大30件。',
+    inputSchema: _searchEarthquakesSchema,
+    fn: (input, _) => runner.searchEarthquakes(
+      magnitudeGte: (input['magnitudeGte'] as num?)?.toDouble(),
+      magnitudeLte: (input['magnitudeLte'] as num?)?.toDouble(),
+      intensityGte: input['intensityGte'] as String?,
+      intensityLte: input['intensityLte'] as String?,
+      depthGte: (input['depthGte'] as num?)?.toInt(),
+      depthLte: (input['depthLte'] as num?)?.toInt(),
+      limit: (input['limit'] as num?)?.toInt(),
+    ),
+  );
+
+  ai.defineTool<Map<String, Object?>, Map<String, Object?>>(
+    name: 'get_earthquake_detail',
+    description: '特定の地震イベントID (eventId) の詳細情報を取得する。',
+    inputSchema: _getEarthquakeDetailSchema,
+    fn: (input, _) =>
+        runner.getEarthquakeDetail(eventId: input['eventId']! as String),
+  );
+
+  ai.defineTool<Map<String, Object?>, Map<String, Object?>>(
+    name: 'search_by_epicenter',
+    description:
+        '同じ震央 (epicenterCode) で過去に発生した地震を一覧する。ある地震の詳細から取得した hypocenter.code を整数化して渡すこと。',
+    inputSchema: _searchByEpicenterSchema,
+    fn: (input, _) => runner.searchByEpicenter(
+      epicenterCode: (input['epicenterCode']! as num).toInt(),
+      limit: (input['limit'] as num?)?.toInt(),
+    ),
+  );
+}
+
+SchemanticType<Map<String, Object?>> get _searchEarthquakesSchema =>
+    SchemanticType.from<Map<String, Object?>>(
+      jsonSchema: const {
+        'type': 'object',
+        'properties': {
+          'magnitudeGte': {
+            'type': 'number',
+            'description': 'マグニチュードの下限 (0〜10程度)。',
+          },
+          'magnitudeLte': {
+            'type': 'number',
+            'description': 'マグニチュードの上限。',
+          },
+          'intensityGte': {
+            'type': 'string',
+            'description': '最大震度の下限。例: "5-", "5+", "6-", "6+", "7"。',
+          },
+          'intensityLte': {
+            'type': 'string',
+            'description': '最大震度の上限。',
+          },
+          'depthGte': {
+            'type': 'integer',
+            'description': '震源の深さの下限 (km)。',
+          },
+          'depthLte': {
+            'type': 'integer',
+            'description': '震源の深さの上限 (km)。',
+          },
+          'limit': {
+            'type': 'integer',
+            'description': '取得件数。デフォルト 10、最大 30。',
+          },
+        },
+      },
+      parse: (json) => Map<String, Object?>.from(json as Map),
+    );
+
+SchemanticType<Map<String, Object?>> get _getEarthquakeDetailSchema =>
+    SchemanticType.from<Map<String, Object?>>(
+      jsonSchema: const {
+        'type': 'object',
+        'properties': {
+          'eventId': {
+            'type': 'string',
+            'description': '地震イベントID。',
+          },
+        },
+        'required': ['eventId'],
+      },
+      parse: (json) => Map<String, Object?>.from(json as Map),
+    );
+
+SchemanticType<Map<String, Object?>> get _searchByEpicenterSchema =>
+    SchemanticType.from<Map<String, Object?>>(
+      jsonSchema: const {
+        'type': 'object',
+        'properties': {
+          'epicenterCode': {
+            'type': 'integer',
+            'description': '震央地コード。hypocenter.code を整数化したもの。',
+          },
+          'limit': {
+            'type': 'integer',
+            'description': '取得件数。デフォルト 10、最大 30。',
+          },
+        },
+        'required': ['epicenterCode'],
+      },
+      parse: (json) => Map<String, Object?>.from(json as Map),
+    );

--- a/app/lib/feature/ai_chat/data/model/ai_credentials.dart
+++ b/app/lib/feature/ai_chat/data/model/ai_credentials.dart
@@ -1,0 +1,41 @@
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_provider.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'ai_credentials.freezed.dart';
+part 'ai_credentials.g.dart';
+
+@freezed
+abstract class AiCredentials with _$AiCredentials {
+  const factory AiCredentials({
+    required AiProvider provider,
+    required String model,
+    required String apiKey,
+  }) = _AiCredentials;
+
+  factory AiCredentials.fromJson(Map<String, dynamic> json) =>
+      _$AiCredentialsFromJson(json);
+}
+
+@freezed
+abstract class AiCredentialsStore with _$AiCredentialsStore {
+  const factory AiCredentialsStore({
+    required AiProvider selectedProvider,
+    @Default({}) Map<AiProvider, AiCredentials> credentials,
+  }) = _AiCredentialsStore;
+
+  const AiCredentialsStore._();
+
+  factory AiCredentialsStore.fromJson(Map<String, dynamic> json) =>
+      _$AiCredentialsStoreFromJson(json);
+
+  factory AiCredentialsStore.initial() => const AiCredentialsStore(
+    selectedProvider: AiProvider.anthropic,
+  );
+
+  /// 現在選択されているプロバイダーの認証情報。
+  AiCredentials? get selected => credentials[selectedProvider];
+
+  /// 選択中のプロバイダーが API キーを保持しているか。
+  bool get hasUsableCredentials =>
+      selected != null && selected!.apiKey.trim().isNotEmpty;
+}

--- a/app/lib/feature/ai_chat/data/model/ai_credentials.freezed.dart
+++ b/app/lib/feature/ai_chat/data/model/ai_credentials.freezed.dart
@@ -1,0 +1,555 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'ai_credentials.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$AiCredentials {
+
+ AiProvider get provider; String get model; String get apiKey;
+/// Create a copy of AiCredentials
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AiCredentialsCopyWith<AiCredentials> get copyWith => _$AiCredentialsCopyWithImpl<AiCredentials>(this as AiCredentials, _$identity);
+
+  /// Serializes this AiCredentials to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AiCredentials&&(identical(other.provider, provider) || other.provider == provider)&&(identical(other.model, model) || other.model == model)&&(identical(other.apiKey, apiKey) || other.apiKey == apiKey));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,provider,model,apiKey);
+
+@override
+String toString() {
+  return 'AiCredentials(provider: $provider, model: $model, apiKey: $apiKey)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AiCredentialsCopyWith<$Res>  {
+  factory $AiCredentialsCopyWith(AiCredentials value, $Res Function(AiCredentials) _then) = _$AiCredentialsCopyWithImpl;
+@useResult
+$Res call({
+ AiProvider provider, String model, String apiKey
+});
+
+
+
+
+}
+/// @nodoc
+class _$AiCredentialsCopyWithImpl<$Res>
+    implements $AiCredentialsCopyWith<$Res> {
+  _$AiCredentialsCopyWithImpl(this._self, this._then);
+
+  final AiCredentials _self;
+  final $Res Function(AiCredentials) _then;
+
+/// Create a copy of AiCredentials
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? provider = null,Object? model = null,Object? apiKey = null,}) {
+  return _then(_self.copyWith(
+provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
+as AiProvider,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String,apiKey: null == apiKey ? _self.apiKey : apiKey // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AiCredentials].
+extension AiCredentialsPatterns on AiCredentials {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AiCredentials value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AiCredentials() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AiCredentials value)  $default,){
+final _that = this;
+switch (_that) {
+case _AiCredentials():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AiCredentials value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AiCredentials() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AiProvider provider,  String model,  String apiKey)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AiCredentials() when $default != null:
+return $default(_that.provider,_that.model,_that.apiKey);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AiProvider provider,  String model,  String apiKey)  $default,) {final _that = this;
+switch (_that) {
+case _AiCredentials():
+return $default(_that.provider,_that.model,_that.apiKey);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AiProvider provider,  String model,  String apiKey)?  $default,) {final _that = this;
+switch (_that) {
+case _AiCredentials() when $default != null:
+return $default(_that.provider,_that.model,_that.apiKey);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _AiCredentials implements AiCredentials {
+  const _AiCredentials({required this.provider, required this.model, required this.apiKey});
+  factory _AiCredentials.fromJson(Map<String, dynamic> json) => _$AiCredentialsFromJson(json);
+
+@override final  AiProvider provider;
+@override final  String model;
+@override final  String apiKey;
+
+/// Create a copy of AiCredentials
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AiCredentialsCopyWith<_AiCredentials> get copyWith => __$AiCredentialsCopyWithImpl<_AiCredentials>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AiCredentialsToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AiCredentials&&(identical(other.provider, provider) || other.provider == provider)&&(identical(other.model, model) || other.model == model)&&(identical(other.apiKey, apiKey) || other.apiKey == apiKey));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,provider,model,apiKey);
+
+@override
+String toString() {
+  return 'AiCredentials(provider: $provider, model: $model, apiKey: $apiKey)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AiCredentialsCopyWith<$Res> implements $AiCredentialsCopyWith<$Res> {
+  factory _$AiCredentialsCopyWith(_AiCredentials value, $Res Function(_AiCredentials) _then) = __$AiCredentialsCopyWithImpl;
+@override @useResult
+$Res call({
+ AiProvider provider, String model, String apiKey
+});
+
+
+
+
+}
+/// @nodoc
+class __$AiCredentialsCopyWithImpl<$Res>
+    implements _$AiCredentialsCopyWith<$Res> {
+  __$AiCredentialsCopyWithImpl(this._self, this._then);
+
+  final _AiCredentials _self;
+  final $Res Function(_AiCredentials) _then;
+
+/// Create a copy of AiCredentials
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? provider = null,Object? model = null,Object? apiKey = null,}) {
+  return _then(_AiCredentials(
+provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
+as AiProvider,model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String,apiKey: null == apiKey ? _self.apiKey : apiKey // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$AiCredentialsStore {
+
+ AiProvider get selectedProvider; Map<AiProvider, AiCredentials> get credentials;
+/// Create a copy of AiCredentialsStore
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AiCredentialsStoreCopyWith<AiCredentialsStore> get copyWith => _$AiCredentialsStoreCopyWithImpl<AiCredentialsStore>(this as AiCredentialsStore, _$identity);
+
+  /// Serializes this AiCredentialsStore to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AiCredentialsStore&&(identical(other.selectedProvider, selectedProvider) || other.selectedProvider == selectedProvider)&&const DeepCollectionEquality().equals(other.credentials, credentials));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,selectedProvider,const DeepCollectionEquality().hash(credentials));
+
+@override
+String toString() {
+  return 'AiCredentialsStore(selectedProvider: $selectedProvider, credentials: $credentials)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AiCredentialsStoreCopyWith<$Res>  {
+  factory $AiCredentialsStoreCopyWith(AiCredentialsStore value, $Res Function(AiCredentialsStore) _then) = _$AiCredentialsStoreCopyWithImpl;
+@useResult
+$Res call({
+ AiProvider selectedProvider, Map<AiProvider, AiCredentials> credentials
+});
+
+
+
+
+}
+/// @nodoc
+class _$AiCredentialsStoreCopyWithImpl<$Res>
+    implements $AiCredentialsStoreCopyWith<$Res> {
+  _$AiCredentialsStoreCopyWithImpl(this._self, this._then);
+
+  final AiCredentialsStore _self;
+  final $Res Function(AiCredentialsStore) _then;
+
+/// Create a copy of AiCredentialsStore
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? selectedProvider = null,Object? credentials = null,}) {
+  return _then(_self.copyWith(
+selectedProvider: null == selectedProvider ? _self.selectedProvider : selectedProvider // ignore: cast_nullable_to_non_nullable
+as AiProvider,credentials: null == credentials ? _self.credentials : credentials // ignore: cast_nullable_to_non_nullable
+as Map<AiProvider, AiCredentials>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AiCredentialsStore].
+extension AiCredentialsStorePatterns on AiCredentialsStore {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AiCredentialsStore value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AiCredentialsStore() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AiCredentialsStore value)  $default,){
+final _that = this;
+switch (_that) {
+case _AiCredentialsStore():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AiCredentialsStore value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AiCredentialsStore() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( AiProvider selectedProvider,  Map<AiProvider, AiCredentials> credentials)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AiCredentialsStore() when $default != null:
+return $default(_that.selectedProvider,_that.credentials);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( AiProvider selectedProvider,  Map<AiProvider, AiCredentials> credentials)  $default,) {final _that = this;
+switch (_that) {
+case _AiCredentialsStore():
+return $default(_that.selectedProvider,_that.credentials);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( AiProvider selectedProvider,  Map<AiProvider, AiCredentials> credentials)?  $default,) {final _that = this;
+switch (_that) {
+case _AiCredentialsStore() when $default != null:
+return $default(_that.selectedProvider,_that.credentials);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _AiCredentialsStore extends AiCredentialsStore {
+  const _AiCredentialsStore({required this.selectedProvider, final  Map<AiProvider, AiCredentials> credentials = const {}}): _credentials = credentials,super._();
+  factory _AiCredentialsStore.fromJson(Map<String, dynamic> json) => _$AiCredentialsStoreFromJson(json);
+
+@override final  AiProvider selectedProvider;
+ final  Map<AiProvider, AiCredentials> _credentials;
+@override@JsonKey() Map<AiProvider, AiCredentials> get credentials {
+  if (_credentials is EqualUnmodifiableMapView) return _credentials;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_credentials);
+}
+
+
+/// Create a copy of AiCredentialsStore
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AiCredentialsStoreCopyWith<_AiCredentialsStore> get copyWith => __$AiCredentialsStoreCopyWithImpl<_AiCredentialsStore>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AiCredentialsStoreToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AiCredentialsStore&&(identical(other.selectedProvider, selectedProvider) || other.selectedProvider == selectedProvider)&&const DeepCollectionEquality().equals(other._credentials, _credentials));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,selectedProvider,const DeepCollectionEquality().hash(_credentials));
+
+@override
+String toString() {
+  return 'AiCredentialsStore(selectedProvider: $selectedProvider, credentials: $credentials)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AiCredentialsStoreCopyWith<$Res> implements $AiCredentialsStoreCopyWith<$Res> {
+  factory _$AiCredentialsStoreCopyWith(_AiCredentialsStore value, $Res Function(_AiCredentialsStore) _then) = __$AiCredentialsStoreCopyWithImpl;
+@override @useResult
+$Res call({
+ AiProvider selectedProvider, Map<AiProvider, AiCredentials> credentials
+});
+
+
+
+
+}
+/// @nodoc
+class __$AiCredentialsStoreCopyWithImpl<$Res>
+    implements _$AiCredentialsStoreCopyWith<$Res> {
+  __$AiCredentialsStoreCopyWithImpl(this._self, this._then);
+
+  final _AiCredentialsStore _self;
+  final $Res Function(_AiCredentialsStore) _then;
+
+/// Create a copy of AiCredentialsStore
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? selectedProvider = null,Object? credentials = null,}) {
+  return _then(_AiCredentialsStore(
+selectedProvider: null == selectedProvider ? _self.selectedProvider : selectedProvider // ignore: cast_nullable_to_non_nullable
+as AiProvider,credentials: null == credentials ? _self._credentials : credentials // ignore: cast_nullable_to_non_nullable
+as Map<AiProvider, AiCredentials>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/ai_chat/data/model/ai_credentials.g.dart
+++ b/app/lib/feature/ai_chat/data/model/ai_credentials.g.dart
@@ -1,0 +1,70 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'ai_credentials.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_AiCredentials _$AiCredentialsFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('_AiCredentials', json, ($checkedConvert) {
+      final val = _AiCredentials(
+        provider: $checkedConvert(
+          'provider',
+          (v) => $enumDecode(_$AiProviderEnumMap, v),
+        ),
+        model: $checkedConvert('model', (v) => v as String),
+        apiKey: $checkedConvert('api_key', (v) => v as String),
+      );
+      return val;
+    }, fieldKeyMap: const {'apiKey': 'api_key'});
+
+Map<String, dynamic> _$AiCredentialsToJson(_AiCredentials instance) =>
+    <String, dynamic>{
+      'provider': _$AiProviderEnumMap[instance.provider]!,
+      'model': instance.model,
+      'api_key': instance.apiKey,
+    };
+
+const _$AiProviderEnumMap = {
+  AiProvider.anthropic: 'anthropic',
+  AiProvider.gemini: 'gemini',
+  AiProvider.openai: 'openai',
+};
+
+_AiCredentialsStore _$AiCredentialsStoreFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      '_AiCredentialsStore',
+      json,
+      ($checkedConvert) {
+        final val = _AiCredentialsStore(
+          selectedProvider: $checkedConvert(
+            'selected_provider',
+            (v) => $enumDecode(_$AiProviderEnumMap, v),
+          ),
+          credentials: $checkedConvert(
+            'credentials',
+            (v) =>
+                (v as Map<String, dynamic>?)?.map(
+                  (k, e) => MapEntry(
+                    $enumDecode(_$AiProviderEnumMap, k),
+                    AiCredentials.fromJson(e as Map<String, dynamic>),
+                  ),
+                ) ??
+                const {},
+          ),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'selectedProvider': 'selected_provider'},
+    );
+
+Map<String, dynamic> _$AiCredentialsStoreToJson(_AiCredentialsStore instance) =>
+    <String, dynamic>{
+      'selected_provider': _$AiProviderEnumMap[instance.selectedProvider]!,
+      'credentials': instance.credentials.map(
+        (k, e) => MapEntry(_$AiProviderEnumMap[k]!, e),
+      ),
+    };

--- a/app/lib/feature/ai_chat/data/model/ai_provider.dart
+++ b/app/lib/feature/ai_chat/data/model/ai_provider.dart
@@ -1,0 +1,31 @@
+/// AI チャットで利用するプロバイダー。
+enum AiProvider {
+  anthropic('Anthropic', 'claude-sonnet-4-5'),
+  gemini('Google Gemini', 'gemini-2.5-pro'),
+  openai('OpenAI', 'gpt-4o')
+  ;
+
+  const AiProvider(this.displayName, this.defaultModel);
+
+  final String displayName;
+  final String defaultModel;
+
+  /// 各プロバイダーで選択可能な代表的なモデル。
+  /// 一般的に利用される代表的な高品質モデルに絞っている。
+  List<String> get availableModels => switch (this) {
+    AiProvider.anthropic => const [
+      'claude-sonnet-4-5',
+      'claude-opus-4-5',
+      'claude-haiku-4-5',
+    ],
+    AiProvider.gemini => const [
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
+    ],
+    AiProvider.openai => const [
+      'gpt-4o',
+      'gpt-4o-mini',
+      'gpt-4.1',
+    ],
+  };
+}

--- a/app/lib/feature/ai_chat/data/model/chat_turn.dart
+++ b/app/lib/feature/ai_chat/data/model/chat_turn.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_turn.freezed.dart';
+
+/// チャットの 1 メッセージ単位（UI 表示用）。
+@freezed
+sealed class ChatTurn with _$ChatTurn {
+  /// ユーザー発話。
+  const factory ChatTurn.user(String text) = ChatTurnUser;
+
+  /// AI のテキスト応答（A2UI で UI を生成しないチャンクの集約）。
+  const factory ChatTurn.assistantText(String text) = ChatTurnAssistantText;
+
+  /// AI が生成した A2UI サーフェスの参照（実体は SurfaceController が保持）。
+  const factory ChatTurn.assistantSurface(String surfaceId) =
+      ChatTurnAssistantSurface;
+
+  /// LLM 呼び出し中。
+  const factory ChatTurn.thinking() = ChatTurnThinking;
+
+  /// エラー。
+  const factory ChatTurn.error(String message) = ChatTurnError;
+}

--- a/app/lib/feature/ai_chat/data/model/chat_turn.freezed.dart
+++ b/app/lib/feature/ai_chat/data/model/chat_turn.freezed.dart
@@ -1,0 +1,488 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_turn.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$ChatTurn {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChatTurn);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ChatTurn()';
+}
+
+
+}
+
+/// @nodoc
+class $ChatTurnCopyWith<$Res>  {
+$ChatTurnCopyWith(ChatTurn _, $Res Function(ChatTurn) __);
+}
+
+
+/// Adds pattern-matching-related methods to [ChatTurn].
+extension ChatTurnPatterns on ChatTurn {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( ChatTurnUser value)?  user,TResult Function( ChatTurnAssistantText value)?  assistantText,TResult Function( ChatTurnAssistantSurface value)?  assistantSurface,TResult Function( ChatTurnThinking value)?  thinking,TResult Function( ChatTurnError value)?  error,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case ChatTurnUser() when user != null:
+return user(_that);case ChatTurnAssistantText() when assistantText != null:
+return assistantText(_that);case ChatTurnAssistantSurface() when assistantSurface != null:
+return assistantSurface(_that);case ChatTurnThinking() when thinking != null:
+return thinking(_that);case ChatTurnError() when error != null:
+return error(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( ChatTurnUser value)  user,required TResult Function( ChatTurnAssistantText value)  assistantText,required TResult Function( ChatTurnAssistantSurface value)  assistantSurface,required TResult Function( ChatTurnThinking value)  thinking,required TResult Function( ChatTurnError value)  error,}){
+final _that = this;
+switch (_that) {
+case ChatTurnUser():
+return user(_that);case ChatTurnAssistantText():
+return assistantText(_that);case ChatTurnAssistantSurface():
+return assistantSurface(_that);case ChatTurnThinking():
+return thinking(_that);case ChatTurnError():
+return error(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( ChatTurnUser value)?  user,TResult? Function( ChatTurnAssistantText value)?  assistantText,TResult? Function( ChatTurnAssistantSurface value)?  assistantSurface,TResult? Function( ChatTurnThinking value)?  thinking,TResult? Function( ChatTurnError value)?  error,}){
+final _that = this;
+switch (_that) {
+case ChatTurnUser() when user != null:
+return user(_that);case ChatTurnAssistantText() when assistantText != null:
+return assistantText(_that);case ChatTurnAssistantSurface() when assistantSurface != null:
+return assistantSurface(_that);case ChatTurnThinking() when thinking != null:
+return thinking(_that);case ChatTurnError() when error != null:
+return error(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String text)?  user,TResult Function( String text)?  assistantText,TResult Function( String surfaceId)?  assistantSurface,TResult Function()?  thinking,TResult Function( String message)?  error,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case ChatTurnUser() when user != null:
+return user(_that.text);case ChatTurnAssistantText() when assistantText != null:
+return assistantText(_that.text);case ChatTurnAssistantSurface() when assistantSurface != null:
+return assistantSurface(_that.surfaceId);case ChatTurnThinking() when thinking != null:
+return thinking();case ChatTurnError() when error != null:
+return error(_that.message);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String text)  user,required TResult Function( String text)  assistantText,required TResult Function( String surfaceId)  assistantSurface,required TResult Function()  thinking,required TResult Function( String message)  error,}) {final _that = this;
+switch (_that) {
+case ChatTurnUser():
+return user(_that.text);case ChatTurnAssistantText():
+return assistantText(_that.text);case ChatTurnAssistantSurface():
+return assistantSurface(_that.surfaceId);case ChatTurnThinking():
+return thinking();case ChatTurnError():
+return error(_that.message);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String text)?  user,TResult? Function( String text)?  assistantText,TResult? Function( String surfaceId)?  assistantSurface,TResult? Function()?  thinking,TResult? Function( String message)?  error,}) {final _that = this;
+switch (_that) {
+case ChatTurnUser() when user != null:
+return user(_that.text);case ChatTurnAssistantText() when assistantText != null:
+return assistantText(_that.text);case ChatTurnAssistantSurface() when assistantSurface != null:
+return assistantSurface(_that.surfaceId);case ChatTurnThinking() when thinking != null:
+return thinking();case ChatTurnError() when error != null:
+return error(_that.message);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class ChatTurnUser implements ChatTurn {
+  const ChatTurnUser(this.text);
+  
+
+ final  String text;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChatTurnUserCopyWith<ChatTurnUser> get copyWith => _$ChatTurnUserCopyWithImpl<ChatTurnUser>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChatTurnUser&&(identical(other.text, text) || other.text == text));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'ChatTurn.user(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChatTurnUserCopyWith<$Res> implements $ChatTurnCopyWith<$Res> {
+  factory $ChatTurnUserCopyWith(ChatTurnUser value, $Res Function(ChatTurnUser) _then) = _$ChatTurnUserCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChatTurnUserCopyWithImpl<$Res>
+    implements $ChatTurnUserCopyWith<$Res> {
+  _$ChatTurnUserCopyWithImpl(this._self, this._then);
+
+  final ChatTurnUser _self;
+  final $Res Function(ChatTurnUser) _then;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(ChatTurnUser(
+null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class ChatTurnAssistantText implements ChatTurn {
+  const ChatTurnAssistantText(this.text);
+  
+
+ final  String text;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChatTurnAssistantTextCopyWith<ChatTurnAssistantText> get copyWith => _$ChatTurnAssistantTextCopyWithImpl<ChatTurnAssistantText>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChatTurnAssistantText&&(identical(other.text, text) || other.text == text));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'ChatTurn.assistantText(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChatTurnAssistantTextCopyWith<$Res> implements $ChatTurnCopyWith<$Res> {
+  factory $ChatTurnAssistantTextCopyWith(ChatTurnAssistantText value, $Res Function(ChatTurnAssistantText) _then) = _$ChatTurnAssistantTextCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChatTurnAssistantTextCopyWithImpl<$Res>
+    implements $ChatTurnAssistantTextCopyWith<$Res> {
+  _$ChatTurnAssistantTextCopyWithImpl(this._self, this._then);
+
+  final ChatTurnAssistantText _self;
+  final $Res Function(ChatTurnAssistantText) _then;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(ChatTurnAssistantText(
+null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class ChatTurnAssistantSurface implements ChatTurn {
+  const ChatTurnAssistantSurface(this.surfaceId);
+  
+
+ final  String surfaceId;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChatTurnAssistantSurfaceCopyWith<ChatTurnAssistantSurface> get copyWith => _$ChatTurnAssistantSurfaceCopyWithImpl<ChatTurnAssistantSurface>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChatTurnAssistantSurface&&(identical(other.surfaceId, surfaceId) || other.surfaceId == surfaceId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,surfaceId);
+
+@override
+String toString() {
+  return 'ChatTurn.assistantSurface(surfaceId: $surfaceId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChatTurnAssistantSurfaceCopyWith<$Res> implements $ChatTurnCopyWith<$Res> {
+  factory $ChatTurnAssistantSurfaceCopyWith(ChatTurnAssistantSurface value, $Res Function(ChatTurnAssistantSurface) _then) = _$ChatTurnAssistantSurfaceCopyWithImpl;
+@useResult
+$Res call({
+ String surfaceId
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChatTurnAssistantSurfaceCopyWithImpl<$Res>
+    implements $ChatTurnAssistantSurfaceCopyWith<$Res> {
+  _$ChatTurnAssistantSurfaceCopyWithImpl(this._self, this._then);
+
+  final ChatTurnAssistantSurface _self;
+  final $Res Function(ChatTurnAssistantSurface) _then;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? surfaceId = null,}) {
+  return _then(ChatTurnAssistantSurface(
+null == surfaceId ? _self.surfaceId : surfaceId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class ChatTurnThinking implements ChatTurn {
+  const ChatTurnThinking();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChatTurnThinking);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ChatTurn.thinking()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class ChatTurnError implements ChatTurn {
+  const ChatTurnError(this.message);
+  
+
+ final  String message;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChatTurnErrorCopyWith<ChatTurnError> get copyWith => _$ChatTurnErrorCopyWithImpl<ChatTurnError>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChatTurnError&&(identical(other.message, message) || other.message == message));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'ChatTurn.error(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChatTurnErrorCopyWith<$Res> implements $ChatTurnCopyWith<$Res> {
+  factory $ChatTurnErrorCopyWith(ChatTurnError value, $Res Function(ChatTurnError) _then) = _$ChatTurnErrorCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChatTurnErrorCopyWithImpl<$Res>
+    implements $ChatTurnErrorCopyWith<$Res> {
+  _$ChatTurnErrorCopyWithImpl(this._self, this._then);
+
+  final ChatTurnError _self;
+  final $Res Function(ChatTurnError) _then;
+
+/// Create a copy of ChatTurn
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(ChatTurnError(
+null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/ai_chat/data/model/token_usage.dart
+++ b/app/lib/feature/ai_chat/data/model/token_usage.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'token_usage.freezed.dart';
+
+@freezed
+abstract class TokenUsage with _$TokenUsage {
+  const factory TokenUsage({
+    @Default(0) int inputTokens,
+    @Default(0) int outputTokens,
+    @Default(0) int totalTokens,
+    @Default(0) int turns,
+  }) = _TokenUsage;
+
+  const TokenUsage._();
+
+  /// 累積トークン使用量を更新。
+  TokenUsage add({int? input, int? output, int? total}) {
+    final i = inputTokens + (input ?? 0);
+    final o = outputTokens + (output ?? 0);
+    return TokenUsage(
+      inputTokens: i,
+      outputTokens: o,
+      totalTokens: total != null ? totalTokens + total : i + o,
+      turns: turns + 1,
+    );
+  }
+}

--- a/app/lib/feature/ai_chat/data/model/token_usage.freezed.dart
+++ b/app/lib/feature/ai_chat/data/model/token_usage.freezed.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'token_usage.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$TokenUsage {
+
+ int get inputTokens; int get outputTokens; int get totalTokens; int get turns;
+/// Create a copy of TokenUsage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TokenUsageCopyWith<TokenUsage> get copyWith => _$TokenUsageCopyWithImpl<TokenUsage>(this as TokenUsage, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TokenUsage&&(identical(other.inputTokens, inputTokens) || other.inputTokens == inputTokens)&&(identical(other.outputTokens, outputTokens) || other.outputTokens == outputTokens)&&(identical(other.totalTokens, totalTokens) || other.totalTokens == totalTokens)&&(identical(other.turns, turns) || other.turns == turns));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,inputTokens,outputTokens,totalTokens,turns);
+
+@override
+String toString() {
+  return 'TokenUsage(inputTokens: $inputTokens, outputTokens: $outputTokens, totalTokens: $totalTokens, turns: $turns)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TokenUsageCopyWith<$Res>  {
+  factory $TokenUsageCopyWith(TokenUsage value, $Res Function(TokenUsage) _then) = _$TokenUsageCopyWithImpl;
+@useResult
+$Res call({
+ int inputTokens, int outputTokens, int totalTokens, int turns
+});
+
+
+
+
+}
+/// @nodoc
+class _$TokenUsageCopyWithImpl<$Res>
+    implements $TokenUsageCopyWith<$Res> {
+  _$TokenUsageCopyWithImpl(this._self, this._then);
+
+  final TokenUsage _self;
+  final $Res Function(TokenUsage) _then;
+
+/// Create a copy of TokenUsage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? inputTokens = null,Object? outputTokens = null,Object? totalTokens = null,Object? turns = null,}) {
+  return _then(_self.copyWith(
+inputTokens: null == inputTokens ? _self.inputTokens : inputTokens // ignore: cast_nullable_to_non_nullable
+as int,outputTokens: null == outputTokens ? _self.outputTokens : outputTokens // ignore: cast_nullable_to_non_nullable
+as int,totalTokens: null == totalTokens ? _self.totalTokens : totalTokens // ignore: cast_nullable_to_non_nullable
+as int,turns: null == turns ? _self.turns : turns // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TokenUsage].
+extension TokenUsagePatterns on TokenUsage {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TokenUsage value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TokenUsage() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TokenUsage value)  $default,){
+final _that = this;
+switch (_that) {
+case _TokenUsage():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TokenUsage value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TokenUsage() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int inputTokens,  int outputTokens,  int totalTokens,  int turns)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TokenUsage() when $default != null:
+return $default(_that.inputTokens,_that.outputTokens,_that.totalTokens,_that.turns);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int inputTokens,  int outputTokens,  int totalTokens,  int turns)  $default,) {final _that = this;
+switch (_that) {
+case _TokenUsage():
+return $default(_that.inputTokens,_that.outputTokens,_that.totalTokens,_that.turns);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int inputTokens,  int outputTokens,  int totalTokens,  int turns)?  $default,) {final _that = this;
+switch (_that) {
+case _TokenUsage() when $default != null:
+return $default(_that.inputTokens,_that.outputTokens,_that.totalTokens,_that.turns);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _TokenUsage extends TokenUsage {
+  const _TokenUsage({this.inputTokens = 0, this.outputTokens = 0, this.totalTokens = 0, this.turns = 0}): super._();
+  
+
+@override@JsonKey() final  int inputTokens;
+@override@JsonKey() final  int outputTokens;
+@override@JsonKey() final  int totalTokens;
+@override@JsonKey() final  int turns;
+
+/// Create a copy of TokenUsage
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TokenUsageCopyWith<_TokenUsage> get copyWith => __$TokenUsageCopyWithImpl<_TokenUsage>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TokenUsage&&(identical(other.inputTokens, inputTokens) || other.inputTokens == inputTokens)&&(identical(other.outputTokens, outputTokens) || other.outputTokens == outputTokens)&&(identical(other.totalTokens, totalTokens) || other.totalTokens == totalTokens)&&(identical(other.turns, turns) || other.turns == turns));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,inputTokens,outputTokens,totalTokens,turns);
+
+@override
+String toString() {
+  return 'TokenUsage(inputTokens: $inputTokens, outputTokens: $outputTokens, totalTokens: $totalTokens, turns: $turns)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TokenUsageCopyWith<$Res> implements $TokenUsageCopyWith<$Res> {
+  factory _$TokenUsageCopyWith(_TokenUsage value, $Res Function(_TokenUsage) _then) = __$TokenUsageCopyWithImpl;
+@override @useResult
+$Res call({
+ int inputTokens, int outputTokens, int totalTokens, int turns
+});
+
+
+
+
+}
+/// @nodoc
+class __$TokenUsageCopyWithImpl<$Res>
+    implements _$TokenUsageCopyWith<$Res> {
+  __$TokenUsageCopyWithImpl(this._self, this._then);
+
+  final _TokenUsage _self;
+  final $Res Function(_TokenUsage) _then;
+
+/// Create a copy of TokenUsage
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? inputTokens = null,Object? outputTokens = null,Object? totalTokens = null,Object? turns = null,}) {
+  return _then(_TokenUsage(
+inputTokens: null == inputTokens ? _self.inputTokens : inputTokens // ignore: cast_nullable_to_non_nullable
+as int,outputTokens: null == outputTokens ? _self.outputTokens : outputTokens // ignore: cast_nullable_to_non_nullable
+as int,totalTokens: null == totalTokens ? _self.totalTokens : totalTokens // ignore: cast_nullable_to_non_nullable
+as int,turns: null == turns ? _self.turns : turns // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/ai_chat/data/provider/ai_chat_session_provider.dart
+++ b/app/lib/feature/ai_chat/data/provider/ai_chat_session_provider.dart
@@ -1,0 +1,38 @@
+import 'package:eqmonitor/feature/ai_chat/data/ai_chat_session.dart';
+import 'package:eqmonitor/feature/ai_chat/data/llm/genkit_client.dart';
+import 'package:eqmonitor/feature/ai_chat/data/provider/ai_credentials_provider.dart';
+import 'package:eqmonitor/feature/ai_chat/data/tool/eq_tool_runner.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+import 'package:genui/genui.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ai_chat_session_provider.g.dart';
+
+@riverpod
+Future<AiChatSession> aiChatSession(
+  Ref ref, {
+  String? initialMessage,
+  String? extraSystemPrompt,
+}) async {
+  final store = await ref.watch(aiCredentialsProvider.future);
+  final credentials = store.selected;
+  if (credentials == null || credentials.apiKey.trim().isEmpty) {
+    throw StateError('AI 認証情報が未設定です。');
+  }
+  final repository = await ref.watch(
+    earthquakeHistoryRepositoryProvider.future,
+  );
+  final toolRunner = EqToolRunner(repository: repository);
+  final client = createGenkitClient(
+    credentials: credentials,
+    toolRunner: toolRunner,
+  );
+  final session = AiChatSession(
+    client: client,
+    catalog: BasicCatalogItems.asCatalog(),
+    initialMessage: initialMessage,
+    extraSystemPrompt: extraSystemPrompt,
+  );
+  ref.onDispose(session.dispose);
+  return session;
+}

--- a/app/lib/feature/ai_chat/data/provider/ai_chat_session_provider.g.dart
+++ b/app/lib/feature/ai_chat/data/provider/ai_chat_session_provider.g.dart
@@ -1,0 +1,105 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'ai_chat_session_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(aiChatSession)
+final aiChatSessionProvider = AiChatSessionFamily._();
+
+final class AiChatSessionProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AiChatSession>,
+          AiChatSession,
+          FutureOr<AiChatSession>
+        >
+    with $FutureModifier<AiChatSession>, $FutureProvider<AiChatSession> {
+  AiChatSessionProvider._({
+    required AiChatSessionFamily super.from,
+    required ({String? initialMessage, String? extraSystemPrompt})
+    super.argument,
+  }) : super(
+         retry: null,
+         name: r'aiChatSessionProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$aiChatSessionHash();
+
+  @override
+  String toString() {
+    return r'aiChatSessionProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<AiChatSession> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<AiChatSession> create(Ref ref) {
+    final argument =
+        this.argument as ({String? initialMessage, String? extraSystemPrompt});
+    return aiChatSession(
+      ref,
+      initialMessage: argument.initialMessage,
+      extraSystemPrompt: argument.extraSystemPrompt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AiChatSessionProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$aiChatSessionHash() => r'f30a48b1236820a775a1afd8d1cf9269a73ba6d8';
+
+final class AiChatSessionFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<AiChatSession>,
+          ({String? initialMessage, String? extraSystemPrompt})
+        > {
+  AiChatSessionFamily._()
+    : super(
+        retry: null,
+        name: r'aiChatSessionProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  AiChatSessionProvider call({
+    String? initialMessage,
+    String? extraSystemPrompt,
+  }) => AiChatSessionProvider._(
+    argument: (
+      initialMessage: initialMessage,
+      extraSystemPrompt: extraSystemPrompt,
+    ),
+    from: this,
+  );
+
+  @override
+  String toString() => r'aiChatSessionProvider';
+}

--- a/app/lib/feature/ai_chat/data/provider/ai_credentials_provider.dart
+++ b/app/lib/feature/ai_chat/data/provider/ai_credentials_provider.dart
@@ -1,0 +1,42 @@
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_credentials.dart';
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_provider.dart';
+import 'package:eqmonitor/feature/ai_chat/data/repository/ai_credentials_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ai_credentials_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class AiCredentialsNotifier extends _$AiCredentialsNotifier {
+  @override
+  Future<AiCredentialsStore> build() async {
+    return ref.read(aiCredentialsRepositoryProvider).load();
+  }
+
+  Future<void> selectProvider(AiProvider provider) async {
+    final current = await future;
+    final next = current.copyWith(selectedProvider: provider);
+    await ref.read(aiCredentialsRepositoryProvider).save(next);
+    state = AsyncData(next);
+  }
+
+  Future<void> upsertCredentials(AiCredentials credentials) async {
+    final current = await future;
+    final updated = Map<AiProvider, AiCredentials>.from(current.credentials)
+      ..[credentials.provider] = credentials;
+    final next = current.copyWith(
+      selectedProvider: credentials.provider,
+      credentials: updated,
+    );
+    await ref.read(aiCredentialsRepositoryProvider).save(next);
+    state = AsyncData(next);
+  }
+
+  Future<void> clearProvider(AiProvider provider) async {
+    final current = await future;
+    final updated = Map<AiProvider, AiCredentials>.from(current.credentials)
+      ..remove(provider);
+    final next = current.copyWith(credentials: updated);
+    await ref.read(aiCredentialsRepositoryProvider).save(next);
+    state = AsyncData(next);
+  }
+}

--- a/app/lib/feature/ai_chat/data/provider/ai_credentials_provider.g.dart
+++ b/app/lib/feature/ai_chat/data/provider/ai_credentials_provider.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'ai_credentials_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(AiCredentialsNotifier)
+final aiCredentialsProvider = AiCredentialsNotifierProvider._();
+
+final class AiCredentialsNotifierProvider
+    extends $AsyncNotifierProvider<AiCredentialsNotifier, AiCredentialsStore> {
+  AiCredentialsNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'aiCredentialsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$aiCredentialsNotifierHash();
+
+  @$internal
+  @override
+  AiCredentialsNotifier create() => AiCredentialsNotifier();
+}
+
+String _$aiCredentialsNotifierHash() =>
+    r'614d02067ba7631ef2629b910d4f3672d9d5a699';
+
+abstract class _$AiCredentialsNotifier
+    extends $AsyncNotifier<AiCredentialsStore> {
+  FutureOr<AiCredentialsStore> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<AiCredentialsStore>, AiCredentialsStore>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<AiCredentialsStore>, AiCredentialsStore>,
+              AsyncValue<AiCredentialsStore>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/ai_chat/data/repository/ai_credentials_repository.dart
+++ b/app/lib/feature/ai_chat/data/repository/ai_credentials_repository.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_credentials.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ai_credentials_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+AiCredentialsRepository aiCredentialsRepository(Ref ref) {
+  const storage = FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock,
+    ),
+  );
+  return AiCredentialsRepository(storage: storage);
+}
+
+class AiCredentialsRepository {
+  AiCredentialsRepository({required FlutterSecureStorage storage})
+    : _storage = storage;
+
+  static const _storageKey = 'eqmonitor.ai_chat.credentials_store.v1';
+
+  final FlutterSecureStorage _storage;
+
+  Future<AiCredentialsStore> load() async {
+    final raw = await _storage.read(key: _storageKey);
+    if (raw == null || raw.isEmpty) {
+      return AiCredentialsStore.initial();
+    }
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      return AiCredentialsStore.fromJson(json);
+    } on Exception {
+      return AiCredentialsStore.initial();
+    }
+  }
+
+  Future<void> save(AiCredentialsStore store) async {
+    await _storage.write(
+      key: _storageKey,
+      value: jsonEncode(store.toJson()),
+    );
+  }
+
+  Future<void> clear() async {
+    await _storage.delete(key: _storageKey);
+  }
+}

--- a/app/lib/feature/ai_chat/data/repository/ai_credentials_repository.g.dart
+++ b/app/lib/feature/ai_chat/data/repository/ai_credentials_repository.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'ai_credentials_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(aiCredentialsRepository)
+final aiCredentialsRepositoryProvider = AiCredentialsRepositoryProvider._();
+
+final class AiCredentialsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          AiCredentialsRepository,
+          AiCredentialsRepository,
+          AiCredentialsRepository
+        >
+    with $Provider<AiCredentialsRepository> {
+  AiCredentialsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'aiCredentialsRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$aiCredentialsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<AiCredentialsRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AiCredentialsRepository create(Ref ref) {
+    return aiCredentialsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AiCredentialsRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AiCredentialsRepository>(value),
+    );
+  }
+}
+
+String _$aiCredentialsRepositoryHash() =>
+    r'34050bd5864f5e78fb5e10b92bcf3680e42d0add';

--- a/app/lib/feature/ai_chat/data/tool/eq_tool_runner.dart
+++ b/app/lib/feature/ai_chat/data/tool/eq_tool_runner.dart
@@ -1,0 +1,157 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+
+/// LLM が呼び出すツールを EarthquakeHistoryRepository へ橋渡し。
+class EqToolRunner {
+  EqToolRunner({required EarthquakeHistoryRepository repository})
+    : _repository = repository;
+
+  final EarthquakeHistoryRepository _repository;
+
+  Future<Map<String, Object?>> searchEarthquakes({
+    double? magnitudeGte,
+    double? magnitudeLte,
+    String? intensityGte,
+    String? intensityLte,
+    int? depthGte,
+    int? depthLte,
+    int? limit,
+  }) async {
+    final response = await _repository.fetchEarthquakeList(
+      limit: limit?.clamp(1, 30) ?? 10,
+      magnitudeGte: magnitudeGte,
+      magnitudeLte: magnitudeLte,
+      depthGte: depthGte,
+      depthLte: depthLte,
+      intensityGte: _parseIntensity(intensityGte),
+      intensityLte: _parseIntensity(intensityLte),
+    );
+    return {
+      'count': response.items.length,
+      'items': [
+        for (final eq in response.items) _serializePartial(eq),
+      ],
+      'nextToken': response.nextToken,
+    };
+  }
+
+  Future<Map<String, Object?>> getEarthquakeDetail({
+    required String eventId,
+  }) async {
+    final detail = await _repository.fetchEarthquakeDetail(eventId: eventId);
+    return _serializeEarthquake(detail);
+  }
+
+  Future<Map<String, Object?>> searchByEpicenter({
+    required int epicenterCode,
+    int? limit,
+  }) async {
+    final response = await _repository.searchByEpicenter(
+      code: epicenterCode,
+      limit: limit?.clamp(1, 30) ?? 10,
+    );
+    return {
+      'count': response.items.length,
+      'items': [
+        for (final item in response.items)
+          {
+            'eventId': item.eventId,
+            'epicenter': {
+              'code': item.epicenter.code,
+              'name': item.epicenter.name,
+            },
+            ..._serializePartial(item.earthquake),
+          },
+      ],
+      'nextToken': response.nextToken,
+    };
+  }
+
+  Map<String, Object?> _serializePartial(EarthquakePartial eq) {
+    return {
+      'eventId': eq.eventId,
+      'originTime': eq.originTime?.toIso8601String(),
+      'arrivalTime': eq.arrivalTime?.toIso8601String(),
+      'hypocenter': _serializeHypocenter(eq.hypocenter),
+      'maxIntensity': eq.intensity?.maxIntensity.label,
+      'status': eq.status.name,
+    };
+  }
+
+  Map<String, Object?> _serializeEarthquake(Earthquake eq) {
+    return {
+      'eventId': eq.eventId,
+      'originTime': eq.originTime?.toIso8601String(),
+      'arrivalTime': eq.arrivalTime?.toIso8601String(),
+      'hypocenter': _serializeHypocenter(eq.hypocenter),
+      'maxIntensity': eq.intensity?.maxIntensity.label,
+      'status': eq.status.name,
+    };
+  }
+
+  Map<String, Object?>? _serializeHypocenter(EarthquakeHypocenter? h) {
+    if (h == null) {
+      return null;
+    }
+    final coord = h.coordinates;
+    return {
+      'code': h.code,
+      'name': h.name,
+      'detailedName': h.detailedName,
+      'latitude': switch (coord) {
+        CoordinateLatLng(:final latitude) => latitude,
+        CoordinateUnknown() => null,
+      },
+      'longitude': switch (coord) {
+        CoordinateLatLng(:final longitude) => longitude,
+        CoordinateUnknown() => null,
+      },
+      'magnitude': switch (h.magnitude) {
+        EarthquakeMagnitudeValue(:final value) => value,
+        EarthquakeMagnitudeOverM8() => 'M8以上',
+        EarthquakeMagnitudeUnknown() => null,
+      },
+      'depthKm': switch (h.depth) {
+        EarthquakeDepthValue(:final value) => value,
+        EarthquakeDepthShallow() => 'ごく浅い',
+        EarthquakeDepthOver700km() => '700km以上',
+        EarthquakeDepthUnknown() => null,
+      },
+    };
+  }
+
+  JmaIntensity? _parseIntensity(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return null;
+    }
+    final v = value.trim().toLowerCase();
+    for (final intensity in JmaIntensity.values) {
+      if (intensity.label.toLowerCase() == v ||
+          intensity.name.toLowerCase() == v) {
+        return intensity;
+      }
+    }
+    const map = <String, JmaIntensity>{
+      '1': JmaIntensity.one,
+      '2': JmaIntensity.two,
+      '3': JmaIntensity.three,
+      '4': JmaIntensity.four,
+      '5弱': JmaIntensity.fiveLower,
+      '5-': JmaIntensity.fiveLower,
+      '5+': JmaIntensity.fiveUpper,
+      '5強': JmaIntensity.fiveUpper,
+      '6弱': JmaIntensity.sixLower,
+      '6-': JmaIntensity.sixLower,
+      '6+': JmaIntensity.sixUpper,
+      '6強': JmaIntensity.sixUpper,
+      '7': JmaIntensity.seven,
+    };
+    return map[v];
+  }
+}

--- a/app/lib/feature/ai_chat/ui/ai_chat_page.dart
+++ b/app/lib/feature/ai_chat/ui/ai_chat_page.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/ai_chat/data/ai_chat_session.dart';
+import 'package:eqmonitor/feature/ai_chat/data/model/chat_turn.dart';
+import 'package:eqmonitor/feature/ai_chat/data/provider/ai_chat_session_provider.dart';
+import 'package:eqmonitor/feature/ai_chat/data/provider/ai_credentials_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:genui/genui.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class AiChatPage extends HookConsumerWidget {
+  const AiChatPage({super.key, this.eventId, this.epicenterName});
+
+  /// 地震詳細から飛んできた場合の eventId（あれば最初のヒントに使う）
+  final String? eventId;
+  final String? epicenterName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final storeAsync = ref.watch(aiCredentialsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AI チャット (実験)'),
+        actions: [
+          IconButton(
+            tooltip: '設定',
+            icon: const Icon(Icons.settings),
+            onPressed: () => const AiChatSettingsRoute().push<void>(context),
+          ),
+        ],
+      ),
+      body: storeAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('エラー: $e')),
+        data: (store) {
+          if (!store.hasUsableCredentials) {
+            return _NoCredentialsView();
+          }
+          return _ChatBody(
+            eventId: eventId,
+            epicenterName: epicenterName,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _NoCredentialsView extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.key_off, size: 48),
+            const SizedBox(height: 12),
+            const Text('AI API キーが未設定です'),
+            const SizedBox(height: 12),
+            FilledButton(
+              onPressed: () => const AiChatSettingsRoute().push<void>(context),
+              child: const Text('設定画面を開く'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChatBody extends HookConsumerWidget {
+  const _ChatBody({this.eventId, this.epicenterName});
+
+  final String? eventId;
+  final String? epicenterName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final extraSystemPrompt = useMemoized(() {
+      if (eventId == null) {
+        return null;
+      }
+      final hint = epicenterName == null ? '' : ' (震央: $epicenterName)';
+      return '初期の関心対象は eventId="$eventId"$hint。 まず get_earthquake_detail でこの地震の詳細を取得し、 続いて search_by_epicenter で同じ震央の過去地震を提示してください。';
+    }, [eventId, epicenterName]);
+
+    final sessionAsync = ref.watch(
+      aiChatSessionProvider(
+        initialMessage: eventId == null
+            ? null
+            : 'この地震 (eventId=$eventId) について教えて。 同じ震央付近で過去に起きた地震もあわせて教えてください。',
+        extraSystemPrompt: extraSystemPrompt,
+      ),
+    );
+
+    return sessionAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('セッションエラー: $e')),
+      data: (session) => _ChatWithSession(session: session),
+    );
+  }
+}
+
+class _ChatWithSession extends HookConsumerWidget {
+  const _ChatWithSession({required this.session});
+
+  final AiChatSession session;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final inputCtrl = useTextEditingController();
+    final scrollCtrl = useScrollController();
+    final turns = useValueListenable(session.turns);
+    final isWaiting = useValueListenable(session.isWaiting);
+
+    // 初期メッセージが既に追加されている場合は最初に送信
+    useEffect(() {
+      final hasInitialUser = turns.isNotEmpty && turns.first is ChatTurnUser;
+      if (hasInitialUser && session.turns.value.length == 1) {
+        final first = turns.first as ChatTurnUser;
+        unawaited(Future.microtask(() => session.sendText(first.text)));
+      }
+      return null;
+    }, const []);
+
+    // 新しいターン追加時に末尾までスクロール
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (scrollCtrl.hasClients) {
+          unawaited(
+            scrollCtrl.animateTo(
+              scrollCtrl.position.maxScrollExtent,
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOut,
+            ),
+          );
+        }
+      });
+      return null;
+    }, [turns.length]);
+
+    void send() {
+      final text = inputCtrl.text.trim();
+      if (text.isEmpty || isWaiting) {
+        return;
+      }
+      inputCtrl.clear();
+      unawaited(session.sendText(text));
+    }
+
+    return Column(
+      children: [
+        _UsageBar(session: session),
+        Expanded(
+          child: ListView.builder(
+            controller: scrollCtrl,
+            padding: const EdgeInsets.all(12),
+            itemCount: turns.length + (isWaiting ? 1 : 0),
+            itemBuilder: (context, index) {
+              if (index == turns.length && isWaiting) {
+                return const _ThinkingBubble();
+              }
+              return _TurnView(
+                turn: turns[index],
+                session: session,
+              );
+            },
+          ),
+        ),
+        const Divider(height: 1),
+        SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: inputCtrl,
+                    minLines: 1,
+                    maxLines: 4,
+                    enabled: !isWaiting,
+                    decoration: InputDecoration(
+                      hintText: isWaiting ? 'AI 応答待ち...' : 'メッセージを入力',
+                      border: const OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) => send(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton.filled(
+                  onPressed: isWaiting ? null : send,
+                  icon: const Icon(Icons.send),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _UsageBar extends HookWidget {
+  const _UsageBar({required this.session});
+
+  final AiChatSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    final usage = useValueListenable(session.usage);
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: DefaultTextStyle.merge(
+        style: theme.textTheme.labelSmall,
+        child: Row(
+          children: [
+            const Icon(Icons.bolt, size: 14),
+            const SizedBox(width: 4),
+            Text(
+              'in ${_fmt(usage.inputTokens)} / out ${_fmt(usage.outputTokens)}'
+              ' / total ${_fmt(usage.totalTokens)} tokens'
+              ' (turns: ${usage.turns})',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _fmt(int v) => v.toString().replaceAllMapped(
+    RegExp(r'(\d)(?=(\d{3})+(?!\d))'),
+    (m) => '${m[1]},',
+  );
+}
+
+class _TurnView extends StatelessWidget {
+  const _TurnView({required this.turn, required this.session});
+
+  final ChatTurn turn;
+  final AiChatSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (turn) {
+      ChatTurnUser(:final text) => _Bubble(text: text, isUser: true),
+      ChatTurnAssistantText(:final text) => _Bubble(text: text, isUser: false),
+      ChatTurnAssistantSurface(:final surfaceId) => _SurfaceView(
+        session: session,
+        surfaceId: surfaceId,
+      ),
+      ChatTurnThinking() => const _ThinkingBubble(),
+      ChatTurnError(:final message) => _ErrorBubble(message: message),
+    };
+  }
+}
+
+class _Bubble extends StatelessWidget {
+  const _Bubble({required this.text, required this.isUser});
+
+  final String text;
+  final bool isUser;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bg = isUser
+        ? theme.colorScheme.primaryContainer
+        : theme.colorScheme.surfaceContainerHighest;
+    final fg = isUser
+        ? theme.colorScheme.onPrimaryContainer
+        : theme.colorScheme.onSurface;
+    final align = isUser ? Alignment.centerRight : Alignment.centerLeft;
+    return Align(
+      alignment: align,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        constraints: const BoxConstraints(maxWidth: 360),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(text, style: TextStyle(color: fg)),
+      ),
+    );
+  }
+}
+
+class _ThinkingBubble extends StatelessWidget {
+  const _ThinkingBubble();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          SizedBox(width: 8),
+          Text('AI が考えています...'),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorBubble extends StatelessWidget {
+  const _ErrorBubble({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.error_outline, color: theme.colorScheme.onErrorContainer),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: theme.colorScheme.onErrorContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SurfaceView extends StatelessWidget {
+  const _SurfaceView({required this.session, required this.surfaceId});
+
+  final AiChatSession session;
+  final String surfaceId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: Border.all(
+          color: Theme.of(context).dividerColor,
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Surface(
+        surfaceContext: session.surfaceController.contextFor(surfaceId),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/ai_chat/ui/ai_chat_settings_page.dart
+++ b/app/lib/feature/ai_chat/ui/ai_chat_settings_page.dart
@@ -1,0 +1,208 @@
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_credentials.dart';
+import 'package:eqmonitor/feature/ai_chat/data/model/ai_provider.dart';
+import 'package:eqmonitor/feature/ai_chat/data/provider/ai_credentials_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class AiChatSettingsPage extends HookConsumerWidget {
+  const AiChatSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final storeAsync = ref.watch(aiCredentialsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('AI チャット 設定')),
+      body: storeAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('エラー: $e')),
+        data: (store) => _Body(store: store),
+      ),
+    );
+  }
+}
+
+class _Body extends HookConsumerWidget {
+  const _Body({required this.store});
+
+  final AiCredentialsStore store;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = useState(store.selectedProvider);
+    final credentials = store.credentials[provider.value];
+    final apiKeyCtrl = useTextEditingController(
+      text: credentials?.apiKey ?? '',
+    );
+    final selectedModel = useState(
+      credentials?.model ?? provider.value.defaultModel,
+    );
+    final isSaving = useState(false);
+    final obscure = useState(true);
+
+    // プロバイダ切替時にコントローラを差し替える
+    useEffect(() {
+      final c = store.credentials[provider.value];
+      apiKeyCtrl.text = c?.apiKey ?? '';
+      selectedModel.value = c?.model ?? provider.value.defaultModel;
+      return null;
+    }, [provider.value]);
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const _Note(),
+        const SizedBox(height: 16),
+        Text('プロバイダ', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        SegmentedButton<AiProvider>(
+          segments: AiProvider.values
+              .map(
+                (p) => ButtonSegment(value: p, label: Text(p.displayName)),
+              )
+              .toList(),
+          selected: {provider.value},
+          onSelectionChanged: (s) => provider.value = s.first,
+        ),
+        const SizedBox(height: 24),
+        Text('モデル', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        DropdownButtonFormField<String>(
+          initialValue:
+              provider.value.availableModels.contains(
+                selectedModel.value,
+              )
+              ? selectedModel.value
+              : provider.value.defaultModel,
+          items: provider.value.availableModels
+              .map((m) => DropdownMenuItem(value: m, child: Text(m)))
+              .toList(),
+          onChanged: (v) {
+            if (v != null) {
+              selectedModel.value = v;
+            }
+          },
+          decoration: const InputDecoration(border: OutlineInputBorder()),
+        ),
+        const SizedBox(height: 24),
+        Text('API キー', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        TextField(
+          controller: apiKeyCtrl,
+          obscureText: obscure.value,
+          decoration: InputDecoration(
+            border: const OutlineInputBorder(),
+            suffixIcon: IconButton(
+              onPressed: () => obscure.value = !obscure.value,
+              icon: Icon(
+                obscure.value ? Icons.visibility : Icons.visibility_off,
+              ),
+            ),
+            hintText: switch (provider.value) {
+              AiProvider.anthropic => 'sk-ant-...',
+              AiProvider.gemini => 'AIza...',
+              AiProvider.openai => 'sk-...',
+            },
+          ),
+        ),
+        const SizedBox(height: 24),
+        Row(
+          children: [
+            Expanded(
+              child: FilledButton.icon(
+                onPressed: isSaving.value
+                    ? null
+                    : () async {
+                        isSaving.value = true;
+                        try {
+                          await ref
+                              .read(aiCredentialsProvider.notifier)
+                              .upsertCredentials(
+                                AiCredentials(
+                                  provider: provider.value,
+                                  model: selectedModel.value,
+                                  apiKey: apiKeyCtrl.text.trim(),
+                                ),
+                              );
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('保存しました')),
+                            );
+                          }
+                        } finally {
+                          isSaving.value = false;
+                        }
+                      },
+                icon: const Icon(Icons.save),
+                label: const Text('保存して選択中にする'),
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              onPressed: credentials == null
+                  ? null
+                  : () async {
+                      await ref
+                          .read(aiCredentialsProvider.notifier)
+                          .clearProvider(provider.value);
+                      apiKeyCtrl.clear();
+                    },
+              tooltip: 'このプロバイダのキーを削除',
+              icon: const Icon(Icons.delete_outline),
+            ),
+          ],
+        ),
+        const Divider(height: 32),
+        Text('保存済み', style: Theme.of(context).textTheme.titleMedium),
+        for (final p in AiProvider.values)
+          ListTile(
+            title: Text(p.displayName),
+            subtitle: Text(
+              store.credentials[p]?.model ?? '未設定',
+            ),
+            trailing: store.selectedProvider == p
+                ? const Icon(Icons.check_circle, color: Colors.green)
+                : null,
+            onTap: store.credentials[p] == null
+                ? null
+                : () => ref
+                      .read(aiCredentialsProvider.notifier)
+                      .selectProvider(p),
+          ),
+      ],
+    );
+  }
+}
+
+class _Note extends StatelessWidget {
+  const _Note();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Theme.of(context).colorScheme.tertiaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: DefaultTextStyle.merge(
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onTertiaryContainer,
+          ),
+          child: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '実験機能 (デバッグメニュー専用)',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 4),
+              Text(
+                'API キーは端末の Secure Storage に保存されます。 通信は各プロバイダーへ直接行われ、サーバ経由ではありません。 使用するモデルおよびその料金体系はユーザの責任となります。',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/data/provider/current_location_intensity_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/current_location_intensity_provider.g.dart
@@ -78,7 +78,7 @@ final class CurrentLocationIntensityProvider
 }
 
 String _$currentLocationIntensityHash() =>
-    r'a6219e5b9521e563641f4760e499e9b846d4fd40';
+    r'7009c0001eb587192959df037260b0f61c21b11d';
 
 final class CurrentLocationIntensityFamily extends $Family
     with

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -1,13 +1,17 @@
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/component/sheet/basic_modal_sheet.dart';
+import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
+import 'package:eqmonitor/feature/ai_chat/data/provider/ai_credentials_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/current_location_intensity_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/region_intensity.dart';
+import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -96,7 +100,7 @@ class EarthquakeHistoryDetailsPage extends HookConsumerWidget {
   }
 }
 
-class _Sheet extends StatelessWidget {
+class _Sheet extends ConsumerWidget {
   const _Sheet({
     required this.item,
   });
@@ -104,7 +108,10 @@ class _Sheet extends StatelessWidget {
   final Earthquake item;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isDebugEnabled = ref.watch(debugProvider).value ?? false;
+    final isBeta = ref.watch(buildConfigProvider).isBetaTesting;
+    final aiEnabled = kDebugMode || isBeta || isDebugEnabled;
     return SafeArea(
       bottom: false,
       child: BasicModalSheet(
@@ -124,11 +131,45 @@ class _Sheet extends StatelessWidget {
                       DateTime.now().difference(item.originTime!) >
                           const Duration(hours: 24))
                     const AdBanner(),
+                  if (aiEnabled) _AiChatButton(item: item),
                   _TelegramListButton(eventId: item.eventId),
                 ],
               ),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AiChatButton extends ConsumerWidget {
+  const _AiChatButton({required this.item});
+
+  final Earthquake item;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final storeAsync = ref.watch(aiCredentialsProvider);
+    final theme = Theme.of(context);
+    final epicenterName = item.hypocenter?.name;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: FilledButton.tonalIcon(
+        onPressed: () => AiChatRoute(
+          eventId: item.eventId,
+          epicenterName: epicenterName,
+        ).push<void>(context),
+        icon: const Icon(Icons.auto_awesome),
+        label: Text(
+          storeAsync.value?.hasUsableCredentials ?? false
+              ? 'AI に質問する (実験)'
+              : 'AI 機能を試す (API キー要設定)',
+        ),
+        style: FilledButton.styleFrom(
+          minimumSize: const Size(double.infinity, 48),
+          backgroundColor: theme.colorScheme.tertiaryContainer,
+          foregroundColor: theme.colorScheme.onTertiaryContainer,
         ),
       ),
     );

--- a/app/lib/feature/earthquake_replay/data/notifier/replay_notifier.g.dart
+++ b/app/lib/feature/earthquake_replay/data/notifier/replay_notifier.g.dart
@@ -43,7 +43,7 @@ final class ReplayNotifierProvider
   }
 }
 
-String _$replayNotifierHash() => r'd1261eacf321da78b8f4601f426c0f3afa53fe99';
+String _$replayNotifierHash() => r'973f239750243e9ca4f49d01b7765484c905feba';
 
 abstract class _$ReplayNotifier extends $Notifier<ReplayState?> {
   ReplayState? build();

--- a/app/lib/feature/map/features/icon/data/provider/intensity_icon_provider.g.dart
+++ b/app/lib/feature/map/features/icon/data/provider/intensity_icon_provider.g.dart
@@ -50,4 +50,4 @@ final class IntensityIconProvider
   }
 }
 
-String _$intensityIconHash() => r'b6bf9c72d2c5ff3344aaf250f5b3a7bfa479c3fe';
+String _$intensityIconHash() => r'78a9521ee5bedd7dfe706e4c522f224da8264ebd';

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -67,7 +67,9 @@ class _DebugWidget extends ConsumerWidget {
             title: const Text('ビルド時刻'),
             leading: const Icon(Icons.schedule),
             subtitle: Text(
-              buildCfg.buildTimestamp.isEmpty ? '(not set)' : buildCfg.buildTimestamp,
+              buildCfg.buildTimestamp.isEmpty
+                  ? '(not set)'
+                  : buildCfg.buildTimestamp,
               style: const TextStyle(fontFamily: FontFamily.googleSansCode),
             ),
           ),
@@ -75,7 +77,9 @@ class _DebugWidget extends ConsumerWidget {
             title: const Text('ビルド時コミットメッセージ'),
             leading: const Icon(Icons.commit),
             subtitle: Text(
-              buildCfg.buildCommitMessage.isEmpty ? '(not set)' : buildCfg.buildCommitMessage,
+              buildCfg.buildCommitMessage.isEmpty
+                  ? '(not set)'
+                  : buildCfg.buildCommitMessage,
               style: const TextStyle(fontFamily: FontFamily.googleSansCode),
             ),
           ),
@@ -181,6 +185,15 @@ class _DebugWidget extends ConsumerWidget {
             title: const Text('Playground'),
             leading: const Icon(Icons.list),
             onTap: () async => const PlaygroundRoute().push(context),
+          ),
+          ListTile(
+            title: const Text('AI チャット (実験)'),
+            subtitle: Text(
+              'Anthropic / Gemini / OpenAI + GenUI/A2UI で地震情報を会話検索',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            leading: const Icon(Icons.auto_awesome),
+            onTap: () async => const AiChatRoute().push<void>(context),
           ),
           ListTile(
             title: const Text('地震リプレイ'),
@@ -442,7 +455,9 @@ class _ParameterDebugSection extends HookConsumerWidget {
                   subtitle: Text(
                     'ver: ${item.sourceVersion}  generated: ${item.generatedAt}\n'
                     'sha256: ${item.sha256.substring(0, 8)}…',
-                    style: const TextStyle(fontFamily: FontFamily.googleSansCode),
+                    style: const TextStyle(
+                      fontFamily: FontFamily.googleSansCode,
+                    ),
                   ),
                   isThreeLine: true,
                 ),
@@ -516,8 +531,7 @@ class _StartApiDebugSection extends ConsumerWidget {
           trailing: IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: '強制再取得',
-            onPressed: () =>
-                ref.read(startProvider.notifier).refresh(),
+            onPressed: () => ref.read(startProvider.notifier).refresh(),
           ),
         ),
         switch (startAsync) {
@@ -570,12 +584,12 @@ class _StartApiDebugSection extends ConsumerWidget {
                 title: const Text('requiredVersions'),
                 subtitle: Text(
                   value.app.version.requiredVersions
-                      .map((r) => r.version)
-                      .join(', ')
-                      .isNotEmpty
-                      ? value.app.version.requiredVersions
                           .map((r) => r.version)
                           .join(', ')
+                          .isNotEmpty
+                      ? value.app.version.requiredVersions
+                            .map((r) => r.version)
+                            .join(', ')
                       : '(なし)',
                 ),
               ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -100,6 +100,11 @@ dependencies:
       url: https://github.com/YumNumm/flutter_udid.git
       ref: d8f72a1e9e09a9f76f4e5051f167b31c5e2af52e
   freezed_annotation: ^3.0.0
+  genkit: ^0.13.2
+  genkit_anthropic: ^0.2.7
+  genkit_google_genai: ^0.2.7
+  genkit_openai: ^0.3.0
+  genui: ^0.9.0
   geobase: ^1.5.0
   geodata: ^1.3.0
   geolocator: ^14.0.1
@@ -138,6 +143,7 @@ dependencies:
   purchases_flutter: ^10.0.1
   riverpod: ^3.2.1
   riverpod_annotation: ^4.0.0
+  schemantic: ^0.1.3
   screenshot: 3.0.0
   sensors_plus: ^7.0.0
   share_plus: ^12.0.0

--- a/plans/ai_chat_genui_implementation.md
+++ b/plans/ai_chat_genui_implementation.md
@@ -1,0 +1,257 @@
+# AI チャット (GenUI / A2UI) 実装計画
+
+## ゴール
+
+EQMonitor に LLM ベースのアシスタント機能を追加し、ユーザが自然言語で地震情報を探索できるようにする。AI の応答は単なるテキストではなく、`flutter/genui` パッケージを介して **A2UI プロトコル** で動的にレンダリングされた Flutter ウィジェット（地震カード、リスト、震源マップ等）として表示する。
+
+### 対象ユースケース（最初の PR）
+
+1. **自然言語による地震履歴検索** — 「先週東北で起きた M5 以上の地震を見せて」「最大震度 5 弱以上の最近の地震は？」
+2. **地震ごとの近隣震央／過去地震の探索** — 詳細画面から「この震源付近で過去に発生した地震は？」と聞ける
+
+スコープ外（将来）: EEW の解説、リアルタイム情報の AI 連携、防災行動アドバイス、課金連携。
+
+---
+
+## 制約 / リスクの明記
+
+| 項目 | 内容 |
+|------|------|
+| **`genui` パッケージのステータス** | **0.9.1 / Alpha**。将来破壊的変更あり。`pubspec.yaml` でバージョン固定する |
+| **Firebase AI Logic は使わない** | ユーザ指示。Anthropic / Gemini / OpenAI を直接アプリから叩く |
+| **API キーの保管** | `flutter_secure_storage`（既にアプリに導入済み）。デバッグメニュー経由のみ。**正式リリース時はサーバプロキシ要検討** |
+| **System Prompt のサイズ** | `PromptBuilder.chat(catalog: ...)` は ~3〜5k トークンの system prompt を生成。チャットごとにコスト発生 |
+| **モデル選定** | 小さいモデルは A2UI JSON を壊しやすい。Claude Sonnet / Gemini 2.5 Pro / GPT-4o 以上を推奨し、デフォルトとする |
+| **デバッグ画面からのみ起動** | 一般ユーザには非公開。kDebugMode / Beta ビルドでのみ表示 |
+
+---
+
+## アーキテクチャ概要
+
+```
+┌───────────────────────────────────────────────────┐
+│  AiChatPage  (HookConsumerWidget)                 │
+│   ├─ ChatMessageView / Surface ウィジェット表示    │
+│   └─ TextField + Send                              │
+└───────────────────────────────────────────────────┘
+                 │
+                 ▼ Conversation.sendRequest(ChatMessage)
+┌───────────────────────────────────────────────────┐
+│  Conversation (genui)                              │
+│   ├─ SurfaceController                             │
+│   └─ Transport = A2uiTransportAdapter              │
+│         onSend: (msg) ──▶ LlmClient.chat(...)      │
+│         addChunk(text) ◀── stream                  │
+└───────────────────────────────────────────────────┘
+                 │
+                 ▼ プロバイダ抽象
+┌───────────────────────────────────────────────────┐
+│  LlmClient (interface)                             │
+│   ├─ AnthropicLlmClient                            │
+│   ├─ GeminiLlmClient                               │
+│   └─ OpenAiLlmClient                               │
+│      tool_use / functionCall を捌き、               │
+│      EqToolRunner にディスパッチ                    │
+└───────────────────────────────────────────────────┘
+                 │
+                 ▼
+┌───────────────────────────────────────────────────┐
+│  EqToolRunner                                     │
+│   ├─ searchEarthquakes(...)                       │
+│   ├─ getEarthquakeDetail(eventId)                 │
+│   └─ searchByEpicenter(code)                      │
+│   ※ 中身は EarthquakeHistoryRepository を呼ぶだけ  │
+└───────────────────────────────────────────────────┘
+```
+
+### A2UI と tool calling の役割分担（重要）
+
+- **tool calling** … LLM がデータを取りに行く手段。`EarthquakeHistoryRepository` の呼び出し。
+- **A2UI** … LLM がそのデータをどう表示するか。`createSurface` 等の JSON コマンドを **テキストストリーム内** に流す。
+
+両者は同じ LLM ターンで同居する。各プロバイダごとに「tool_use 検知 → 関数実行 → 結果を会話に戻す → 続きのテキストを A2UI として addChunk」というループを書く必要がある。
+
+---
+
+## ディレクトリ構成
+
+```
+app/lib/feature/ai_chat/
+├── data/
+│   ├── model/
+│   │   ├── ai_provider.dart            # enum: anthropic / gemini / openai
+│   │   ├── ai_credentials.dart         # freezed: apiKey, model, provider
+│   │   └── eq_tool_definitions.dart    # JSON-schema による tool 定義
+│   ├── llm/
+│   │   ├── llm_client.dart             # abstract interface
+│   │   ├── anthropic_llm_client.dart
+│   │   ├── gemini_llm_client.dart
+│   │   └── openai_llm_client.dart
+│   ├── tool/
+│   │   └── eq_tool_runner.dart         # EarthquakeHistoryRepository に委譲
+│   ├── repository/
+│   │   └── ai_credentials_repository.dart  # flutter_secure_storage
+│   └── provider/
+│       ├── ai_credentials_provider.dart
+│       ├── llm_client_provider.dart
+│       └── ai_conversation_provider.dart
+└── ui/
+    ├── ai_chat_page.dart               # メインチャット画面
+    ├── ai_chat_settings_page.dart      # APIキー・モデル選択
+    └── component/
+        ├── chat_input.dart
+        └── chat_surface_list.dart      # Surface を順に表示
+```
+
+`packages/` には切り出さず、`app/lib/feature/ai_chat/` 配下で完結させる（実験段階のため）。
+
+---
+
+## 依存関係の追加（`app/pubspec.yaml`）
+
+```yaml
+dependencies:
+  genui: ^0.9.1                # AlphaなのでCaret許容範囲は要観察
+  # LLMプロバイダ: SDK は薄いラッパで十分なため、まずはDio直叩きの自前実装で行う
+  # （将来 langchain_dart 等への切り替え余地を確保）
+```
+
+LLM プロバイダ用 SDK は **採用しない**。理由:
+- 各 SDK は依存が重く、ストリーミング tool 呼び出しの挙動も微妙に異なる
+- EQMonitor は既に `dio` を使っており、HTTP の自前ラップが現実的
+- 3社の最小 API（chat completion + streaming + tool_use）だけサポートすれば足りる
+
+---
+
+## フェーズ別実装
+
+### Phase 0: パッケージ追加 / 動作確認 (~30 分)
+
+1. `app/pubspec.yaml` に `genui: ^0.9.1` を追加
+2. `melos bootstrap` → ビルド通ることを確認
+3. `app/lib/feature/ai_chat/ui/ai_chat_page.dart` に最小骨格（送信→`A2uiTransportAdapter`にダミーチャンクを流す）を作り、Surface 表示確認
+
+### Phase 1: API キー・モデル設定 UI (~1h)
+
+4. `AiCredentials`（freezed: provider, apiKey, model）を `flutter_secure_storage` に保存／復元する `AiCredentialsRepository` を追加（K-NET 認証の実装パターンに準拠）
+5. `AiChatSettingsPage` を実装。3 プロバイダごとに APIキー・モデル名（プルダウン: Anthropic = `claude-sonnet-4-5-20250929` ほか / Gemini = `gemini-2.5-pro` ほか / OpenAI = `gpt-4o`, `gpt-5` ほか）を入力可能
+6. デフォルトプロバイダを保存
+
+### Phase 2: LlmClient 抽象と Anthropic 実装 (~3h)
+
+7. `LlmClient` interface 定義
+   ```dart
+   abstract class LlmClient {
+     Stream<String> chat({
+       required String systemPrompt,
+       required List<LlmMessage> history,
+       required List<LlmTool> tools,
+       required Future<String> Function(String name, Map<String, dynamic> args) onToolCall,
+     });
+   }
+   ```
+8. `AnthropicLlmClient` を実装（`https://api.anthropic.com/v1/messages` SSE ストリーミング, tool_use ブロック検知 → onToolCall → tool_result 送信 → 続き）
+9. `GeminiLlmClient` / `OpenAiLlmClient` は **スタブ** として骨格のみ作成し、UI からは選択可能にしておく（実装は次回 PR）
+
+### Phase 3: ツール定義と EqToolRunner (~1h)
+
+10. `eq_tool_definitions.dart` で 3 つのツールを JSON-schema 定義
+    - `search_earthquakes(magnitude_gte?, intensity_gte?, origin_time_gte?, origin_time_lte?, limit?)`
+    - `get_earthquake_detail(event_id)`
+    - `search_by_epicenter(epicenter_code)`
+11. `EqToolRunner` が `EarthquakeHistoryRepository` の既存メソッドへ委譲。結果は JSON 文字列にして LLM に返す（最大件数を 10 程度に絞り、トークンを節約）
+
+### Phase 4: GenUI 統合 (~2h)
+
+12. `Catalog`: **basic catalog のみ** （Card, Column, Text, Image, List, Button）でスタート。カスタムウィジェットは Phase 6
+13. `PromptBuilder.chat(catalog: ..., systemPromptFragments: [...])` で system prompt を生成
+    - `systemPromptFragments` に EQMonitor 特化の追加指示
+      - 「あなたは EQMonitor のアシスタント。日本の地震情報の検索・解説を行う」
+      - 「データ取得には常に提供されたツールを使うこと」
+      - 「結果は createSurface で地震カードのリストとして表示すること」
+      - 「震源コードがわかったら近隣震央検索を提案すること」
+14. `Conversation` + `SurfaceController` を Riverpod で provide。`AiChatPage` で Surface を `ListView` 表示
+
+### Phase 5: デバッグ画面からの起動 (~30 分)
+
+15. ルート追加: `/settings/debug/ai-chat` (`DebugAiChatRoute`)
+16. `debug_page.dart` に「AI チャット (実験)」ListTile を追加。タップで `AiChatSettingsPage` を経由（APIキー未設定なら）または直接 `AiChatPage` へ
+17. 地震詳細画面 (`earthquake_history_details_page.dart`) にも debug-only の「AI に質問」ボタンを追加（既知の eventId を初期メッセージに含めて起動）
+
+### Phase 6 (任意): カスタム CatalogItem (~3h)
+
+未着手で OK。次回 PR の候補:
+- `EarthquakeCard` — 震度アイコン、震源、M、深さの Flutter ウィジェットで描画
+- `EpicenterMiniMap` — MapLibre の小さいマップで震央位置を表示
+
+basic catalog のみでも 文字＋カードで十分意味のあるデモになる。
+
+---
+
+## テスト方針
+
+- `EqToolRunner` のユニットテスト（Repository をモック）
+- `AnthropicLlmClient` の SSE 行パーサユニットテスト（実際の Anthropic レスポンスサンプルを fixture 化）
+- 結合テストは手動 — デバッグメニューから起動して以下を確認:
+  1. 「最大震度5強以上の最近の地震を5件見せて」→ 地震カードリストが Surface として描画される
+  2. 詳細画面から「この震源付近の過去地震を見せて」→ 関連地震が表示される
+
+---
+
+## CI / コード生成
+
+- Freezed クラス追加 → `melos run generate`
+- `dart analyze` を通す
+- `dart format` を通す
+- 単体テストを `test/feature/ai_chat/` に追加し `melos run test:flutter` を通す
+
+---
+
+## PR 構成
+
+ブランチ: `feature/ai-chat-genui`（現在の worktree から派生）  
+ベース: `develop`（YumNumm リポジトリ）  
+タイトル: `feat(ai-chat): AI チャット (GenUI/A2UI) を試験導入 - デバッグメニュー経由`
+
+PR Description には以下を明記:
+- 実験機能であること（kDebugMode / Beta のみ）
+- API キーは端末ローカル保存、リリース前にサーバプロキシ化が必要
+- 対応プロバイダは Anthropic のみフル実装、Gemini/OpenAI はスタブ
+- スクリーンショット添付
+
+---
+
+## 想定工数
+
+| Phase | 工数 |
+|-------|------|
+| 0. パッケージ追加 | 0.5h |
+| 1. 認証 UI | 1h |
+| 2. LlmClient (Anthropic) | 3h |
+| 3. EqToolRunner | 1h |
+| 4. GenUI 統合 | 2h |
+| 5. デバッグ画面導線 | 0.5h |
+| **合計 (MVP)** | **約 8h** |
+| 6. カスタムウィジェット | +3h |
+
+---
+
+## オープンクエスチョン
+
+1. **モデルのデフォルト** — Anthropic は `claude-sonnet-4-5-20250929` を推奨で良いか？
+2. **会話履歴の永続化** — 今 PR ではメモリ上のみ（画面離脱で消える）でよいか？永続化するなら `shared_preferences` でよい？
+3. **コスト保護** — トークン上限・1日のリクエスト数制限を入れるか？（Phase 0 では入れない想定）
+4. **デバッグ画面起動位置** — 既存の「Playground」枠に統合するか、独立した ListTile にするか？（独立を想定）
+
+これらは実装中に「現実的にこちらで進めます」と判断してよい場合は明示してください。
+
+---
+
+## ユーザの承認が必要な確認事項
+
+- 上記スコープ（Anthropic フル + Gemini/OpenAI スタブ）でよいか
+- API キーを端末保存する方針を許容するか
+- ディレクトリ構成 `app/lib/feature/ai_chat/` でよいか
+- PR は `feature/ai-chat-genui` ブランチ・タイトル案でよいか
+
+承認をもらえたら Phase 0 から順に実装に入ります。

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "93.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -34,13 +34,13 @@ packages:
     source: hosted
     version: "0.3.4"
   analyzer:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.1"
   analyzer_buffer:
     dependency: transitive
     description:
@@ -50,13 +50,13 @@ packages:
     source: hosted
     version: "0.3.0"
   analyzer_plugin:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer_plugin
-      sha256: "6645a029da947ffd823d98118f385d4bd26b54eb069c006b22e0b94e451814b5"
+      sha256: "9a81dc36f7f71890d7cf83960a3a7df1e6c9a24035f98eb848e91ad48b1d21c6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.11"
+    version: "0.14.9"
   ansi_styles:
     dependency: transitive
     description:
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  anthropic_sdk_dart:
+    dependency: transitive
+    description:
+      name: anthropic_sdk_dart
+      sha256: c6156e106927eea40b75c4a97f193ea93e12adb033c41d51742b61b7ea122f17
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   app_settings:
     dependency: transitive
     description:
@@ -105,6 +113,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audioplayers:
+    dependency: transitive
+    description:
+      name: audioplayers
+      sha256: a72dd459d1a48f61a6fb9c0134dba26597c9236af40639ff0eb70eb4e0baab70
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  audioplayers_android:
+    dependency: transitive
+    description:
+      name: audioplayers_android
+      sha256: "60a6728277228413a85755bd3ffd6fab98f6555608923813ce383b190a360605"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
+  audioplayers_darwin:
+    dependency: transitive
+    description:
+      name: audioplayers_darwin
+      sha256: c994b3bb3a921e4904ac40e013fbc94488e824fd7c1de6326f549943b0b44a91
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  audioplayers_linux:
+    dependency: transitive
+    description:
+      name: audioplayers_linux
+      sha256: f75bce1ce864170ef5e6a2c6a61cd3339e1a17ce11e99a25bae4474ea491d001
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
+  audioplayers_platform_interface:
+    dependency: transitive
+    description:
+      name: audioplayers_platform_interface
+      sha256: "0e2f6a919ab56d0fec272e801abc07b26ae7f31980f912f24af4748763e5a656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  audioplayers_web:
+    dependency: transitive
+    description:
+      name: audioplayers_web
+      sha256: faa8fa6587f996a6f604433b53af44c57a1407d4fe8dff5766cf63d6875e8de9
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.0"
+  audioplayers_windows:
+    dependency: transitive
+    description:
+      name: audioplayers_windows
+      sha256: bafff2b38b6f6d331887558ba6e0a01c9c208d9dbb3ad0005234db065122a734
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -354,13 +418,13 @@ packages:
     source: hosted
     version: "0.2.1"
   dart_style:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: "6f6b30cba0301e7b38f32bdc9a6bdae6f5921a55f0a1eb9450e1e6515645dbb2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.6"
   dartx:
     dependency: transitive
     description:
@@ -377,6 +441,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.4"
   device_info_plus:
     dependency: transitive
     description:
@@ -417,6 +489,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.1"
+  email_validator:
+    dependency: transitive
+    description:
+      name: email_validator
+      sha256: b19aa5d92fdd76fbc65112060c94d45ba855105a28bb6e462de7ff03b12fa1fb
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   equatable:
     dependency: transitive
     description:
@@ -796,6 +876,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7+1"
+  flutter_markdown_plus:
+    dependency: transitive
+    description:
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -919,6 +1007,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  genai_primitives:
+    dependency: transitive
+    description:
+      name: genai_primitives
+      sha256: "2468ecd2984f32232ab199315e384821c61a198e356828e34b9a5bcf0fda863e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
+  genkit:
+    dependency: transitive
+    description:
+      name: genkit
+      sha256: b55e406a0feacc25510fa1486ec2af0b9f7b6cacb786a2bf8672d2d00a562740
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.2"
+  genkit_anthropic:
+    dependency: transitive
+    description:
+      name: genkit_anthropic
+      sha256: "2dcd6aeb6c92135eed3d78f319a4275d28ffa05f20d30ee4c04f1654d3cd5fbe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.7"
+  genkit_google_genai:
+    dependency: transitive
+    description:
+      name: genkit_google_genai
+      sha256: e5cb3a3764650d2ef05a8c0b33385e0deab2376d57046f1adaa2ba2c6d3ee8d9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.7"
+  genkit_openai:
+    dependency: transitive
+    description:
+      name: genkit_openai
+      sha256: "76ccca99358c750635ab5f8cba049b78fd88eebaf490949b80d2d39f617bf69c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
+  genui:
+    dependency: transitive
+    description:
+      name: genui
+      sha256: be0d9d689e15991c43ef6f1f6aa45a3bdea1ffe2a2259ac0ab38881cf8f346dd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0"
   geobase:
     dependency: transitive
     description:
@@ -1215,6 +1351,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  json_schema_builder:
+    dependency: transitive
+    description:
+      name: json_schema_builder
+      sha256: "65035d48d028401ad0ffc8c2f173209c7b1441e465a942a0f909070fae33170c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   json_serializable:
     dependency: transitive
     description:
@@ -1477,6 +1621,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  openai_dart:
+    dependency: transitive
+    description:
+      name: openai_dart
+      sha256: "96f86ce316c92e5198550168235782ba84695808d85d8b971592c43826d65fba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  opentelemetry:
+    dependency: transitive
+    description:
+      name: opentelemetry
+      sha256: "92d63a2e0731d34a7548add82420b8f3819ccda569f9bdfdcc4b25e00fe88da4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.11"
   os_detect:
     dependency: transitive
     description:
@@ -1733,6 +1893,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   record_use:
     dependency: transitive
     description:
@@ -1805,6 +1973,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  schemantic:
+    dependency: transitive
+    description:
+      name: schemantic
+      sha256: b593e339f89658b68ebaac3151379c65da487364512a6269daeddbce2407a70d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   screenshot:
     dependency: transitive
     description:
@@ -2371,6 +2547,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  video_player_win:
+    dependency: transitive
+    description:
+      name: video_player_win
+      sha256: a4caca55ead1eb469d10060592e7ecdcbcd4493c6e2b63e4e666ff5446c790f1
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,16 @@ workspace:
   - packages/*
 dependencies:
   melos: ^7.4.0
+
+# Genkit Dart (schemantic) は analyzer >=10 を要求するが、
+# altive_lints/yumemi_lints/eqmonitor_lints は ^9 を要求する。
+# AI チャット機能のため一時的に analyzer 系を強制的に新しいバージョンへ揃える。
+# カスタムリントは実行時に互換性が壊れる可能性があるため、
+# 影響を受けたら lint 設定の見直しが必要。
+dependency_overrides:
+  analyzer: ">=10.0.0 <10.0.2"
+  analyzer_plugin: ^0.14.1
+  dart_style: ">=3.1.4 <3.1.7"
 melos:
   repository: https://github.com/YumNumm/EQMonitor
   command:


### PR DESCRIPTION
## Summary

- Flutter `genui` (A2UI v0.9) + `genkit` Dart で自然言語による地震情報検索を実装
- 対応プロバイダー: **Anthropic / Google Gemini / OpenAI** をデバッグ設定で選択可能（API キーは Secure Storage）
- LLM が以下 3 ツールを呼んで EarthquakeHistoryRepository から実データを取得 → A2UI で Card/Column/Text として動的描画
  - `search_earthquakes` (M / 震度 / 深さで絞り込み)
  - `get_earthquake_detail` (eventId 指定)
  - `search_by_epicenter` (同じ震央の過去地震)
- 起動導線:
  - 設定 → デバッグ → **「AI チャット (実験)」**
  - 地震詳細シート (kDebugMode / Beta / デバッグモード時のみ) → **「AI に質問する」**

## なぜこれを入れるか

地震履歴の **自然言語探索** と、ある地震を起点とした **近隣震央／過去地震の連想** をユーザに提供することで、既存の検索 UI では拾いにくい「先週東北で起きた M5 以上は？」「この震源の過去地震は？」といったユースケースに踏み込めるかを試すための実験基盤です。

## アーキテクチャ

```
User text → Conversation.sendRequest (GenUI)
          → A2uiTransportAdapter.onSend
          → Genkit.generateStream(messages, tools)
          → tool_use があれば EqToolRunner → JSON 結果を返却
          → text chunks を addChunk(text)
          → A2UI コマンドを Surface に反映
```

- `app/lib/feature/ai_chat/data/llm/genkit_client.dart` … 3プロバイダー切替 + ツール登録
- `app/lib/feature/ai_chat/data/tool/eq_tool_runner.dart` … `EarthquakeHistoryRepository` への薄いブリッジ
- `app/lib/feature/ai_chat/data/ai_chat_session.dart` … GenUI Conversation × Genkit を結線
- `app/lib/feature/ai_chat/ui/ai_chat_page.dart` … メッセージ + Surface 表示 + トークン使用量バー
- `app/lib/feature/ai_chat/ui/ai_chat_settings_page.dart` … API キー / モデル選択

## 制約 / 既知の注意点

- `genui` は **0.9.0 (Alpha)**、`genkit` / プラグイン群は活発に更新中。バージョンは固定済み
- `genkit` が依存する `schemantic` は `analyzer >=10` を要求するが、既存の `altive_lints` / `yumemi_lints` 系は `^9`。workspace 直下の `pubspec.yaml` に `dependency_overrides` で `analyzer: ">=10.0.0 <10.0.2"` / `analyzer_plugin: ^0.14.1` / `dart_style: ">=3.1.4 <3.1.7"` を導入して解決
  - `meta` は Flutter SDK 側で 1.17.0 に pin されているため、analyzer 10.0.1 までしか使えない
  - カスタムリント自体は実行時に互換性が壊れる可能性があるため、要観察
- API キーは端末ローカル保存のみ。**正式リリース時はサーバプロキシ化が必要**
- System Prompt はカタログ全文を含むため 3〜5k トークン規模。コストはユーザ責任 (UI 上にトークン使用量を都度表示)
- カタログは GenUI の basic catalog のみ。カスタム `EarthquakeCard` 等は次回 PR の候補

## Test plan

- [ ] `dart analyze . --fatal-infos` クリーン (確認済み)
- [ ] iOS / Android の Debug ビルドでクラッシュなく起動できること
- [ ] デバッグメニュー → 「AI チャット (実験)」 から各プロバイダーで「最大震度 5 強以上の最近の地震を 5 件見せて」が動くこと
- [ ] 地震詳細から「AI に質問する」を押すと、その eventId を起点に詳細＋同震央の過去地震がカードで表示されること
- [ ] トークン使用量バーが各ターンで増えること
- [ ] APIキー未設定時に設定画面への導線が表示されること

## Out of scope

- カスタム CatalogItem (`EarthquakeCard`, `EpicenterMiniMap` 等)
- 会話履歴の永続化
- レートリミット / 月次上限
- リリースビルドへの露出（現状は kDebugMode / Beta / `debugProvider` ON のみ）