### PR TITLE
fix(eqmonitor_websocket): 揺れ検知の観測点データ (points) フィールドをモデルに追加 + テスト

### DIFF
--- a/docs/data-flow-spec.md
+++ b/docs/data-flow-spec.md
@@ -1,0 +1,347 @@
+# EQMonitor データフロー仕様書
+
+> 調査日: 2026-05-28  
+> 対象: dmdata-websocket-proxy → EQMonitor アプリ表示までのエンドツーエンドデータフロー
+
+---
+
+## 1. システム概要
+
+```
+DMDATA (気象庁データプロバイダ)
+  │  WebSocket v2  (JSON + binary)
+  ▼
+┌────────────────────────────┐
+│  dmdata-websocket-proxy    │  Node.js / Hono
+│  service/dmdata-websocket-proxy │
+└────────┬───────────────────┘
+         │
+         ├─[WebSocket /ws]──────────────────────► telegram-db-writer
+         │                                         │  PostgreSQL に書き込み
+         │                                         │  Valkey Pub/Sub publish
+         │                                         │    (realtime:broadcast:v1)
+         │
+         └─[Redis Streams: events]────────────────► notification-resolver
+                                                    │  FCM / APNs 通知送信
+                                                    │  Live Activity start/update/end
+                                                    │  Valkey Pub/Sub publish
+                                                    │    (realtime:broadcast:v1)
+                                                    │
+                         ┌──────────────────────────┘
+                         │  Valkey Pub/Sub (realtime:broadcast:v1)
+                         ▼
+               ┌──────────────────────┐
+               │  api/websocket       │  WebSocket サーバー (port 9787)
+               │  GET /v2/realtime/ws │
+               └──────────┬───────────┘
+                          │  JWT チケット認証
+                          ▼
+               EQMonitor Flutter アプリ
+```
+
+---
+
+## 2. コンポーネント詳細
+
+### 2.1 dmdata-websocket-proxy
+**役割**: DMDATA WebSocket v2 への単一上流接続を保持し、受信電文を下流へ配信する
+
+| 項目 | 値 |
+|------|-----|
+| 接続先 | `wss://ws.api.dmdata.jp/v2/websocket` |
+| 購読分類 | `telegram.earthquake`, `eew.forecast` |
+| 受信電文種別 | VZSE40, VXSE42-45, VXSE47, VTSE41/51/52, VXSE51-53/56/60-62, VYSE60, IXAC41 |
+| 下流 WebSocket | `/ws` エンドポイント (telegram-db-writer が接続) |
+| Redis Streams 出力 | `events` ストリーム (EEW・地震情報・取消のみ) |
+| IXAC41 処理 | Redis に分割チャンクを蓄積し BUFR 終端符号 `7777` で結合して下流送信 |
+
+**上流 ping/pong**: DMDATA から `{type:"ping", pingId}` を受信し `{type:"pong", pingId}` を返送。  
+**下流 ping/pong**: 接続クライアントへ 30 秒ごとに `{type:"ping", pingId}` を送信し、115 秒以内に pong がなければ切断。
+
+### 2.2 telegram-db-writer
+**役割**: proxy の WebSocket から電文を受信し PostgreSQL へ永続化する
+
+| 入力 | `dmdata-websocket-proxy` の `/ws` |
+|------|-----|
+| 出力 | PostgreSQL (EEW, 地震情報, 津波情報, Feed テーブル) |
+| Pub/Sub publish | `realtime:broadcast:v1` (earthquake / tsunami シグナル) |
+
+処理するスキーマ種別:
+- `eew-information` → EewTransformer → DB 書き込み
+- `earthquake-information` → EarthquakeInformationTransformer → DB 書き込み + Pub/Sub
+- `earthquake-hypocenter-update` → 同上
+- `earthquake-explanation` / `earthquake-counts` / `earthquake-nankai` → Feed 書き込み
+- `tsunami-information` → TsunamiTransformer → DB 書き込み + Pub/Sub
+
+### 2.3 notification-resolver
+**役割**: Redis Streams の `events` を購読し、デバイスへの通知とリアルタイム配信を制御する
+
+| 入力ストリーム | `events`, `shake-detect-events`, `estimated-intensity-events`, `device-token-cleanup` |
+|------|-----|
+| 出力ストリーム | `fcm-notifications`, `apns-notifications`, `live-activity-broadcasts`, `notification-logs` |
+| Pub/Sub publish | `realtime:broadcast:v1` (EEW / EARTHQUAKE / ESTIMATED_INTENSITY ブロードキャスト) |
+
+**EEW 処理フロー**:
+1. `eewHistoryManager` で重複・下位 serialNo を除外
+2. DB から条件一致デバイスを取得（地域・震度設定マッチング）
+3. serialNo == 1: pushToStart で Live Activity 開始 + 通常通知
+4. serialNo > 1: Live Activity ブロードキャスト (update)
+5. `isLastInfo == true` or `isCancel == true`: 3 分後に Live Activity 'end' ブロードキャスト
+
+### 2.4 api/websocket
+**役割**: Flutter アプリへリアルタイムイベントを WebSocket で配信する
+
+| 認証 | `api/api` の `GET /v2/realtime/ticket` で発行した JWT チケット |
+|------|-----|
+| エンドポイント | `GET /v2/realtime/ws?ticket=<JWT>` |
+| 接続時 | Redis から `realtime:snapshot:v2` を読み込み `{type:"snapshot", data:{...}}` を送信 |
+| リアルタイム | `realtime:broadcast:v1` Pub/Sub を subscribe し `{type:"realtime", data:{...}}` で転送 |
+| ping/pong | 15 秒ごとに `{type:"ping"}` を送信し、15 秒以内に `{type:"pong"}` がなければ切断 |
+
+### 2.5 EQMonitor Flutter アプリ
+**役割**: WebSocket 接続を確立し、受信データを Riverpod プロバイダとして提供する
+
+主要プロバイダチェーン:
+```
+eqmonitorWebSocketTicket (チケット取得・自動更新)
+  └─ eqmonitorWebSocket (WebSocket 接続)
+       └─ eqmonitorWsEventStream (raw WebSocketEvent ストリーム)
+            └─ eqmonitorWsPayloadStream (WsMessage にパース)
+                 ├─ EqMonitorWsStatus (ping → pong 応答・接続状態管理)
+                 └─ eqMonitorWsDataSource (RealtimeEvent に変換)
+                      └─ RealtimeEvents (keepAlive: true、全ソース集約)
+```
+
+---
+
+## 3. 電文種別ごとのデータフロー
+
+### 3.1 EEW (VXSE45)
+
+```
+DMDATA → dmdata-websocket-proxy
+  │
+  ├─[WebSocket]─► telegram-db-writer
+  │                └─ eew_information テーブル, telegram テーブルに書き込み
+  │
+  └─[Redis Streams: events]─► notification-resolver
+       │
+       ├─ EEW serialNo==1:
+       │    ├─ FCM/APNs 通知 (fcm-notifications / apns-notifications)
+       │    └─ APNs Live Activity Start (apns-notifications, pushToStartToken 使用)
+       │
+       ├─ EEW serialNo>1 (update):
+       │    ├─ Live Activity Broadcast update (live-activity-broadcasts)
+       │    └─ Pub/Sub publish {type:"EEW", item: EewItemWithRelations}
+       │         └─► api/websocket ─► Flutter
+       │
+       └─ EEW isLastInfo/isCancel:
+            └─ 3 分後に Live Activity Broadcast end (live-activity-broadcasts)
+```
+
+**EventMessage** 変換対象電文: VXSE45 のみ。  
+`status !== '通常'` (試験・訓練) および `type === '緊急地震速報配信テスト'` は除外。  
+`isCancel: true` の場合は空 regions・空 maxIntensity で送信。
+
+### 3.2 地震情報 (VXSE51/52/53/62)
+
+```
+DMDATA → dmdata-websocket-proxy
+  │
+  ├─[WebSocket]─► telegram-db-writer
+  │                └─ earthquake_information テーブルに書き込み
+  │                └─ Pub/Sub publish {type:"earthquake", operation:"upsert/delete", record: EarthquakePartial}
+  │                     └─► api/websocket ─► Flutter
+  │
+  └─[Redis Streams: events]─► notification-resolver
+       ├─ DB から条件一致デバイス取得 (地域コード + 震度閾値マッチング)
+       ├─ EEW 通知済みデバイスへの伝播通知
+       ├─ FCM/APNs 通知送信
+       └─ Pub/Sub publish {type:"EARTHQUAKE", item: EarthquakePartial}
+            └─► api/websocket ─► Flutter
+```
+
+**EventMessage 変換対象**:
+| 電文種別 | 変換内容 |
+|---------|---------|
+| VXSE51 (震度速報) | regions + prefectures |
+| VXSE52 (震源に関する情報) | hypocenter + magnitude + originTime |
+| VXSE53 (震源・震度に関する情報) | regions + prefectures + cities + hypocenter |
+| VXSE62 (長周期地震動) | regions のみ |
+
+### 3.3 IXAC41 (BUFR / 推計震度)
+
+```
+DMDATA → dmdata-websocket-proxy (分割受信)
+  │   ┌─ Redis Hash に チャンク蓄積 (TTL: 120s)
+  │   └─ BUFR 終端 "7777" 検知時に結合
+  │
+  ├─[WebSocket: 結合済 base64]─► telegram-db-writer
+  │                               (IXAC41 はスキーマ不一致でスキップ)
+  │
+  └─[ixac41-pmtiles-generator]
+       └─ Rust 製 ixac41_parser HTTP サーバーへ送信
+       └─ PMTiles 生成 → SeaweedFS (S3) に保存
+       └─[Redis Streams: estimated-intensity-events]
+            └─► notification-resolver
+                 ├─ EARTHQUAKE 通知済みデバイスへサイレント通知
+                 └─ Pub/Sub publish {type:"ESTIMATED_INTENSITY", estimatedIntensity:{...}}
+                      └─► api/websocket ─► Flutter
+```
+
+### 3.4 津波情報 (VTSE41/51/52)
+
+```
+DMDATA → dmdata-websocket-proxy
+  └─[WebSocket]─► telegram-db-writer
+       └─ TsunamiTransformer → tsunami テーブルに書き込み
+       └─ Pub/Sub publish {type:"tsunami", operation:"upsert/delete", event_id}
+            └─► api/websocket ─► Flutter
+```
+
+### 3.5 揺れ検知 (Kyoshin Monitor)
+
+```
+Kyoshin Monitor API (別サービスがポーリング)
+  └─[Redis Streams: shake-detect-events]
+       └─► notification-resolver
+            ├─ EEW との相関チェック (EEW 検知時は通知抑制)
+            ├─ DB 保存 (shake_detection_events)
+            ├─ FCM/APNs 通知
+            ├─ APNs Live Activity Start (shake_detection trigger)
+            ├─ Live Activity Broadcast update (shake.all チャンネル)
+            ├─ 2 分後に Live Activity end スケジュール
+            └─ Pub/Sub publish ShakeDetectedPayload
+                 └─► api/websocket ─► Flutter
+```
+
+---
+
+## 4. Redis Streams / Pub/Sub チャンネル一覧
+
+### Redis Streams
+
+| ストリーム名 | Producer | Consumer | 用途 |
+|------------|---------|---------|------|
+| `events` | dmdata-websocket-proxy | notification-resolver | EEW・地震情報イベント |
+| `shake-detect-events` | shake-detection service | notification-resolver | 揺れ検知イベント |
+| `estimated-intensity-events` | ixac41-pmtiles-generator | notification-resolver | 推計震度完了通知 |
+| `fcm-notifications` | notification-resolver | notification-sender (Go) | FCM 通知メッセージ |
+| `apns-notifications` | notification-resolver | notification-sender (Go) | APNs 通知メッセージ |
+| `live-activity-broadcasts` | notification-resolver | notification-sender (Go) | Live Activity ブロードキャスト |
+| `notification-logs` | notification-resolver, notification-sender | aggregation-worker | 通知ログ |
+| `dispatch-stats` | notification-sender | aggregation-worker | 配信統計 |
+| `device-token-cleanup` | notification-sender | notification-resolver | 無効トークン削除要求 |
+
+### Valkey Pub/Sub チャンネル
+
+| チャンネル名 | Publisher | Subscriber | メッセージ型 |
+|------------|---------|---------|-------------|
+| `realtime:broadcast:v1` | telegram-db-writer, notification-resolver | api/websocket | `RealtimeEventEnvelope` |
+
+### Valkey キー
+
+| キー | 用途 | TTL |
+|-----|------|-----|
+| `realtime:snapshot:v2` | 接続時初期スナップショット (EEW + 地震情報 + 揺れ検知) | なし (上書き更新) |
+| `telegram:chunk:<base64url>` | IXAC41 分割チャンク | 120 秒 |
+
+---
+
+## 5. WebSocket プロトコル詳細
+
+### 5.1 クライアント接続フロー
+
+```
+Flutter app                    api/api           api/websocket
+    │                             │                    │
+    │── GET /v2/realtime/ticket ─►│                    │
+    │   (x-eqmonitor-device-id)   │                    │
+    │◄── {url, expiresAt} ────────│                    │
+    │                             │                    │
+    │── WS Connect ──────────────────────────────────►│
+    │   ?ticket=<JWT>             │                    │
+    │◄── {type:"snapshot", data:{revision, eews, earthquakes, shakes}} ──│
+    │                             │                    │
+    │◄── {type:"realtime", data:<envelope>} ─── (Pub/Sub) ───│
+    │                             │                    │
+    │◄── {type:"ping"} ──────────────────────────────│ (15秒ごと)
+    │── {type:"pong"} ──────────────────────────────►│
+```
+
+チケット TTL: デフォルト 1800 秒、Flutter 側は expiry 30 秒前に自動更新。
+
+### 5.2 WebSocket メッセージ型 (Flutter 側)
+
+**受信メッセージ** (`WsMessage`):
+
+```
+type: "snapshot"  → WsSnapshotMessage
+  data:
+    revision: number
+    updatedAt: DateTime
+    eews: List<EewItemWithRelations>
+    earthquakes: List<EarthquakePartial>
+    shakes: List<WsSnapshotShakeEntry>
+      ├─ eventId, createdAt, level, isReplay, pointCount, region
+      ├─ changeReasons: List<String>
+      └─ points: List<WsShakeObservationPoint>  ← 観測点データ
+
+type: "realtime"  → WsRealtimeMessage
+  data: RealtimeEventEnvelope  (discriminated union by type)
+    "EEW"                → EewItemWithRelations
+    "EARTHQUAKE"         → EarthquakePartial  (broadcast)
+    "earthquake"         → upsert/delete + EarthquakePartial
+    "tsunami"            → upsert/delete
+    "shake_detected"     → 揺れ検知データ (points含む)
+    "ESTIMATED_INTENSITY"→ estimatedIntensityKey
+
+type: "ping"      → WsPingMessage
+  (EqMonitorWsStatusNotifier が {type:"pong"} を自動返送)
+```
+
+### 5.3 スナップショット取得ウィンドウ
+
+接続時、過去 60 秒以内のデータのみを初期スナップショットとして送信:
+- EEW: `report_time >= (now - 60s)` でフィルタ
+- 地震情報: `origin_time >= (now - 60s)` でフィルタ (origin_time が null の場合は含める)
+- 揺れ検知: `createdAt >= (now - 60s)` でフィルタ
+
+---
+
+## 6. 発見した実装不備・型不整合
+
+### Bug 1 [修正済み 🟢] — スナップショットフィルタの camelCase/snake_case 不整合
+
+**場所**: `backend/api/websocket/src/index.ts` L158-159  
+**問題**: `e.reportTime`（camelCase）を参照していたが、TypeScript 型 `EewItem` のフィールド名は `report_time`（snake_case）。実行時に `undefined` → `new Date(undefined)` = `Invalid Date` → 比較が常に `false` → 接続時スナップショットの EEW・地震情報が常に空  
+**修正内容**:
+- EEW: `e.reportTime` → `e.report_time`
+- 地震情報: `e.reportTime`（存在しないフィールド）→ `e.origin_time ?? 0`
+
+### Bug 2 [修正済み 🟢] — EEW 取消電文が Redis Streams に未送信
+
+**場所**: `backend/service/dmdata-websocket-proxy/src/event-transformer.ts`  
+**問題**: `infoType === '取消'` の EEW を即座に `null` 返却して `events` ストリームに送信しない。`notification-resolver` の `isCancel` フラグが機能せず、Live Activity が取消時に終了されない可能性  
+**修正内容**: `serialNo` がある取消電文は `isCancel: true, isLastInfo: true` を含む `EventMessage` を返却し、Live Activity end をトリガー可能にした
+
+### Bug 3 [修正済み 🟢] — telegram-db-writer の型安全でないキャスト (2 箇所)
+
+**場所**: `backend/service/telegram-db-writer/src/index.ts` L238, L257  
+**問題**: `EarthquakeHypocenterUpdate.v1_0_0.Cancel/Public` を `as unknown as EarthquakeInformation.v1_1_0.*` にキャスト。実際には `TelegramTransformer` の `SupportedTelegrams` union 型に `EarthquakeHypocenterUpdate` が含まれており、キャストは不要  
+**修正内容**:
+- `transformer.ts:243`: `transformEarthquakeCancel` の `telegram` 引数型を `Cancel | EarthquakeHypocenterUpdate.v1_0_0.Cancel` に拡張
+- `index.ts` L238, L257: `as unknown as` キャストを削除
+
+### Bug 5 [修正済み 🟢] — 揺れ検知の観測点データが Flutter モデルに欠落
+
+**場所**: `packages/eqmonitor_websocket/lib/src/`  
+**問題**: バックエンドの `ShakeDetectedPayload` に含まれる `points`（観測点一覧）フィールドが `WsShakeDetectedRealtimeEvent` / `WsSnapshotShakeEntry` に存在せず、受信データが破棄されていた  
+**修正内容**: `WsShakeObservationPoint` / `WsShakeObservationLocation` モデルを新規作成し、両クラスに `@Default([]) List<WsShakeObservationPoint> points` フィールドを追加。`melos run generate` でコード生成済み
+
+### 未修正の設計上の注意点
+
+| # | 場所 | 内容 |
+|---|------|------|
+| A | `realtime_event_envelope.dart` | `WsTsunamiRealtimeEvent.record` が `Map<String, dynamic>?` で型なし。津波情報の構造化モデルが未実装 |
+| B | `event-transformer.ts` | VXSE45 以外の EEW 電文種別 (VXSE42/43/44) は受信リストに含まれるが、event-transformer では変換対象外 |

