### PR TITLE
fix(map): 地震履歴・EEWマップのバグ修正・ref.invalidate asReload対応

### DIFF
--- a/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
@@ -47,19 +47,6 @@ class EewStaticPsWaveLayer extends HookConsumerWidget {
       [styleController, eew, travelTimeMap],
     );
 
-    useEffect(
-      () {
-        if (styleController == null || !isInitialized.value) {
-          return null;
-        }
-
-        unawaited(_updateLayers(styleController, eew, travelTimeMap));
-
-        return null;
-      },
-      [styleController, eew, travelTimeMap],
-    );
-
     return const SizedBox.shrink();
   }
 

--- a/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
@@ -195,7 +195,7 @@ class EewHypocenterLayer extends HookConsumerWidget {
 
         return null;
       },
-      [styleController, normalEews],
+      [styleController, normalEews, lowPreciseEews],
     );
 
     return const SizedBox.shrink();

--- a/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
@@ -192,8 +192,10 @@ class _EewPsWaveLayerBody extends HookConsumerWidget {
           return null;
         }
 
+        var disposed = false;
+
         void listener() {
-          if (!isInitialized.value) {
+          if (disposed || !isInitialized.value) {
             return;
           }
           final travelTimeMap = ref.read(travelTimeDepthMapProvider);
@@ -225,6 +227,7 @@ class _EewPsWaveLayerBody extends HookConsumerWidget {
         }
 
         return () {
+          disposed = true;
           timer?.cancel();
           animationController.removeListener(listener);
         };


### PR DESCRIPTION
## Summary
### 地震履歴詳細マップ
- **Fill レイヤー z-order 修正**: `belowLayerId` を追加し、震度アイコン・観測点が塗り潰しレイヤーの上に正しく表示されるように
- **地域震度アイコン配置修正**: ベクタータイルポリゴンソースから GeoJSON polylabel ポイントソースに変更。JMA map の polylabel 座標を使用し、地域の重心にアイコンを配置
- **現在地震度カードちらつき修正**: `HookConsumerWidget` 化し `useMemoized`/`useRef` で前回有効な area codes をキャッシュ。ローディング中のちらつき防止

### EEW マップレイヤー
- **eew_hypocenter_layer**: useEffect 依存配列に `lowPreciseEews` を追加（低精度 EEW 変化時の更新漏れ修正）
- **eew_static_ps_wave_layer**: 二重 useEffect による `_updateLayers` 重複呼び出しを除去
- **eew_ps_wave_layer**: アニメーションリスナーに `disposed` ガードを追加（dispose 後の `ref.read` 防止）

### 全体
- 全 `ref.invalidate` 呼び出し（25 ファイル/約 40 箇所）に `asReload: true` を追加

## Test plan
- [ ] 地震履歴詳細マップを開き、震度アイコンが塗り潰しの上に表示されることを確認
- [ ] 観測点（ドット・アイコン）が塗り潰しの上に表示されることを確認
- [ ] 地域震度アイコンが地域の重心付近に配置されていることを確認
- [ ] ズームイン/アウトで地域→市区町村→観測点のアイコン切替が正常に動作すること
- [ ] 現在地震度カードがちらつかないことを確認
- [ ] EEW 発生時に PLUM 法震央マーカーが正しく表示されること
- [ ] EEW の PS 波円が正常にアニメーションすること
- [ ] 各画面のリフレッシュ時にローディング表示が一瞬出ないことを確認（asReload 効果）