### PR TITLE
feat(app): 再生モード基盤 (TimeMode + appClock) を導入し時刻参照を統一

### DIFF
--- a/app/lib/core/provider/clock/app_clock.dart
+++ b/app/lib/core/provider/clock/app_clock.dart
@@ -1,0 +1,46 @@
+import 'package:clock/clock.dart';
+import 'package:eqmonitor/core/provider/clock/time_mode.dart';
+import 'package:eqmonitor/core/provider/ntp/ntp_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'app_clock.g.dart';
+
+/// アプリ全体の現在時刻を提供する統一クロック。
+///
+/// 状態として現在の [TimeMode] を保持し、`now` でモードに応じた「現在時刻」を返す。
+/// - ベース時刻は NTP 補正済み時刻（`Ntp.now`）を優先し、未同期時は `clock` にフォールバックする。
+/// - 強震モニタ・EEW・揺れ検知はこのクロックを参照することで、通常/タイムシフト/リプレイの
+///   いずれのモードでも整合した時刻基準で動作する。
+@Riverpod(keepAlive: true)
+class AppClock extends _$AppClock {
+  @override
+  TimeMode build() => const TimeMode.realtime();
+
+  /// 現在のモードに応じた「現在時刻」を返す。
+  DateTime now() {
+    final base = ref.read(ntpProvider.notifier).now() ?? clock.now();
+    return switch (state) {
+      RealtimeTimeMode() => base,
+      TimeShiftTimeMode(:final offset) => base.add(offset),
+      ReplayTimeMode(:final currentTime) => currentTime,
+    };
+  }
+
+  /// 通常再生へ戻す。
+  void returnToRealtime() => state = const TimeMode.realtime();
+
+  /// タイムシフト再生へ切り替える。[offset] は過去方向（負の [Duration]）。
+  void enterTimeShift(Duration offset) =>
+      state = TimeMode.timeShift(offset: offset);
+
+  /// リプレイファイル再生へ切り替える。
+  void enterReplay(DateTime currentTime) =>
+      state = TimeMode.replay(currentTime: currentTime);
+
+  /// リプレイ再生中の再生位置を更新する。リプレイ中でない場合は何もしない。
+  void updateReplayTime(DateTime currentTime) {
+    if (state is ReplayTimeMode) {
+      state = TimeMode.replay(currentTime: currentTime);
+    }
+  }
+}