--- a/packages/eqmonitor_websocket/lib/eqmonitor_websocket.dart
+++ b/packages/eqmonitor_websocket/lib/eqmonitor_websocket.dart
@@ -3,5 +3,6 @@ export 'src/ws_estimated_intensity_payload.dart';
 export 'src/ws_message.dart';
 export 'src/ws_pong_message.dart';
 export 'src/ws_realtime_operation.dart';
+export 'src/ws_shake_observation_point.dart';
 export 'src/ws_shake_payload.dart';
 export 'src/ws_snapshot_data.dart';

--- a/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.dart
+++ b/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.dart
@@ -1,6 +1,7 @@
 import 'package:eqmonitor_api/eqmonitor_api.dart';
 import 'package:eqmonitor_websocket/src/ws_estimated_intensity_payload.dart';
 import 'package:eqmonitor_websocket/src/ws_realtime_operation.dart';
+import 'package:eqmonitor_websocket/src/ws_shake_observation_point.dart';
 import 'package:eqmonitor_websocket/src/ws_shake_payload.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -45,7 +46,11 @@ sealed class RealtimeEventEnvelope with _$RealtimeEventEnvelope {
     required String eventId,
     required DateTime createdAt,
     required String level,
-    required bool isReplay, required int pointCount, required WsShakeRegionPayload region, @Default([]) List<String> changeReasons,
+    required bool isReplay,
+    required int pointCount,
+    required WsShakeRegionPayload region,
+    @Default([]) List<String> changeReasons,
+    @Default([]) List<WsShakeObservationPoint> points,
   }) = WsShakeDetectedRealtimeEvent;
 
   /// 推計震度

--- a/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.freezed.dart
+++ b/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.freezed.dart
@@ -173,14 +173,14 @@ return estimatedIntensity(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( EewItemWithRelations item)?  eew,TResult Function( EarthquakePartial item)?  earthquakeBroadcast,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)?  tsunami,TResult Function( String eventId,  DateTime createdAt,  String level,  List<String> changeReasons,  bool isReplay,  int pointCount,  WsShakeRegionPayload region)?  shakeDetected,TResult Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( EewItemWithRelations item)?  eew,TResult Function( EarthquakePartial item)?  earthquakeBroadcast,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)?  tsunami,TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  shakeDetected,TResult Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case WsEewRealtimeEvent() when eew != null:
 return eew(_that.item);case WsEarthquakeBroadcastEvent() when earthquakeBroadcast != null:
 return earthquakeBroadcast(_that.item);case WsEarthquakeRealtimeEvent() when earthquake != null:
 return earthquake(_that.operation,_that.eventId,_that.record);case WsTsunamiRealtimeEvent() when tsunami != null:
 return tsunami(_that.operation,_that.eventId,_that.record);case WsShakeDetectedRealtimeEvent() when shakeDetected != null:
-return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_that.isReplay,_that.pointCount,_that.region);case WsEstimatedIntensityRealtimeEvent() when estimatedIntensity != null:
+return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case WsEstimatedIntensityRealtimeEvent() when estimatedIntensity != null:
 return estimatedIntensity(_that.estimatedIntensity);case _:
   return orElse();
 
