### PR TITLE
feat(app): タイムシフト再生を追加 (Phase B)

### DIFF
--- a/app/lib/feature/home/ui/component/map/home_map_view.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_view.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
-import 'package:eqmonitor/feature/debug/replay/debug_replay_modal.dart';
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
@@ -21,6 +20,7 @@ import 'package:eqmonitor/feature/kyoshin_monitor/page/components/kyoshin_monito
 import 'package:eqmonitor/feature/kyoshin_monitor/ui/components/kyoshin_monitor_scale_card.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:eqmonitor/feature/map/ui/maplibre_event_provider.dart';
+import 'package:eqmonitor/feature/playback_mode/ui/playback_mode_modal.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
 import 'package:eqmonitor/feature/shake_detection/data/provider/shake_detection_merge_provider.dart';
 import 'package:flutter/material.dart';
@@ -206,7 +206,7 @@ class _MapHeader extends ConsumerWidget {
           const HomeMapLayerRoute().push<void>(context),
       onLocationButtonTap: () =>
           ref.read(homeMapCameraStateProvider.notifier).returnToHome(),
-      onDebugButtonTap: isDebug ? () => DebugReplayModal.show(context) : null,
+      onDebugButtonTap: isDebug ? () => PlaybackModeModal.show(context) : null,
     );
 
     return Padding(

--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'dart:typed_data';
 
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/data_source/kyoshin_monitor_web_api_data_source.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_settings_model.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/model/kyoshin_monitor_state.dart';
@@ -69,7 +70,9 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
         .api
         .imageFetchInterval;
     final delay = imageFetchInterval + const Duration(seconds: 5);
-    final isDelayed = targetTime.difference(DateTime.now()) > delay;
+    final isDelayed =
+        targetTime.difference(ref.read(appClockProvider.notifier).now()) >
+        delay;
 
     if (state.isLoading) {
       return;

--- a/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_timer_stream.dart
+++ b/app/lib/feature/kyoshin_monitor/data/provider/kyoshin_monitor_timer_stream.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/periodic_timer.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_timer_notifier.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_monitor_settings.dart';
@@ -13,6 +14,10 @@ part 'kyoshin_monitor_timer_stream.g.dart';
 @riverpod
 Stream<DateTime> kyoshinMonitorTimerStream(Ref ref) async* {
   final streamController = StreamController<DateTime>();
+
+  // 再生モード(通常/タイムシフト)が変化したら即座に対象時刻を再取得するため監視する。
+  ref.watch(appClockProvider);
+  final clock = ref.read(appClockProvider.notifier);
 
   final interval = ref.watch(
     kyoshinMonitorSettingsProvider.select(
@@ -35,7 +40,7 @@ Stream<DateTime> kyoshinMonitorTimerStream(Ref ref) async* {
         }
 
         final delay = value.delayFromDevice;
-        streamController.add(DateTime.now().subtract(delay));
+        streamController.add(clock.now().subtract(delay));
       }
     })
     ..listen(periodicTimerProvider(interval), (_, next) async {
@@ -54,7 +59,7 @@ Stream<DateTime> kyoshinMonitorTimerStream(Ref ref) async* {
             .value
             ?.delayFromDevice;
         if (delay != null) {
-          streamController.add(DateTime.now().subtract(delay));
+          streamController.add(clock.now().subtract(delay));
         }
       }
     });
@@ -64,7 +69,7 @@ Stream<DateTime> kyoshinMonitorTimerStream(Ref ref) async* {
   );
   final delay = kyoshinMonitorTimerNotifier.value?.delayFromDevice;
   if (delay != null) {
-    streamController.add(DateTime.now().subtract(delay));
+    streamController.add(clock.now().subtract(delay));
   }
   ref.onDispose(streamController.close);
 

--- a/app/lib/feature/playback_mode/ui/playback_mode_modal.dart
+++ b/app/lib/feature/playback_mode/ui/playback_mode_modal.dart
@@ -1,0 +1,89 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/core/provider/clock/time_mode.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// タイムシフトで選択できる過去方向のオフセットプリセット。
+const _kTimeShiftPresets = <(String, Duration)>[
+  ('10秒前', Duration(seconds: -10)),
+  ('30秒前', Duration(seconds: -30)),
+  ('1分前', Duration(minutes: -1)),
+  ('3分前', Duration(minutes: -3)),
+  ('5分前', Duration(minutes: -5)),
+];
+
+/// 再生モード（通常再生 / タイムシフト）を切り替えるモーダル。
+///
+/// 強震モニタ・EEW・揺れ検知の表示時刻はすべて [AppClock] に従うため、
+/// ここでモードを切り替えると本物の表示パイプラインがその時刻基準で再生される。
+class PlaybackModeModal extends ConsumerWidget {
+  const PlaybackModeModal({super.key});
+
+  static Future<void> show(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const PlaybackModeModal(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final designSystem = context.designSystem;
+    final spacing = designSystem.spacing;
+    final typography = designSystem.typography;
+    final textColor = designSystem.textColor;
+
+    final mode = ref.watch(appClockProvider);
+    final notifier = ref.read(appClockProvider.notifier);
+    final currentOffset = switch (mode) {
+      TimeShiftTimeMode(:final offset) => offset,
+      _ => null,
+    };
+
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.all(spacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.history_rounded, color: textColor.secondary),
+                SizedBox(width: spacing.sm),
+                Text('再生モード', style: typography.titleMedium),
+              ],
+            ),
+            SizedBox(height: spacing.xs),
+            Text(
+              'タイムシフトを選ぶと強震モニタ・EEW・揺れ検知が指定時刻基準で再生されます。',
+              style: typography.labelSmall.copyWith(color: textColor.secondary),
+            ),
+            SizedBox(height: spacing.md),
+            Wrap(
+              spacing: spacing.sm,
+              runSpacing: spacing.sm,
+              children: [
+                ChoiceChip(
+                  avatar: const Icon(Icons.play_arrow_rounded),
+                  label: const Text('通常再生'),
+                  selected: mode is RealtimeTimeMode,
+                  onSelected: (_) => notifier.returnToRealtime(),
+                ),
+                for (final (label, offset) in _kTimeShiftPresets)
+                  ChoiceChip(
+                    label: Text(label),
+                    selected: currentOffset == offset,
+                    onSelected: (_) => notifier.enterTimeShift(offset),
+                  ),
+              ],
+            ),
+            SizedBox(height: spacing.sm),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/feature/playback_mode/ui/playback_mode_modal_test.dart
+++ b/app/test/feature/playback_mode/ui/playback_mode_modal_test.dart
@@ -1,0 +1,64 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/core/provider/clock/time_mode.dart';
+import 'package:eqmonitor/feature/playback_mode/ui/playback_mode_modal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<ProviderContainer> pumpModal(WidgetTester tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: ThemeData.light().copyWith(
+            extensions: <ThemeExtension<dynamic>>[
+              DesignSystemThemeExtension.light(),
+            ],
+          ),
+          home: const Scaffold(body: PlaybackModeModal()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  testWidgets('初期状態は通常再生で、通常/タイムシフトのチップが並ぶこと', (tester) async {
+    final container = await pumpModal(tester);
+
+    expect(container.read(appClockProvider), const TimeMode.realtime());
+    expect(find.text('通常再生'), findsOneWidget);
+    expect(find.text('1分前'), findsOneWidget);
+  });
+
+  testWidgets('タイムシフトのプリセットをタップすると offset が設定されること', (tester) async {
+    final container = await pumpModal(tester);
+
+    await tester.tap(find.text('1分前'));
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(appClockProvider),
+      const TimeMode.timeShift(offset: Duration(minutes: -1)),
+    );
+  });
+
+  testWidgets('タイムシフト後に通常再生をタップすると realtime へ戻ること', (tester) async {
+    final container = await pumpModal(tester);
+    container
+        .read(appClockProvider.notifier)
+        .enterTimeShift(const Duration(minutes: -5));
+    await tester.pump();
+
+    await tester.tap(find.text('通常再生'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(appClockProvider), const TimeMode.realtime());
+  });
+}


### PR DESCRIPTION
## 概要

`debug_replay` 廃止 → EQRP リプレイ + タイムシフト再生の一連の作業のうち **Phase B（タイムシフト再生）** です。Phase A（#1293, develop にマージ済み）を前提とします。

強震モニタを過去時刻へ遡って再生できる **タイムシフト** を追加します。`AppClock` のモード（Phase A 導入）を切り替えるだけで、強震モニタ・EEW・揺れ検知が指定時刻基準で再生されます。

## 変更点

- **`kyoshinMonitorTimerStream`**: 取得対象時刻を `appClock.now() - delay` に統一
  - `realtime`(offset=0) と `timeShift(offset<0)` を**同一式**で表現（タイムシフトは過去フレームを HTTP 取得するだけ＝既存 data_source をそのまま再利用）
  - `appClockProvider` を watch し、モード変更時に即座に対象時刻を再取得
- **`KyoshinMonitorNotifier`**: 遅延判定 (`isDelayed`) を `appClock` 基準へ移行
- **`PlaybackModeModal`**（新規）: 通常再生 / タイムシフト offset プリセット（10秒〜5分前）を `AppClock` に対して切り替える UI。home のデバッグボタンから起動
  - デバッグボタンの導線を旧 `DebugReplayModal` から差し替え（旧 debug_replay は Phase C で EQRP リプレイへ置換・削除予定のため、本PRでは未参照のまま温存）
- EEW / 揺れ検知は Phase A の `appClock` 追従により追加変更なしでモードに同期

## このPRに含まないもの（後続）

- **Phase C**: EQRP リプレイ（`packages/earthquake_replay` に type 1003 `EqMonitorEewReplayData` パーサ追加、replay データソース seam、replay コントロールUI、旧 `debug_replay`/`EarthquakeReplayPage` 削除）
- **Phase D**: リアルタイムイベント発生時の自動復帰（設定可能）

## テスト

- 追加: `test/feature/playback_mode/ui/playback_mode_modal_test.dart`（3 ケース・widget テスト: 初期状態、プリセットタップで offset 設定、通常再生で復帰）
- `melos run analyze`（全パッケージ, `--fatal-infos`）: **SUCCESS**
- 関連テスト（playback_mode / clock / eew / shake_detection）: **79 件 green**

> ℹ️ 全体 `flutter test` の既存失敗2件（`debug_eew_asset_parse_test`・`home_earthquake_history_parameter_provider_test`）は develop でも失敗する本変更と無関係な既存不具合です。