--- a/app/lib/core/provider/clock/app_clock.g.dart
+++ b/app/lib/core/provider/clock/app_clock.g.dart
@@ -1,0 +1,88 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'app_clock.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// アプリ全体の現在時刻を提供する統一クロック。
+///
+/// 状態として現在の [TimeMode] を保持し、`now` でモードに応じた「現在時刻」を返す。
+/// - ベース時刻は NTP 補正済み時刻（`Ntp.now`）を優先し、未同期時は `clock` にフォールバックする。
+/// - 強震モニタ・EEW・揺れ検知はこのクロックを参照することで、通常/タイムシフト/リプレイの
+///   いずれのモードでも整合した時刻基準で動作する。
+
+@ProviderFor(AppClock)
+final appClockProvider = AppClockProvider._();
+
+/// アプリ全体の現在時刻を提供する統一クロック。
+///
+/// 状態として現在の [TimeMode] を保持し、`now` でモードに応じた「現在時刻」を返す。
+/// - ベース時刻は NTP 補正済み時刻（`Ntp.now`）を優先し、未同期時は `clock` にフォールバックする。
+/// - 強震モニタ・EEW・揺れ検知はこのクロックを参照することで、通常/タイムシフト/リプレイの
+///   いずれのモードでも整合した時刻基準で動作する。
+final class AppClockProvider extends $NotifierProvider<AppClock, TimeMode> {
+  /// アプリ全体の現在時刻を提供する統一クロック。
+  ///
+  /// 状態として現在の [TimeMode] を保持し、`now` でモードに応じた「現在時刻」を返す。
+  /// - ベース時刻は NTP 補正済み時刻（`Ntp.now`）を優先し、未同期時は `clock` にフォールバックする。
+  /// - 強震モニタ・EEW・揺れ検知はこのクロックを参照することで、通常/タイムシフト/リプレイの
+  ///   いずれのモードでも整合した時刻基準で動作する。
+  AppClockProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'appClockProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$appClockHash();
+
+  @$internal
+  @override
+  AppClock create() => AppClock();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(TimeMode value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<TimeMode>(value),
+    );
+  }
+}
+
+String _$appClockHash() => r'fb6978de4293d91a9df3d7afee1a64f5e3dd385d';
+
+/// アプリ全体の現在時刻を提供する統一クロック。
+///
+/// 状態として現在の [TimeMode] を保持し、`now` でモードに応じた「現在時刻」を返す。
+/// - ベース時刻は NTP 補正済み時刻（`Ntp.now`）を優先し、未同期時は `clock` にフォールバックする。
+/// - 強震モニタ・EEW・揺れ検知はこのクロックを参照することで、通常/タイムシフト/リプレイの
+///   いずれのモードでも整合した時刻基準で動作する。
+
+abstract class _$AppClock extends $Notifier<TimeMode> {
+  TimeMode build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<TimeMode, TimeMode>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<TimeMode, TimeMode>,
+              TimeMode,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/core/provider/clock/time_mode.dart
+++ b/app/lib/core/provider/clock/time_mode.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'time_mode.freezed.dart';
+
+/// アプリの再生モード。
+///
+/// 強震モニタ・EEW・揺れ検知の表示すべてがこのモードに従って時刻基準を切り替える。
+/// - [RealtimeTimeMode] : 通常再生（NTP 補正済みの現在時刻）
+/// - [TimeShiftTimeMode] : タイムシフト再生（現在時刻からの `offset` で過去を表現）
+/// - [ReplayTimeMode] : リプレイファイル再生（再生位置の `currentTime`）
+@freezed
+sealed class TimeMode with _$TimeMode {
+  const factory TimeMode.realtime() = RealtimeTimeMode;
+
+  /// `offset` は過去方向（負の [Duration]）を表す。
+  const factory TimeMode.timeShift({required Duration offset}) =
+      TimeShiftTimeMode;
+
+  /// `currentTime` はリプレイファイル上の現在の再生位置。
+  const factory TimeMode.replay({required DateTime currentTime}) =
+      ReplayTimeMode;
+}

--- a/app/lib/core/provider/clock/time_mode.freezed.dart
+++ b/app/lib/core/provider/clock/time_mode.freezed.dart
@@ -1,0 +1,344 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'time_mode.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$TimeMode {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TimeMode);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'TimeMode()';
+}
+
+
+}
+
+/// @nodoc
+class $TimeModeCopyWith<$Res>  {
+$TimeModeCopyWith(TimeMode _, $Res Function(TimeMode) __);
+}
+
+
+/// Adds pattern-matching-related methods to [TimeMode].
+extension TimeModePatterns on TimeMode {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( RealtimeTimeMode value)?  realtime,TResult Function( TimeShiftTimeMode value)?  timeShift,TResult Function( ReplayTimeMode value)?  replay,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case RealtimeTimeMode() when realtime != null:
+return realtime(_that);case TimeShiftTimeMode() when timeShift != null:
+return timeShift(_that);case ReplayTimeMode() when replay != null:
+return replay(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( RealtimeTimeMode value)  realtime,required TResult Function( TimeShiftTimeMode value)  timeShift,required TResult Function( ReplayTimeMode value)  replay,}){
+final _that = this;
+switch (_that) {
+case RealtimeTimeMode():
+return realtime(_that);case TimeShiftTimeMode():
+return timeShift(_that);case ReplayTimeMode():
+return replay(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( RealtimeTimeMode value)?  realtime,TResult? Function( TimeShiftTimeMode value)?  timeShift,TResult? Function( ReplayTimeMode value)?  replay,}){
+final _that = this;
+switch (_that) {
+case RealtimeTimeMode() when realtime != null:
+return realtime(_that);case TimeShiftTimeMode() when timeShift != null:
+return timeShift(_that);case ReplayTimeMode() when replay != null:
+return replay(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  realtime,TResult Function( Duration offset)?  timeShift,TResult Function( DateTime currentTime)?  replay,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case RealtimeTimeMode() when realtime != null:
+return realtime();case TimeShiftTimeMode() when timeShift != null:
+return timeShift(_that.offset);case ReplayTimeMode() when replay != null:
+return replay(_that.currentTime);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  realtime,required TResult Function( Duration offset)  timeShift,required TResult Function( DateTime currentTime)  replay,}) {final _that = this;
+switch (_that) {
+case RealtimeTimeMode():
+return realtime();case TimeShiftTimeMode():
+return timeShift(_that.offset);case ReplayTimeMode():
+return replay(_that.currentTime);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  realtime,TResult? Function( Duration offset)?  timeShift,TResult? Function( DateTime currentTime)?  replay,}) {final _that = this;
+switch (_that) {
+case RealtimeTimeMode() when realtime != null:
+return realtime();case TimeShiftTimeMode() when timeShift != null:
+return timeShift(_that.offset);case ReplayTimeMode() when replay != null:
+return replay(_that.currentTime);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class RealtimeTimeMode implements TimeMode {
+  const RealtimeTimeMode();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RealtimeTimeMode);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'TimeMode.realtime()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class TimeShiftTimeMode implements TimeMode {
+  const TimeShiftTimeMode({required this.offset});
+  
+
+ final  Duration offset;
+
+/// Create a copy of TimeMode
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TimeShiftTimeModeCopyWith<TimeShiftTimeMode> get copyWith => _$TimeShiftTimeModeCopyWithImpl<TimeShiftTimeMode>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TimeShiftTimeMode&&(identical(other.offset, offset) || other.offset == offset));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,offset);
+
+@override
+String toString() {
+  return 'TimeMode.timeShift(offset: $offset)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TimeShiftTimeModeCopyWith<$Res> implements $TimeModeCopyWith<$Res> {
+  factory $TimeShiftTimeModeCopyWith(TimeShiftTimeMode value, $Res Function(TimeShiftTimeMode) _then) = _$TimeShiftTimeModeCopyWithImpl;
+@useResult
+$Res call({
+ Duration offset
+});
+
+
+
+
+}
+/// @nodoc
+class _$TimeShiftTimeModeCopyWithImpl<$Res>
+    implements $TimeShiftTimeModeCopyWith<$Res> {
+  _$TimeShiftTimeModeCopyWithImpl(this._self, this._then);
+
+  final TimeShiftTimeMode _self;
+  final $Res Function(TimeShiftTimeMode) _then;
+
+/// Create a copy of TimeMode
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? offset = null,}) {
+  return _then(TimeShiftTimeMode(
+offset: null == offset ? _self.offset : offset // ignore: cast_nullable_to_non_nullable
+as Duration,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class ReplayTimeMode implements TimeMode {
+  const ReplayTimeMode({required this.currentTime});
+  
+
+ final  DateTime currentTime;
+
+/// Create a copy of TimeMode
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ReplayTimeModeCopyWith<ReplayTimeMode> get copyWith => _$ReplayTimeModeCopyWithImpl<ReplayTimeMode>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ReplayTimeMode&&(identical(other.currentTime, currentTime) || other.currentTime == currentTime));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,currentTime);
+
+@override
+String toString() {
+  return 'TimeMode.replay(currentTime: $currentTime)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ReplayTimeModeCopyWith<$Res> implements $TimeModeCopyWith<$Res> {
+  factory $ReplayTimeModeCopyWith(ReplayTimeMode value, $Res Function(ReplayTimeMode) _then) = _$ReplayTimeModeCopyWithImpl;
+@useResult
+$Res call({
+ DateTime currentTime
+});
+
+
+
+
+}
+/// @nodoc
+class _$ReplayTimeModeCopyWithImpl<$Res>
+    implements $ReplayTimeModeCopyWith<$Res> {
+  _$ReplayTimeModeCopyWithImpl(this._self, this._then);
+
+  final ReplayTimeMode _self;
+  final $Res Function(ReplayTimeMode) _then;
+
+/// Create a copy of TimeMode
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? currentTime = null,}) {
+  return _then(ReplayTimeMode(
+currentTime: null == currentTime ? _self.currentTime : currentTime // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/core/provider/time_ticker.dart
+++ b/app/lib/core/provider/time_ticker.dart
@@ -1,9 +1,21 @@
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/core/provider/ntp/ntp_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'time_ticker.g.dart';
 
+/// [duration] 周期で現在時刻を配信するティッカー。
+///
+/// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
+/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
 @Riverpod(keepAlive: true)
 Stream<DateTime> timeTicker(
   Ref ref, [
   Duration duration = const Duration(seconds: 1),
-]) => Stream.periodic(duration, (_) => DateTime.now());
+]) {
+  ref
+    ..watch(appClockProvider)
+    ..watch(ntpProvider);
+  final clock = ref.read(appClockProvider.notifier);
+  return Stream.periodic(duration, (_) => clock.now());
+}

--- a/app/lib/core/provider/time_ticker.g.dart
+++ b/app/lib/core/provider/time_ticker.g.dart
@@ -10,14 +10,27 @@ part of 'time_ticker.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// [duration] 周期で現在時刻を配信するティッカー。
+///
+/// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
+/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
 
 @ProviderFor(timeTicker)
 final timeTickerProvider = TimeTickerFamily._();
+
+/// [duration] 周期で現在時刻を配信するティッカー。
+///
+/// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
+/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
 
 final class TimeTickerProvider
     extends
         $FunctionalProvider<AsyncValue<DateTime>, DateTime, Stream<DateTime>>
     with $FutureModifier<DateTime>, $StreamProvider<DateTime> {
+  /// [duration] 周期で現在時刻を配信するティッカー。
+  ///
+  /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
+  /// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
   TimeTickerProvider._({
     required TimeTickerFamily super.from,
     required Duration super.argument,
@@ -61,7 +74,12 @@ final class TimeTickerProvider
   }
 }
 
-String _$timeTickerHash() => r'b6558f45ff8da20b7a1b356a6b43ccd6c0d6d89f';
+String _$timeTickerHash() => r'a3193d2c43a5d0925907de84e2b921e61347dae4';
+
+/// [duration] 周期で現在時刻を配信するティッカー。
+///
+/// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
+/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
 
 final class TimeTickerFamily extends $Family
     with $FunctionalFamilyOverride<Stream<DateTime>, Duration> {
@@ -73,6 +91,11 @@ final class TimeTickerFamily extends $Family
         $allTransitiveDependencies: null,
         isAutoDispose: false,
       );
+
+  /// [duration] 周期で現在時刻を配信するティッカー。
+  ///
+  /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
+  /// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
 
   TimeTickerProvider call([Duration duration = const Duration(seconds: 1)]) =>
       TimeTickerProvider._(argument: duration, from: this);

--- a/app/lib/feature/eew/data/eew_alive_telegram.dart
+++ b/app/lib/feature/eew/data/eew_alive_telegram.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/time_ticker.dart';
 import 'package:eqmonitor/feature/eew/data/eew.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
@@ -30,7 +31,9 @@ class EewAliveTelegram extends _$EewAliveTelegram {
     if (value == null) {
       return null;
     }
-    final now = (tickerTime.value ?? DateTime.now()).toUtc();
+    final now =
+        (tickerTime.value ?? ref.read(appClockProvider.notifier).now())
+            .toUtc();
 
     return value
         .where((e) => !checker.checkMarkAsEventEnded(eew: e, now: now))

--- a/app/lib/feature/eew/data/eew_alive_telegram.g.dart
+++ b/app/lib/feature/eew/data/eew_alive_telegram.g.dart
@@ -99,7 +99,7 @@ final class EewAliveTelegramProvider
   }
 }
 
-String _$eewAliveTelegramHash() => r'7d72c0d999cda7d674197badd1696b8147475718';
+String _$eewAliveTelegramHash() => r'23b0e0d991a98b0891af5fdb9a22ffcf71d6d2b5';
 
 /// イベント終了していないEEW
 

--- a/app/lib/feature/shake_detection/data/provider/shake_detection_merge_provider.dart
+++ b/app/lib/feature/shake_detection/data/provider/shake_detection_merge_provider.dart
@@ -1,4 +1,4 @@
-import 'package:clock/clock.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
@@ -15,7 +15,7 @@ List<ShakeDetectionEvent> shakeDetectionMerged(Ref ref) {
   final shakes = ref.watch(shakeDetectionProvider);
   final eews = ref.watch(eewAliveTelegramProvider) ?? [];
   final travelTimeMap = ref.watch(travelTimeDepthMapProvider);
-  final now = clock.now().toUtc();
+  final now = ref.read(appClockProvider.notifier).now().toUtc();
 
   return shakes.map((shake) {
     final mergedId = _findMergedEew(shake, eews, travelTimeMap, now);

--- a/app/lib/feature/shake_detection/data/provider/shake_detection_merge_provider.g.dart
+++ b/app/lib/feature/shake_detection/data/provider/shake_detection_merge_provider.g.dart
@@ -61,7 +61,7 @@ final class ShakeDetectionMergedProvider
 }
 
 String _$shakeDetectionMergedHash() =>
-    r'723135e47ed20df6fef41040e8cc15a01f847653';
+    r'3ce6403a2fd5f77a2a67a6a3c05334b0248e8c11';
 
 /// 未結合（表示対象）の揺れ検知イベントのみを返す
 

--- a/app/lib/feature/shake_detection/data/provider/shake_detection_provider.dart
+++ b/app/lib/feature/shake_detection/data/provider/shake_detection_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
 import 'package:eqmonitor/core/realtime/model/realtime_shake_data.dart';
 import 'package:eqmonitor/core/realtime/realtime_event_provider.dart';
@@ -69,7 +70,7 @@ class ShakeDetection extends _$ShakeDetection {
   }
 
   void _cleanup() {
-    final now = DateTime.now().toUtc();
+    final now = ref.read(appClockProvider.notifier).now().toUtc();
     state = state
         .where((e) => now.difference(e.createdAt.toUtc()) < _eventTtl)
         .toList();

--- a/app/lib/feature/shake_detection/data/provider/shake_detection_provider.g.dart
+++ b/app/lib/feature/shake_detection/data/provider/shake_detection_provider.g.dart
@@ -43,7 +43,7 @@ final class ShakeDetectionProvider
   }
 }
 
-String _$shakeDetectionHash() => r'ab8892c572f5a9108c644455d6f51791bbec1061';
+String _$shakeDetectionHash() => r'da0ae660cc8921654d0e024b9e93b7ac9e088084';
 
 abstract class _$ShakeDetection extends $Notifier<List<ShakeDetectionEvent>> {
   List<ShakeDetectionEvent> build();

--- a/app/test/core/provider/clock/app_clock_test.dart
+++ b/app/test/core/provider/clock/app_clock_test.dart
@@ -1,0 +1,147 @@
+import 'package:clock/clock.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/core/provider/clock/time_mode.dart';
+import 'package:eqmonitor/core/provider/ntp/ntp_provider.dart';
+import 'package:eqmonitor/core/provider/ntp/ntp_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// NTP の補正時刻を固定値で返すスタブ。
+/// `fixedNow` が null の場合は未同期（補正なし）を表す。
+class _StubNtp extends Ntp {
+  _StubNtp(this._fixedNow);
+
+  final DateTime? _fixedNow;
+
+  @override
+  Future<NtpState> build() async => const NtpState();
+
+  @override
+  DateTime? now() => _fixedNow;
+}
+
+ProviderContainer _container({DateTime? ntpNow}) {
+  final container = ProviderContainer(
+    overrides: [ntpProvider.overrideWith(() => _StubNtp(ntpNow))],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('AppClock.now', () {
+    final fixedWallClock = DateTime.utc(2025, 1, 1, 12);
+
+    test('NTP 未同期かつ通常再生では clock.now() を返すこと', () {
+      withClock(Clock.fixed(fixedWallClock), () {
+        final container = _container();
+        final clock = container.read(appClockProvider.notifier);
+
+        expect(clock.now(), fixedWallClock);
+      });
+    });
+
+    test('NTP 同期済みでは NTP 補正時刻を優先すること', () {
+      final ntpNow = DateTime.utc(2025, 1, 1, 12, 0, 5);
+      withClock(Clock.fixed(fixedWallClock), () {
+        final container = _container(ntpNow: ntpNow);
+        final clock = container.read(appClockProvider.notifier);
+
+        expect(clock.now(), ntpNow);
+      });
+    });
+
+    test('タイムシフト中はベース時刻に offset を加算すること', () {
+      withClock(Clock.fixed(fixedWallClock), () {
+        final container = _container();
+        final clock = container.read(appClockProvider.notifier)
+          ..enterTimeShift(const Duration(minutes: -5));
+
+        expect(clock.now(), fixedWallClock.subtract(const Duration(minutes: 5)));
+      });
+    });
+
+    test('タイムシフト中も NTP 補正時刻を基準に offset を加算すること', () {
+      final ntpNow = DateTime.utc(2025, 1, 1, 12, 0, 10);
+      withClock(Clock.fixed(fixedWallClock), () {
+        final container = _container(ntpNow: ntpNow);
+        final clock = container.read(appClockProvider.notifier)
+          ..enterTimeShift(const Duration(minutes: -1));
+
+        expect(clock.now(), ntpNow.subtract(const Duration(minutes: 1)));
+      });
+    });
+
+    test('リプレイ中はベース時刻に依らず currentTime を返すこと', () {
+      final replayTime = DateTime.utc(2024, 1, 1, 7, 10, 8);
+      withClock(Clock.fixed(fixedWallClock), () {
+        final container = _container();
+        final clock = container.read(appClockProvider.notifier)
+          ..enterReplay(replayTime);
+
+        expect(clock.now(), replayTime);
+      });
+    });
+  });
+
+  group('AppClock のモード遷移', () {
+    test('初期状態は通常再生であること', () {
+      final container = _container();
+      expect(container.read(appClockProvider), const TimeMode.realtime());
+    });
+
+    test('enterTimeShift で TimeShiftTimeMode になること', () {
+      final container = _container();
+      container
+          .read(appClockProvider.notifier)
+          .enterTimeShift(const Duration(minutes: -3));
+
+      expect(
+        container.read(appClockProvider),
+        const TimeMode.timeShift(offset: Duration(minutes: -3)),
+      );
+    });
+
+    test('enterReplay で ReplayTimeMode になること', () {
+      final replayTime = DateTime.utc(2024);
+      final container = _container();
+      container.read(appClockProvider.notifier).enterReplay(replayTime);
+
+      expect(
+        container.read(appClockProvider),
+        TimeMode.replay(currentTime: replayTime),
+      );
+    });
+
+    test('returnToRealtime で通常再生へ戻ること', () {
+      final container = _container();
+      final notifier = container.read(appClockProvider.notifier)
+        ..enterTimeShift(const Duration(minutes: -3))
+        ..returnToRealtime();
+
+      expect(container.read(appClockProvider), const TimeMode.realtime());
+      // 念のため now() もベース時刻に戻ることを確認
+      withClock(Clock.fixed(DateTime.utc(2025, 1, 1, 12)), () {
+        expect(notifier.now(), DateTime.utc(2025, 1, 1, 12));
+      });
+    });
+
+    test('updateReplayTime はリプレイ中のみ再生位置を更新すること', () {
+      final container = _container();
+      final notifier = container.read(appClockProvider.notifier);
+
+      // リプレイ中でない場合は無視される
+      notifier.updateReplayTime(DateTime.utc(2024));
+      expect(container.read(appClockProvider), const TimeMode.realtime());
+
+      // リプレイ中は更新される
+      notifier
+        ..enterReplay(DateTime.utc(2024, 1, 1, 0, 0, 1))
+        ..updateReplayTime(DateTime.utc(2024, 1, 1, 0, 0, 2));
+      expect(
+        container.read(appClockProvider),
+        TimeMode.replay(currentTime: DateTime.utc(2024, 1, 1, 0, 0, 2)),
+      );
+    });
+  });
+}

--- a/mise.lock
+++ b/mise.lock
@@ -79,27 +79,27 @@ url = "https://github.com/suzuki-shunsuke/tfcmt/releases/download/v4.14.15/tfcmt
 provenance = "github-attestations"
 
 [[tools.claude]]
-version = "2.1.143"
+version = "2.1.152"
 backend = "aqua:anthropics/claude-code"
 
 [tools.claude."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/linux-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.152/linux-arm64/claude"
 
 [tools.claude."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/linux-arm64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.152/linux-arm64-musl/claude"
 
 [tools.claude."platforms.linux-x64"]
-checksum = "blake3:5615771a35e3fb5634db3f4d92650a5ad038f8957e1d30064e1c3dd0ed932305"
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.152/linux-x64/claude"
 
 [tools.claude."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.152/linux-x64-musl/claude"
 
 [tools.claude."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/darwin-arm64/claude"
+checksum = "blake3:85fd7590da246fcfee0a97ea78eb4a71db2a59594eb38be58843c47768d841f0"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.152/darwin-arm64/claude"
 
 [tools.claude."platforms.macos-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.143/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.152/darwin-x64/claude"
 
 [[tools.firebase]]
 version = "15.18.0"
@@ -130,29 +130,8 @@ version = "3.44.0-stable"
 backend = "asdf:flutter"
 
 [[tools.gcloud]]
-version = "568.0.0"
+version = "569.0.0"
 backend = "asdf:gcloud"
-
-[tools.gcloud."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-568.0.0-linux-arm.tar.gz"
-
-[tools.gcloud."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-568.0.0-linux-arm.tar.gz"
-
-[tools.gcloud."platforms.linux-x64"]
-url = "https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-568.0.0-linux-x86_64.tar.gz"
-
-[tools.gcloud."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-568.0.0-linux-x86_64.tar.gz"
-
-[tools.gcloud."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-568.0.0-darwin-arm.tar.gz"
-
-[tools.gcloud."platforms.macos-x64"]
-url = "https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-568.0.0-darwin-x86_64.tar.gz"
-
-[tools.gcloud."platforms.windows-x64"]
-url = "https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-568.0.0-windows-x86_64.zip"
 
 [[tools.ghalint]]
 version = "1.5.6"
@@ -283,78 +262,78 @@ version = "17.0.2"
 backend = "core:java"
 
 [[tools.node]]
-version = "24.15.0"
+version = "24.16.0"
 backend = "core:node"
 
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:73afc234d558c24919875f51c2d1ea002a2ada4ea6f83601a383869fefa64eed"
-url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-linux-arm64.tar.gz"
+checksum = "sha256:589f5b6dd4fcfee4dfda73013903c966abaa8abd93dbc9d436544e472b4f0e74"
+url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:31e98aa960a067da91edffd5d93bc46657b5d2a8029612c359f5f2ac0060152a"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64-musl.tar.gz"
+checksum = "sha256:85dde27aa73503b03dadfa0410a800067b4e3f702fb7fcaa3beaf284dfcc69e9"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:44836872d9aec49f1e6b52a9a922872db9a2b02d235a616a5681b6a85fec8d89"
-url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-linux-x64.tar.gz"
+checksum = "sha256:2faf6a387e9b62b888e21c54f01249fb27537ffecf1842f29f4c919d0a59a0ff"
+url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:f55af5bd489c5347b113ca6594cae00a54b30ba57ac5875324311bfc6f4762e3"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64-musl.tar.gz"
+checksum = "sha256:50df5d8d474892d4f7b906167df36f77f5b93908f63dc532dc568219cab65841"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4"
-url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz"
+checksum = "sha256:39189dab4eeb15706c424af0ac08a3044c9e48f7db12a7d77f6b7aafc7dd5df6"
+url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz"
 
 [tools.node."platforms.macos-x64"]
-checksum = "sha256:ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b"
-url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-darwin-x64.tar.gz"
+checksum = "sha256:298b4c7b3cb80765c8703e42b90324a4ece3b6634947b89e769c3c980ab55185"
+url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-x64.tar.gz"
 
 [tools.node."platforms.windows-x64"]
-checksum = "sha256:cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62"
-url = "https://nodejs.org/dist/v24.15.0/node-v24.15.0-win-x64.zip"
+checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56"
+url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
 
 [[tools.pinact]]
-version = "3.9.2"
+version = "4.0.0"
 backend = "aqua:suzuki-shunsuke/pinact"
 
 [tools.pinact."platforms.linux-arm64"]
-checksum = "sha256:468bf7afd0f22b30ecb17fcf02f76d8b5c3bca59bb85a29017d7daebde96b33f"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_arm64.tar.gz"
+checksum = "sha256:c5d8ef4b253a749b754ad04f484d93c78fade5470bb549d58df6a8aeca9b18bf"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-arm64-musl"]
-checksum = "sha256:468bf7afd0f22b30ecb17fcf02f76d8b5c3bca59bb85a29017d7daebde96b33f"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_arm64.tar.gz"
+checksum = "sha256:c5d8ef4b253a749b754ad04f484d93c78fade5470bb549d58df6a8aeca9b18bf"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-x64"]
-checksum = "sha256:6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_amd64.tar.gz"
+checksum = "sha256:cc220902615325b10bd3bc52ed3de27488f79adaec52adcd12bd2194c2d2c592"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-x64-musl"]
-checksum = "sha256:6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a916"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_amd64.tar.gz"
+checksum = "sha256:cc220902615325b10bd3bc52ed3de27488f79adaec52adcd12bd2194c2d2c592"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.macos-arm64"]
-checksum = "sha256:4a6b481b16b7bb67153f96aaf60cbe61d3a739bdce35b1cb3fd3de5372f58c31"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_darwin_arm64.tar.gz"
+checksum = "sha256:3260e0d6fa7d89e4b9a7cc6c120345db9217c4e0571742e9a76db2ba3ff63650"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_darwin_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.macos-x64"]
-checksum = "sha256:5facbcd8cd4e20fb88c4ef3ace9c54b7d295735563634ef4373694cd286be67a"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_darwin_amd64.tar.gz"
+checksum = "sha256:242d0697152d31bf04f3759ec5c55cf8ccbf47b6e2680dd24531e63a6d890468"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_darwin_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.windows-x64"]
-checksum = "sha256:a7f82e352eb4f706addfb864a7c4853f34bdcfc604ebef8733adecbbbacaaeef"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_windows_amd64.zip"
+checksum = "sha256:800554b9f87c5136e9469ec9075a1f51fbea5ac402914d99f8afc4ec98a87901"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_windows_amd64.zip"
 provenance = "github-attestations"
 
 [[tools."pipx:codemagic-cli-tools"]]
-version = "0.66.0"
+version = "0.67.0"
 backend = "pipx:codemagic-cli-tools"
 
 [[tools.pkl]]
@@ -362,33 +341,38 @@ version = "0.31.1"
 backend = "aqua:apple/pkl"
 
 [[tools.pnpm]]
-version = "11.0.6"
+version = "11.3.0"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm."platforms.linux-arm64"]
-checksum = "sha256:8cff0a79557ffabcd9b25d40e70d9d859a160f05b5405b483142237460ea850d"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.0.6/pnpm-linux-arm64.tar.gz"
+checksum = "sha256:383f644f50667e9c1752791173d274ba414117262b09c1b027c2d297bf520662"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.3.0/pnpm-linux-arm64.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.linux-arm64-musl"]
-checksum = "sha256:3c2ba745a621e1fd6937675a7609eeddcfbbcf3d737ed90667bc56ec1f300052"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.0.6/pnpm-linux-arm64-musl.tar.gz"
+checksum = "sha256:b489128f5e9a6ef56c1c5ff02c03118635bef7726ef9bb2d44e0ccd16d191883"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.3.0/pnpm-linux-arm64-musl.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.linux-x64"]
-checksum = "sha256:f2781f9e250a7505bfaa6b80fed79f2a967885677c01a09dfadd024f8dce92c9"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.0.6/pnpm-linux-x64.tar.gz"
+checksum = "sha256:6eb506b53297eb1186ba0cbff1577bb26d17713835a01a5342dcafae550827ce"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.3.0/pnpm-linux-x64.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.linux-x64-musl"]
-checksum = "sha256:ca4ba0c69d6c5c36134d866bbb998825dabab6599b5ddb2a63744d1702e668e5"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.0.6/pnpm-linux-x64-musl.tar.gz"
+checksum = "sha256:d728c510e04ac218091ce5dc591b28706bb154a14bd9741a146a0defd3ad466b"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.3.0/pnpm-linux-x64-musl.tar.gz"
+provenance = "github-attestations"
 
 [tools.pnpm."platforms.macos-arm64"]
-checksum = "sha256:ae419c3a40f02988840e9424ba1a97eb88c5bdb2135056cb754c6fb4f4f0f6a7"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.0.6/pnpm-darwin-arm64.tar.gz"
+checksum = "sha256:788958f77b44d7ac05f05f08ccdd520f1b2253d834df2a5eb0cf5ab9b84d40f6"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.3.0/pnpm-darwin-arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pnpm."platforms.windows-x64"]
-checksum = "sha256:ebb3ccdb8dc5d67db4e5e72b558b3db646b3ba623904f889bbdc81e1dff2704a"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.0.6/pnpm-win32-x64.zip"
+checksum = "sha256:1264caa0dcad06849cfd04b939f19a64c5349d5dd49f14dadbc06703c6e42653"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.3.0/pnpm-win32-x64.zip"
+provenance = "github-attestations"
 
 [[tools.shellcheck]]
 version = "0.11.0"
@@ -472,106 +456,106 @@ url = "https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/Swif
 url_api = "https://api.github.com/repos/nicklockwood/SwiftFormat/releases/assets/406642521"
 
 [[tools.terraform]]
-version = "1.15.3"
+version = "1.15.4"
 backend = "aqua:hashicorp/terraform"
 
 [tools.terraform."platforms.linux-arm64"]
-checksum = "sha256:9824eb010b835b2c872440a337a69acfa1782d36c24d3c09fe5defe75defc511"
-url = "https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_linux_arm64.zip"
+checksum = "sha256:87da14c6700fee1bdaffedc943c4aca7bb078aad1f3eeccbdaae0484f90e1bec"
+url = "https://releases.hashicorp.com/terraform/1.15.4/terraform_1.15.4_linux_arm64.zip"
 
 [tools.terraform."platforms.linux-arm64-musl"]
-checksum = "sha256:9824eb010b835b2c872440a337a69acfa1782d36c24d3c09fe5defe75defc511"
-url = "https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_linux_arm64.zip"
+checksum = "sha256:87da14c6700fee1bdaffedc943c4aca7bb078aad1f3eeccbdaae0484f90e1bec"
+url = "https://releases.hashicorp.com/terraform/1.15.4/terraform_1.15.4_linux_arm64.zip"
 
 [tools.terraform."platforms.linux-x64"]
-checksum = "sha256:c3d4b579064745a5f7e918125db23b12ba52a8a7287adb9f32c49d637e02e3bf"
-url = "https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_linux_amd64.zip"
+checksum = "sha256:a71695fa6db9344db02ff1adb69cce891c1b2b4dc31c08df0dd4a12101a33b26"
+url = "https://releases.hashicorp.com/terraform/1.15.4/terraform_1.15.4_linux_amd64.zip"
 
 [tools.terraform."platforms.linux-x64-musl"]
-checksum = "sha256:c3d4b579064745a5f7e918125db23b12ba52a8a7287adb9f32c49d637e02e3bf"
-url = "https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_linux_amd64.zip"
+checksum = "sha256:a71695fa6db9344db02ff1adb69cce891c1b2b4dc31c08df0dd4a12101a33b26"
+url = "https://releases.hashicorp.com/terraform/1.15.4/terraform_1.15.4_linux_amd64.zip"
 
 [tools.terraform."platforms.macos-arm64"]
-checksum = "sha256:b97101c62c11eebd176e83cd42a313336200d54fdd18ce7770f65a5bfb0ab098"
-url = "https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_darwin_arm64.zip"
+checksum = "sha256:d6b99521a436bfc0e44b18ca47e2c8fec37a74039bf3b529ecc3c71d3e5a9fbf"
+url = "https://releases.hashicorp.com/terraform/1.15.4/terraform_1.15.4_darwin_arm64.zip"
 
 [tools.terraform."platforms.macos-x64"]
-checksum = "sha256:448e89a455e854941bd7e1396ba6ca46e92dd7e0ed1cc11d4da4cab637606d8a"
-url = "https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_darwin_amd64.zip"
+checksum = "sha256:5d9d58855d08934fb79e8db04332ff89d5e2218a6a3559f6e596b47ec2f74ecd"
+url = "https://releases.hashicorp.com/terraform/1.15.4/terraform_1.15.4_darwin_amd64.zip"
 
 [tools.terraform."platforms.windows-x64"]
-checksum = "sha256:b9da8df3d92402551c86b8956be30fb87f600245321d2b31751afcf37218018c"
-url = "https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_windows_amd64.zip"
+checksum = "sha256:159169a73fcbdfb1b0ff3e2b7abf4ec94f9ebbb314ae3a0e19e494b357ef1488"
+url = "https://releases.hashicorp.com/terraform/1.15.4/terraform_1.15.4_windows_amd64.zip"
 
 [[tools.tflint]]
-version = "0.62.0"
+version = "0.62.1"
 backend = "aqua:terraform-linters/tflint"
 
 [tools.tflint."platforms.linux-arm64"]
-checksum = "sha256:064206ec85adaf90f637c880eb3cd5a8e07ddce09e4da7c813eb362cb794f95f"
-url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_linux_arm64.zip"
+checksum = "sha256:9f3bce43f7f58f05ddcf193f0bf1f7e7a9c7a79d7f46f72dd38e97f96fcaf14c"
+url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_linux_arm64.zip"
 
 [tools.tflint."platforms.linux-arm64-musl"]
-checksum = "sha256:064206ec85adaf90f637c880eb3cd5a8e07ddce09e4da7c813eb362cb794f95f"
-url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_linux_arm64.zip"
+checksum = "sha256:9f3bce43f7f58f05ddcf193f0bf1f7e7a9c7a79d7f46f72dd38e97f96fcaf14c"
+url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_linux_arm64.zip"
 
 [tools.tflint."platforms.linux-x64"]
-checksum = "sha256:000400d7f4c2236d9ed4b35fec3ee95617c3747571593cc6138169fc78cc226a"
-url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_linux_amd64.zip"
+checksum = "sha256:c004ec45ade3caf87cd4089feb1d2af9f7df57b13140a36df8a63c0a8cc69f14"
+url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_linux_amd64.zip"
 
 [tools.tflint."platforms.linux-x64-musl"]
-checksum = "sha256:000400d7f4c2236d9ed4b35fec3ee95617c3747571593cc6138169fc78cc226a"
-url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_linux_amd64.zip"
+checksum = "sha256:c004ec45ade3caf87cd4089feb1d2af9f7df57b13140a36df8a63c0a8cc69f14"
+url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_linux_amd64.zip"
 
 [tools.tflint."platforms.macos-arm64"]
-checksum = "sha256:56064a392e688f51c893a0d3bc1470fdf523f8d579080c718d026f1692613419"
-url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_darwin_arm64.zip"
+checksum = "sha256:927866fef68382138b8fed038721a03c0928ce9486e1616b18bd3dd11e7cdacb"
+url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_darwin_arm64.zip"
 
 [tools.tflint."platforms.macos-x64"]
-checksum = "sha256:6aa1defaac89eab227008301af399225afd9ee6f124d13e570323cf588491b8a"
-url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_darwin_amd64.zip"
+checksum = "sha256:7f55df3a25deb610c267f600eb4247657e3ff776d0322916ceecd7b58142a73a"
+url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_darwin_amd64.zip"
 
 [tools.tflint."platforms.windows-x64"]
-checksum = "sha256:d2b28caf4f312805edd06c7aede494135d1babb301db32e9b68994d2038936e4"
-url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_windows_amd64.zip"
+checksum = "sha256:bef472fd62dcbdb616bbdf67800f1bcf8db64598529c09610154686555180edd"
+url = "https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_windows_amd64.zip"
 
 [[tools.uv]]
-version = "0.11.10"
+version = "0.11.16"
 backend = "aqua:astral-sh/uv"
 
 [tools.uv."platforms.linux-arm64"]
-checksum = "sha256:14c21bef6b54d268c6583d851095a543e6cb03a8e4bdca9a44ab91532b14cbc2"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:ac022d96411143b9a2dd75ea711fa8dd4cd14538bf248f2e5df3c10a80f7f6a4"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.linux-arm64-musl"]
-checksum = "sha256:14c21bef6b54d268c6583d851095a543e6cb03a8e4bdca9a44ab91532b14cbc2"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:ac022d96411143b9a2dd75ea711fa8dd4cd14538bf248f2e5df3c10a80f7f6a4"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.linux-x64"]
-checksum = "sha256:e3e78e7698d72c133c5ce851a6d60ee83afdc4c0edced382af9fd1f8e11d0105"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:1bc4be1be0a000f893b0d1db97906cf392b63fa22fda9a0ecf33d0d4bbb4bc9a"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.linux-x64-musl"]
-checksum = "sha256:e3e78e7698d72c133c5ce851a6d60ee83afdc4c0edced382af9fd1f8e11d0105"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:1bc4be1be0a000f893b0d1db97906cf392b63fa22fda9a0ecf33d0d4bbb4bc9a"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.macos-arm64"]
-checksum = "sha256:e93d6af7dfff7071edd16342ba9eeccfc28d8a7deaa5707efeecf63a63a74453"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:2b25be1af546be330b340b0a76b99f989daa6d92678fdffb87438e661e9d88fb"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-aarch64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.macos-x64"]
-checksum = "sha256:8fd091211089973f528e147166e3af683ab4ecebd4312a55d0d17d87adbde67a"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-x86_64-apple-darwin.tar.gz"
+checksum = "sha256:6b91ae3de155f51bd1f5b74814821c79f016a176561f252cd9ddfb976939af2e"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-x86_64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.windows-x64"]
-checksum = "sha256:7a0c424c7bc55a74751f13592235953ebbe182fa00355f7ae3fb7ab734a51638"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-x86_64-pc-windows-msvc.zip"
+checksum = "sha256:dd9d6d6554bfab265bfa98aa8e8a406c5c3a7b97582f93de1f4d48d9154a0395"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"
 
 [[tools.xcbeautify]]
@@ -627,26 +611,36 @@ checksum = "sha256:2aee32f1de46a20672f48c25df3018839798bd509143f2ce05fdab1550ff5
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_windows_amd64.exe"
 
 [[tools.zizmor]]
-version = "1.24.1"
+version = "1.25.2"
 backend = "aqua:zizmorcore/zizmor"
 
 [tools.zizmor."platforms.linux-arm64"]
+checksum = "sha256:4b4b9491112c2a09b318101c0d3349b73af1c4f532e097dd6d0164f2abda760d"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-aarch64-unknown-linux-gnu.tar.gz"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-arm64-musl"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-x64"]
+checksum = "sha256:aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-unknown-linux-gnu.tar.gz"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-x64-musl"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-arm64"]
+checksum = "sha256:624ef0e09521aecd862126be0f6d7754669af2646750d68ac48a114be33c3146"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-aarch64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-x64"]
+checksum = "sha256:353271b9ec301dd4ba158af481323c831c6e9b494d5ac3f5aa58cf4b207699cc"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.windows-x64"]
+checksum = "sha256:65d46a8144f701200621b580f632076d80d082d60856de9f88793a95fb5882d7"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"


### PR DESCRIPTION
## 概要

`debug_replay_modal` ベースのリプレイを廃止し、**EQRP リプレイ + タイムシフト再生** を強震モニタ・EEW・揺れ検知の本物の表示パイプラインで実施できるようにする一連の作業の **Phase A（基盤）** です。

「再生中に現在時刻で EEW が出て過去と現在を行き来する」問題を避けるため、`upsert` 注入方式ではなく **アプリの「現在時刻 (now)」そのものを再生モードが支配する** アーキテクチャを採用します。本 PR はその土台を導入します。

## このPRでやること

- **`TimeMode`** (`core/provider/clock/time_mode.dart`): 再生モードを表す Freezed sealed union
  - `realtime` / `timeShift(offset)` / `replay(currentTime)`
- **`AppClock`** (`core/provider/clock/app_clock.dart`): 状態として `TimeMode` を保持し、`now()` でモードに応じた現在時刻を返す統一クロック
  - ベース時刻は **NTP 補正済み時刻**（既存だが未使用だった `ntpProvider`）を優先、未同期時は `clock.now()` にフォールバック
  - `enterTimeShift` / `enterReplay` / `updateReplayTime` / `returnToRealtime` の遷移を提供
- **時刻参照の移行（本PRの範囲）**: 以下を `appClock` 経由へ移行（Realtime では従来挙動 + NTP 補正のみ）
  - `timeTicker`（→ EEW カード・EEW 生存判定が追従）
  - `eewAliveTelegram` のフォールバック now
  - `shakeDetection` の cleanup TTL（直書き `DateTime.now()` → appClock）
  - `shakeDetectionMerged` の EEW 結合判定（`clock.now()` → appClock）

これにより、後続フェーズで `appClock` のモードを切り替えるだけで、EEW 生存判定・予測震度カウントダウン・揺れ検知が**整合した時刻基準**で動くようになります。

### 本PRでは未移行（Phase B/C でモード結線時に同時移行）

Realtime では挙動不変のため本PRのスコープ外とし、各データソース seam を作る際に移行します:
- `eew_ps_wave_layer.dart` の P/S 波半径計算（現状 `clock.now()` 直利用）
- `kyoshin_monitor_notifier.dart` の遅延判定 / `lastUpdatedAt`（現状 `DateTime.now()` 直利用）

## 後続フェーズ（本PRには含まない）

- **Phase B**: タイムシフト再生（強震モニタを過去へHTTP取得、`timeMode` 駆動の timer stream + UI）
- **Phase C**: EQRP リプレイ（`packages/earthquake_replay` に type 1003 `EqMonitorEewReplayData` パーサ追加、replay データソース seam、コントロールUI、旧 `debug_replay`/`EarthquakeReplayPage` 削除）
- **Phase D**: 自動復帰（リアルタイムEEW/揺れ検知発生時に通常再生へ戻すか設定可能）

## テスト

- 追加: `test/core/provider/clock/app_clock_test.dart`（10 ケース）
  - 3モード × NTP有無の `now()` 解決、モード遷移、`updateReplayTime` のガード
- `melos run analyze`（全パッケージ, `--fatal-infos`）: **SUCCESS**
- 関連テスト（eew / shake_detection / clock）: **76 件 green**

> ℹ️ 全体 `flutter test` には develop でも失敗する **既存の失敗が2件**あります（`debug_eew_asset_parse_test` の matcher 誤用、`home_earthquake_history_parameter_provider_test` の現在地解決）。本PRの変更とは無関係であることを stash で確認済みです。
