### PR TITLE
fix(lint): Dart Analyzer の3つの警告を修正

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,7 @@
+plugins:
+  eqmonitor_lints:
+    diagnostics:
+      avoid_stateful_widget: true
+      avoid_null_assertion_operator: true
+      avoid_top_level_functions: true
+      avoid_print: true

--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -6,13 +6,3 @@ analyzer:
     document_ignores: ignore
     lines_longer_than_80_chars: ignore
     unnecessary_async: ignore
-  enable-experiment:
-    - dot-shorthands
-
-plugins:
-  eqmonitor_lints:
-    diagnostics:
-      avoid_stateful_widget: true
-      avoid_null_assertion_operator: true
-      avoid_top_level_functions: true
-      avoid_print: true

--- a/packages/eqmonitor_lints/lib/analysis_options.yaml
+++ b/packages/eqmonitor_lints/lib/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:yumemi_lints/flutter/3.44/recommended.yaml
+include: package:yumemi_lints/flutter/3.41/recommended.yaml
 
 formatter:
   trailing_commas: preserve


### PR DESCRIPTION
## Summary

CI の Dart Analyzer で検出された3つの警告を修正します。

- `package:yumemi_lints/flutter/3.44/recommended.yaml` が `yumemi_lints 4.4.0` に存在しないため `flutter/3.41/recommended.yaml` に変更
- `enable-experiment: dot-shorthands` は Dart 3.11 で正式機能となりフラグが不要になったため削除
- `plugins:` セクションを pub workspace ルートの `analysis_options.yaml` に移動（workspace member では指定不可）

## Test plan

- [ ] CI の Dart Analyzer ジョブが通過すること