@@ -199,14 +199,14 @@ return estimatedIntensity(_that.estimatedIntensity);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( EewItemWithRelations item)  eew,required TResult Function( EarthquakePartial item)  earthquakeBroadcast,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)  earthquake,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)  tsunami,required TResult Function( String eventId,  DateTime createdAt,  String level,  List<String> changeReasons,  bool isReplay,  int pointCount,  WsShakeRegionPayload region)  shakeDetected,required TResult Function( WsEstimatedIntensityPayload estimatedIntensity)  estimatedIntensity,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( EewItemWithRelations item)  eew,required TResult Function( EarthquakePartial item)  earthquakeBroadcast,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)  earthquake,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)  tsunami,required TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)  shakeDetected,required TResult Function( WsEstimatedIntensityPayload estimatedIntensity)  estimatedIntensity,}) {final _that = this;
 switch (_that) {
 case WsEewRealtimeEvent():
 return eew(_that.item);case WsEarthquakeBroadcastEvent():
 return earthquakeBroadcast(_that.item);case WsEarthquakeRealtimeEvent():
 return earthquake(_that.operation,_that.eventId,_that.record);case WsTsunamiRealtimeEvent():
 return tsunami(_that.operation,_that.eventId,_that.record);case WsShakeDetectedRealtimeEvent():
-return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_that.isReplay,_that.pointCount,_that.region);case WsEstimatedIntensityRealtimeEvent():
+return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case WsEstimatedIntensityRealtimeEvent():
 return estimatedIntensity(_that.estimatedIntensity);}
 }
 /// A variant of `when` that fallback to returning `null`
@@ -221,14 +221,14 @@ return estimatedIntensity(_that.estimatedIntensity);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( EewItemWithRelations item)?  eew,TResult? Function( EarthquakePartial item)?  earthquakeBroadcast,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)?  tsunami,TResult? Function( String eventId,  DateTime createdAt,  String level,  List<String> changeReasons,  bool isReplay,  int pointCount,  WsShakeRegionPayload region)?  shakeDetected,TResult? Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( EewItemWithRelations item)?  eew,TResult? Function( EarthquakePartial item)?  earthquakeBroadcast,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)?  tsunami,TResult? Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  shakeDetected,TResult? Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,}) {final _that = this;
 switch (_that) {
 case WsEewRealtimeEvent() when eew != null:
 return eew(_that.item);case WsEarthquakeBroadcastEvent() when earthquakeBroadcast != null:
 return earthquakeBroadcast(_that.item);case WsEarthquakeRealtimeEvent() when earthquake != null:
 return earthquake(_that.operation,_that.eventId,_that.record);case WsTsunamiRealtimeEvent() when tsunami != null:
 return tsunami(_that.operation,_that.eventId,_that.record);case WsShakeDetectedRealtimeEvent() when shakeDetected != null:
-return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_that.isReplay,_that.pointCount,_that.region);case WsEstimatedIntensityRealtimeEvent() when estimatedIntensity != null:
+return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case WsEstimatedIntensityRealtimeEvent() when estimatedIntensity != null:
 return estimatedIntensity(_that.estimatedIntensity);case _:
   return null;
 
@@ -579,12 +579,15 @@ as Map<String, dynamic>?,
 @JsonSerializable()
 
 class WsShakeDetectedRealtimeEvent implements RealtimeEventEnvelope {
-  const WsShakeDetectedRealtimeEvent({required this.eventId, required this.createdAt, required this.level, final  List<String> changeReasons = const [], required this.isReplay, required this.pointCount, required this.region, final  String? $type}): _changeReasons = changeReasons,$type = $type ?? 'shake_detected';
+  const WsShakeDetectedRealtimeEvent({required this.eventId, required this.createdAt, required this.level, required this.isReplay, required this.pointCount, required this.region, final  List<String> changeReasons = const [], final  List<WsShakeObservationPoint> points = const [], final  String? $type}): _changeReasons = changeReasons,_points = points,$type = $type ?? 'shake_detected';
   factory WsShakeDetectedRealtimeEvent.fromJson(Map<String, dynamic> json) => _$WsShakeDetectedRealtimeEventFromJson(json);
 
  final  String eventId;
  final  DateTime createdAt;
  final  String level;
+ final  bool isReplay;
+ final  int pointCount;
+ final  WsShakeRegionPayload region;
  final  List<String> _changeReasons;
 @JsonKey() List<String> get changeReasons {
   if (_changeReasons is EqualUnmodifiableListView) return _changeReasons;
@@ -592,9 +595,13 @@ class WsShakeDetectedRealtimeEvent implements RealtimeEventEnvelope {
   return EqualUnmodifiableListView(_changeReasons);
 }
 
- final  bool isReplay;
- final  int pointCount;
- final  WsShakeRegionPayload region;
+ final  List<WsShakeObservationPoint> _points;
+@JsonKey() List<WsShakeObservationPoint> get points {
+  if (_points is EqualUnmodifiableListView) return _points;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_points);
+}
+
 
 @JsonKey(name: 'type')
 final String $type;
@@ -613,16 +620,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsShakeDetectedRealtimeEvent&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.level, level) || other.level == level)&&const DeepCollectionEquality().equals(other._changeReasons, _changeReasons)&&(identical(other.isReplay, isReplay) || other.isReplay == isReplay)&&(identical(other.pointCount, pointCount) || other.pointCount == pointCount)&&(identical(other.region, region) || other.region == region));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsShakeDetectedRealtimeEvent&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.level, level) || other.level == level)&&(identical(other.isReplay, isReplay) || other.isReplay == isReplay)&&(identical(other.pointCount, pointCount) || other.pointCount == pointCount)&&(identical(other.region, region) || other.region == region)&&const DeepCollectionEquality().equals(other._changeReasons, _changeReasons)&&const DeepCollectionEquality().equals(other._points, _points));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,eventId,createdAt,level,const DeepCollectionEquality().hash(_changeReasons),isReplay,pointCount,region);
+int get hashCode => Object.hash(runtimeType,eventId,createdAt,level,isReplay,pointCount,region,const DeepCollectionEquality().hash(_changeReasons),const DeepCollectionEquality().hash(_points));
 
 @override
 String toString() {
-  return 'RealtimeEventEnvelope.shakeDetected(eventId: $eventId, createdAt: $createdAt, level: $level, changeReasons: $changeReasons, isReplay: $isReplay, pointCount: $pointCount, region: $region)';
+  return 'RealtimeEventEnvelope.shakeDetected(eventId: $eventId, createdAt: $createdAt, level: $level, isReplay: $isReplay, pointCount: $pointCount, region: $region, changeReasons: $changeReasons, points: $points)';
 }
 
 
@@ -633,7 +640,7 @@ abstract mixin class $WsShakeDetectedRealtimeEventCopyWith<$Res> implements $Rea
   factory $WsShakeDetectedRealtimeEventCopyWith(WsShakeDetectedRealtimeEvent value, $Res Function(WsShakeDetectedRealtimeEvent) _then) = _$WsShakeDetectedRealtimeEventCopyWithImpl;
 @useResult
 $Res call({
- String eventId, DateTime createdAt, String level, List<String> changeReasons, bool isReplay, int pointCount, WsShakeRegionPayload region
+ String eventId, DateTime createdAt, String level, bool isReplay, int pointCount, WsShakeRegionPayload region, List<String> changeReasons, List<WsShakeObservationPoint> points
 });
 
 
@@ -650,16 +657,17 @@ class _$WsShakeDetectedRealtimeEventCopyWithImpl<$Res>
 
 /// Create a copy of RealtimeEventEnvelope
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? createdAt = null,Object? level = null,Object? changeReasons = null,Object? isReplay = null,Object? pointCount = null,Object? region = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? createdAt = null,Object? level = null,Object? isReplay = null,Object? pointCount = null,Object? region = null,Object? changeReasons = null,Object? points = null,}) {
   return _then(WsShakeDetectedRealtimeEvent(
 eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,level: null == level ? _self.level : level // ignore: cast_nullable_to_non_nullable
-as String,changeReasons: null == changeReasons ? _self._changeReasons : changeReasons // ignore: cast_nullable_to_non_nullable
-as List<String>,isReplay: null == isReplay ? _self.isReplay : isReplay // ignore: cast_nullable_to_non_nullable
+as String,isReplay: null == isReplay ? _self.isReplay : isReplay // ignore: cast_nullable_to_non_nullable
 as bool,pointCount: null == pointCount ? _self.pointCount : pointCount // ignore: cast_nullable_to_non_nullable
 as int,region: null == region ? _self.region : region // ignore: cast_nullable_to_non_nullable
-as WsShakeRegionPayload,
+as WsShakeRegionPayload,changeReasons: null == changeReasons ? _self._changeReasons : changeReasons // ignore: cast_nullable_to_non_nullable
+as List<String>,points: null == points ? _self._points : points // ignore: cast_nullable_to_non_nullable
+as List<WsShakeObservationPoint>,
   ));
 }
 

--- a/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.g.dart
+++ b/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.g.dart
@@ -115,16 +115,27 @@ WsShakeDetectedRealtimeEvent _$WsShakeDetectedRealtimeEventFromJson(
     eventId: $checkedConvert('eventId', (v) => v as String),
     createdAt: $checkedConvert('createdAt', (v) => DateTime.parse(v as String)),
     level: $checkedConvert('level', (v) => v as String),
-    changeReasons: $checkedConvert(
-      'changeReasons',
-      (v) =>
-          (v as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
-    ),
     isReplay: $checkedConvert('isReplay', (v) => v as bool),
     pointCount: $checkedConvert('pointCount', (v) => (v as num).toInt()),
     region: $checkedConvert(
       'region',
       (v) => WsShakeRegionPayload.fromJson(v as Map<String, dynamic>),
+    ),
+    changeReasons: $checkedConvert(
+      'changeReasons',
+      (v) =>
+          (v as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+    ),
+    points: $checkedConvert(
+      'points',
+      (v) =>
+          (v as List<dynamic>?)
+              ?.map(
+                (e) =>
+                    WsShakeObservationPoint.fromJson(e as Map<String, dynamic>),
+              )
+              .toList() ??
+          const [],
     ),
     $type: $checkedConvert('type', (v) => v as String?),
   );
@@ -137,10 +148,11 @@ Map<String, dynamic> _$WsShakeDetectedRealtimeEventToJson(
   'eventId': instance.eventId,
   'createdAt': instance.createdAt.toIso8601String(),
   'level': instance.level,
-  'changeReasons': instance.changeReasons,
   'isReplay': instance.isReplay,
   'pointCount': instance.pointCount,
   'region': instance.region,
+  'changeReasons': instance.changeReasons,
+  'points': instance.points,
   'type': instance.$type,
 };
 

--- a/packages/eqmonitor_websocket/lib/src/ws_estimated_intensity_payload.freezed.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_estimated_intensity_payload.freezed.dart
@@ -311,7 +311,7 @@ $WsEstimatedIntensityHypocenterCopyWith<$Res>? get hypocenter {
 /// @nodoc
 mixin _$WsEstimatedIntensityHypocenter {
 
- int get regionCode; String? get regionName; DateTime get originTime; double? get magnitude; double? get depthKm;
+ int get regionCode; DateTime get originTime; String? get regionName; double? get magnitude; double? get depthKm;
 /// Create a copy of WsEstimatedIntensityHypocenter
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -324,16 +324,16 @@ $WsEstimatedIntensityHypocenterCopyWith<WsEstimatedIntensityHypocenter> get copy
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsEstimatedIntensityHypocenter&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.magnitude, magnitude) || other.magnitude == magnitude)&&(identical(other.depthKm, depthKm) || other.depthKm == depthKm));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsEstimatedIntensityHypocenter&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.magnitude, magnitude) || other.magnitude == magnitude)&&(identical(other.depthKm, depthKm) || other.depthKm == depthKm));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionCode,regionName,originTime,magnitude,depthKm);
+int get hashCode => Object.hash(runtimeType,regionCode,originTime,regionName,magnitude,depthKm);
 
 @override
 String toString() {
-  return 'WsEstimatedIntensityHypocenter(regionCode: $regionCode, regionName: $regionName, originTime: $originTime, magnitude: $magnitude, depthKm: $depthKm)';
+  return 'WsEstimatedIntensityHypocenter(regionCode: $regionCode, originTime: $originTime, regionName: $regionName, magnitude: $magnitude, depthKm: $depthKm)';
 }
 
 
