### PR TITLE
fix(shake_detection): マップ非表示バグ修正・カードUI改善

### DIFF
--- a/app/lib/feature/home/ui/component/map/layer/shake_detection_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/shake_detection_layer.dart
@@ -19,6 +19,7 @@ class ShakeDetectionLayer extends ConsumerWidget {
   static const sourceId = 'shake-detection';
   static const _fillLayerId = 'shake-detection-fill';
   static const _lineLayerId = 'shake-detection-line';
+  static const _centerLayerId = 'shake-detection-center';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -58,41 +59,67 @@ class _ShakeDetectionLayerBody extends HookConsumerWidget {
         }
 
         unawaited(() async {
-          await styleController.addSource(
-            const GeoJsonSource(
-              id: ShakeDetectionLayer.sourceId,
-              data: _emptyGeoJson,
-            ),
-          );
-
-          await (
-            styleController.addLayer(
-              const FillStyleLayer(
-                id: ShakeDetectionLayer._fillLayerId,
-                sourceId: ShakeDetectionLayer.sourceId,
-                paint: {
-                  'fill-color': ['get', 'fillColor'],
-                  'fill-opacity': ['get', 'fillOpacity'],
-                },
+          try {
+            await styleController.addSource(
+              const GeoJsonSource(
+                id: ShakeDetectionLayer.sourceId,
+                data: _emptyGeoJson,
               ),
-            ),
-            styleController.addLayer(
-              const LineStyleLayer(
-                id: ShakeDetectionLayer._lineLayerId,
-                sourceId: ShakeDetectionLayer.sourceId,
-                paint: {
-                  'line-color': ['get', 'lineColor'],
-                  'line-width': 2,
-                  'line-opacity': ['get', 'lineOpacity'],
-                },
-              ),
-            ),
-          ).wait;
+            );
 
-          isInitialized.value = true;
+            await (
+              styleController.addLayer(
+                const FillStyleLayer(
+                  id: ShakeDetectionLayer._fillLayerId,
+                  sourceId: ShakeDetectionLayer.sourceId,
+                  paint: {
+                    'fill-color': ['get', 'fillColor'],
+                    'fill-opacity': 1,
+                  },
+                ),
+              ),
+              styleController.addLayer(
+                const LineStyleLayer(
+                  id: ShakeDetectionLayer._lineLayerId,
+                  sourceId: ShakeDetectionLayer.sourceId,
+                  paint: {
+                    'line-color': ['get', 'lineColor'],
+                    'line-width': 2,
+                    'line-opacity': 1,
+                  },
+                ),
+              ),
+              styleController.addLayer(
+                const CircleStyleLayer(
+                  id: ShakeDetectionLayer._centerLayerId,
+                  sourceId: ShakeDetectionLayer.sourceId,
+                  paint: {
+                    'circle-radius': [
+                      'interpolate',
+                      ['linear'],
+                      ['zoom'],
+                      3, 5,
+                      7, 10,
+                      10, 14,
+                    ],
+                    'circle-color': ['get', 'centerColor'],
+                    'circle-opacity': 1,
+                    'circle-stroke-color': ['get', 'strokeColor'],
+                    'circle-stroke-width': 2,
+                    'circle-stroke-opacity': 1,
+                  },
+                ),
+              ),
+            ).wait;
+
+            isInitialized.value = true;
+          } on Exception catch (e) {
+            debugPrint('ShakeDetectionLayer: failed to init layers: $e');
+          }
         }());
 
         return () async {
+          await styleController.removeLayer(ShakeDetectionLayer._centerLayerId);
           await styleController.removeLayer(ShakeDetectionLayer._fillLayerId);
           await styleController.removeLayer(ShakeDetectionLayer._lineLayerId);
           await styleController.removeSource(ShakeDetectionLayer.sourceId);
@@ -227,7 +254,11 @@ class _ShakeDetectionLayerBody extends HookConsumerWidget {
   ) {
     final features = <Map<String, dynamic>>[];
     for (final event in events) {
-      final color = _colorForLevel(event.level);
+      final (r, g, b) = _rgbForLevel(event.level);
+      final fillColor =
+          'rgba($r, $g, $b, ${(opacity * 0.3).toStringAsFixed(3)})';
+      final lineColor =
+          'rgba($r, $g, $b, ${opacity.toStringAsFixed(3)})';
       final polygons = switch (displayMode) {
         HomeShakeDetectionDisplayMode.boundingBox => [
           _boundingBoxPolygon(event),
@@ -242,13 +273,26 @@ class _ShakeDetectionLayerBody extends HookConsumerWidget {
             'coordinates': [coords],
           },
           'properties': {
-            'lineColor': color,
-            'fillColor': color,
-            'fillOpacity': opacity * 0.25,
-            'lineOpacity': opacity,
+            'fillColor': fillColor,
+            'lineColor': lineColor,
           },
         });
       }
+      final centerLat = (event.minLat + event.maxLat) / 2;
+      final centerLng = (event.minLng + event.maxLng) / 2;
+      features.add({
+        'type': 'Feature',
+        'geometry': {
+          'type': 'Point',
+          'coordinates': [centerLng, centerLat],
+        },
+        'properties': {
+          'centerColor':
+              'rgba($r, $g, $b, ${(opacity * 0.8).toStringAsFixed(3)})',
+          'strokeColor':
+              'rgba(255, 255, 255, ${opacity.toStringAsFixed(3)})',
+        },
+      });
     }
     return jsonEncode({'type': 'FeatureCollection', 'features': features});
   }
@@ -280,15 +324,13 @@ class _ShakeDetectionLayerBody extends HookConsumerWidget {
     return polygons;
   }
 
-  String _colorForLevel(ShakeDetectionLevel level) {
-    return switch (level) {
-      ShakeDetectionLevel.weaker => '#88CCFF',
-      ShakeDetectionLevel.weak => '#44AAFF',
-      ShakeDetectionLevel.medium => '#FFDD44',
-      ShakeDetectionLevel.strong => '#FF8800',
-      ShakeDetectionLevel.stronger => '#FF2200',
-    };
-  }
+  (int, int, int) _rgbForLevel(ShakeDetectionLevel level) => switch (level) {
+    ShakeDetectionLevel.weaker => (136, 204, 255),
+    ShakeDetectionLevel.weak => (68, 170, 255),
+    ShakeDetectionLevel.medium => (255, 221, 68),
+    ShakeDetectionLevel.strong => (255, 136, 0),
+    ShakeDetectionLevel.stronger => (255, 34, 0),
+  };
 }
 
 const _emptyGeoJson = '{"type":"FeatureCollection","features":[]}';

--- a/app/lib/feature/home/ui/component/shake_detection/shake_detection_card.dart
+++ b/app/lib/feature/home/ui/component/shake_detection/shake_detection_card.dart
@@ -22,14 +22,6 @@ class ShakeDetectionCard extends ConsumerWidget {
     final spacing = designSystem.spacing;
     final shape = designSystem.shape;
 
-    final regionBody = switch (regionsAsync) {
-      AsyncLoading() => const LinearProgressIndicator(minHeight: 2),
-      AsyncError() => const SizedBox.shrink(),
-      AsyncData(:final value) when value.isNotEmpty =>
-        _ShakeDetectionRegionBody(regions: value),
-      _ => const SizedBox.shrink(),
-    };
-
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: spacing.lg),
       child: Card(
@@ -45,7 +37,10 @@ class ShakeDetectionCard extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _ShakeDetectionCardHeader(event: event),
-            regionBody,
+            _ShakeDetectionCardBody(
+              event: event,
+              regionsAsync: regionsAsync,
+            ),
           ],
         ),
       ),
