### PR TITLE
fix(app): リプレイ中のEEWが毎フレーム消えるバグを修正

### DIFF
--- a/app/lib/core/provider/clock/app_clock.dart
+++ b/app/lib/core/provider/clock/app_clock.dart
@@ -44,3 +44,12 @@ class AppClock extends _$AppClock {
     }
   }
 }
+
+/// リプレイ再生中かどうか。
+///
+/// 値が bool のため、再生位置更新（[AppClock.updateReplayTime] による
+/// 毎フレームの [TimeMode] 再生成）では通知されず、リプレイの開始/終了という
+/// モード遷移時のみ購読側へ通知される。
+@Riverpod(keepAlive: true)
+bool isReplayMode(Ref ref) =>
+    ref.watch(appClockProvider) is ReplayTimeMode;

--- a/app/lib/core/provider/clock/app_clock.g.dart
+++ b/app/lib/core/provider/clock/app_clock.g.dart
@@ -86,3 +86,60 @@ abstract class _$AppClock extends $Notifier<TimeMode> {
     element.handleCreate(ref, build);
   }
 }
+
+/// リプレイ再生中かどうか。
+///
+/// 値が bool のため、再生位置更新（[AppClock.updateReplayTime] による
+/// 毎フレームの [TimeMode] 再生成）では通知されず、リプレイの開始/終了という
+/// モード遷移時のみ購読側へ通知される。
+
+@ProviderFor(isReplayMode)
+final isReplayModeProvider = IsReplayModeProvider._();
+
+/// リプレイ再生中かどうか。
+///
+/// 値が bool のため、再生位置更新（[AppClock.updateReplayTime] による
+/// 毎フレームの [TimeMode] 再生成）では通知されず、リプレイの開始/終了という
+/// モード遷移時のみ購読側へ通知される。
+
+final class IsReplayModeProvider extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// リプレイ再生中かどうか。
+  ///
+  /// 値が bool のため、再生位置更新（[AppClock.updateReplayTime] による
+  /// 毎フレームの [TimeMode] 再生成）では通知されず、リプレイの開始/終了という
+  /// モード遷移時のみ購読側へ通知される。
+  IsReplayModeProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'isReplayModeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$isReplayModeHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return isReplayMode(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$isReplayModeHash() => r'ffd3de0c6622ab10c56b7687418b48812d8f2285';

--- a/app/lib/core/provider/time_ticker.dart
+++ b/app/lib/core/provider/time_ticker.dart
@@ -7,14 +7,16 @@ part 'time_ticker.g.dart';
 /// [duration] 周期で現在時刻を配信するティッカー。
 ///
 /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