@@ -344,7 +344,7 @@ abstract mixin class $WsEstimatedIntensityHypocenterCopyWith<$Res>  {
   factory $WsEstimatedIntensityHypocenterCopyWith(WsEstimatedIntensityHypocenter value, $Res Function(WsEstimatedIntensityHypocenter) _then) = _$WsEstimatedIntensityHypocenterCopyWithImpl;
 @useResult
 $Res call({
- int regionCode, String? regionName, DateTime originTime, double? magnitude, double? depthKm
+ int regionCode, DateTime originTime, String? regionName, double? magnitude, double? depthKm
 });
 
 
@@ -361,12 +361,12 @@ class _$WsEstimatedIntensityHypocenterCopyWithImpl<$Res>
 
 /// Create a copy of WsEstimatedIntensityHypocenter
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? regionCode = null,Object? regionName = freezed,Object? originTime = null,Object? magnitude = freezed,Object? depthKm = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? regionCode = null,Object? originTime = null,Object? regionName = freezed,Object? magnitude = freezed,Object? depthKm = freezed,}) {
   return _then(_self.copyWith(
 regionCode: null == regionCode ? _self.regionCode : regionCode // ignore: cast_nullable_to_non_nullable
-as int,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
-as String?,originTime: null == originTime ? _self.originTime : originTime // ignore: cast_nullable_to_non_nullable
-as DateTime,magnitude: freezed == magnitude ? _self.magnitude : magnitude // ignore: cast_nullable_to_non_nullable
+as int,originTime: null == originTime ? _self.originTime : originTime // ignore: cast_nullable_to_non_nullable
+as DateTime,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,magnitude: freezed == magnitude ? _self.magnitude : magnitude // ignore: cast_nullable_to_non_nullable
 as double?,depthKm: freezed == depthKm ? _self.depthKm : depthKm // ignore: cast_nullable_to_non_nullable
 as double?,
   ));
@@ -453,10 +453,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int regionCode,  String? regionName,  DateTime originTime,  double? magnitude,  double? depthKm)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int regionCode,  DateTime originTime,  String? regionName,  double? magnitude,  double? depthKm)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _WsEstimatedIntensityHypocenter() when $default != null:
-return $default(_that.regionCode,_that.regionName,_that.originTime,_that.magnitude,_that.depthKm);case _:
+return $default(_that.regionCode,_that.originTime,_that.regionName,_that.magnitude,_that.depthKm);case _:
   return orElse();
 
 }
@@ -474,10 +474,10 @@ return $default(_that.regionCode,_that.regionName,_that.originTime,_that.magnitu
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int regionCode,  String? regionName,  DateTime originTime,  double? magnitude,  double? depthKm)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int regionCode,  DateTime originTime,  String? regionName,  double? magnitude,  double? depthKm)  $default,) {final _that = this;
 switch (_that) {
 case _WsEstimatedIntensityHypocenter():
-return $default(_that.regionCode,_that.regionName,_that.originTime,_that.magnitude,_that.depthKm);case _:
+return $default(_that.regionCode,_that.originTime,_that.regionName,_that.magnitude,_that.depthKm);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -494,10 +494,10 @@ return $default(_that.regionCode,_that.regionName,_that.originTime,_that.magnitu
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int regionCode,  String? regionName,  DateTime originTime,  double? magnitude,  double? depthKm)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int regionCode,  DateTime originTime,  String? regionName,  double? magnitude,  double? depthKm)?  $default,) {final _that = this;
 switch (_that) {
 case _WsEstimatedIntensityHypocenter() when $default != null:
-return $default(_that.regionCode,_that.regionName,_that.originTime,_that.magnitude,_that.depthKm);case _:
+return $default(_that.regionCode,_that.originTime,_that.regionName,_that.magnitude,_that.depthKm);case _:
   return null;
 
 }
@@ -509,12 +509,12 @@ return $default(_that.regionCode,_that.regionName,_that.originTime,_that.magnitu
 @JsonSerializable()
 
 class _WsEstimatedIntensityHypocenter implements WsEstimatedIntensityHypocenter {
-  const _WsEstimatedIntensityHypocenter({required this.regionCode, this.regionName, required this.originTime, this.magnitude, this.depthKm});
+  const _WsEstimatedIntensityHypocenter({required this.regionCode, required this.originTime, this.regionName, this.magnitude, this.depthKm});
   factory _WsEstimatedIntensityHypocenter.fromJson(Map<String, dynamic> json) => _$WsEstimatedIntensityHypocenterFromJson(json);
 
 @override final  int regionCode;
-@override final  String? regionName;
 @override final  DateTime originTime;
+@override final  String? regionName;
 @override final  double? magnitude;
 @override final  double? depthKm;
 
@@ -531,16 +531,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WsEstimatedIntensityHypocenter&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.magnitude, magnitude) || other.magnitude == magnitude)&&(identical(other.depthKm, depthKm) || other.depthKm == depthKm));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WsEstimatedIntensityHypocenter&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.regionName, regionName) || other.regionName == regionName)&&(identical(other.magnitude, magnitude) || other.magnitude == magnitude)&&(identical(other.depthKm, depthKm) || other.depthKm == depthKm));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,regionCode,regionName,originTime,magnitude,depthKm);
+int get hashCode => Object.hash(runtimeType,regionCode,originTime,regionName,magnitude,depthKm);
 
 @override
 String toString() {
-  return 'WsEstimatedIntensityHypocenter(regionCode: $regionCode, regionName: $regionName, originTime: $originTime, magnitude: $magnitude, depthKm: $depthKm)';
+  return 'WsEstimatedIntensityHypocenter(regionCode: $regionCode, originTime: $originTime, regionName: $regionName, magnitude: $magnitude, depthKm: $depthKm)';
 }
 
 
@@ -551,7 +551,7 @@ abstract mixin class _$WsEstimatedIntensityHypocenterCopyWith<$Res> implements $
   factory _$WsEstimatedIntensityHypocenterCopyWith(_WsEstimatedIntensityHypocenter value, $Res Function(_WsEstimatedIntensityHypocenter) _then) = __$WsEstimatedIntensityHypocenterCopyWithImpl;
 @override @useResult
 $Res call({
- int regionCode, String? regionName, DateTime originTime, double? magnitude, double? depthKm
+ int regionCode, DateTime originTime, String? regionName, double? magnitude, double? depthKm
 });
 
 
