### PR TITLE
fix(kyoshin_monitor): 遅延判定の差分の符号が逆転していた不具合を修正

### DIFF
--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
@@ -75,9 +75,12 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
         .api
         .imageFetchInterval;
     final delay = imageFetchInterval + const Duration(seconds: 5);
-    final isDelayed =
-        targetTime.difference(ref.read(appClockProvider.notifier).now()) >
-        delay;
+    final now = ref.read(appClockProvider.notifier).now();
+    final isDelayed = isImageDelayed(
+      now: now,
+      targetTime: targetTime,
+      delay: delay,
+    );
 
     if (state.isLoading) {
       return;
@@ -163,4 +166,16 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
       ),
     );
   }
+
+  /// 画像が遅延しているかどうかを判定する。
+  ///
+  /// [targetTime] は取得対象の時刻で、常に現在時刻([now])より過去になる。
+  /// データが [delay] 以上遅れている (= `now - targetTime > delay`) 場合に
+  /// 遅延とみなす。
+  @visibleForTesting
+  static bool isImageDelayed({
+    required DateTime now,
+    required DateTime targetTime,
+    required Duration delay,
+  }) => now.difference(targetTime) > delay;
 }

--- a/app/test/feature/kyoshin_monitor/kyoshin_monitor_delay_test.dart
+++ b/app/test/feature/kyoshin_monitor/kyoshin_monitor_delay_test.dart
@@ -1,0 +1,73 @@
+import 'package:eqmonitor/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // 遅延判定のしきい値。imageFetchInterval(例: 1秒) + 5秒 を想定。
+  const delay = Duration(seconds: 6);
+  // 基準となる現在時刻。テストを決定的にするため固定値を使う。
+  final now = DateTime.utc(2025, 1, 1, 12);
+
+  group('KyoshinMonitorNotifier.isImageDelayed', () {
+    test('targetTime が delay より古い (now - (delay + 1s)) 場合は遅延と判定する', () {
+      final targetTime = now.subtract(delay + const Duration(seconds: 1));
+      expect(
+        KyoshinMonitorNotifier.isImageDelayed(
+          now: now,
+          targetTime: targetTime,
+          delay: delay,
+        ),
+        isTrue,
+      );
+    });
+
+    test('targetTime の遅れが delay 未満 (now - (delay - 1s)) の場合は遅延としない', () {
+      final targetTime = now.subtract(delay - const Duration(seconds: 1));
+      expect(
+        KyoshinMonitorNotifier.isImageDelayed(
+          now: now,
+          targetTime: targetTime,
+          delay: delay,
+        ),
+        isFalse,
+      );
+    });
+
+    test('targetTime == now (差0) の場合は遅延としない', () {
+      expect(
+        KyoshinMonitorNotifier.isImageDelayed(
+          now: now,
+          targetTime: now,
+          delay: delay,
+        ),
+        isFalse,
+      );
+    });
+
+    // 回帰テスト:
+    // 修正前の実装は `targetTime.difference(now) > delay` だった。
+    // targetTime は呼び出し元(kyoshin_monitor_timer_stream.dart)で常に
+    // `clock.now().subtract(delayFromDevice)` として生成されるため、必ず現在時刻
+    // より過去になる。よって `targetTime.difference(now)` は常に負となり、
+    // `負 > 正(delay)` は決して true にならず、遅延判定が永遠に false のままだった。
+    // 正しくは `now.difference(targetTime) > delay`(差分の向きが逆)。
+    // 下記は「明確に遅延している」入力で、旧実装なら false に倒れていたケースが
+    // 現実装では true になることを保証する。
+    test('回帰: 明確に遅延した過去時刻は true になる (旧実装では false に倒れていた)', () {
+      final targetTime = now.subtract(const Duration(minutes: 10));
+
+      // 現実装(正しい向き)では遅延と判定される。
+      expect(
+        KyoshinMonitorNotifier.isImageDelayed(
+          now: now,
+          targetTime: targetTime,
+          delay: delay,
+        ),
+        isTrue,
+      );
+
+      // 旧実装の向き(符号反転バグ)を再現すると false になってしまうことを示す。
+      final buggyResult = targetTime.difference(now) > delay;
+      expect(buggyResult, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## バグ内容

強震モニタ画面の遅延表示機能が常に動作していませんでした。データが遅延していても `KyoshinMonitorState.status` が `delayed` になることが一度もなく、遅延表示が機能していませんでした。

## 原因

`app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart` の `_fetchAndAnalyzeImage` 内の遅延判定で、差分の向き(符号)が逆転していました。

```dart
final isDelayed =
    targetTime.difference(ref.read(appClockProvider.notifier).now()) > delay;
```

- `targetTime` は呼び出し元 (`kyoshin_monitor_timer_stream.dart`) で常に `clock.now().subtract(delayFromDevice)` として生成されるため、**必ず現在時刻より過去**になります。
- そのため `targetTime.difference(now)` は常に負の `Duration` となり、`負 > 正(delay)` は決して `true` になりません。結果として `isDelayed` が永遠に `false` のままで、遅延表示が死んでいました。
- 「interval + 5秒以上遅れている場合は遅延として扱う」という意図に対する正しい式は `now.difference(targetTime) > delay`(差分の向きが逆)です。

## 修正内容

- 遅延判定を純粋関数の静的ヘルパー `isImageDelayed({now, targetTime, delay})` として切り出し、正しい向き `now.difference(targetTime) > delay` に修正しました。
- `_fetchAndAnalyzeImage` 内では `now` を一度だけ読み取り、このヘルパーを呼ぶ形に書き換えました。
- `@visibleForTesting` を付与してテストから検証可能にしています(同ディレクトリの `kyoshin_monitor_timer_notifier.dart` と同様、`package:flutter/widgets.dart` 経由)。

## 追加したテスト

`app/test/feature/kyoshin_monitor/kyoshin_monitor_delay_test.dart` を新規追加し、以下を検証しています。

- `targetTime = now - (delay + 1秒)` → `true`(遅延と判定)
- `targetTime = now - (delay - 1秒)` → `false`
- `targetTime = now`(差0) → `false`
- 回帰: 明確に遅延した過去時刻で現実装は `true` になり、旧実装の向き `targetTime.difference(now) > delay` だと `false` に倒れてしまうことを明示

### テスト実行結果

```
flutter test test/feature/kyoshin_monitor/kyoshin_monitor_delay_test.dart
00:00 +4: All tests passed!
```