### PR TITLE
feat(app): 再生中のリアルタイムイベント自動復帰を追加 (Phase D)

### DIFF
--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -20,6 +20,7 @@ enum SharedPreferencesKey {
   lastApnsTokenHash('last_apns_token_hash'),
   lastApnsPushToStartTokenHash('last_apns_push_to_start_token_hash'),
   adsOptOut('ads_opt_out'),
+  autoReturnToRealtime('auto_return_to_realtime'),
   ;
 
   const SharedPreferencesKey(this.key);

--- a/app/lib/feature/playback_mode/data/auto_return_policy.dart
+++ b/app/lib/feature/playback_mode/data/auto_return_policy.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_return_policy.g.dart';
+
+@Riverpod(keepAlive: true)
+AutoReturnPolicy autoReturnPolicy(Ref ref) => const AutoReturnPolicy();
+
+/// リアルタイムイベントが「通常再生へ自動復帰すべき新規アラート」かを判定する。
+class AutoReturnPolicy {
+  const AutoReturnPolicy();
+
+  /// 復帰トリガーとなるのは、リアルタイムの EEW 更新、および
+  /// リプレイ由来でない揺れ検知イベント。
+  /// 初期スナップショットや地震情報・推定震度などは対象外。
+  bool shouldReturnToRealtime(RealtimeEvent event) => switch (event) {
+    RealtimeEewUpsertEvent() => true,
+    RealtimeShakeDetectedEvent(:final data) => !data.isReplay,
+    _ => false,
+  };
+}

--- a/app/lib/feature/playback_mode/data/auto_return_policy.g.dart
+++ b/app/lib/feature/playback_mode/data/auto_return_policy.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'auto_return_policy.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(autoReturnPolicy)
+final autoReturnPolicyProvider = AutoReturnPolicyProvider._();
+
+final class AutoReturnPolicyProvider
+    extends
+        $FunctionalProvider<
+          AutoReturnPolicy,
+          AutoReturnPolicy,
+          AutoReturnPolicy
+        >
+    with $Provider<AutoReturnPolicy> {
+  AutoReturnPolicyProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoReturnPolicyProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoReturnPolicyHash();
+
+  @$internal
+  @override
+  $ProviderElement<AutoReturnPolicy> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AutoReturnPolicy create(Ref ref) {
+    return autoReturnPolicy(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AutoReturnPolicy value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AutoReturnPolicy>(value),
+    );
+  }
+}
+
+String _$autoReturnPolicyHash() => r'ac63f44efd7e6f69ecec43c9b867283559acd887';

--- a/app/lib/feature/playback_mode/data/notifier/auto_return_to_realtime_notifier.dart
+++ b/app/lib/feature/playback_mode/data/notifier/auto_return_to_realtime_notifier.dart
@@ -1,0 +1,27 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_return_to_realtime_notifier.g.dart';
+
+/// タイムシフト/リプレイ再生中にリアルタイムの EEW・揺れ検知イベントが発生した際、
+/// 通常再生（ライブ）へ自動的に戻すかどうかの設定。
+///
+/// 防災アプリの性質上、デフォルトは有効（戻す）。
+@Riverpod(keepAlive: true)
+class AutoReturnToRealtimeNotifier extends _$AutoReturnToRealtimeNotifier {
+  static const SharedPreferencesKey _key =
+      SharedPreferencesKey.autoReturnToRealtime;
+
+  @override
+  bool build() {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    return prefs.getBool(_key.key) ?? true;
+  }
+
+  Future<void> set({required bool value}) async {
+    final prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setBool(_key.key, value);
+    state = value;
+  }
+}

--- a/app/lib/feature/playback_mode/data/notifier/auto_return_to_realtime_notifier.g.dart
+++ b/app/lib/feature/playback_mode/data/notifier/auto_return_to_realtime_notifier.g.dart
@@ -1,0 +1,82 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'auto_return_to_realtime_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// タイムシフト/リプレイ再生中にリアルタイムの EEW・揺れ検知イベントが発生した際、
+/// 通常再生（ライブ）へ自動的に戻すかどうかの設定。
+///
+/// 防災アプリの性質上、デフォルトは有効（戻す）。
+
+@ProviderFor(AutoReturnToRealtimeNotifier)
+final autoReturnToRealtimeProvider = AutoReturnToRealtimeNotifierProvider._();
+
+/// タイムシフト/リプレイ再生中にリアルタイムの EEW・揺れ検知イベントが発生した際、
+/// 通常再生（ライブ）へ自動的に戻すかどうかの設定。
+///
+/// 防災アプリの性質上、デフォルトは有効（戻す）。
+final class AutoReturnToRealtimeNotifierProvider
+    extends $NotifierProvider<AutoReturnToRealtimeNotifier, bool> {
+  /// タイムシフト/リプレイ再生中にリアルタイムの EEW・揺れ検知イベントが発生した際、
+  /// 通常再生（ライブ）へ自動的に戻すかどうかの設定。
+  ///
+  /// 防災アプリの性質上、デフォルトは有効（戻す）。
+  AutoReturnToRealtimeNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoReturnToRealtimeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoReturnToRealtimeNotifierHash();
+
+  @$internal
+  @override
+  AutoReturnToRealtimeNotifier create() => AutoReturnToRealtimeNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$autoReturnToRealtimeNotifierHash() =>
+    r'19659d7582526b76108bfb8df2d427eb9c241b47';
+
+/// タイムシフト/リプレイ再生中にリアルタイムの EEW・揺れ検知イベントが発生した際、
+/// 通常再生（ライブ）へ自動的に戻すかどうかの設定。
+///
+/// 防災アプリの性質上、デフォルトは有効（戻す）。
+
+abstract class _$AutoReturnToRealtimeNotifier extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/playback_mode/data/notifier/auto_return_watcher.dart
+++ b/app/lib/feature/playback_mode/data/notifier/auto_return_watcher.dart
@@ -1,0 +1,47 @@
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/core/provider/clock/time_mode.dart';
+import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
+import 'package:eqmonitor/core/realtime/realtime_event_provider.dart';
+import 'package:eqmonitor/feature/earthquake_replay/data/notifier/replay_notifier.dart';
+import 'package:eqmonitor/feature/playback_mode/data/auto_return_policy.dart';
+import 'package:eqmonitor/feature/playback_mode/data/notifier/auto_return_to_realtime_notifier.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_return_watcher.g.dart';
+
+/// タイムシフト/リプレイ再生中に、ライブのリアルタイムイベント（EEW・揺れ検知）が
+/// 発生したら通常再生へ自動復帰させる常駐ウォッチャ。
+///
+/// リプレイ中は `eewProvider` 等がライブ受信を遮断するため、ここでは
+/// ライブの [realtimeEventsProvider] を直接購読してモード遷移のみを判断する。
+/// `main` で起動時に常駐させる。
+@Riverpod(keepAlive: true)
+class AutoReturnWatcher extends _$AutoReturnWatcher {
+  @override
+  void build() {
+    ref.listen(realtimeEventsProvider, (_, next) {
+      next.whenData(_onEvent);
+    });
+  }
+
+  void _onEvent(RealtimeEvent event) {
+    // 通常再生中は対象外
+    if (ref.read(appClockProvider) is RealtimeTimeMode) {
+      return;
+    }
+    // 設定で無効化されている場合は何もしない
+    if (!ref.read(autoReturnToRealtimeProvider)) {
+      return;
+    }
+    if (!ref.read(autoReturnPolicyProvider).shouldReturnToRealtime(event)) {
+      return;
+    }
+    // リプレイ中なら再生停止（appClock も通常再生へ戻る）、
+    // タイムシフト中なら通常再生へ戻す。
+    if (ref.read(replayProvider) != null) {
+      ref.read(replayProvider.notifier).exit();
+    } else {
+      ref.read(appClockProvider.notifier).returnToRealtime();
+    }
+  }
+}

--- a/app/lib/feature/playback_mode/data/notifier/auto_return_watcher.g.dart
+++ b/app/lib/feature/playback_mode/data/notifier/auto_return_watcher.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'auto_return_watcher.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// タイムシフト/リプレイ再生中に、ライブのリアルタイムイベント（EEW・揺れ検知）が
+/// 発生したら通常再生へ自動復帰させる常駐ウォッチャ。
+///
+/// リプレイ中は `eewProvider` 等がライブ受信を遮断するため、ここでは
+/// ライブの [realtimeEventsProvider] を直接購読してモード遷移のみを判断する。
+/// `main` で起動時に常駐させる。
+
+@ProviderFor(AutoReturnWatcher)
+final autoReturnWatcherProvider = AutoReturnWatcherProvider._();
+
+/// タイムシフト/リプレイ再生中に、ライブのリアルタイムイベント（EEW・揺れ検知）が
+/// 発生したら通常再生へ自動復帰させる常駐ウォッチャ。
+///
+/// リプレイ中は `eewProvider` 等がライブ受信を遮断するため、ここでは
+/// ライブの [realtimeEventsProvider] を直接購読してモード遷移のみを判断する。
+/// `main` で起動時に常駐させる。
+final class AutoReturnWatcherProvider
+    extends $NotifierProvider<AutoReturnWatcher, void> {
+  /// タイムシフト/リプレイ再生中に、ライブのリアルタイムイベント（EEW・揺れ検知）が
+  /// 発生したら通常再生へ自動復帰させる常駐ウォッチャ。
+  ///
+  /// リプレイ中は `eewProvider` 等がライブ受信を遮断するため、ここでは
+  /// ライブの [realtimeEventsProvider] を直接購読してモード遷移のみを判断する。
+  /// `main` で起動時に常駐させる。
+  AutoReturnWatcherProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'autoReturnWatcherProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$autoReturnWatcherHash();
+
+  @$internal
+  @override
+  AutoReturnWatcher create() => AutoReturnWatcher();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$autoReturnWatcherHash() => r'ccd766520dd9cf725395a4230dfc878add617913';
+
+/// タイムシフト/リプレイ再生中に、ライブのリアルタイムイベント（EEW・揺れ検知）が
+/// 発生したら通常再生へ自動復帰させる常駐ウォッチャ。
+///
+/// リプレイ中は `eewProvider` 等がライブ受信を遮断するため、ここでは
+/// ライブの [realtimeEventsProvider] を直接購読してモード遷移のみを判断する。
+/// `main` で起動時に常駐させる。
+
+abstract class _$AutoReturnWatcher extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/playback_mode/ui/playback_mode_modal.dart
+++ b/app/lib/feature/playback_mode/ui/playback_mode_modal.dart
@@ -2,6 +2,7 @@ import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/clock/time_mode.dart';
 import 'package:eqmonitor/feature/earthquake_replay/data/notifier/replay_notifier.dart';
+import 'package:eqmonitor/feature/playback_mode/data/notifier/auto_return_to_realtime_notifier.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -65,6 +66,9 @@ class PlaybackModeModal extends ConsumerWidget {
               const _OpenReplayFileButton(),
             ],
             SizedBox(height: spacing.sm),
+            const Divider(),
+            const _AutoReturnToggle(),
+            SizedBox(height: spacing.sm),
           ],
         ),
       ),
