### PR TITLE
fix(knet_waveform_parser): 計測震度の0.3秒窓がサンプリング周波数100Hz固定だった不具合を修正

### DIFF
--- a/packages/knet_waveform_parser/lib/src/intensity/knet_intensity_calculator.dart
+++ b/packages/knet_waveform_parser/lib/src/intensity/knet_intensity_calculator.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:knet_waveform_parser/src/csv/knet_csv_parser.dart';
 import 'package:knet_waveform_parser/src/model/knet_channel_direction.dart';
+import 'package:meta/meta.dart';
 
 /// JMA計測震度算出クラス（特許第5946067号の実装）
 ///
@@ -127,6 +128,16 @@ class KnetIntensityCalculator {
     return yd[0];
   }
 
+  /// 0.3秒に相当するサンプル数を算出する。
+  ///
+  /// 気象庁の計測震度算出方法に従い `floor(seconds × サンプリング周波数)`
+  /// を返す。100Hz では 30、200Hz（KiK-net 等）では 60 となる。
+  @visibleForTesting
+  static int durationSampleCount(
+    double samplingFrequencyHz, [
+    double seconds = 0.3,
+  ]) => (samplingFrequencyHz * seconds).floor();
+
   /// CSVレコードからJMA計測震度（小数値）を算出する
   ///
   /// 戻り値は小数第1位まで (0.1 刻み)。
@@ -175,13 +186,17 @@ class KnetIntensityCalculator {
       );
     }
 
-    if (composites.length < 30) {
+    // 気象庁仕様: 3成分合成波形を降順ソートし、大きい方から
+    // floor(0.3 × サンプリング周波数) 番目の加速度値を a0 とする。
+    // サンプリング周波数を固定せず _fs から窓サンプル数を算出する。
+    final n = durationSampleCount(_fs);
+    if (composites.length < n) {
       return 0;
     }
 
-    // 降順ソートして30番目の値を取得（0.3秒相当の最大値）
+    // 降順ソートして floor(0.3×fs) 番目の値を取得（0.3秒相当の値）
     composites.sort((x, y) => y.compareTo(x));
-    final v = composites[29];
+    final v = composites[n - 1];
     if (v <= 0) {
       return 0;
     }

--- a/packages/knet_waveform_parser/pubspec.yaml
+++ b/packages/knet_waveform_parser/pubspec.yaml
@@ -12,6 +12,7 @@ resolution: workspace
 dependencies:
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
+  meta: ^1.12.0
 
 dev_dependencies:
   altive_lints: ^2.1.0

--- a/packages/knet_waveform_parser/test/src/intensity/knet_intensity_calculator_test.dart
+++ b/packages/knet_waveform_parser/test/src/intensity/knet_intensity_calculator_test.dart
@@ -20,6 +20,22 @@ void main() {
       expect(rawInt, lessThan(4.5));
     });
 
+    // 回帰テスト: 100Hz fixture の計測震度値が修正前後で変化しないことを担保する。
+    // 100Hz では floor(0.3×100)=30 となり、修正前の `composites[29]`（30番目）と
+    // 一致するため、本テストの固定値は変わってはならない。
+    test('AIC001 100Hz fixture の計測震度値が修正後も不変（回帰テスト）', () {
+      final csvText = _loadFixture('AIC0011103111446.csv');
+      final record = const KnetCsvParser().parse(csvText);
+
+      expect(record.samplingFrequencyHz, 100);
+
+      final calc = KnetIntensityCalculator(
+        samplingFrequencyHz: record.samplingFrequencyHz,
+      );
+
+      expect(calc.calculate(record), closeTo(3.4, 1e-9));
+    });
+
     test('震度ラベル変換が正しい', () {
       expect(KnetIntensityCalculator.toJmaLabel(0), '0');
       expect(KnetIntensityCalculator.toJmaLabel(0.4), '0');
@@ -67,6 +83,53 @@ void main() {
       );
 
       final calc = KnetIntensityCalculator();
+      expect(calc.calculate(record), equals(0.0));
+    });
+
+    group('durationSampleCount (0.3秒窓のサンプル数)', () {
+      test('floor(0.3 × サンプリング周波数) を返す', () {
+        // 100Hz: floor(0.3×100)=30（従来挙動と一致）
+        expect(KnetIntensityCalculator.durationSampleCount(100), 30);
+        // 200Hz (KiK-net 等): floor(0.3×200)=60
+        expect(KnetIntensityCalculator.durationSampleCount(200), 60);
+        // 50Hz: floor(0.3×50)=15
+        expect(KnetIntensityCalculator.durationSampleCount(50), 15);
+      });
+
+      test('秒数を明示しても 100Hz では 30 になる', () {
+        // 秒数を明示的に指定しても既定値と同じ結果になることを確認する。
+        // ignore: avoid_redundant_argument_values
+        expect(KnetIntensityCalculator.durationSampleCount(100, 0.3), 30);
+      });
+    });
+
+    test('200Hz でサンプル数が窓サイズ(60)未満なら 0.0 を返す（境界）', () {
+      // 200Hz では 0.3秒窓 = 60サンプル必要。
+      // 40サンプルしか無い場合、合成波形長は 60 未満となりデータ不足扱い。
+      // 修正前は窓サイズが 30 固定だったため値を返していた箇所。
+      final record = KnetCsvRecord(
+        earthquakeInfo: null,
+        stationInfo: null,
+        offsets: [],
+        channelDirections: const [
+          KnetChannelDirection.ns,
+          KnetChannelDirection.ew,
+          KnetChannelDirection.ud,
+        ],
+        dataPoints: List.generate(
+          40,
+          (i) => KnetCsvDataPoint(
+            time: DateTime(2024),
+            relativeTimeSec: i * 0.005,
+            accelerationsGal: [100.0, 100.0, 100.0],
+          ),
+        ),
+        samplingFrequencyHz: 200,
+        durationTimeSec: 0.2,
+        networkType: KnetNetworkType.knet,
+      );
+
+      final calc = KnetIntensityCalculator(samplingFrequencyHz: 200);
       expect(calc.calculate(record), equals(0.0));
     });
 


