### PR TITLE
fix(deps): renovate の制約引き上げによる依存解決衝突を解消

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -140,7 +140,7 @@ dependencies:
   riverpod_annotation: ^4.0.0
   screenshot: 3.0.0
   sensors_plus: ^7.0.0
-  share_plus: ^13.0.0
+  share_plus: ^12.0.0
   shared_preferences: ^2.3.3
   shared_preferences_foundation: ^2.5.6
   sheet:

--- a/packages/eqmonitor_lints/pubspec.yaml
+++ b/packages/eqmonitor_lints/pubspec.yaml
@@ -10,7 +10,9 @@ dependencies:
   altive_lints: ^2.1.0
   analysis_server_plugin: ^0.3.4
   analyzer: ^9.0.0
-  analyzer_plugin: ^0.14.0
+  # analyzer_plugin 0.14 は analyzer >=10 を要求し analyzer ^9.0.0 と衝突するため
+  # analyzer ^9 互換の ^0.13.11 に固定する (altive_lints ^2.x の制約とも一致)。
+  analyzer_plugin: ^0.13.11
   flutter:
     sdk: flutter
   yumemi_lints: ^4.1.1


### PR DESCRIPTION
## 概要

workspace 全体で `pub get` / `melos bootstrap` / `flutter test` / `build_runner` が **依存解決失敗**で実行できなくなっていた問題を修正します。原因は renovate による制約引き上げが lock 再生成・エコシステム追従を伴わず、矛盾した状態でマージされていたことです。

## 衝突の内容

1. **analyzer_plugin**（#1270 由来）
  `eqmonitor_lints` が `analyzer ^9.0.0` と `analyzer_plugin ^0.14.0` を同時要求。しかし `analyzer_plugin 0.14` は `analyzer >=10.0.0` 必須で両立不可。さらに `altive_lints ^2.x` は `analyzer_plugin ^0.13.11` を要求。
2. **share_plus / win32**（#1280 由来）
  `share_plus ^13` は `win32 ^6` を要求するが、`package_info_plus 9` / `file_picker 11` が依存する `win32 ^5` と衝突（win32 6 を強制すると package_info_plus がコンパイルエラー）。
3. いずれも `pubspec.lock`（analyzer_plugin 0.13.11 / share_plus 12.0.2 / win32 5.x）が制約引き上げ前の値のままで、pubspec と不整合。

## 修正

制約を **committed lock と整合する既知の良好バージョンへ差し戻し**ます（最小差分・lock 変更なし）:

- `eqmonitor_lints`: `analyzer_plugin ^0.14.0` → `^0.13.11`
- `app`: `share_plus ^13.0.0` → `^12.0.0`

`pubspec.lock` は変更不要（上記で pubspec と一致）。

> renovate の前方アップグレード（analyzer 10 系・share_plus 13 系）を意図的に進める場合は、analyzer 依存パッケージ群および package_info_plus / file_picker を含めた協調アップグレードが別途必要です。本PRはまず CI/開発環境を復旧させることを目的とします。

## 検証

- `melos run analyze`（全パッケージ・`--fatal-infos`）: **SUCCESS**
- `flutter test`（app 全体）: 244 passed（既存の無関係な2件のみ失敗: `debug_eew_asset_parse_test` の matcher 誤用 / `home_earthquake_history_parameter_provider_test`）