@@ -116,6 +120,24 @@ class _TimeShiftSection extends ConsumerWidget {
           ],
         ),
       ],
+    );
+  }
+}
+
+class _AutoReturnToggle extends ConsumerWidget {
+  const _AutoReturnToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabled = ref.watch(autoReturnToRealtimeProvider);
+    return SwitchListTile(
+      contentPadding: EdgeInsets.zero,
+      title: const Text('リアルタイムイベントで通常再生に戻る'),
+      subtitle: const Text('再生中にEEW・揺れ検知が発生したら自動で現在へ復帰します'),
+      value: enabled,
+      onChanged: (value) async => ref
+          .read(autoReturnToRealtimeProvider.notifier)
+          .set(value: value),
     );
   }
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:eqmonitor/feature/kyoshin_monitor/data/kyoshin_color_map_data_so
 import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_color_map.dart';
 import 'package:eqmonitor/feature/live_activity/data/repository/live_activity_token_sync_service.dart';
 import 'package:eqmonitor/feature/location/data/background_location_service.dart';
+import 'package:eqmonitor/feature/playback_mode/data/notifier/auto_return_watcher.dart';
 import 'package:eqmonitor/firebase_options.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -217,6 +218,8 @@ Future<void> _main() async {
 
   container.read(eqMonitorWsStatusProvider);
   container.read(realtimeEventsProvider);
