### PR TITLE
fix(android): extractAnnotations タスクを無効化 — Flutter 3.44 KGP 競合の回避

### DIFF
--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -16,6 +16,17 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Workaround: extractXxxAnnotations tasks are only needed for AAR publishing,
+// not for app builds. With Flutter 3.44's built-in Kotlin, having KGP in the
+// build classpath causes a classloader conflict that breaks these tasks.
+subprojects {
+    afterEvaluate {
+        tasks.matching { it.name.startsWith("extract") && it.name.endsWith("Annotations") }.configureEach {
+            enabled = false
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## 問題の経緯

Flutter 3.44 へのアップグレード後、Android ビルドが断続的に失敗している。

| 試行 | 設定 | 結果 |
|---|---|---|
| Flutter 3.44 直後 | KGP 2.2.21 あり + `kotlin-android` あり | `google_api_availability` lint 失敗 |
| #1260 (KGP 完全削除) | KGP なし | `app_settings 7.0.0` Kotlin 2.0 非互換エラー |
| #1261 (KGP バージョンのみ復元) | KGP 2.2.21 + `kotlin-android` なし | `google_api_availability` lint 再失敗 |

## 根本原因

Flutter 3.44 の built-in Kotlin (2.0.0) と `settings.gradle.kts` の KGP 2.2.21 宣言が Gradle build classpath 上で競合し、`google_api_availability_android:extractReleaseAnnotations` タスクの `AndroidLintWorkAction` クラスローダが破壊される。

```
Execution failed for task ':google_api_availability_android:extractReleaseAnnotations'.
> Could not generate a decorated class for type AndroidLintWorkAction.
```

## 解決策

`extractXxxAnnotations` タスクはライブラリを Maven に **パブリッシュ** する際にアノテーション情報を抽出するためのものであり、**アプリビルドには不要**。ルートの `build.gradle.kts` で全サブプロジェクト（プラグイン依存）のこのタスクを無効化することで、競合を回避しつつ Kotlin 2.2.21 を維持できる。

## Test plan

- [ ] CI の Deploy App (Android AAB) が成功すること
- [ ] `app_settings 7.0.0` の Kotlin 2.2.0 互換エラーが出ないこと