### PR DESCRIPTION
## バグ内容

`KnetIntensityCalculator` はコンストラクタ `KnetIntensityCalculator({double samplingFrequencyHz = 100.0})` で任意のサンプリング周波数 `_fs` を受け取り、バターワース HPF や補正フィルタ係数（`_initHpf` / `_initA11` 等）はすべて `_fs` から動的に計算する設計になっている（=100Hz 専用ではない）。

ところが「0.3秒窓」の判定だけが `composites.length < 30` と `composites[29]` のマジックナンバーでハードコードされており、**100Hz でしか正しくなかった**。

## 気象庁仕様の根拠

気象庁の[計測震度の算出方法](https://www.data.jma.go.jp/eqev/data/kyoshin/kaisetsu/calc_sindo.htm)では、3成分合成波形を降順ソートし、大きい方から数えて **floor(0.3 × サンプリング周波数)** 番目の加速度値を a0 とし、`I = 2·log10(a0) + 0.94` で計測震度を定義する。

- 100Hz: floor(0.3 × 100) = 30 → index 29
- 200Hz（KiK-net 等）: floor(0.3 × 200) = 60 → index 59

## 影響

- **100Hz では挙動不変**: floor(0.3×100)=30 → index 29 となり従来の `composites[29]` と一致するため回帰しない。
- **200Hz 等では過大評価していた**: 本来 0.3秒 = 60サンプル目（index 59）を使うべきところ、従来は 30番目（index 29 = 0.145秒相当）を使っており、より大きな合成値を a0 として採用することで**震度を過大評価**していた。

## 修正内容

- 0.3秒窓のサンプル数を算出する純粋な静的ヘルパー `durationSampleCount(double samplingFrequencyHz, [double seconds = 0.3])` を `@visibleForTesting` で切り出し（`floor(seconds × fs)`）。
- 計算本体を `final n = durationSampleCount(_fs);` で一元化し、ガード条件 `composites.length < n` と取得インデックス `composites[n - 1]` に変更。マジックナンバーの二重定義を解消。
- スコープ厳守: ゲイン `_gainG`、フィルタ係数、`I = 2·log10(a)+0.94` の式、`toJmaLabel` などは一切変更していない。窓サンプル数の算出のみ修正。
- `meta` を直接依存に追加（`@visibleForTesting` 用）。

## 追加テスト

- **窓サイズ単体テスト**: `durationSampleCount(100)==30`, `durationSampleCount(200)==60`, `durationSampleCount(50)==15`, `durationSampleCount(100, 0.3)==30`。
- **100Hz 回帰テスト**: 既存 fixture（AIC001 / 2011 東北地震 / 100Hz）の計測震度が修正後も `3.4` で不変であることを固定 assert。
- **200Hz 境界テスト**: 200Hz で合成波形長が窓サイズ(60)未満（40サンプル）のとき 0.0（データ不足扱い）を返すこと。修正前は窓サイズ 30 固定のため値を返していた箇所。

## テスト結果

`packages/knet_waveform_parser` 内で `dart test` 実行: All tests passed!（32 件）。`dart analyze lib test`: No issues found!