+  // リプレイ/タイムシフト中にライブイベントが来たら通常再生へ戻すウォッチャを常駐させる。
+  container.read(autoReturnWatcherProvider);
   // killed状態で永続化された位置情報の反映と、live位置更新の購読を開始する。
   // backgroundLocationServiceProvider は keepAlive: true で常駐させる。
   container.listen(backgroundLocationServiceProvider, (_, _) {});

--- a/app/test/feature/playback_mode/data/auto_return_policy_test.dart
+++ b/app/test/feature/playback_mode/data/auto_return_policy_test.dart
@@ -1,0 +1,75 @@
+import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
+import 'package:eqmonitor/core/realtime/model/realtime_shake_data.dart';
+import 'package:eqmonitor/feature/playback_mode/data/auto_return_policy.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+RealtimeShakeData _shake({required bool isReplay}) => RealtimeShakeData(
+  eventId: 'shake-1',
+  createdAt: DateTime.utc(2024, 1, 1, 7, 10, 8),
+  level: 'weak',
+  isReplay: isReplay,
+  pointCount: 1,
+  minLat: 36,
+  maxLat: 38,
+  minLng: 136,
+  maxLng: 138,
+);
+
+EewItemWithRelations _eewItem() => EewItemWithRelations.fromJson(const {
+  'event_id': '20240101161010',
+  'type': 'VXSE45',
+  'status': 'NORMAL',
+  'info_type': 'PUBLICATION',
+  'serial_no': 1,
+  'headline': null,
+  'is_canceled': false,
+  'is_warning': null,
+  'is_last_info': false,
+  'origin_time': null,
+  'arrival_time': null,
+  'accuracy': null,
+  'is_plum': false,
+  'editorial_office': null,
+  'report_time': '2024-01-01T07:10:16.000Z',
+});
+
+void main() {
+  const policy = AutoReturnPolicy();
+
+  group('AutoReturnPolicy.shouldReturnToRealtime', () {
+    test('EEW更新は復帰トリガーになること', () {
+      final event = RealtimeEvent.eewUpsert(
+        item: _eewItem(),
+        source: RealtimeSource.eqmonitor,
+      );
+      expect(policy.shouldReturnToRealtime(event), isTrue);
+    });
+
+    test('リプレイ由来でない揺れ検知は復帰トリガーになること', () {
+      final event = RealtimeEvent.shakeDetected(
+        data: _shake(isReplay: false),
+        source: RealtimeSource.eqmonitor,
+      );
+      expect(policy.shouldReturnToRealtime(event), isTrue);
+    });
+
+    test('リプレイ由来の揺れ検知は復帰トリガーにならないこと', () {
+      final event = RealtimeEvent.shakeDetected(
+        data: _shake(isReplay: true),
+        source: RealtimeSource.eqmonitor,
+      );
+      expect(policy.shouldReturnToRealtime(event), isFalse);
+    });
+
+    test('初期スナップショットは復帰トリガーにならないこと', () {
+      const event = RealtimeEvent.snapshot(
+        eews: [],
+        earthquakes: [],
+        shakes: [],
+        source: RealtimeSource.eqmonitor,
+      );
+      expect(policy.shouldReturnToRealtime(event), isFalse);
+    });
+  });
+}

