### PR TITLE
fix(ci): TestFlight外部配布のビルド照会をIPAの実CFBundleVersionに変更

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -288,11 +288,19 @@ jobs:
       - name: Distribute to TestFlight external group
         if: ${{ needs.define-matrix.outputs.deploy-ios-external == 'true' }}
         run: |
+          # アップロードした IPA の実際の CFBundleVersion を取得して照会する。
+          # 最終的なビルド番号は github.run_number ではなくプロジェクト側の
+          # 採番（連番）に従うため、run_number で filter すると見つからない。
+          UNZIP_DIR=$(mktemp -d)
+          unzip -q build/EQMonitor.ipa -d "$UNZIP_DIR"
+          INFO_PLIST=$(ls "$UNZIP_DIR"/Payload/*.app/Info.plist)
+          BUILD_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$INFO_PLIST")
+          echo "CFBundleVersion=${BUILD_VERSION}"
           export ASC_KEY_ID="$APP_STORE_CONNECT_API_KEY_ID"
           export ASC_ISSUER_ID="$APP_STORE_CONNECT_API_ISSUER_ID"
           export ASC_KEY_PATH="$HOME/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
           export ASC_APP_ID="6447546703"
-          export ASC_BUILD_VERSION="${{ github.run_number }}"
+          export ASC_BUILD_VERSION="${BUILD_VERSION}"
           export ASC_BETA_GROUP_ID="bd75f066-fd92-4175-b2d6-f34952737557"
           export ASC_LOCALE="ja"
           pnpm -C scripts/testflight install --frozen-lockfile


### PR DESCRIPTION
## 背景

[external] コミットによる TestFlight 外部グループ自動配布（develop の run #593）で、配布ステップが起動はしたものの **ビルドが見つからずタイムアウト** して失敗した。

原因: 照会キーに `github.run_number`（=624）を使っていたが、iOS の実際の `CFBundleVersion` はプロジェクト独自採番（連番、当該ビルドは **1544**）で、`flutter build ios --build-number=${{ github.run_number }}` を渡しても最終的なビルド番号には反映されていなかった。そのため `filter[version]=624` が永遠に 0 件となりポーリングが30分でタイムアウトしていた。

ローカルから ASC API を照会して確認:
- `filter[version]=624` → count 0
- 直近アップロード → `version=1544 state=VALID`（今回 run のビルド）

なお認証・[external] 判定・ポーリング・タイムアウト枠（ビルドは約12分後に出現）はすべて正常だった。唯一の不具合がビルド番号の指定方法。

## 変更

`deploy-ios` の Distribute ステップで、アップロード済み `build/EQMonitor.ipa` から `PlistBuddy` で実際の `CFBundleVersion` を抽出し、それを `ASC_BUILD_VERSION` として照会する。

## Test Plan

- [ ] develop マージ後、`[external]` を含むコミットで Deploy App を実行
- [ ] Distribute ステップのログに `CFBundleVersion=<n>` → `state=VALID` → `whatsNew set` → `added build to external group` → `submitted for beta app review` が出る
- [ ] App Store Connect で当該ビルドが外部グループ `bd75f066-...` に追加され、What to Test が埋まっていること