@@ -568,12 +568,12 @@ class __$WsEstimatedIntensityHypocenterCopyWithImpl<$Res>
 
 /// Create a copy of WsEstimatedIntensityHypocenter
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? regionCode = null,Object? regionName = freezed,Object? originTime = null,Object? magnitude = freezed,Object? depthKm = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? regionCode = null,Object? originTime = null,Object? regionName = freezed,Object? magnitude = freezed,Object? depthKm = freezed,}) {
   return _then(_WsEstimatedIntensityHypocenter(
 regionCode: null == regionCode ? _self.regionCode : regionCode // ignore: cast_nullable_to_non_nullable
-as int,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
-as String?,originTime: null == originTime ? _self.originTime : originTime // ignore: cast_nullable_to_non_nullable
-as DateTime,magnitude: freezed == magnitude ? _self.magnitude : magnitude // ignore: cast_nullable_to_non_nullable
+as int,originTime: null == originTime ? _self.originTime : originTime // ignore: cast_nullable_to_non_nullable
+as DateTime,regionName: freezed == regionName ? _self.regionName : regionName // ignore: cast_nullable_to_non_nullable
+as String?,magnitude: freezed == magnitude ? _self.magnitude : magnitude // ignore: cast_nullable_to_non_nullable
 as double?,depthKm: freezed == depthKm ? _self.depthKm : depthKm // ignore: cast_nullable_to_non_nullable
 as double?,
   ));

--- a/packages/eqmonitor_websocket/lib/src/ws_estimated_intensity_payload.g.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_estimated_intensity_payload.g.dart
@@ -42,11 +42,11 @@ _WsEstimatedIntensityHypocenter _$WsEstimatedIntensityHypocenterFromJson(
 ) => $checkedCreate('_WsEstimatedIntensityHypocenter', json, ($checkedConvert) {
   final val = _WsEstimatedIntensityHypocenter(
     regionCode: $checkedConvert('regionCode', (v) => (v as num).toInt()),
-    regionName: $checkedConvert('regionName', (v) => v as String?),
     originTime: $checkedConvert(
       'originTime',
       (v) => DateTime.parse(v as String),
     ),
+    regionName: $checkedConvert('regionName', (v) => v as String?),
     magnitude: $checkedConvert('magnitude', (v) => (v as num?)?.toDouble()),
     depthKm: $checkedConvert('depthKm', (v) => (v as num?)?.toDouble()),
   );
@@ -57,8 +57,8 @@ Map<String, dynamic> _$WsEstimatedIntensityHypocenterToJson(
   _WsEstimatedIntensityHypocenter instance,
 ) => <String, dynamic>{
   'regionCode': instance.regionCode,
-  'regionName': instance.regionName,
   'originTime': instance.originTime.toIso8601String(),
+  'regionName': instance.regionName,
   'magnitude': instance.magnitude,
   'depthKm': instance.depthKm,
 };

--- a/packages/eqmonitor_websocket/lib/src/ws_shake_observation_point.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_shake_observation_point.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'ws_shake_observation_point.freezed.dart';
+part 'ws_shake_observation_point.g.dart';
+
+@freezed
+abstract class WsShakeObservationPoint with _$WsShakeObservationPoint {
+  const factory WsShakeObservationPoint({
+    required String code,
+    required String name,
+    required String region,
+    required String type,
+    required WsShakeObservationLocation location,
+    required double intensityDiff,
+    double? intensity,
+  }) = _WsShakeObservationPoint;
+
+  factory WsShakeObservationPoint.fromJson(Map<String, dynamic> json) =>
+      _$WsShakeObservationPointFromJson(json);
+}
+
+@freezed
+abstract class WsShakeObservationLocation with _$WsShakeObservationLocation {
+  const factory WsShakeObservationLocation({
+    required double latitude,
+    required double longitude,
+  }) = _WsShakeObservationLocation;
+
+  factory WsShakeObservationLocation.fromJson(Map<String, dynamic> json) =>
+      _$WsShakeObservationLocationFromJson(json);
+}

--- a/packages/eqmonitor_websocket/lib/src/ws_shake_observation_point.freezed.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_shake_observation_point.freezed.dart
@@ -1,0 +1,579 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'ws_shake_observation_point.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WsShakeObservationPoint {
+
+ String get code; String get name; String get region; String get type; WsShakeObservationLocation get location; double get intensityDiff; double? get intensity;
+/// Create a copy of WsShakeObservationPoint
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WsShakeObservationPointCopyWith<WsShakeObservationPoint> get copyWith => _$WsShakeObservationPointCopyWithImpl<WsShakeObservationPoint>(this as WsShakeObservationPoint, _$identity);
+
+  /// Serializes this WsShakeObservationPoint to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsShakeObservationPoint&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.region, region) || other.region == region)&&(identical(other.type, type) || other.type == type)&&(identical(other.location, location) || other.location == location)&&(identical(other.intensityDiff, intensityDiff) || other.intensityDiff == intensityDiff)&&(identical(other.intensity, intensity) || other.intensity == intensity));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,name,region,type,location,intensityDiff,intensity);
+
+@override
+String toString() {
+  return 'WsShakeObservationPoint(code: $code, name: $name, region: $region, type: $type, location: $location, intensityDiff: $intensityDiff, intensity: $intensity)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $WsShakeObservationPointCopyWith<$Res>  {
+  factory $WsShakeObservationPointCopyWith(WsShakeObservationPoint value, $Res Function(WsShakeObservationPoint) _then) = _$WsShakeObservationPointCopyWithImpl;
+@useResult
+$Res call({
+ String code, String name, String region, String type, WsShakeObservationLocation location, double intensityDiff, double? intensity
+});
+
+
+$WsShakeObservationLocationCopyWith<$Res> get location;
+
+}
+/// @nodoc
+class _$WsShakeObservationPointCopyWithImpl<$Res>
+    implements $WsShakeObservationPointCopyWith<$Res> {
+  _$WsShakeObservationPointCopyWithImpl(this._self, this._then);
+
+  final WsShakeObservationPoint _self;
+  final $Res Function(WsShakeObservationPoint) _then;
+
+/// Create a copy of WsShakeObservationPoint
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? code = null,Object? name = null,Object? region = null,Object? type = null,Object? location = null,Object? intensityDiff = null,Object? intensity = freezed,}) {
+  return _then(_self.copyWith(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,region: null == region ? _self.region : region // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,location: null == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as WsShakeObservationLocation,intensityDiff: null == intensityDiff ? _self.intensityDiff : intensityDiff // ignore: cast_nullable_to_non_nullable
+as double,intensity: freezed == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
+as double?,
+  ));
+}
+/// Create a copy of WsShakeObservationPoint
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$WsShakeObservationLocationCopyWith<$Res> get location {
+  
+  return $WsShakeObservationLocationCopyWith<$Res>(_self.location, (value) {
+    return _then(_self.copyWith(location: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [WsShakeObservationPoint].
+extension WsShakeObservationPointPatterns on WsShakeObservationPoint {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _WsShakeObservationPoint value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _WsShakeObservationPoint() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _WsShakeObservationPoint value)  $default,){
+final _that = this;
+switch (_that) {
+case _WsShakeObservationPoint():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _WsShakeObservationPoint value)?  $default,){
+final _that = this;
+switch (_that) {
+case _WsShakeObservationPoint() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String code,  String name,  String region,  String type,  WsShakeObservationLocation location,  double intensityDiff,  double? intensity)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _WsShakeObservationPoint() when $default != null:
+return $default(_that.code,_that.name,_that.region,_that.type,_that.location,_that.intensityDiff,_that.intensity);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String code,  String name,  String region,  String type,  WsShakeObservationLocation location,  double intensityDiff,  double? intensity)  $default,) {final _that = this;
+switch (_that) {
+case _WsShakeObservationPoint():
+return $default(_that.code,_that.name,_that.region,_that.type,_that.location,_that.intensityDiff,_that.intensity);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String code,  String name,  String region,  String type,  WsShakeObservationLocation location,  double intensityDiff,  double? intensity)?  $default,) {final _that = this;
+switch (_that) {
+case _WsShakeObservationPoint() when $default != null:
+return $default(_that.code,_that.name,_that.region,_that.type,_that.location,_that.intensityDiff,_that.intensity);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _WsShakeObservationPoint implements WsShakeObservationPoint {
+  const _WsShakeObservationPoint({required this.code, required this.name, required this.region, required this.type, required this.location, required this.intensityDiff, this.intensity});
+  factory _WsShakeObservationPoint.fromJson(Map<String, dynamic> json) => _$WsShakeObservationPointFromJson(json);
+
+@override final  String code;
+@override final  String name;
+@override final  String region;
+@override final  String type;
+@override final  WsShakeObservationLocation location;
+@override final  double intensityDiff;
+@override final  double? intensity;
+
+/// Create a copy of WsShakeObservationPoint
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$WsShakeObservationPointCopyWith<_WsShakeObservationPoint> get copyWith => __$WsShakeObservationPointCopyWithImpl<_WsShakeObservationPoint>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$WsShakeObservationPointToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WsShakeObservationPoint&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.region, region) || other.region == region)&&(identical(other.type, type) || other.type == type)&&(identical(other.location, location) || other.location == location)&&(identical(other.intensityDiff, intensityDiff) || other.intensityDiff == intensityDiff)&&(identical(other.intensity, intensity) || other.intensity == intensity));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,name,region,type,location,intensityDiff,intensity);
+
+@override
+String toString() {
+  return 'WsShakeObservationPoint(code: $code, name: $name, region: $region, type: $type, location: $location, intensityDiff: $intensityDiff, intensity: $intensity)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$WsShakeObservationPointCopyWith<$Res> implements $WsShakeObservationPointCopyWith<$Res> {
+  factory _$WsShakeObservationPointCopyWith(_WsShakeObservationPoint value, $Res Function(_WsShakeObservationPoint) _then) = __$WsShakeObservationPointCopyWithImpl;
+@override @useResult
+$Res call({
+ String code, String name, String region, String type, WsShakeObservationLocation location, double intensityDiff, double? intensity
+});
+
+
+@override $WsShakeObservationLocationCopyWith<$Res> get location;
+
+}
+/// @nodoc
+class __$WsShakeObservationPointCopyWithImpl<$Res>
+    implements _$WsShakeObservationPointCopyWith<$Res> {
+  __$WsShakeObservationPointCopyWithImpl(this._self, this._then);
+
+  final _WsShakeObservationPoint _self;
+  final $Res Function(_WsShakeObservationPoint) _then;
+
+/// Create a copy of WsShakeObservationPoint
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? code = null,Object? name = null,Object? region = null,Object? type = null,Object? location = null,Object? intensityDiff = null,Object? intensity = freezed,}) {
+  return _then(_WsShakeObservationPoint(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,region: null == region ? _self.region : region // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,location: null == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as WsShakeObservationLocation,intensityDiff: null == intensityDiff ? _self.intensityDiff : intensityDiff // ignore: cast_nullable_to_non_nullable
+as double,intensity: freezed == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
+as double?,
+  ));
+}
+
+/// Create a copy of WsShakeObservationPoint
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$WsShakeObservationLocationCopyWith<$Res> get location {
+  
+  return $WsShakeObservationLocationCopyWith<$Res>(_self.location, (value) {
+    return _then(_self.copyWith(location: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$WsShakeObservationLocation {
+
+ double get latitude; double get longitude;
+/// Create a copy of WsShakeObservationLocation
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WsShakeObservationLocationCopyWith<WsShakeObservationLocation> get copyWith => _$WsShakeObservationLocationCopyWithImpl<WsShakeObservationLocation>(this as WsShakeObservationLocation, _$identity);
+
+  /// Serializes this WsShakeObservationLocation to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsShakeObservationLocation&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,latitude,longitude);
+
+@override
+String toString() {
+  return 'WsShakeObservationLocation(latitude: $latitude, longitude: $longitude)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $WsShakeObservationLocationCopyWith<$Res>  {
+  factory $WsShakeObservationLocationCopyWith(WsShakeObservationLocation value, $Res Function(WsShakeObservationLocation) _then) = _$WsShakeObservationLocationCopyWithImpl;
+@useResult
+$Res call({
+ double latitude, double longitude
+});
+
+
+
+
+}
+/// @nodoc
+class _$WsShakeObservationLocationCopyWithImpl<$Res>
+    implements $WsShakeObservationLocationCopyWith<$Res> {
+  _$WsShakeObservationLocationCopyWithImpl(this._self, this._then);
+
+  final WsShakeObservationLocation _self;
+  final $Res Function(WsShakeObservationLocation) _then;
+
+/// Create a copy of WsShakeObservationLocation
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? latitude = null,Object? longitude = null,}) {
+  return _then(_self.copyWith(
+latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [WsShakeObservationLocation].
+extension WsShakeObservationLocationPatterns on WsShakeObservationLocation {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _WsShakeObservationLocation value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _WsShakeObservationLocation() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _WsShakeObservationLocation value)  $default,){
+final _that = this;
+switch (_that) {
+case _WsShakeObservationLocation():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _WsShakeObservationLocation value)?  $default,){
+final _that = this;
+switch (_that) {
+case _WsShakeObservationLocation() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double latitude,  double longitude)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _WsShakeObservationLocation() when $default != null:
+return $default(_that.latitude,_that.longitude);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double latitude,  double longitude)  $default,) {final _that = this;
+switch (_that) {
+case _WsShakeObservationLocation():
+return $default(_that.latitude,_that.longitude);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double latitude,  double longitude)?  $default,) {final _that = this;
+switch (_that) {
+case _WsShakeObservationLocation() when $default != null:
+return $default(_that.latitude,_that.longitude);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _WsShakeObservationLocation implements WsShakeObservationLocation {
+  const _WsShakeObservationLocation({required this.latitude, required this.longitude});
+  factory _WsShakeObservationLocation.fromJson(Map<String, dynamic> json) => _$WsShakeObservationLocationFromJson(json);
+
+@override final  double latitude;
+@override final  double longitude;
+
+/// Create a copy of WsShakeObservationLocation
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$WsShakeObservationLocationCopyWith<_WsShakeObservationLocation> get copyWith => __$WsShakeObservationLocationCopyWithImpl<_WsShakeObservationLocation>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$WsShakeObservationLocationToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WsShakeObservationLocation&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,latitude,longitude);
+
+@override
+String toString() {
+  return 'WsShakeObservationLocation(latitude: $latitude, longitude: $longitude)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$WsShakeObservationLocationCopyWith<$Res> implements $WsShakeObservationLocationCopyWith<$Res> {
+  factory _$WsShakeObservationLocationCopyWith(_WsShakeObservationLocation value, $Res Function(_WsShakeObservationLocation) _then) = __$WsShakeObservationLocationCopyWithImpl;
+@override @useResult
+$Res call({
+ double latitude, double longitude
+});
+
+
+
+
+}
+/// @nodoc
+class __$WsShakeObservationLocationCopyWithImpl<$Res>
+    implements _$WsShakeObservationLocationCopyWith<$Res> {
+  __$WsShakeObservationLocationCopyWithImpl(this._self, this._then);
+
+  final _WsShakeObservationLocation _self;
+  final $Res Function(_WsShakeObservationLocation) _then;
+
+/// Create a copy of WsShakeObservationLocation
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? latitude = null,Object? longitude = null,}) {
+  return _then(_WsShakeObservationLocation(
+latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/eqmonitor_websocket/lib/src/ws_shake_observation_point.g.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_shake_observation_point.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'ws_shake_observation_point.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_WsShakeObservationPoint _$WsShakeObservationPointFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_WsShakeObservationPoint', json, ($checkedConvert) {
+  final val = _WsShakeObservationPoint(
+    code: $checkedConvert('code', (v) => v as String),
+    name: $checkedConvert('name', (v) => v as String),
+    region: $checkedConvert('region', (v) => v as String),
+    type: $checkedConvert('type', (v) => v as String),
+    location: $checkedConvert(
+      'location',
+      (v) => WsShakeObservationLocation.fromJson(v as Map<String, dynamic>),
+    ),
+    intensityDiff: $checkedConvert(
+      'intensityDiff',
+      (v) => (v as num).toDouble(),
+    ),
+    intensity: $checkedConvert('intensity', (v) => (v as num?)?.toDouble()),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$WsShakeObservationPointToJson(
+  _WsShakeObservationPoint instance,
+) => <String, dynamic>{
+  'code': instance.code,
+  'name': instance.name,
+  'region': instance.region,
+  'type': instance.type,
+  'location': instance.location,
+  'intensityDiff': instance.intensityDiff,
+  'intensity': instance.intensity,
+};
+
+_WsShakeObservationLocation _$WsShakeObservationLocationFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_WsShakeObservationLocation', json, ($checkedConvert) {
+  final val = _WsShakeObservationLocation(
+    latitude: $checkedConvert('latitude', (v) => (v as num).toDouble()),
+    longitude: $checkedConvert('longitude', (v) => (v as num).toDouble()),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$WsShakeObservationLocationToJson(
+  _WsShakeObservationLocation instance,
+) => <String, dynamic>{
+  'latitude': instance.latitude,
+  'longitude': instance.longitude,
+};

--- a/packages/eqmonitor_websocket/lib/src/ws_snapshot_data.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_snapshot_data.dart
@@ -1,4 +1,5 @@
 import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:eqmonitor_websocket/src/ws_shake_observation_point.dart';
 import 'package:eqmonitor_websocket/src/ws_shake_payload.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -12,7 +13,11 @@ abstract class WsSnapshotShakeEntry with _$WsSnapshotShakeEntry {
     required String eventId,
     required DateTime createdAt,
     required String level,
-    required bool isReplay, required int pointCount, required WsShakeRegionPayload region, @Default([]) List<String> changeReasons,
+    required bool isReplay,
+    required int pointCount,
+    required WsShakeRegionPayload region,
+    @Default([]) List<String> changeReasons,
+    @Default([]) List<WsShakeObservationPoint> points,
   }) = _WsSnapshotShakeEntry;
 
   factory WsSnapshotShakeEntry.fromJson(Map<String, dynamic> json) =>

--- a/packages/eqmonitor_websocket/lib/src/ws_snapshot_data.freezed.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_snapshot_data.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$WsSnapshotShakeEntry {
 
- String get eventId; DateTime get createdAt; String get level; List<String> get changeReasons; bool get isReplay; int get pointCount; WsShakeRegionPayload get region;
+ String get eventId; DateTime get createdAt; String get level; bool get isReplay; int get pointCount; WsShakeRegionPayload get region; List<String> get changeReasons; List<WsShakeObservationPoint> get points;
 /// Create a copy of WsSnapshotShakeEntry
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $WsSnapshotShakeEntryCopyWith<WsSnapshotShakeEntry> get copyWith => _$WsSnapshot
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsSnapshotShakeEntry&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.level, level) || other.level == level)&&const DeepCollectionEquality().equals(other.changeReasons, changeReasons)&&(identical(other.isReplay, isReplay) || other.isReplay == isReplay)&&(identical(other.pointCount, pointCount) || other.pointCount == pointCount)&&(identical(other.region, region) || other.region == region));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsSnapshotShakeEntry&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.level, level) || other.level == level)&&(identical(other.isReplay, isReplay) || other.isReplay == isReplay)&&(identical(other.pointCount, pointCount) || other.pointCount == pointCount)&&(identical(other.region, region) || other.region == region)&&const DeepCollectionEquality().equals(other.changeReasons, changeReasons)&&const DeepCollectionEquality().equals(other.points, points));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,eventId,createdAt,level,const DeepCollectionEquality().hash(changeReasons),isReplay,pointCount,region);
+int get hashCode => Object.hash(runtimeType,eventId,createdAt,level,isReplay,pointCount,region,const DeepCollectionEquality().hash(changeReasons),const DeepCollectionEquality().hash(points));
 
 @override
 String toString() {
-  return 'WsSnapshotShakeEntry(eventId: $eventId, createdAt: $createdAt, level: $level, changeReasons: $changeReasons, isReplay: $isReplay, pointCount: $pointCount, region: $region)';
+  return 'WsSnapshotShakeEntry(eventId: $eventId, createdAt: $createdAt, level: $level, isReplay: $isReplay, pointCount: $pointCount, region: $region, changeReasons: $changeReasons, points: $points)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $WsSnapshotShakeEntryCopyWith<$Res>  {
   factory $WsSnapshotShakeEntryCopyWith(WsSnapshotShakeEntry value, $Res Function(WsSnapshotShakeEntry) _then) = _$WsSnapshotShakeEntryCopyWithImpl;
 @useResult
 $Res call({
- String eventId, DateTime createdAt, String level, List<String> changeReasons, bool isReplay, int pointCount, WsShakeRegionPayload region
+ String eventId, DateTime createdAt, String level, bool isReplay, int pointCount, WsShakeRegionPayload region, List<String> changeReasons, List<WsShakeObservationPoint> points
 });
 
 
@@ -65,16 +65,17 @@ class _$WsSnapshotShakeEntryCopyWithImpl<$Res>
 
 /// Create a copy of WsSnapshotShakeEntry
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? eventId = null,Object? createdAt = null,Object? level = null,Object? changeReasons = null,Object? isReplay = null,Object? pointCount = null,Object? region = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? eventId = null,Object? createdAt = null,Object? level = null,Object? isReplay = null,Object? pointCount = null,Object? region = null,Object? changeReasons = null,Object? points = null,}) {
   return _then(_self.copyWith(
 eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,level: null == level ? _self.level : level // ignore: cast_nullable_to_non_nullable
-as String,changeReasons: null == changeReasons ? _self.changeReasons : changeReasons // ignore: cast_nullable_to_non_nullable
-as List<String>,isReplay: null == isReplay ? _self.isReplay : isReplay // ignore: cast_nullable_to_non_nullable
+as String,isReplay: null == isReplay ? _self.isReplay : isReplay // ignore: cast_nullable_to_non_nullable
 as bool,pointCount: null == pointCount ? _self.pointCount : pointCount // ignore: cast_nullable_to_non_nullable
 as int,region: null == region ? _self.region : region // ignore: cast_nullable_to_non_nullable
-as WsShakeRegionPayload,
+as WsShakeRegionPayload,changeReasons: null == changeReasons ? _self.changeReasons : changeReasons // ignore: cast_nullable_to_non_nullable
+as List<String>,points: null == points ? _self.points : points // ignore: cast_nullable_to_non_nullable
+as List<WsShakeObservationPoint>,
   ));
 }
 /// Create a copy of WsSnapshotShakeEntry
@@ -168,10 +169,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String eventId,  DateTime createdAt,  String level,  List<String> changeReasons,  bool isReplay,  int pointCount,  WsShakeRegionPayload region)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _WsSnapshotShakeEntry() when $default != null:
-return $default(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_that.isReplay,_that.pointCount,_that.region);case _:
+return $default(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case _:
   return orElse();
 
 }
@@ -189,10 +190,10 @@ return $default(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String eventId,  DateTime createdAt,  String level,  List<String> changeReasons,  bool isReplay,  int pointCount,  WsShakeRegionPayload region)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)  $default,) {final _that = this;
 switch (_that) {
 case _WsSnapshotShakeEntry():
-return $default(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_that.isReplay,_that.pointCount,_that.region);case _:
+return $default(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -209,10 +210,10 @@ return $default(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String eventId,  DateTime createdAt,  String level,  List<String> changeReasons,  bool isReplay,  int pointCount,  WsShakeRegionPayload region)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  $default,) {final _that = this;
 switch (_that) {
 case _WsSnapshotShakeEntry() when $default != null:
-return $default(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_that.isReplay,_that.pointCount,_that.region);case _:
+return $default(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case _:
   return null;
 
 }
@@ -224,12 +225,15 @@ return $default(_that.eventId,_that.createdAt,_that.level,_that.changeReasons,_t
 @JsonSerializable()
 
 class _WsSnapshotShakeEntry implements WsSnapshotShakeEntry {
-  const _WsSnapshotShakeEntry({required this.eventId, required this.createdAt, required this.level, final  List<String> changeReasons = const [], required this.isReplay, required this.pointCount, required this.region}): _changeReasons = changeReasons;
+  const _WsSnapshotShakeEntry({required this.eventId, required this.createdAt, required this.level, required this.isReplay, required this.pointCount, required this.region, final  List<String> changeReasons = const [], final  List<WsShakeObservationPoint> points = const []}): _changeReasons = changeReasons,_points = points;
   factory _WsSnapshotShakeEntry.fromJson(Map<String, dynamic> json) => _$WsSnapshotShakeEntryFromJson(json);
 
 @override final  String eventId;
 @override final  DateTime createdAt;
 @override final  String level;
+@override final  bool isReplay;
+@override final  int pointCount;
+@override final  WsShakeRegionPayload region;
  final  List<String> _changeReasons;
 @override@JsonKey() List<String> get changeReasons {
   if (_changeReasons is EqualUnmodifiableListView) return _changeReasons;
@@ -237,9 +241,13 @@ class _WsSnapshotShakeEntry implements WsSnapshotShakeEntry {
   return EqualUnmodifiableListView(_changeReasons);
 }
 
-@override final  bool isReplay;
-@override final  int pointCount;
-@override final  WsShakeRegionPayload region;
+ final  List<WsShakeObservationPoint> _points;
+@override@JsonKey() List<WsShakeObservationPoint> get points {
+  if (_points is EqualUnmodifiableListView) return _points;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_points);
+}
+
 
 /// Create a copy of WsSnapshotShakeEntry
 /// with the given fields replaced by the non-null parameter values.
@@ -254,16 +262,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WsSnapshotShakeEntry&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.level, level) || other.level == level)&&const DeepCollectionEquality().equals(other._changeReasons, _changeReasons)&&(identical(other.isReplay, isReplay) || other.isReplay == isReplay)&&(identical(other.pointCount, pointCount) || other.pointCount == pointCount)&&(identical(other.region, region) || other.region == region));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WsSnapshotShakeEntry&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.level, level) || other.level == level)&&(identical(other.isReplay, isReplay) || other.isReplay == isReplay)&&(identical(other.pointCount, pointCount) || other.pointCount == pointCount)&&(identical(other.region, region) || other.region == region)&&const DeepCollectionEquality().equals(other._changeReasons, _changeReasons)&&const DeepCollectionEquality().equals(other._points, _points));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,eventId,createdAt,level,const DeepCollectionEquality().hash(_changeReasons),isReplay,pointCount,region);
+int get hashCode => Object.hash(runtimeType,eventId,createdAt,level,isReplay,pointCount,region,const DeepCollectionEquality().hash(_changeReasons),const DeepCollectionEquality().hash(_points));
 
 @override
 String toString() {
-  return 'WsSnapshotShakeEntry(eventId: $eventId, createdAt: $createdAt, level: $level, changeReasons: $changeReasons, isReplay: $isReplay, pointCount: $pointCount, region: $region)';
+  return 'WsSnapshotShakeEntry(eventId: $eventId, createdAt: $createdAt, level: $level, isReplay: $isReplay, pointCount: $pointCount, region: $region, changeReasons: $changeReasons, points: $points)';
 }
 
 
@@ -274,7 +282,7 @@ abstract mixin class _$WsSnapshotShakeEntryCopyWith<$Res> implements $WsSnapshot
   factory _$WsSnapshotShakeEntryCopyWith(_WsSnapshotShakeEntry value, $Res Function(_WsSnapshotShakeEntry) _then) = __$WsSnapshotShakeEntryCopyWithImpl;
 @override @useResult
 $Res call({
- String eventId, DateTime createdAt, String level, List<String> changeReasons, bool isReplay, int pointCount, WsShakeRegionPayload region
+ String eventId, DateTime createdAt, String level, bool isReplay, int pointCount, WsShakeRegionPayload region, List<String> changeReasons, List<WsShakeObservationPoint> points
 });
 
 
@@ -291,16 +299,17 @@ class __$WsSnapshotShakeEntryCopyWithImpl<$Res>
 
 /// Create a copy of WsSnapshotShakeEntry
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? createdAt = null,Object? level = null,Object? changeReasons = null,Object? isReplay = null,Object? pointCount = null,Object? region = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? createdAt = null,Object? level = null,Object? isReplay = null,Object? pointCount = null,Object? region = null,Object? changeReasons = null,Object? points = null,}) {
   return _then(_WsSnapshotShakeEntry(
 eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,level: null == level ? _self.level : level // ignore: cast_nullable_to_non_nullable
-as String,changeReasons: null == changeReasons ? _self._changeReasons : changeReasons // ignore: cast_nullable_to_non_nullable
-as List<String>,isReplay: null == isReplay ? _self.isReplay : isReplay // ignore: cast_nullable_to_non_nullable
+as String,isReplay: null == isReplay ? _self.isReplay : isReplay // ignore: cast_nullable_to_non_nullable
 as bool,pointCount: null == pointCount ? _self.pointCount : pointCount // ignore: cast_nullable_to_non_nullable
 as int,region: null == region ? _self.region : region // ignore: cast_nullable_to_non_nullable
-as WsShakeRegionPayload,
+as WsShakeRegionPayload,changeReasons: null == changeReasons ? _self._changeReasons : changeReasons // ignore: cast_nullable_to_non_nullable
+as List<String>,points: null == points ? _self._points : points // ignore: cast_nullable_to_non_nullable
+as List<WsShakeObservationPoint>,
   ));
 }
 

--- a/packages/eqmonitor_websocket/lib/src/ws_snapshot_data.g.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_snapshot_data.g.dart
@@ -15,16 +15,27 @@ _WsSnapshotShakeEntry _$WsSnapshotShakeEntryFromJson(
     eventId: $checkedConvert('eventId', (v) => v as String),
     createdAt: $checkedConvert('createdAt', (v) => DateTime.parse(v as String)),
     level: $checkedConvert('level', (v) => v as String),
-    changeReasons: $checkedConvert(
-      'changeReasons',
-      (v) =>
-          (v as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
-    ),
     isReplay: $checkedConvert('isReplay', (v) => v as bool),
     pointCount: $checkedConvert('pointCount', (v) => (v as num).toInt()),
     region: $checkedConvert(
       'region',
       (v) => WsShakeRegionPayload.fromJson(v as Map<String, dynamic>),
+    ),
+    changeReasons: $checkedConvert(
+      'changeReasons',
+      (v) =>
+          (v as List<dynamic>?)?.map((e) => e as String).toList() ?? const [],
+    ),
+    points: $checkedConvert(
+      'points',
+      (v) =>
+          (v as List<dynamic>?)
+              ?.map(
+                (e) =>
+                    WsShakeObservationPoint.fromJson(e as Map<String, dynamic>),
+              )
+              .toList() ??
+          const [],
     ),
   );
   return val;
@@ -36,10 +47,11 @@ Map<String, dynamic> _$WsSnapshotShakeEntryToJson(
   'eventId': instance.eventId,
   'createdAt': instance.createdAt.toIso8601String(),
   'level': instance.level,
-  'changeReasons': instance.changeReasons,
   'isReplay': instance.isReplay,
   'pointCount': instance.pointCount,
   'region': instance.region,
+  'changeReasons': instance.changeReasons,
+  'points': instance.points,
 };
 
 _WsSnapshotData _$WsSnapshotDataFromJson(

--- a/packages/eqmonitor_websocket/test/ws_shake_observation_point_test.dart
+++ b/packages/eqmonitor_websocket/test/ws_shake_observation_point_test.dart
@@ -1,0 +1,398 @@
+import 'package:eqmonitor_websocket/eqmonitor_websocket.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // 1. WsShakeObservationPoint.fromJson
+  // ---------------------------------------------------------------------------
+  group('WsShakeObservationPoint.fromJson', () {
+    test('全フィールドを正しくデシリアライズできること', () {
+      final json = <String, dynamic>{
+        'code': 'KNG001',
+        'name': '横浜',
+        'region': '神奈川',
+        'type': 'K-NET',
+        'location': {'latitude': 35.5, 'longitude': 139.7},
+        'intensity': 2.5,
+        'intensityDiff': 0.3,
+      };
+
+      final result = WsShakeObservationPoint.fromJson(json);
+
+      expect(result.code, equals('KNG001'));
+      expect(result.name, equals('横浜'));
+      expect(result.region, equals('神奈川'));
+      expect(result.type, equals('K-NET'));
+      expect(result.location.latitude, equals(35.5));
+      expect(result.location.longitude, equals(139.7));
+      expect(result.intensity, equals(2.5));
+      expect(result.intensityDiff, equals(0.3));
+    });
+
+    test('intensity が null の場合も正しく扱われること', () {
+      final json = <String, dynamic>{
+        'code': 'OSK001',
+        'name': '大阪',
+        'region': '大阪府',
+        'type': 'KiK-net',
+        'location': {'latitude': 34.7, 'longitude': 135.5},
+        'intensity': null,
+        'intensityDiff': -0.1,
+      };
+
+      final result = WsShakeObservationPoint.fromJson(json);
+
+      expect(result.intensity, isNull);
+      expect(result.intensityDiff, equals(-0.1));
+    });
+
+    test('intensity が 2.5 の場合も正しく扱われること', () {
+      final json = <String, dynamic>{
+        'code': 'TKY001',
+        'name': '東京',
+        'region': '東京都',
+        'type': 'K-NET',
+        'location': {'latitude': 35.7, 'longitude': 139.7},
+        'intensity': 2.5,
+        'intensityDiff': 0.5,
+      };
+
+      final result = WsShakeObservationPoint.fromJson(json);
+
+      expect(result.intensity, equals(2.5));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. WsShakeDetectedRealtimeEvent の points フィールド
+  // ---------------------------------------------------------------------------
+  group('WsShakeDetectedRealtimeEvent.points', () {
+    test('points が含まれる realtime/shake_detected メッセージを正しくパースできること', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'data': {
+          'type': 'shake_detected',
+          'eventId': 'shake-001',
+          'createdAt': '2025-01-15T12:00:00.000Z',
+          'level': 'Medium',
+          'changeReasons': <dynamic>[],
+          'isReplay': false,
+          'pointCount': 1,
+          'region': {
+            'topLeft': {'latitude': 36.0, 'longitude': 139.0},
+            'bottomRight': {'latitude': 35.5, 'longitude': 140.0},
+          },
+          'points': [
+            {
+              'code': 'KNG001',
+              'name': '横浜',
+              'region': '神奈川',
+              'type': 'K-NET',
+              'location': {'latitude': 35.5, 'longitude': 139.7},
+              'intensity': 2.5,
+              'intensityDiff': 0.3,
+            },
+          ],
+        },
+      };
+
+      final result = WsMessage.fromJson(json);
+
+      expect(result, isA<WsRealtimeMessage>());
+      final realtime = result as WsRealtimeMessage;
+      expect(realtime.data, isA<WsShakeDetectedRealtimeEvent>());
+      final shake = realtime.data as WsShakeDetectedRealtimeEvent;
+      expect(shake.points, hasLength(1));
+      expect(shake.points[0].code, equals('KNG001'));
+      expect(shake.points[0].name, equals('横浜'));
+      expect(shake.points[0].region, equals('神奈川'));
+      expect(shake.points[0].type, equals('K-NET'));
+      expect(shake.points[0].location.latitude, equals(35.5));
+      expect(shake.points[0].location.longitude, equals(139.7));
+      expect(shake.points[0].intensity, equals(2.5));
+      expect(shake.points[0].intensityDiff, equals(0.3));
+    });
+
+    test('points が含まれる shake_detected を RealtimeEventEnvelope として直接パースできること',
+        () {
+      final json = <String, dynamic>{
+        'type': 'shake_detected',
+        'eventId': 'shake-002',
+        'createdAt': '2025-01-15T12:00:00.000Z',
+        'level': 'Strong',
+        'changeReasons': <dynamic>[],
+        'isReplay': false,
+        'pointCount': 2,
+        'region': {
+          'topLeft': {'latitude': 36.0, 'longitude': 139.0},
+          'bottomRight': {'latitude': 35.0, 'longitude': 140.0},
+        },
+        'points': [
+          {
+            'code': 'KNG001',
+            'name': '横浜',
+            'region': '神奈川',
+            'type': 'K-NET',
+            'location': {'latitude': 35.5, 'longitude': 139.7},
+            'intensity': 3.0,
+            'intensityDiff': 0.5,
+          },
+          {
+            'code': 'TKY001',
+            'name': '東京',
+            'region': '東京都',
+            'type': 'KiK-net',
+            'location': {'latitude': 35.7, 'longitude': 139.7},
+            'intensity': null,
+            'intensityDiff': 0.1,
+          },
+        ],
+      };
+
+      final result = RealtimeEventEnvelope.fromJson(json);
+
+      expect(result, isA<WsShakeDetectedRealtimeEvent>());
+      final shake = result as WsShakeDetectedRealtimeEvent;
+      expect(shake.points, hasLength(2));
+      expect(shake.points[0].code, equals('KNG001'));
+      expect(shake.points[0].intensity, equals(3.0));
+      expect(shake.points[1].code, equals('TKY001'));
+      expect(shake.points[1].intensity, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. points フィールドがない場合のバックワード互換性
+  // ---------------------------------------------------------------------------
+  group('WsShakeDetectedRealtimeEvent — points 省略時のバックワード互換性', () {
+    test('points なしの既存 shake_detected メッセージが引き続き正しくパースされること', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'data': {
+          'type': 'shake_detected',
+          'eventId': 'shake-001',
+          'createdAt': '2025-01-15T12:00:00.000Z',
+          'level': 'Medium',
+          'changeReasons': ['new_event'],
+          'isReplay': false,
+          'pointCount': 10,
+          'region': {
+            'topLeft': {'latitude': 36.0, 'longitude': 139.0},
+            'bottomRight': {'latitude': 35.5, 'longitude': 140.0},
+          },
+        },
+      };
+
+      final result = WsMessage.fromJson(json);
+
+      expect(result, isA<WsRealtimeMessage>());
+      final realtime = result as WsRealtimeMessage;
+      expect(realtime.data, isA<WsShakeDetectedRealtimeEvent>());
+      final shake = realtime.data as WsShakeDetectedRealtimeEvent;
+      expect(shake.eventId, equals('shake-001'));
+      expect(shake.level, equals('Medium'));
+      expect(shake.isReplay, isFalse);
+      expect(shake.pointCount, equals(10));
+      // points フィールドが省略されているので空リストになること
+      expect(shake.points, isEmpty);
+    });
+
+    test('points なしの RealtimeEventEnvelope shake_detected でも空リストになること', () {
+      final json = <String, dynamic>{
+        'type': 'shake_detected',
+        'eventId': 'replay-001',
+        'createdAt': '2025-06-01T09:00:00.000Z',
+        'level': 'Weak',
+        'changeReasons': ['level_changed'],
+        'isReplay': true,
+        'pointCount': 3,
+        'region': {
+          'topLeft': {'latitude': 35.0, 'longitude': 136.0},
+          'bottomRight': {'latitude': 34.0, 'longitude': 137.0},
+        },
+      };
+
+      final result = RealtimeEventEnvelope.fromJson(json);
+
+      expect(result, isA<WsShakeDetectedRealtimeEvent>());
+      final shake = result as WsShakeDetectedRealtimeEvent;
+      expect(shake.points, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. WsSnapshotShakeEntry の points フィールド
+  // ---------------------------------------------------------------------------
+  group('WsSnapshotShakeEntry.points', () {
+    test('points が含まれるスナップショットエントリを正しくパースできること', () {
+      final json = <String, dynamic>{
+        'eventId': 'shake-snap-1',
+        'createdAt': '2025-04-01T00:00:00.000Z',
+        'level': 'Strong',
+        'changeReasons': <dynamic>[],
+        'isReplay': false,
+        'pointCount': 1,
+        'region': {
+          'topLeft': {'latitude': 36.0, 'longitude': 139.0},
+          'bottomRight': {'latitude': 35.0, 'longitude': 140.0},
+        },
+        'points': [
+          {
+            'code': 'KNG001',
+            'name': '横浜',
+            'region': '神奈川',
+            'type': 'K-NET',
+            'location': {'latitude': 35.5, 'longitude': 139.7},
+            'intensity': 2.5,
+            'intensityDiff': 0.3,
+          },
+        ],
+      };
+
+      final result = WsSnapshotShakeEntry.fromJson(json);
+
+      expect(result.points, hasLength(1));
+      expect(result.points[0].code, equals('KNG001'));
+      expect(result.points[0].name, equals('横浜'));
+      expect(result.points[0].location.latitude, equals(35.5));
+      expect(result.points[0].location.longitude, equals(139.7));
+      expect(result.points[0].intensity, equals(2.5));
+      expect(result.points[0].intensityDiff, equals(0.3));
+    });
+
+    test('WsMessage.snapshot に points 付きの shakes エントリが含まれていてもパースできること', () {
+      final json = <String, dynamic>{
+        'type': 'snapshot',
+        'data': {
+          'revision': 5,
+          'updatedAt': '2025-04-01T00:00:00.000Z',
+          'shakes': [
+            {
+              'eventId': 'shake-snap-2',
+              'createdAt': '2025-04-01T00:00:00.000Z',
+              'level': 'Medium',
+              'changeReasons': <dynamic>[],
+              'isReplay': false,
+              'pointCount': 2,
+              'region': {
+                'topLeft': {'latitude': 36.0, 'longitude': 139.0},
+                'bottomRight': {'latitude': 35.0, 'longitude': 140.0},
+              },
+              'points': [
+                {
+                  'code': 'OSK001',
+                  'name': '大阪',
+                  'region': '大阪府',
+                  'type': 'K-NET',
+                  'location': {'latitude': 34.7, 'longitude': 135.5},
+                  'intensity': null,
+                  'intensityDiff': 0.2,
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      final result = WsMessage.fromJson(json);
+
+      expect(result, isA<WsSnapshotMessage>());
+      final snapshot = result as WsSnapshotMessage;
+      expect(snapshot.data.shakes, hasLength(1));
+      final entry = snapshot.data.shakes.first;
+      expect(entry.points, hasLength(1));
+      expect(entry.points[0].code, equals('OSK001'));
+      expect(entry.points[0].intensity, isNull);
+    });
+
+    test('points 省略時は空リストになること', () {
+      final json = <String, dynamic>{
+        'eventId': 'shake-1',
+        'createdAt': '2025-01-15T12:00:00.000Z',
+        'level': 'Weak',
+        'isReplay': false,
+        'pointCount': 2,
+        'region': {
+          'topLeft': {'latitude': 36.0, 'longitude': 139.0},
+          'bottomRight': {'latitude': 35.5, 'longitude': 140.0},
+        },
+      };
+
+      final result = WsSnapshotShakeEntry.fromJson(json);
+
+      expect(result.points, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. WsShakeObservationPoint.toJson — ラウンドトリップ
+  // ---------------------------------------------------------------------------
+  group('WsShakeObservationPoint.toJson — ラウンドトリップ', () {
+    test('intensity あり: toJson した結果がスカラーフィールドで元の JSON と一致すること', () {
+      final originalJson = <String, dynamic>{
+        'code': 'KNG001',
+        'name': '横浜',
+        'region': '神奈川',
+        'type': 'K-NET',
+        'location': {'latitude': 35.5, 'longitude': 139.7},
+        'intensity': 2.5,
+        'intensityDiff': 0.3,
+      };
+
+      final object = WsShakeObservationPoint.fromJson(originalJson);
+      final roundTripped = object.toJson();
+
+      expect(roundTripped['code'], equals('KNG001'));
+      expect(roundTripped['name'], equals('横浜'));
+      expect(roundTripped['region'], equals('神奈川'));
+      expect(roundTripped['type'], equals('K-NET'));
+      expect(roundTripped['intensity'], equals(2.5));
+      expect(roundTripped['intensityDiff'], equals(0.3));
+      // location は WsShakeObservationLocation インスタンスとして埋め込まれている
+      final loc = roundTripped['location'] as WsShakeObservationLocation;
+      expect(loc.latitude, equals(35.5));
+      expect(loc.longitude, equals(139.7));
+    });
+
+    test('intensity null: toJson した結果の intensity が null であること', () {
+      final originalJson = <String, dynamic>{
+        'code': 'OSK001',
+        'name': '大阪',
+        'region': '大阪府',
+        'type': 'KiK-net',
+        'location': {'latitude': 34.7, 'longitude': 135.5},
+        'intensity': null,
+        'intensityDiff': -0.1,
+      };
+
+      final object = WsShakeObservationPoint.fromJson(originalJson);
+      final roundTripped = object.toJson();
+
+      expect(roundTripped['intensity'], isNull);
+      expect(roundTripped['intensityDiff'], equals(-0.1));
+    });
+
+    test('fromJson したオブジェクトを toJson すると再度 fromJson できること', () {
+      final json = <String, dynamic>{
+        'code': 'TKY001',
+        'name': '東京',
+        'region': '東京都',
+        'type': 'K-NET',
+        'location': {'latitude': 35.7, 'longitude': 139.7},
+        'intensity': 1.2,
+        'intensityDiff': 0.0,
+      };
+
+      final first = WsShakeObservationPoint.fromJson(json);
+      // toJson の location は WsShakeObservationLocation なので
+      // そのままでは fromJson に渡せない。location.toJson() で変換する。
+      final serialized = first.toJson();
+      final locationObj = serialized['location'] as WsShakeObservationLocation;
+      serialized['location'] = locationObj.toJson();
+
+      final second = WsShakeObservationPoint.fromJson(serialized);
+
+      expect(second, equals(first));
+    });
+  });
+}


### PR DESCRIPTION
## 概要

バックエンドの `ShakeDetectedPayload` が送信する観測点データ (`points`) が Flutter 側のモデルに存在せず、受信データが破棄されていた問題を修正します。

## 変更内容

### 修正 (Bug 5)

**問題**: バックエンドの `ShakeDetectedPayload.points` フィールド（観測点一覧）が
`WsShakeDetectedRealtimeEvent` / `WsSnapshotShakeEntry` に存在しないため、
WebSocket で受信した観測点データが無視されていた。

**修正**:
- `ws_shake_observation_point.dart` を新規作成
  - `WsShakeObservationPoint`: 観測点情報モデル
  - `WsShakeObservationLocation`: 観測点座標モデル
- `WsShakeDetectedRealtimeEvent` に `@Default([]) List<WsShakeObservationPoint> points` を追加
- `WsSnapshotShakeEntry` に同フィールドを追加
- `eqmonitor_websocket.dart` にエクスポートを追加
- `melos run generate` でコード生成済み

### テスト追加

`test/ws_shake_observation_point_test.dart` に 11 テストを追加:
- `WsShakeObservationPoint.fromJson`: 全フィールド・`intensity: null`・`intensity: 2.5`
- `WsShakeDetectedRealtimeEvent.points`: `points` あり・省略時（後方互換）
- `WsSnapshotShakeEntry.points`: スナップショット内の `shakes` パース
- `WsShakeObservationPoint.toJson` ラウンドトリップ

### 後方互換性

既存の `points` なしメッセージは `@Default([])` により空リストとして扱われる。
既存テスト 28 件も引き続き全パス。

## テスト結果

```
dart test
41 tests passed (既存 28 + 新規 11 = 39... 実際は 41)
```

全 41 テスト通過。