### PR TITLE
fix(map): 地震履歴詳細マップのバグ修正・ref.invalidate asReload対応

### DIFF
--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart
@@ -45,11 +45,11 @@ Stream<WebSocketEvent> eqmonitorWsEventStream(Ref ref) async* {
       talker.warning(
         'EQMonitor WebSocket: closed with code $code and reason $reason',
       );
-      ref.invalidate(eqmonitorWebSocketProvider);
+      ref.invalidate(eqmonitorWebSocketProvider, asReload: true);
       return;
     }
   }
-  ref.invalidate(eqmonitorWebSocketProvider);
+  ref.invalidate(eqmonitorWebSocketProvider, asReload: true);
 }
 
 @riverpod

--- a/app/lib/feature/devices/data/notifier/push_token_sync_notifier.dart
+++ b/app/lib/feature/devices/data/notifier/push_token_sync_notifier.dart
@@ -30,7 +30,7 @@ class PushTokenSyncNotifier extends _$PushTokenSyncNotifier {
   Future<void> handleAuthenticationFailure() async {
     final repo = ref.read(deviceProvisioningRepositoryProvider);
     await repo.clearProvisioned();
-    ref.invalidate(deviceProvisioningProvider);
+    ref.invalidate(deviceProvisioningProvider, asReload: true);
   }
 
   @override

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -40,8 +40,8 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
     final syncSnapshot = ref.watch(pushTokenSyncProvider);
 
     Future<void> onRefresh() async {
-      ref.invalidate(deviceProvisioningProvider);
-      ref.invalidate(pushTokenSyncProvider);
+      ref.invalidate(deviceProvisioningProvider, asReload: true);
+      ref.invalidate(pushTokenSyncProvider, asReload: true);
       await ref.read(deviceProvisioningProvider.future);
     }
 
@@ -300,7 +300,7 @@ class _NotificationPermissionSection extends ConsumerWidget {
       trailing: IconButton(
         tooltip: '再取得',
         icon: const Icon(Icons.refresh),
-        onPressed: () => ref.invalidate(_osNotificationPermissionProvider),
+        onPressed: () => ref.invalidate(_osNotificationPermissionProvider, asReload: true),
       ),
       child: switch (permAsync) {
         AsyncData(:final value) => Column(
@@ -608,7 +608,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
       }
       switch (result) {
         case Success():
-          ref.invalidate(_notificationSettingsProvider(deviceId));
+          ref.invalidate(_notificationSettingsProvider(deviceId), asReload: true);
           messenger.showSnackBar(
             const SnackBar(content: Text('通知設定を更新しました')),
           );
@@ -771,7 +771,7 @@ class _HistorySection extends ConsumerWidget {
       title: '通知履歴',
       trailing: IconButton(
         tooltip: '更新',
-        onPressed: () => ref.invalidate(_notificationHistoryProvider(deviceId)),
+        onPressed: () => ref.invalidate(_notificationHistoryProvider(deviceId), asReload: true),
         icon: const Icon(Icons.refresh),
       ),
       child: switch (historyAsync) {

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
@@ -30,7 +30,7 @@ Future<EarthquakeHistoryDataSource> earthquakeHistoryDataSource(
   final dataSource = EarthquakeHistoryDataSource(
     repository: repository,
     parameter: parameter,
-    onRefreshStarted: () => ref.invalidate(earthquakeHistoryDetailsProvider),
+    onRefreshStarted: () => ref.invalidate(earthquakeHistoryDetailsProvider, asReload: true),
   );
 
   ref.onDispose(dataSource.dispose);

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart
@@ -58,7 +58,7 @@ class EarthquakeHistoryNotifier extends _$EarthquakeHistoryNotifier {
     required EarthquakeHistoryParameter param,
     required int limit,
   }) async {
-    ref.invalidate(earthquakeHistoryDetailsProvider);
+    ref.invalidate(earthquakeHistoryDetailsProvider, asReload: true);
     return _fetchData(param: param, limit: limit, cursor: null);
   }
 

--- a/app/lib/feature/earthquake_history/ui/components/current_location_intensity_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/current_location_intensity_card.dart
@@ -11,11 +11,12 @@ import 'package:eqmonitor/feature/location/data/location.dart';
 import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lat_lng/lat_lng.dart';
 
 /// 現在地に対応する震度を表示する。
-class CurrentLocationIntensityCard extends ConsumerWidget {
+class CurrentLocationIntensityCard extends HookConsumerWidget {
   const CurrentLocationIntensityCard({required this.item, super.key});
 
   final Earthquake item;
@@ -27,20 +28,43 @@ class CurrentLocationIntensityCard extends ConsumerWidget {
     }
 
     final position = ref.watch(locationStreamProvider).value;
-    final latLng = position != null
-        ? LatLng(position.latitude, position.longitude)
-        : null;
+    final latLng = useMemoized(
+      () => position != null
+          ? LatLng(position.latitude, position.longitude)
+          : null,
+      [position?.latitude, position?.longitude],
+    );
 
     if (latLng == null) {
       return const SizedBox.shrink();
     }
 
-    final city = ref
+    final cityCode = ref
         .watch(
           jmaMapAreaInformationCityInsideProvider(latLng),
         )
-        .value;
-    final cityCode = city?.property?.code;
+        .value
+        ?.property
+        ?.code;
+    final regionCode = ref
+        .watch(
+          jmaMapAreaForecastLocalEInsideProvider(latLng),
+        )
+        .value
+        ?.property
+        ?.code;
+
+    final cachedCityCode = useRef<String?>(null);
+    final cachedRegionCode = useRef<String?>(null);
+    if (cityCode != null) {
+      cachedCityCode.value = cityCode;
+    }
+    if (regionCode != null) {
+      cachedRegionCode.value = regionCode;
+    }
+    final effectiveCityCode = cityCode ?? cachedCityCode.value;
+    final effectiveRegionCode = regionCode ?? cachedRegionCode.value;
+
     final cityParameter = ref.watch(
       parameterSetProvider.select(
         (v) => v.value?.earthquake.prefectures
@@ -51,45 +75,30 @@ class CurrentLocationIntensityCard extends ConsumerWidget {
                 ),
               ),
             )
-            .firstWhereOrNull((e) => e.city.code == cityCode),
+            .firstWhereOrNull((e) => e.city.code == effectiveCityCode),
       ),
     );
     final cityParameterName = cityParameter != null
         ? '${cityParameter.prefecture.name.ja}${cityParameter.city.name.ja}'
         : null;
-    final region = ref
-        .watch(
-          jmaMapAreaForecastLocalEInsideProvider(latLng),
-        )
-        .value;
-    final regionCode = region?.property?.code;
     final regionParameter = ref.watch(
       parameterSetProvider.select(
         (v) => v.value?.earthquake.prefectures
             .expand((p) => p.regions)
-            .firstWhereOrNull((r) => r.code == regionCode),
+            .firstWhereOrNull((r) => r.code == effectiveRegionCode),
       ),
     );
 
     final state = ref.watch(
       currentLocationIntensityProvider(
         eventId: item.eventId,
-        cityAreaCode: city?.property?.code,
-        regionAreaCode: region?.property?.code,
+        cityAreaCode: effectiveCityCode,
+        regionAreaCode: effectiveRegionCode,
       ),
     );
 
     return state.when(
-      loading: () => const Padding(
-        padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        child: Center(
-          child: SizedBox(
-            width: 24,
-            height: 24,
-            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-          ),
-        ),
-      ),
+      loading: () => const SizedBox.shrink(),
       error: (error, stackTrace) => const SizedBox.shrink(),
       data: (value) => switch (value) {
         CurrentLocationIntensityDisplayNone() => const SizedBox.shrink(),

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
@@ -10,6 +10,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart'
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/layer/model/earthquake_history_map_layer_mode.dart';
+import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -111,7 +112,13 @@ class _ResolvedEarthquakeHistoryFillLayer extends HookConsumerWidget {
               if (disposed) {
                 return;
               }
-              await styleController.addLayer(layer);
+              final belowLayerId = layer.id.contains('-city-')
+                  ? BaseLayer.areaInformationCityQuakeLine.name
+                  : BaseLayer.areaForecastLocalELine.name;
+              await styleController.addLayer(
+                layer,
+                belowLayerId: belowLayerId,
+              );
               addedLayerIds.add(layer.id);
             }
           } on Exception catch (e) {

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_intensity_icon_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_intensity_icon_layer.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
 
-import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
@@ -11,6 +11,7 @@ import 'package:eqmonitor/feature/map/features/icon/data/provider/intensity_icon
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:jma_map/jma_map.dart';
 import 'package:maplibre/maplibre.dart';
 
 /// 地震履歴詳細の地域・市区町村レベル震度アイコンレイヤー
@@ -33,6 +34,11 @@ class EarthquakeHistoryIntensityIconLayer extends HookConsumerWidget {
   final Earthquake earthquake;
   final EarthquakeHistoryDetailConfig config;
   final EarthquakeHistoryMapLayerZoomThresholds zoomThresholds;
+
+  static const _regionSourceId = 'eq-history-icon-region-geojson';
+  static const _regionLayerId = 'eq-history-icon-region-symbol';
+  static const _citySourceId = 'eq-history-icon-city-geojson';
+  static const _cityLayerId = 'eq-history-icon-city-symbol';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -68,100 +74,91 @@ class EarthquakeHistoryIntensityIconLayer extends HookConsumerWidget {
           return null;
         }
 
+        final addedSourceIds = <String>[];
+        final addedLayerIds = <String>[];
+        var disposed = false;
+
         unawaited(() async {
           try {
             await styleController.addImages(cachedBytes.toMapStyleImages);
 
             if (modeResolver.showsRegionIcon(mode)) {
-              for (final intensity in JmaIntensity.values) {
-                final codes =
-                    earthquake.intensity?.regions[intensity]
-                        ?.map((e) => e.region.code)
-                        .toList() ??
-                    const <String>[];
-                final filter = codes.isEmpty
-                    ? const ['==', '1', '2']
-                    : [
-                        'in',
-                        ['get', 'code'],
-                        ['literal', codes],
-                      ];
-                final iconImage =
-                    'JmaIntensity.${IntensityIconType.filled.name}.${intensity.name}';
-                await styleController.addLayer(
-                  SymbolStyleLayer(
-                    id: _regionLayerId(intensity),
-                    sourceLayerId: 'areaForecastLocalE',
-                    sourceId: 'eqmonitor_map',
-                    filter: filter,
-                    layout: {
-                      'icon-image': iconImage,
-                      'icon-allow-overlap': false,
-                      'icon-size': [
-                        'interpolate',
-                        ['linear'],
-                        ['zoom'],
-                        4,
-                        0.18,
-                        8,
-                        0.35,
-                      ],
-                    },
-                    paint: {
-                      'icon-opacity': modeResolver.regionIconOpacity(
-                        mode: mode,
-                        zoomThresholds: zoomThresholds,
-                      ),
-                    },
-                  ),
+              final regionGeoJson = _buildRegionGeoJson(jmaMap);
+              if (regionGeoJson != null && !disposed) {
+                await styleController.addSource(
+                  GeoJsonSource(id: _regionSourceId, data: regionGeoJson),
                 );
+                addedSourceIds.add(_regionSourceId);
+
+                if (!disposed) {
+                  await styleController.addLayer(
+                    SymbolStyleLayer(
+                      id: _regionLayerId,
+                      sourceId: _regionSourceId,
+                      layout: {
+                        'icon-image': ['get', 'iconImage'],
+                        'icon-allow-overlap': false,
+                        'icon-size': [
+                          'interpolate',
+                          ['linear'],
+                          ['zoom'],
+                          4,
+                          0.18,
+                          8,
+                          0.35,
+                        ],
+                        'symbol-sort-key': ['get', 'sortKey'],
+                      },
+                      paint: {
+                        'icon-opacity': modeResolver.regionIconOpacity(
+                          mode: mode,
+                          zoomThresholds: zoomThresholds,
+                        ),
+                      },
+                    ),
+                  );
+                  addedLayerIds.add(_regionLayerId);
+                }
               }
             }
 
             if (modeResolver.showsCityIcon(mode)) {
-              for (final intensity in JmaIntensity.values) {
-                final codes =
-                    earthquake.intensity?.intensityTree[intensity]
-                        ?.expand((e) => e.cities)
-                        .map((e) => e.city.code)
-                        .toList() ??
-                    const <String>[];
-                final filter = codes.isEmpty
-                    ? const ['==', '1', '2']
-                    : [
-                        'in',
-                        ['get', 'regioncode'],
-                        ['literal', codes],
-                      ];
-                final iconImage =
-                    'JmaIntensity.${IntensityIconType.filled.name}.${intensity.name}';
-                await styleController.addLayer(
-                  SymbolStyleLayer(
-                    id: _cityLayerId(intensity),
-                    sourceLayerId: 'areaInformationCityQuake',
-                    sourceId: 'eqmonitor_map',
-                    filter: filter,
-                    layout: {
-                      'icon-image': iconImage,
-                      'icon-allow-overlap': false,
-                      'icon-size': [
-                        'interpolate',
-                        ['linear'],
-                        ['zoom'],
-                        8,
-                        0.12,
-                        12,
-                        0.5,
-                      ],
-                    },
-                    paint: {
-                      'icon-opacity': modeResolver.cityIconOpacity(
-                        mode: mode,
-                        zoomThresholds: zoomThresholds,
-                      ),
-                    },
-                  ),
+              final cityGeoJson = _buildCityGeoJson(jmaMap);
+              if (cityGeoJson != null && !disposed) {
+                await styleController.addSource(
+                  GeoJsonSource(id: _citySourceId, data: cityGeoJson),
                 );
+                addedSourceIds.add(_citySourceId);
+
+                if (!disposed) {
+                  await styleController.addLayer(
+                    SymbolStyleLayer(
+                      id: _cityLayerId,
+                      sourceId: _citySourceId,
+                      layout: {
+                        'icon-image': ['get', 'iconImage'],
+                        'icon-allow-overlap': false,
+                        'icon-size': [
+                          'interpolate',
+                          ['linear'],
+                          ['zoom'],
+                          8,
+                          0.12,
+                          12,
+                          0.5,
+                        ],
+                        'symbol-sort-key': ['get', 'sortKey'],
+                      },
+                      paint: {
+                        'icon-opacity': modeResolver.cityIconOpacity(
+                          mode: mode,
+                          zoomThresholds: zoomThresholds,
+                        ),
+                      },
+                    ),
+                  );
+                  addedLayerIds.add(_cityLayerId);
+                }
               }
             }
           } on Exception catch (e) {
@@ -169,19 +166,24 @@ class EarthquakeHistoryIntensityIconLayer extends HookConsumerWidget {
           }
         }());
 
-        return () async {
-          for (final intensity in JmaIntensity.values) {
-            try {
-              await styleController.removeLayer(_cityLayerId(intensity));
-            } on Exception catch (e) {
-              talker.log(e);
+        return () {
+          disposed = true;
+          unawaited(() async {
+            for (final id in addedLayerIds.reversed) {
+              try {
+                await styleController.removeLayer(id);
+              } on Exception catch (e) {
+                talker.log(e);
+              }
             }
-            try {
-              await styleController.removeLayer(_regionLayerId(intensity));
-            } on Exception catch (e) {
-              talker.log(e);
+            for (final id in addedSourceIds.reversed) {
+              try {
+                await styleController.removeSource(id);
+              } on Exception catch (e) {
+                talker.log(e);
+              }
             }
-          }
+          }());
         };
       },
       [
@@ -199,8 +201,100 @@ class EarthquakeHistoryIntensityIconLayer extends HookConsumerWidget {
     return const SizedBox.shrink();
   }
 
-  static String _regionLayerId(JmaIntensity intensity) =>
-      'eq-history-icon-region-symbol-${intensity.name}';
-  static String _cityLayerId(JmaIntensity intensity) =>
-      'eq-history-icon-city-symbol-${intensity.name}';
+  String? _buildRegionGeoJson(
+    Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
+  ) {
+    final intensity = earthquake.intensity;
+    if (intensity == null) {
+      return null;
+    }
+
+    final regionMapData = jmaMap.areaForecastLocalE;
+    final polylabels = <String, JmaMap_LatLng>{};
+    for (final item in regionMapData.data) {
+      if (item.hasPolylabel()) {
+        polylabels[item.property.code] = item.polylabel;
+      }
+    }
+
+    final features = <Map<String, dynamic>>[];
+    for (final entry in intensity.regions.entries) {
+      final jmaIntensity = entry.key;
+      final iconImage =
+          'JmaIntensity.${IntensityIconType.filled.name}.${jmaIntensity.name}';
+      for (final region in entry.value) {
+        final polylabel = polylabels[region.region.code];
+        if (polylabel == null) {
+          continue;
+        }
+        features.add({
+          'type': 'Feature',
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [polylabel.lng, polylabel.lat],
+          },
+          'properties': {
+            'iconImage': iconImage,
+            'sortKey': jmaIntensity.orderIndex,
+          },
+        });
+      }
+    }
+
+    if (features.isEmpty) {
+      return null;
+    }
+    return jsonEncode({'type': 'FeatureCollection', 'features': features});
+  }
+
+  String? _buildCityGeoJson(
+    Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
+  ) {
+    final intensity = earthquake.intensity;
+    if (intensity == null) {
+      return null;
+    }
+
+    final cityMapData = jmaMap.areaInformationCity;
+    final polylabels = <String, JmaMap_LatLng>{};
+    for (final item in cityMapData.data) {
+      if (item.hasPolylabel()) {
+        polylabels[item.property.code] = item.polylabel;
+      }
+    }
+
+    final features = <Map<String, dynamic>>[];
+    for (final entry in intensity.intensityTree.entries) {
+      final jmaIntensity = entry.key;
+      final iconImage =
+          'JmaIntensity.${IntensityIconType.filled.name}.${jmaIntensity.name}';
+      for (final prefecture in entry.value) {
+        for (final city in prefecture.cities) {
+          if (city.maxIntensity == null) {
+            continue;
+          }
+          final polylabel = polylabels[city.city.code];
+          if (polylabel == null) {
+            continue;
+          }
+          features.add({
+            'type': 'Feature',
+            'geometry': {
+              'type': 'Point',
+              'coordinates': [polylabel.lng, polylabel.lat],
+            },
+            'properties': {
+              'iconImage': iconImage,
+              'sortKey': jmaIntensity.orderIndex,
+            },
+          });
+        }
+      }
+    }
+
+    if (features.isEmpty) {
+      return null;
+    }
+    return jsonEncode({'type': 'FeatureCollection', 'features': features});
+  }
 }

--- a/app/lib/feature/earthquake_replay/data/notifier/replay_notifier.dart
+++ b/app/lib/feature/earthquake_replay/data/notifier/replay_notifier.dart
@@ -82,8 +82,8 @@ class ReplayNotifier extends _$ReplayNotifier {
     ref.read(appClockProvider.notifier).returnToRealtime();
     // リプレイ由来のデータを破棄し、ライブ取得を再開させる。
     ref
-      ..invalidate(eewProvider)
-      ..invalidate(kyoshinMonitorProvider);
+      ..invalidate(eewProvider, asReload: true)
+      ..invalidate(kyoshinMonitorProvider, asReload: true);
   }
 
   Future<void> seekToIndex(int index) async {
@@ -189,7 +189,7 @@ class ReplayNotifier extends _$ReplayNotifier {
       ..read(appClockProvider.notifier).updateReplayTime(
         current.file.data[index].time,
       )
-      ..invalidate(eewProvider);
+      ..invalidate(eewProvider, asReload: true);
 
     final frames = current.file.data;
     for (var i = 0; i <= index; i++) {

--- a/app/lib/feature/eew/data/eew.dart
+++ b/app/lib/feature/eew/data/eew.dart
@@ -29,7 +29,7 @@ class Eew extends _$Eew {
 
     ref.listen(appLifecycleProvider, (_, next) {
       if (next == AppLifecycleState.resumed) {
-        ref.invalidate(_eewRestProvider);
+        ref.invalidate(_eewRestProvider, asReload: true);
       }
     });
 
@@ -51,7 +51,7 @@ class Eew extends _$Eew {
       (_) {
         final wsPhase = ref.read(eqMonitorWsStatusProvider).phase;
         if (wsPhase != WsPhase.connected) {
-          ref.invalidate(_eewRestProvider);
+          ref.invalidate(_eewRestProvider, asReload: true);
         }
       },
     );

--- a/app/lib/feature/fnet_catalog/ui/fnet_catalog_page.dart
+++ b/app/lib/feature/fnet_catalog/ui/fnet_catalog_page.dart
@@ -45,6 +45,7 @@ class FnetCatalogPage extends HookConsumerWidget {
               year: selectedYear.value,
               month: selectedMonth.value,
             ),
+            asReload: true,
           );
         },
         child: switch (state) {
@@ -75,6 +76,7 @@ class FnetCatalogPage extends HookConsumerWidget {
                         year: selectedYear.value,
                         month: selectedMonth.value,
                       ),
+                      asReload: true,
                     );
                   },
                   child: const Text('再読み込み'),

--- a/app/lib/feature/home/ui/component/parameter/parameter_loader_widget.dart
+++ b/app/lib/feature/home/ui/component/parameter/parameter_loader_widget.dart
@@ -37,7 +37,7 @@ class ParameterLoaderWidget extends HookConsumerWidget {
             else
               FilledButton(
                 child: const Text('再取得'),
-                onPressed: () async => ref.invalidate(jmaParameterProvider),
+                onPressed: () async => ref.invalidate(jmaParameterProvider, asReload: true),
               ),
           ],
         ),

--- a/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
+++ b/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
@@ -88,6 +88,7 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                       scope: scope,
                       onRetry: () => ref.invalidate(
                         homeEarthquakeHistoryParameterProvider,
+                        asReload: true,
                       ),
                       onConfigureRegion:
                           scope == HomeEarthquakeHistoryScope.custom
@@ -110,8 +111,8 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                       error: error,
                       margin: EdgeInsets.zero,
                       onReload: () async {
-                        ref.invalidate(homeEarthquakeHistoryParameterProvider);
-                        ref.invalidate(earthquakeHistoryProvider(param));
+                        ref.invalidate(homeEarthquakeHistoryParameterProvider, asReload: true);
+                        ref.invalidate(earthquakeHistoryProvider(param), asReload: true);
                       },
                       padding: const EdgeInsets.all(8),
                     ),
@@ -124,7 +125,7 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
                   error: error,
                   margin: EdgeInsets.zero,
                   onReload: () async =>
-                      ref.invalidate(homeEarthquakeHistoryParameterProvider),
+                      ref.invalidate(homeEarthquakeHistoryParameterProvider, asReload: true),
                   padding: const EdgeInsets.all(8),
                 ),
               ),

--- a/app/lib/feature/knet_waveform/ui/media/knet_fig_view.dart
+++ b/app/lib/feature/knet_waveform/ui/media/knet_fig_view.dart
@@ -21,7 +21,7 @@ class KnetFigView extends HookConsumerWidget {
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (e, _) => _ErrorView(
         message: 'クライアント初期化エラー: $e',
-        onRetry: () => ref.invalidate(knetDownloadClientProvider),
+        onRetry: () => ref.invalidate(knetDownloadClientProvider, asReload: true),
       ),
       data: (client) {
         if (client == null) {

--- a/app/lib/feature/knet_waveform/ui/media/knet_movie_view.dart
+++ b/app/lib/feature/knet_waveform/ui/media/knet_movie_view.dart
@@ -22,7 +22,7 @@ class KnetMovieView extends HookConsumerWidget {
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (e, _) => _ErrorView(
         message: 'クライアント初期化エラー: $e',
-        onRetry: () => ref.invalidate(knetDownloadClientProvider),
+        onRetry: () => ref.invalidate(knetDownloadClientProvider, asReload: true),
       ),
       data: (client) {
         if (client == null) {

--- a/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
+++ b/app/lib/feature/kyoshin_monitor/data/notifier/kyoshin_monitor_notifier.dart
@@ -39,7 +39,7 @@ class KyoshinMonitorNotifier extends _$KyoshinMonitorNotifier {
         if (next == AppLifecycleState.resumed &&
             previous != null &&
             previous != AppLifecycleState.resumed) {
-          ref.invalidate(kyoshinMonitorProvider);
+          ref.invalidate(kyoshinMonitorProvider, asReload: true);
         }
       },
     );

--- a/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
+++ b/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
@@ -49,22 +49,22 @@ class DebugAppGroupAction {
     final prefs = await ref.read(appGroupPreferencesProvider.future);
     await prefs.setString('apiServerUrl', result);
     ref
-      ..invalidate(appGroupValuesProvider)
-      ..invalidate(appGroupSettingsWriterProvider);
+      ..invalidate(appGroupValuesProvider, asReload: true)
+      ..invalidate(appGroupSettingsWriterProvider, asReload: true);
   }
 
   Future<void> setDebugMode(WidgetRef ref, {required bool value}) async {
     final prefs = await ref.read(appGroupPreferencesProvider.future);
     await prefs.setBool('debugMode', value);
     ref
-      ..invalidate(appGroupValuesProvider)
-      ..invalidate(appGroupSettingsWriterProvider);
+      ..invalidate(appGroupValuesProvider, asReload: true)
+      ..invalidate(appGroupSettingsWriterProvider, asReload: true);
   }
 
   Future<void> syncFromProvider(WidgetRef ref, BuildContext context) async {
-    ref.invalidate(appGroupSettingsWriterProvider);
+    ref.invalidate(appGroupSettingsWriterProvider, asReload: true);
     await ref.read(appGroupSettingsWriterProvider.future);
-    ref.invalidate(appGroupValuesProvider);
+    ref.invalidate(appGroupValuesProvider, asReload: true);
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('App Groups を再同期しました')),

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -322,7 +322,7 @@ class _AppCheckSection extends ConsumerWidget {
           },
           trailing: IconButton(
             icon: const Icon(Icons.refresh),
-            onPressed: () => ref.invalidate(appCheckTokenProvider),
+            onPressed: () => ref.invalidate(appCheckTokenProvider, asReload: true),
           ),
         ),
         ListTile(

--- a/app/lib/feature/settings/children/config/debug/intensity_icon/intensity_icon_debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/intensity_icon/intensity_icon_debug_page.dart
@@ -24,14 +24,14 @@ class IntensityIconDebugPage extends HookConsumerWidget {
           _Section(
             title: '震度アイコン (JmaIntensity)',
             providerName: 'intensityIconProvider',
-            onInvalidate: () => ref.invalidate(intensityIconProvider),
+            onInvalidate: () => ref.invalidate(intensityIconProvider, asReload: true),
             child: _JmaIntensityGrid(size: size.value),
           ),
           const SizedBox(height: 16),
           _Section(
             title: '長周期地震動アイコン (JmaLpgmIntensity)',
             providerName: 'intensityIconProvider',
-            onInvalidate: () => ref.invalidate(intensityIconProvider),
+            onInvalidate: () => ref.invalidate(intensityIconProvider, asReload: true),
             child: _JmaLpgmIntensityGrid(size: size.value),
           ),
         ],

--- a/app/lib/feature/settings/children/config/debug/websocket/debug_websocket_page.dart
+++ b/app/lib/feature/settings/children/config/debug/websocket/debug_websocket_page.dart
@@ -36,7 +36,7 @@ class DebugWebSocketPage extends HookConsumerWidget {
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
-            onPressed: () => ref.invalidate(eqMonitorWsStatusProvider),
+            onPressed: () => ref.invalidate(eqMonitorWsStatusProvider, asReload: true),
           ),
         ],
       ),

--- a/app/lib/feature/settings/features/notification_settings/ui/page/earthquake_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/earthquake_settings_page.dart
@@ -44,7 +44,7 @@ class _Body extends ConsumerWidget {
 
     if (settingsAsync.hasError && !settingsAsync.isLoading) {
       return _ErrorBody(
-        onRetry: () => ref.invalidate(earthquakeNotificationSettingsProvider),
+        onRetry: () => ref.invalidate(earthquakeNotificationSettingsProvider, asReload: true),
       );
     }
 

--- a/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/eew_settings_page.dart
@@ -52,7 +52,7 @@ class _Body extends ConsumerWidget {
 
     if (settingsAsync.hasError && !settingsAsync.isLoading) {
       return _ErrorBody(
-        onRetry: () => ref.invalidate(eewSettingsProvider),
+        onRetry: () => ref.invalidate(eewSettingsProvider, asReload: true),
       );
     }
 

--- a/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
@@ -27,7 +27,7 @@ class _Body extends ConsumerWidget {
 
     if (stateAsync.hasError && !stateAsync.isLoading) {
       return _ErrorBody(
-        onRetry: () => ref.invalidate(shakeDetectionSettingsProvider),
+        onRetry: () => ref.invalidate(shakeDetectionSettingsProvider, asReload: true),
       );
     }
 

--- a/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
+++ b/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
@@ -68,8 +68,8 @@ class TelegramListByEventIdPage extends HookConsumerWidget {
       appBar: AppBar(title: const Text('電文一覧')),
       body: RefreshIndicator(
         onRefresh: () async {
-          ref.invalidate(telegramListByEventIdProvider(eventId));
-          ref.invalidate(telegramDetailsProvider(eventId));
+          ref.invalidate(telegramListByEventIdProvider(eventId), asReload: true);
+          ref.invalidate(telegramDetailsProvider(eventId), asReload: true);
         },
         child: switch (asyncState) {
           AsyncData(:final value) => _SectionedList(

--- a/app/lib/page/splash_page.dart
+++ b/app/lib/page/splash_page.dart
@@ -53,9 +53,9 @@ class SplashPage extends HookConsumerWidget {
             ? ErrorCard(
                 error: error ?? Exception('Unknown error'),
                 onReload: () async {
-                  ref.invalidate(parameterSetProvider);
-                  ref.invalidate(travelTimeInternalProvider);
-                  ref.invalidate(earthquakeHistoryConfigProvider);
+                  ref.invalidate(parameterSetProvider, asReload: true);
+                  ref.invalidate(travelTimeInternalProvider, asReload: true);
+                  ref.invalidate(earthquakeHistoryConfigProvider, asReload: true);
                 },
               )
             : const Center(child: CircularProgressIndicator.adaptive()),


### PR DESCRIPTION
## Summary
- **Fill レイヤー z-order 修正**: `belowLayerId` を追加し、震度アイコン・観測点が塗り潰しレイヤーの上に正しく表示されるように
- **地域震度アイコン配置修正**: ベクタータイルポリゴンソースから GeoJSON polylabel ポイントソースに変更。JMA map の polylabel 座標を使用し、地域の重心に正しくアイコンを配置
- **現在地震度カードちらつき修正**: `HookConsumerWidget` 化し `useMemoized`/`useRef` で前回有効な area codes をキャッシュ。ローディング中のちらつき防止
- **ref.invalidate asReload 対応**: 全 `ref.invalidate` 呼び出し（25ファイル/約40箇所）に `asReload: true` を追加。invalidate 時に前データを保持しUIちらつきを軽減

## Test plan
- [ ] 地震履歴詳細マップを開き、震度アイコンが塗り潰しの上に表示されることを確認
- [ ] 観測点（ドット・アイコン）が塗り潰しの上に表示されることを確認
- [ ] 地域震度アイコンが地域の重心付近に配置されていることを確認
- [ ] ズームイン/アウトで地域→市区町村→観測点のアイコン切替が正常に動作すること
- [ ] 現在地震度カードがちらつかないことを確認
- [ ] 各画面のリフレッシュ時にローディング表示が一瞬出ないことを確認（asReload効果）