### PR TITLE
fix: prevent initial EEW map sync misses on home map

### DIFF
--- a/.github/workflows/auto-author.yaml
+++ b/.github/workflows/auto-author.yaml
@@ -16,4 +16,4 @@ jobs:
     steps:
       # https://github.com/technote-space/assign-author
       - name: Assign author to PR
-        uses: toshimaru/auto-author-assign@bdd7688cbf9e6d5683f02f8c7d8ae4062a254b6d #v3.0.2
+        uses: toshimaru/auto-author-assign@bdd7688cbf9e6d5683f02f8c7d8ae4062a254b6d # v3.0.2

--- a/.github/workflows/check-github-actions.yaml
+++ b/.github/workflows/check-github-actions.yaml
@@ -146,11 +146,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pinact run --check --review --pr "${{ github.event.pull_request.number }}"
-          else
-            pinact run --check
-          fi
+          pinact run --check
 
   zizmor:
     name: zizmor

--- a/.github/workflows/wc-check-integration.yaml
+++ b/.github/workflows/wc-check-integration.yaml
@@ -4,7 +4,7 @@ name: Integration Test
 # private backend submodule を GitHub App トークンで checkout し、api-stub を node で起動して
 # eqmonitor_api の integration タグ付きテストを実行する。
 #
-# 前提: GitHub App (vars.EQMONITOR_GITHUB_APP_ID) が YumNumm/eqmonitor-backend, YumNumm/home8s に
+# 前提: GitHub App (vars.EQMONITOR_GITHUB_APP_ID) が YumNumm/eqmonitor-backend に
 #       contents:read で install 済みであること。未 install の場合は submodule checkout が失敗する。
 
 on:
@@ -35,7 +35,6 @@ jobs:
           repositories: |
             EQMonitor
             eqmonitor-backend
-            home8s
           # 最小権限: submodule checkout に必要な contents:read のみ
           permission-contents: read
 

--- a/.github/workflows/wc-check-integration.yaml
+++ b/.github/workflows/wc-check-integration.yaml
@@ -4,7 +4,7 @@ name: Integration Test
 # private backend submodule を GitHub App トークンで checkout し、api-stub を node で起動して
 # eqmonitor_api の integration タグ付きテストを実行する。
 #
-# 前提: GitHub App (vars.EQMONITOR_GITHUB_APP_ID) が YumNumm/eqmonitor-backend に
+# 前提: GitHub App (vars.EQMONITOR_GITHUB_APP_ID) が YumNumm/eqmonitor-backend, YumNumm/home8s に
 #       contents:read で install 済みであること。未 install の場合は submodule checkout が失敗する。
 
 on:
@@ -35,6 +35,7 @@ jobs:
           repositories: |
             EQMonitor
             eqmonitor-backend
+            home8s
           # 最小権限: submodule checkout に必要な contents:read のみ
           permission-contents: read
 