@@ -66,7 +61,7 @@ class _ShakeDetectionCardHeader extends StatelessWidget {
 
     final bgColor = _headerColorForLevel(event.level);
     final title = _titleForLevel(event.level);
-    final timeStr = DateFormat('HH:mm').format(event.createdAt.toLocal());
+    final timeStr = DateFormat('HH:mm:ss').format(event.createdAt.toLocal());
 
     return DecoratedBox(
       decoration: BoxDecoration(color: bgColor),
@@ -117,10 +112,14 @@ class _ShakeDetectionCardHeader extends StatelessWidget {
       };
 }
 
-class _ShakeDetectionRegionBody extends StatelessWidget {
-  const _ShakeDetectionRegionBody({required this.regions});
+class _ShakeDetectionCardBody extends StatelessWidget {
+  const _ShakeDetectionCardBody({
+    required this.event,
+    required this.regionsAsync,
+  });
 
-  final Map<String, List<String>> regions;
+  final ShakeDetectionEvent event;
+  final AsyncValue<Map<String, List<String>>> regionsAsync;
 
   @override
   Widget build(BuildContext context) {
@@ -129,25 +128,43 @@ class _ShakeDetectionRegionBody extends StatelessWidget {
     final textColor = designSystem.textColor;
     final spacing = designSystem.spacing;
 
+    final regions = regionsAsync.asData?.value ?? {};
+
     return Padding(
-      padding: EdgeInsets.all(spacing.sm),
+      padding: EdgeInsets.symmetric(
+        horizontal: spacing.sm,
+        vertical: spacing.sm,
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          for (final entry in regions.entries) ...[
-            Text(
-              entry.key,
-              style: typography.titleSmall,
+          Text(
+            '${event.pointCount}地点で検知',
+            style: typography.labelMedium.copyWith(
+              color: textColor.secondary,
             ),
-            Padding(
-              padding: EdgeInsets.only(left: spacing.sm),
-              child: Text(
-                entry.value.join(' '),
-                style: typography.bodySmall.copyWith(
-                  color: textColor.secondary,
+          ),
+          if (regionsAsync.isLoading) ...[
+            SizedBox(height: spacing.xs),
+            const LinearProgressIndicator(minHeight: 2),
+          ],
+          if (regions.isNotEmpty) ...[
+            SizedBox(height: spacing.xs),
+            for (final entry in regions.entries) ...[
+              Text(
+                entry.key,
+                style: typography.titleSmall,
+              ),
+              Padding(
+                padding: EdgeInsets.only(left: spacing.sm),
+                child: Text(
+                  entry.value.join(' '),
+                  style: typography.bodySmall.copyWith(
+                    color: textColor.secondary,
+                  ),
                 ),
               ),
-            ),
+            ],
           ],
         ],
       ),


### PR DESCRIPTION
## Summary
- 揺れ検知がマップに表示されないバグを修正
- 揺れ検知カードのUI改善（地点数表示・時刻秒表示・リージョン表示改善）

## 原因
`fill-opacity: ['get', 'fillOpacity']` / `line-opacity: ['get', 'lineOpacity']` のデータ駆動式opacity表現が maplibre-native でサポートされておらず、`addLayer` が例外を投げていた。`unawaited()` 内でキャッチされないため `isInitialized` が `true` にならず、GeoJSONデータ更新が永久にスキップされていた。

## 修正内容

### マップレイヤー (`shake_detection_layer.dart`)
- `fill-opacity` / `line-opacity` を定数 `1` に変更し、opacity値をRGBAカラーのαチャンネルにベイク
- 中心点マーカー (`CircleStyleLayer`) を追加 — 低ズームでもバウンディングボックスの位置が視認可能
- `try/catch` を追加してレイヤー初期化失敗時にデバッグログ出力

### カード (`shake_detection_card.dart`)
- 時刻表示: `HH:mm` → `HH:mm:ss`
- 常に「N地点で検知」を表示（地域情報未取得時でも有用な情報を提供）
- ローディング中はプログレスインジケーター表示
- 地域情報がある場合は従来どおり都道府県+地域名を表示

## Test plan
- [ ] 揺れ検知イベント発生時にマップ上にバウンディングボックス + 中心点マーカーが表示されることを確認
- [ ] blinkアニメーションで点滅動作が正常に動くことを確認
- [ ] カードに「N地点で検知」が表示されることを確認
- [ ] 地域情報がある場合は都道府県+地域名が表示されることを確認
- [ ] `dart analyze` パス確認済み