-/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
+/// NTP 補正に追従する。各 tick で [AppClock] の現在時刻を読むため、
+/// リプレイ中の再生位置更新では張り直さず、リプレイ開始/終了と NTP 同期時のみ
+/// ストリームを張り直す（毎フレーム張り直しによる周期停止を防ぐ）。
 @Riverpod(keepAlive: true)
 Stream<DateTime> timeTicker(
   Ref ref, [
   Duration duration = const Duration(seconds: 1),
 ]) {
   ref
-    ..watch(appClockProvider)
+    ..watch(isReplayModeProvider)
     ..watch(ntpProvider);
   final clock = ref.read(appClockProvider.notifier);
   return Stream.periodic(duration, (_) => clock.now());

--- a/app/lib/core/provider/time_ticker.g.dart
+++ b/app/lib/core/provider/time_ticker.g.dart
@@ -13,7 +13,9 @@ part of 'time_ticker.dart';
 /// [duration] 周期で現在時刻を配信するティッカー。
 ///
 /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
-/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
+/// NTP 補正に追従する。各 tick で [AppClock] の現在時刻を読むため、
+/// リプレイ中の再生位置更新では張り直さず、リプレイ開始/終了と NTP 同期時のみ
+/// ストリームを張り直す（毎フレーム張り直しによる周期停止を防ぐ）。
 
 @ProviderFor(timeTicker)
 final timeTickerProvider = TimeTickerFamily._();
@@ -21,7 +23,9 @@ final timeTickerProvider = TimeTickerFamily._();
 /// [duration] 周期で現在時刻を配信するティッカー。
 ///
 /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
-/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
+/// NTP 補正に追従する。各 tick で [AppClock] の現在時刻を読むため、
+/// リプレイ中の再生位置更新では張り直さず、リプレイ開始/終了と NTP 同期時のみ
+/// ストリームを張り直す（毎フレーム張り直しによる周期停止を防ぐ）。
 
 final class TimeTickerProvider
     extends
@@ -30,7 +34,9 @@ final class TimeTickerProvider
   /// [duration] 周期で現在時刻を配信するティッカー。
   ///
   /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
-  /// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
+  /// NTP 補正に追従する。各 tick で [AppClock] の現在時刻を読むため、
+  /// リプレイ中の再生位置更新では張り直さず、リプレイ開始/終了と NTP 同期時のみ
+  /// ストリームを張り直す（毎フレーム張り直しによる周期停止を防ぐ）。
   TimeTickerProvider._({
     required TimeTickerFamily super.from,
     required Duration super.argument,
@@ -74,12 +80,14 @@ final class TimeTickerProvider
   }
 }
 
-String _$timeTickerHash() => r'a3193d2c43a5d0925907de84e2b921e61347dae4';
+String _$timeTickerHash() => r'3a0f645f3e86df31a145fad4d20be52845feb2ac';
 
 /// [duration] 周期で現在時刻を配信するティッカー。
 ///
 /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
-/// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
+/// NTP 補正に追従する。各 tick で [AppClock] の現在時刻を読むため、
+/// リプレイ中の再生位置更新では張り直さず、リプレイ開始/終了と NTP 同期時のみ
+/// ストリームを張り直す（毎フレーム張り直しによる周期停止を防ぐ）。
 
 final class TimeTickerFamily extends $Family
     with $FunctionalFamilyOverride<Stream<DateTime>, Duration> {
@@ -95,7 +103,9 @@ final class TimeTickerFamily extends $Family
   /// [duration] 周期で現在時刻を配信するティッカー。
   ///
   /// 時刻は [AppClock] を経由するため、再生モード（通常/タイムシフト/リプレイ）と
-  /// NTP 補正に追従する。モードや NTP offset が変化した場合はストリームを張り直す。
+  /// NTP 補正に追従する。各 tick で [AppClock] の現在時刻を読むため、
+  /// リプレイ中の再生位置更新では張り直さず、リプレイ開始/終了と NTP 同期時のみ
+  /// ストリームを張り直す（毎フレーム張り直しによる周期停止を防ぐ）。
 
   TimeTickerProvider call([Duration duration = const Duration(seconds: 1)]) =>
       TimeTickerProvider._(argument: duration, from: this);

--- a/app/lib/feature/eew/data/eew.dart
+++ b/app/lib/feature/eew/data/eew.dart
@@ -4,7 +4,6 @@ import 'dart:ui';
 import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
 import 'package:eqmonitor/core/provider/clock/app_clock.dart';
-import 'package:eqmonitor/core/provider/clock/time_mode.dart';
 import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart';
 import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_state.dart';
 import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
@@ -20,7 +19,9 @@ class Eew extends _$Eew {
   AsyncValue<List<EewTelegramItem>> build() {
     // リプレイ再生中はライブ受信を切り離し、リプレイ由来のEEWのみを保持する。
     // モードが通常/タイムシフトへ戻ると build が再実行されライブへ復帰する。
-    if (ref.watch(appClockProvider) is ReplayTimeMode) {
+    // isReplayModeProvider は bool のため、再生位置更新では再ビルドされず
+    // upsert 済みEEWが毎フレーム消えることを防ぐ。
+    if (ref.watch(isReplayModeProvider)) {
       return const AsyncData([]);
     }
 

--- a/app/test/feature/eew/data/eew_replay_gating_test.dart
+++ b/app/test/feature/eew/data/eew_replay_gating_test.dart
@@ -44,5 +44,23 @@ void main() {
       expect(state, hasLength(1));
       expect(state.single.eventId, '20240101161010');
     });
+
+    test('再生位置の更新(updateReplayTime)で upsert 済みEEWが消えないこと', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final clock = container.read(appClockProvider.notifier)
+        ..enterReplay(DateTime.utc(2024, 1, 1, 7, 10, 8));
+      container.read(eewProvider.notifier).upsert(_eew('20240101161010'));
+
+      // フレームが進むたびに updateReplayTime が呼ばれる状況を再現
+      clock
+        ..updateReplayTime(DateTime.utc(2024, 1, 1, 7, 10, 9))
+        ..updateReplayTime(DateTime.utc(2024, 1, 1, 7, 10, 10));
+
+      final state = container.read(eewProvider).value!;
+      expect(state, hasLength(1));
+      expect(state.single.eventId, '20240101161010');
+    });
   });
 }


### PR DESCRIPTION
## 概要

#1297（Phase C）でマージされた EQRP リプレイの **重大バグを修正**します。

## バグ

`eewProvider.build()` がリプレイ判定で `ref.watch(appClockProvider)`（`TimeMode` 全体）を購読していたため、再生中フレームごとに呼ばれる `AppClock.updateReplayTime`（毎回新しい `TimeMode.replay` インスタンスを生成）で `build` が再実行され、`return const AsyncData([])` により **upsert 済みのリプレイ EEW が毎フレーム消える**状態でした。結果、リプレイ中に EEW が地図へほぼ表示されません。

## 修正

- **`isReplayMode`（bool）provider** を新設。値が bool のため、再生位置更新による `TimeMode` 再生成では通知されず、**リプレイ開始/終了のモード遷移時のみ**購読側へ通知される。
- `eewProvider` はこれを購読して遮断判定する（毎フレーム再ビルドしない）。
- `timeTicker` も同様に `isReplayMode` を購読するよう変更。従来は `appClockProvider` 購読で再生位置更新のたびに `Stream.periodic` を張り直しており、フレームが 1 秒より速い場合に 1 秒周期ティックが発火し続けない問題があった。

## テスト

- 回帰テスト追加: `再生位置の更新(updateReplayTime)で upsert 済みEEWが消えないこと`（修正前は失敗・修正後 green を確認）
- `dart analyze`（core/provider・eew）: No issues found
- 既存の clock / eew gating テスト: green