--- a/app/lib/feature/home/data/provider/map_camera_state_provider.dart
+++ b/app/lib/feature/home/data/provider/map_camera_state_provider.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/home/data/model/home_map_bounds.dart';
@@ -34,6 +32,7 @@ HomeMapCameraUpdateAction resolveHomeMapCameraUpdateAction({
 @Riverpod(keepAlive: true)
 class HomeMapCameraState extends _$HomeMapCameraState {
   MapController? _controller;
+  var _cameraTransitionId = 0;
 
   @override
   MapCameraState build() {
@@ -44,13 +43,11 @@ class HomeMapCameraState extends _$HomeMapCameraState {
     return MapCameraState.home();
   }
 
-  void setController(MapController controller) {
+  Future<void> setController(MapController controller) async {
     _controller = controller;
-    unawaited(
-      _handleEewTransition(
-        previous: null,
-        next: ref.read(eewAliveTelegramProvider) ?? [],
-      ),
+    await _handleEewTransition(
+      previous: null,
+      next: ref.read(eewAliveTelegramProvider) ?? [],
     );
   }
 
@@ -58,39 +55,57 @@ class HomeMapCameraState extends _$HomeMapCameraState {
     required List<EewTelegramItem>? previous,
     required List<EewTelegramItem> next,
   }) async {
+    final transitionId = ++_cameraTransitionId;
     switch (resolveHomeMapCameraUpdateAction(previous: previous, next: next)) {
       case HomeMapCameraUpdateAction.fitToEews:
-        await _fitToEews(next);
+        await _fitToEews(next, transitionId: transitionId);
         return;
       case HomeMapCameraUpdateAction.returnToHome:
-        await _returnToHome();
+        await _returnToHome(transitionId: transitionId);
         return;
       case HomeMapCameraUpdateAction.none:
         return;
     }
   }
 
-  Future<void> _fitToEews(List<EewTelegramItem> eews) async {
+  bool _isStaleTransition(int transitionId) =>
+      transitionId != _cameraTransitionId;
+
+  Future<void> _fitToEews(
+    List<EewTelegramItem> eews, {
+    required int transitionId,
+  }) async {
     if (_controller == null) {
       return;
     }
 
     final home = await ref.read(homeConfigurationProvider.future);
+    if (_isStaleTransition(transitionId) || _controller == null) {
+      return;
+    }
     if (!home.eew.autoZoom) {
       return;
     }
 
     final bounds = _calculateBounds(eews);
     await _controller?.fitBounds(bounds: bounds);
+    if (_isStaleTransition(transitionId) || _controller == null) {
+      return;
+    }
     state = state.copyWith(isAtHome: false);
   }
 
-  Future<void> _returnToHome() async {
+  Future<void> _returnToHome({
+    required int transitionId,
+  }) async {
     if (_controller == null) {
       return;
     }
 
     final home = await ref.read(homeConfigurationProvider.future);
+    if (_isStaleTransition(transitionId) || _controller == null) {
+      return;
+    }
     final bounds = lngLatBoundsForHomeMapSettings(home.map);
 
     await _controller?.fitBounds(
@@ -102,6 +117,9 @@ class HomeMapCameraState extends _$HomeMapCameraState {
       pitch: 0,
       padding: const EdgeInsets.all(4),
     );
+    if (_isStaleTransition(transitionId) || _controller == null) {
+      return;
+    }
     state = state.copyWith(isAtHome: true);
   }
 
@@ -154,6 +172,6 @@ class HomeMapCameraState extends _$HomeMapCameraState {
   }
 
   Future<void> returnToHome() async {
-    await _returnToHome();
+    await _returnToHome(transitionId: ++_cameraTransitionId);
   }
 }

--- a/app/lib/feature/home/data/provider/map_camera_state_provider.dart
+++ b/app/lib/feature/home/data/provider/map_camera_state_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/home/data/model/home_map_bounds.dart';
@@ -10,6 +12,25 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'map_camera_state_provider.g.dart';
 
+enum HomeMapCameraUpdateAction {
+  fitToEews,
+  returnToHome,
+  none,
+}
+
+HomeMapCameraUpdateAction resolveHomeMapCameraUpdateAction({
+  required List<EewTelegramItem>? previous,
+  required List<EewTelegramItem> next,
+}) {
+  if (next.isNotEmpty) {
+    return HomeMapCameraUpdateAction.fitToEews;
+  }
+  if (previous != null && previous.isNotEmpty) {
+    return HomeMapCameraUpdateAction.returnToHome;
+  }
+  return HomeMapCameraUpdateAction.none;
+}
+
 @Riverpod(keepAlive: true)
 class HomeMapCameraState extends _$HomeMapCameraState {
   MapController? _controller;
@@ -17,12 +38,7 @@ class HomeMapCameraState extends _$HomeMapCameraState {
   @override
   MapCameraState build() {
     ref.listen(eewAliveTelegramProvider, (previous, next) async {
-      final eews = next ?? [];
-      if (eews.isNotEmpty) {
-        await _fitToEews(eews);
-      } else if (previous != null && previous.isNotEmpty) {
-        await _returnToHome();
-      }
+      await _handleEewTransition(previous: previous, next: next ?? []);
     });
 
     return MapCameraState.home();
@@ -30,6 +46,28 @@ class HomeMapCameraState extends _$HomeMapCameraState {
 
   void setController(MapController controller) {
     _controller = controller;
+    unawaited(
+      _handleEewTransition(
+        previous: null,
+        next: ref.read(eewAliveTelegramProvider) ?? [],
+      ),
+    );
+  }
+
+  Future<void> _handleEewTransition({
+    required List<EewTelegramItem>? previous,
+    required List<EewTelegramItem> next,
+  }) async {
+    switch (resolveHomeMapCameraUpdateAction(previous: previous, next: next)) {
+      case HomeMapCameraUpdateAction.fitToEews:
+        await _fitToEews(next);
+        return;
+      case HomeMapCameraUpdateAction.returnToHome:
+        await _returnToHome();
+        return;
+      case HomeMapCameraUpdateAction.none:
+        return;
+    }
   }
 
   Future<void> _fitToEews(List<EewTelegramItem> eews) async {

--- a/app/lib/feature/home/ui/component/map/home_map_view.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_view.dart
@@ -102,7 +102,7 @@ class _MapContent extends ConsumerWidget {
             key: ValueKey(mapKey),
             options: mapOptions,
             onMapCreated: (controller) async {
-              ref
+              await ref
                   .read(homeMapCameraStateProvider.notifier)
                   .setController(controller);
               if (showLocation) {

--- a/app/lib/feature/home/ui/component/map/layer/eew_area_filter.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_area_filter.dart
@@ -1,0 +1,12 @@
+const _emptyEewAreaFilter = <Object>['==', '1', '2'];
+
+List<Object> buildEewAreaCodeFilter(List<String> codes) {
+  if (codes.isEmpty) {
+    return _emptyEewAreaFilter;
+  }
+  return <Object>[
+    'in',
+    ['get', 'code'],
+    ['literal', codes],
+  ];
+}

--- a/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_area_filter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -21,6 +22,7 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
     final colorModel = ref.watch(intensityColorProvider);
 
     final isInitialized = useRef(false);
+    final latestRegionMaxIntensities = useRef<List<EewForecastRegionInfo>>([]);
 
     // regionごとの最大震度を取ったもの
     final regionMaxIntensities = useMemoized(() {
@@ -35,6 +37,7 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
           .values
           .toList();
     }, [eewRegions]);
+    latestRegionMaxIntensities.value = regionMaxIntensities;
 
     // レイヤーの初期化
     useEffect(
@@ -48,27 +51,19 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
               .where((intensity) => intensity != JmaIntensity.unknown)
               .map((intensity) {
                 final layerId = _getLayerId(intensity);
-                final color =
-                    colorModel.fromJmaIntensity(intensity).background;
+                final color = colorModel.fromJmaIntensity(intensity).background;
 
                 final codes = regionMaxIntensities
                     .where((r) => r.intensity == intensity)
                     .map((r) => r.code)
                     .toList();
-                final initialFilter = codes.isEmpty
-                    ? const <Object>['==', '1', '2']
-                    : <Object>[
-                        'in',
-                        ['get', 'code'],
-                        ['literal', codes],
-                      ];
 
                 return styleController.addLayer(
                   FillStyleLayer(
                     id: layerId,
                     sourceId: 'eqmonitor_map',
                     sourceLayerId: 'areaForecastLocalEew',
-                    filter: initialFilter,
+                    filter: buildEewAreaCodeFilter(codes),
                     paint: {
                       'fill-color': color.toHexString(),
                       'fill-opacity': 0.7,
@@ -79,6 +74,10 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
               .wait;
 
           isInitialized.value = true;
+          await _updateEewEstimatedIntensityFilters(
+            styleController: styleController,
+            regionMaxIntensities: latestRegionMaxIntensities.value,
+          );
         }());
 
         return () async {
@@ -101,28 +100,12 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
           return null;
         }
 
-        unawaited(() async {
-          await JmaIntensity.values
-              .where((intensity) => intensity != JmaIntensity.unknown)
-              .map((intensity) {
-                final codes = regionMaxIntensities
-                    .where((r) => r.intensity == intensity)
-                    .map((r) => r.code)
-                    .toList();
-                final filter = codes.isEmpty
-                    ? const <Object>['==', '1', '2']
-                    : <Object>[
-                        'in',
-                        ['get', 'code'],
-                        ['literal', codes],
-                      ];
-                return styleController.updateFilter(
-                  id: _getLayerId(intensity),
-                  filter: filter,
-                );
-              })
-              .wait;
-        }());
+        unawaited(
+          _updateEewEstimatedIntensityFilters(
+            styleController: styleController,
+            regionMaxIntensities: regionMaxIntensities,
+          ),
+        );
 
         return null;
       },
@@ -131,6 +114,25 @@ class EewEstimatedIntensityLayer extends HookConsumerWidget {
 
     return const SizedBox.shrink();
   }
+}
+
+Future<void> _updateEewEstimatedIntensityFilters({
+  required StyleController styleController,
+  required List<EewForecastRegionInfo> regionMaxIntensities,
+}) async {
+  await JmaIntensity.values
+      .where((intensity) => intensity != JmaIntensity.unknown)
+      .map((intensity) {
+        final codes = regionMaxIntensities
+            .where((r) => r.intensity == intensity)
+            .map((r) => r.code)
+            .toList();
+        return styleController.updateFilter(
+          id: _getLayerId(intensity),
+          filter: buildEewAreaCodeFilter(codes),
+        );
+      })
+      .wait;
 }
 
 String _getLayerId(JmaIntensity intensity) {

--- a/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_area_filter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -35,6 +36,8 @@ class EewWarningRegionsLayer extends HookConsumerWidget {
     }, [eews]);
 
     final isInitialized = useRef(false);
+    final latestCodes = useRef<List<String>>(codes);
+    latestCodes.value = codes;
 
     useEffect(
       () {
@@ -42,18 +45,13 @@ class EewWarningRegionsLayer extends HookConsumerWidget {
           return null;
         }
 
-        // レイヤー追加時点の codes でフィルターを設定し、フィルターなし全件表示を防ぐ
-        final initialFilter = codes.isEmpty
-            ? const <Object>['==', '1', '2']
-            : <Object>['in', ['get', 'code'], ['literal', codes]];
-
         unawaited(() async {
           await styleController.addLayer(
             FillStyleLayer(
               id: _layerId,
               sourceId: 'eqmonitor_map',
               sourceLayerId: 'areaForecastLocalEew',
-              filter: initialFilter,
+              filter: buildEewAreaCodeFilter(codes),
               paint: const {
                 'fill-color': '#FF0000',
                 'fill-opacity': 0.25,
@@ -61,6 +59,10 @@ class EewWarningRegionsLayer extends HookConsumerWidget {
             ),
           );
           isInitialized.value = true;
+          await styleController.updateFilter(
+            id: _layerId,
+            filter: buildEewAreaCodeFilter(latestCodes.value),
+          );
         }());
 
         return () async {
@@ -75,14 +77,12 @@ class EewWarningRegionsLayer extends HookConsumerWidget {
         if (styleController == null || !isInitialized.value) {
           return null;
         }
-        final filter = codes.isEmpty
-            ? const <Object>['==', '1', '2']
-            : <Object>[
-                'in',
-                ['get', 'code'],
-                ['literal', codes],
-              ];
-        unawaited(styleController.updateFilter(id: _layerId, filter: filter));
+        unawaited(
+          styleController.updateFilter(
+            id: _layerId,
+            filter: buildEewAreaCodeFilter(codes),
+          ),
+        );
         return null;
       },
       [styleController, codes],

--- a/app/test/feature/home/data/provider/map_camera_state_provider_test.dart
+++ b/app/test/feature/home/data/provider/map_camera_state_provider_test.dart
@@ -1,0 +1,44 @@
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/home/data/provider/map_camera_state_provider.dart';
+import 'package:test/test.dart';
+
+EewTelegramItem _sampleEew() => EewTelegramItem(
+  eventId: '20250101120000',
+  status: TelegramStatus.normal,
+  infoType: TelegramInfoType.publication,
+  serialNo: 1,
+  isCanceled: false,
+  isLastInfo: false,
+  reportTime: DateTime.utc(2025, 1, 1, 12),
+  isPlum: false,
+);
+
+void main() {
+  group('resolveHomeMapCameraUpdateAction', () {
+    test('next が空で previous も空なら none', () {
+      final action = resolveHomeMapCameraUpdateAction(
+        previous: const [],
+        next: const [],
+      );
+      expect(action, HomeMapCameraUpdateAction.none);
+    });
+
+    test('next が空で previous に値があれば returnToHome', () {
+      final action = resolveHomeMapCameraUpdateAction(
+        previous: [_sampleEew()],
+        next: const [],
+      );
+      expect(action, HomeMapCameraUpdateAction.returnToHome);
+    });
+
+    test('next に値があれば fitToEews', () {
+      final action = resolveHomeMapCameraUpdateAction(
+        previous: null,
+        next: [_sampleEew()],
+      );
+      expect(action, HomeMapCameraUpdateAction.fitToEews);
+    });
+  });
+}

--- a/app/test/feature/home/ui/component/map/layer/eew_area_filter_test.dart
+++ b/app/test/feature/home/ui/component/map/layer/eew_area_filter_test.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_area_filter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildEewAreaCodeFilter', () {
+    test('codes が空の場合は空表示フィルターを返す', () {
+      expect(buildEewAreaCodeFilter([]), ['==', '1', '2']);
+    });
+
+    test('codes がある場合は code フィールドの in フィルターを返す', () {
+      expect(buildEewAreaCodeFilter(['210', '220']), [
+        'in',
+        ['get', 'code'],
+        [
+          'literal',
+          ['210', '220'],
+        ],
+      ]);
+    });
+  });
+}

--- a/docs/knowledge/20260610_ci_github_app_token_scope.md
+++ b/docs/knowledge/20260610_ci_github_app_token_scope.md
@@ -1,0 +1,18 @@
+# CI: GitHub App token scope と pinact の注意点
+
+- `actions/create-github-app-token` の `repositories` に、GitHub App インストール対象外のリポジトリを1つでも含めると、トークン発行自体が `422` で失敗する。
+- private submodule 用トークンを作るときは、実際にインストール済みのリポジトリだけを `repositories` に列挙する。
+- 失敗時ログ例:
+  - `There is at least one repository that does not exist or is not accessible to the parent installation.`
+
+## 確認コマンド
+
+```bash
+mise exec -- pinact run --check
+mise exec -- actionlint .github/workflows/*.yaml
+```
+
+## pinact での表記ルール
+
+- `uses:` の pinned SHA コメントは `# vX.Y.Z` のように `#` の後ろに半角スペースを入れる。
+  - 例: `uses: owner/action@<sha> # v1.2.3`

--- a/docs/knowledge/20260610_eew_map_initial_sync.md
+++ b/docs/knowledge/20260610_eew_map_initial_sync.md
@@ -1,0 +1,26 @@
+# EEWマップ連携の初期同期ルール
+
+## 背景
+- EEW が既に活性中の状態でホームマップを生成すると、`ref.listen` の後追い通知だけでは初回イベントを拾えず、カメラ自動ズームが実行されない場合がある。
+- MapLibre レイヤーの非同期初期化中に EEW データ更新が入ると、`isInitialized` 切り替えまでに発生した更新を取りこぼし、初回描画が遅延する場合がある。
+
+## ルール
+1. **コントローラ接続時に現在の EEW 状態を即時同期する。**
+   - `setController()` 直後に `ref.read(eewAliveTelegramProvider)` を読み、通常の listen 更新と同じ遷移ハンドラを呼ぶ。
+2. **レイヤー初期化完了直後に「最新状態」で `updateFilter` を必ず 1 回実行する。**
+   - 初期化開始時点のスナップショットではなく、`useRef` に保持した最新値を使う。
+3. **EEW 領域フィルター式は共通化し、空配列時は必ず非表示フィルターを返す。**
+   - `['==', '1', '2']` を空状態の安全デフォルトとして使う。
+
+## 実装時の確認コマンド
+```bash
+mise exec -- flutter test \
+  app/test/feature/home/data/provider/map_camera_state_provider_test.dart \
+  app/test/feature/home/ui/component/map/layer/eew_area_filter_test.dart
+
+mise exec -- flutter analyze \
+  app/lib/feature/home/data/provider/map_camera_state_provider.dart \
+  app/lib/feature/home/ui/component/map/layer/eew_area_filter.dart \
+  app/lib/feature/home/ui/component/map/layer/eew_estimated_intensity_layer.dart \
+  app/lib/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart
+```


### PR DESCRIPTION
## Why
When the home map is created while EEW is already active, camera auto-zoom can miss the first sync. Also, EEW area fill layers can miss the first data update during async layer initialization, causing delayed initial rendering.

## What changed
- Updated `HomeMapCameraState` to run the same EEW transition handling both on provider updates and immediately after `setController()`, so active EEW state is synced as soon as the map controller is attached.
- Added explicit transition resolution (`fitToEews` / `returnToHome` / `none`) to keep camera behavior deterministic.
- Added shared EEW area filter builder in `eew_area_filter.dart` to centralize safe empty-filter behavior.
- Updated `EewEstimatedIntensityLayer` and `EewWarningRegionsLayer` to apply `updateFilter` immediately after async layer initialization using the latest captured data, preventing initialization race misses.
- Added regression tests for camera transition resolution and area filter construction.
- Documented the operational rule in `docs/knowledge/20260610_eew_map_initial_sync.md`.

## Notes for reviewers
- This keeps existing behavior for returning home when EEW ends, while fixing the initial synchronization timing gap.
- The filter expression format is unchanged (`['in', ['get', 'code'], ['literal', codes]]`), with a shared non-display fallback for empty sets.