--- a/app/test/feature/playback_mode/ui/playback_mode_modal_test.dart
+++ b/app/test/feature/playback_mode/ui/playback_mode_modal_test.dart
@@ -1,16 +1,26 @@
 import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
 import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/clock/time_mode.dart';
+import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
 import 'package:eqmonitor/feature/playback_mode/ui/playback_mode_modal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   Future<ProviderContainer> pumpModal(WidgetTester tester) async {
-    final container = ProviderContainer();
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        app_prefs.sharedPreferencesProvider.overrideWithValue(
+          app_prefs.SharedPreferencesAsync(prefs),
+        ),
+      ],
+    );
     addTearDown(container.dispose);
     await tester.pumpWidget(
       UncontrolledProviderScope(


### PR DESCRIPTION
## 概要

EQRP リプレイ／タイムシフト機能の **Phase D（リアルタイムイベント自動復帰）** です。タイムシフト/リプレイ再生中に**ライブの EEW・揺れ検知が発生したら通常再生へ自動的に戻す**仕組みと、その有効/無効を切り替える設定を追加します。

> ℹ️ EEW 表示の根幹に関わる #1298（リプレイ中EEWが毎フレーム消えるバグ修正）が未マージの場合は、先にそちらをマージ推奨です（本PRは独立して動作しますが、リプレイ中のEEW表示自体が #1298 に依存します）。

## 変更点

- **`AutoReturnToRealtimeNotifier`**: 自動復帰の有効/無効を `SharedPreferences` で永続化。防災アプリの性質上**デフォルト有効**。
- **`AutoReturnPolicy`**: 復帰トリガー判定（純粋ロジック・DI）。リアルタイムの **EEW 更新** と **リプレイ由来でない揺れ検知**のみを復帰対象とし、初期スナップショット・地震情報等は対象外。
- **`AutoReturnWatcher`**: ライブ `realtimeEventsProvider` を**常駐購読**（リプレイ中は `eewProvider` 等がライブを遮断するため、watcher が直接購読）。非通常再生中に復帰トリガーを受けたら、リプレイ中は再生終了・タイムシフト中は通常再生へ戻す。`main` の起動時に常駐させる。
- **`PlaybackModeModal`**: 「リアルタイムイベントで通常再生に戻る」トグルを追加。

## テスト

- 追加: `auto_return_policy_test.dart`（EEW更新→復帰 / 非リプレイ揺れ→復帰 / リプレイ揺れ→非復帰 / スナップショット→非復帰）
- 既存 `playback_mode_modal_test.dart` をトグル追加に合わせて更新（SharedPreferences モック注入）
- `melos run analyze`（全パッケージ・`--fatal-infos`）: **SUCCESS**
- playback_mode テスト: green

## これで EQRP リプレイ機能一式（Phase A〜D）が完了

A: 再生モード基盤(appClock/NTP) → B: タイムシフト → C: EQRP リプレイ(強震モニタ+EEW)・旧debug_replay削除 → D: 自動復帰。
