### PR TITLE
feat(lints): UI層での eqmonitor_api 直接利用を禁止する lint ルール追加

### DIFF
--- a/app/lib/feature/changelog/ui/page/changelog_page.dart
+++ b/app/lib/feature/changelog/ui/page/changelog_page.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'dart:async';
 
 import 'package:eqmonitor/feature/changelog/data/notifier/changelog_notifier.dart';

--- a/app/lib/feature/home/ui/component/map/layer/shake_detection_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/shake_detection_layer.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;

--- a/app/lib/feature/home/ui/component/shake_detection/shake_detection_card.dart
+++ b/app/lib/feature/home/ui/component/shake_detection/shake_detection_card.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
 import 'package:eqmonitor/feature/shake_detection/data/model/shake_detection_event.dart';
 import 'package:eqmonitor/feature/shake_detection/data/provider/shake_detection_region_provider.dart';

--- a/app/lib/feature/live_activity/ui/page/live_activity_test_page.dart
+++ b/app/lib/feature/live_activity/ui/page/live_activity_test_page.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/feature/live_activity/data/notifier/live_activity_test_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;

--- a/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/shake_detection_settings_page.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/shake_detection_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;

--- a/app/lib/feature/shake_detection/ui/shake_detection_history_details_page.dart
+++ b/app/lib/feature/shake_detection/ui/shake_detection_history_details_page.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'dart:async';
 import 'dart:convert';
 

--- a/app/lib/feature/shake_detection/ui/shake_detection_history_page.dart
+++ b/app/lib/feature/shake_detection/ui/shake_detection_history_page.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/router/router.dart';

--- a/app/lib/feature/start/ui/component/forced_update_dialog.dart
+++ b/app/lib/feature/start/ui/component/forced_update_dialog.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'dart:async';
 import 'dart:io';
 

--- a/app/lib/feature/start/ui/component/whats_new_banner.dart
+++ b/app/lib/feature/start/ui/component/whats_new_banner.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'dart:async';
 
 import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';

--- a/app/lib/feature/telegram_list/ui/components/earthquake_telegram_tile.dart
+++ b/app/lib/feature/telegram_list/ui/components/earthquake_telegram_tile.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/model/telegram/telegram_type.dart';
 import 'package:eqmonitor/feature/telegram_list/data/model/earthquake_body_diff.dart';
 import 'package:eqmonitor/feature/telegram_list/data/model/telegram_item.dart';

--- a/app/lib/feature/telegram_list/ui/components/hypocenter_summary.dart
+++ b/app/lib/feature/telegram_list/ui/components/hypocenter_summary.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/feature/telegram_list/data/model/earthquake_body_diff.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';
 import 'package:flutter/material.dart';

--- a/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
+++ b/app/lib/feature/telegram_list/ui/telegram_list_by_event_id_page.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/component/widget/app_empty_state.dart';
 import 'package:eqmonitor/core/model/telegram/telegram_type.dart';

--- a/app/lib/feature/tsunami/ui/components/current_location_tsunami_card.dart
+++ b/app/lib/feature/tsunami/ui/components/current_location_tsunami_card.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/component/decoration/warning_stripe_decoration.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/location/data/location.dart';

--- a/app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'dart:async';
 import 'dart:convert';
 

--- a/app/lib/feature/tsunami/ui/components/tsunami_earthquake_card.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_earthquake_card.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';

--- a/app/lib/feature/tsunami/ui/components/tsunami_observation_station_tile.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_observation_station_tile.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';
 import 'package:flutter/material.dart';

--- a/app/lib/feature/tsunami/ui/components/tsunami_region_list.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_region_list.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/tsunami/ui/components/tsunami_observation_station_tile.dart';
 import 'package:eqmonitor/feature/tsunami/ui/utils/tsunami_warning_color.dart';

--- a/app/lib/feature/tsunami/ui/components/tsunami_warning_history_overlay.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_warning_history_overlay.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/tsunami/ui/utils/tsunami_warning_color.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';

--- a/app/lib/feature/tsunami/ui/components/tsunami_warning_status_card.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_warning_status_card.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 import 'package:eqmonitor/core/component/decoration/warning_stripe_decoration.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/tsunami/ui/components/tsunami_warning_history_overlay.dart';

--- a/app/lib/feature/tsunami/ui/utils/tsunami_warning_color.dart
+++ b/app/lib/feature/tsunami/ui/utils/tsunami_warning_color.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
 // ignore_for_file: avoid_classes_with_only_static_members
 
 import 'dart:ui';

--- a/packages/eqmonitor_lints/lib/main.dart
+++ b/packages/eqmonitor_lints/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:analysis_server_plugin/plugin.dart';
 import 'package:analysis_server_plugin/registry.dart';
 import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:eqmonitor_lints/src/rules/avoid_eqmonitor_api_in_ui.dart';
 import 'package:eqmonitor_lints/src/rules/avoid_null_assertion_operator.dart';
 import 'package:eqmonitor_lints/src/rules/avoid_print_call.dart';
 import 'package:eqmonitor_lints/src/rules/avoid_stateful_widget.dart';
@@ -21,6 +22,7 @@ class _EqmonitorLintsPlugin extends Plugin {
       AvoidNullAssertionOperator(),
       AvoidTopLevelFunctions(),
       AvoidPrintCall(),
+      AvoidEqmonitorApiInUi(),
     ].forEach(registry.registerLintRule);
   }
 }

--- a/packages/eqmonitor_lints/lib/src/rules/avoid_eqmonitor_api_in_ui.dart
+++ b/packages/eqmonitor_lints/lib/src/rules/avoid_eqmonitor_api_in_ui.dart
@@ -7,12 +7,17 @@ import 'package:analyzer/error/error.dart';
 
 class AvoidEqmonitorApiInUi extends AnalysisRule {
   AvoidEqmonitorApiInUi()
-    : super(name: _code.name, description: _code.problemMessage);
+    : super(
+        name: _code.name,
+        description: _code.problemMessage,
+      );
 
   static const _code = LintCode(
     'avoid_eqmonitor_api_in_ui',
     'UI 層 (ui/ 配下) で package:eqmonitor_api を import してはいけません。',
-    correctionMessage: 'data 層でアプリ用ドメインモデルへ変換し、UI からはドメイン型のみ参照してください。',
+    correctionMessage:
+        'data 層でアプリ用ドメインモデルへ変換し、'
+        ' UI からはドメイン型のみ参照してください。',
     severity: DiagnosticSeverity.WARNING,
   );
 

--- a/packages/eqmonitor_lints/lib/src/rules/avoid_eqmonitor_api_in_ui.dart
+++ b/packages/eqmonitor_lints/lib/src/rules/avoid_eqmonitor_api_in_ui.dart
@@ -1,0 +1,52 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+class AvoidEqmonitorApiInUi extends AnalysisRule {
+  AvoidEqmonitorApiInUi()
+    : super(name: _code.name, description: _code.problemMessage);
+
+  static const _code = LintCode(
+    'avoid_eqmonitor_api_in_ui',
+    'UI 層 (ui/ 配下) で package:eqmonitor_api を import してはいけません。',
+    correctionMessage: 'data 層でアプリ用ドメインモデルへ変換し、UI からはドメイン型のみ参照してください。',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  @override
+  DiagnosticCode get diagnosticCode => _code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    final path = context.definingUnit.unit.declaredFragment?.source.fullName;
+    if (path == null || !_isInUiLayer(path)) {
+      return;
+    }
+    registry.addImportDirective(this, _Visitor(this));
+  }
+
+  static bool _isInUiLayer(String path) {
+    final normalized = path.replaceAll(r'\', '/');
+    return normalized.contains('/ui/');
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final AnalysisRule rule;
+
+  @override
+  void visitImportDirective(ImportDirective node) {
+    final uri = node.uri.stringValue;
+    if (uri != null && uri.startsWith('package:eqmonitor_api')) {
+      rule.reportAtNode(node);
+    }
+  }
+}


### PR DESCRIPTION
## 概要

UI 層（`**/ui/**` 配下）で `package:eqmonitor_api`（API 生成型）を直接 import することを禁止する custom lint `avoid_eqmonitor_api_in_ui` を追加します。API 型は data 層でアプリ用ドメインモデルへ変換し、UI からはドメイン型のみ参照する、というレイヤリング規約を強制するためのものです。

## 変更内容

- `packages/eqmonitor_lints/lib/src/rules/avoid_eqmonitor_api_in_ui.dart` を追加
  - import directive を走査し、解析中ファイルのパスに `/ui/` を含む場合に `package:eqmonitor_api` 始まりの import を WARNING で報告
  - 既存ルール（`avoid_stateful_widget` 等）と同じ `analysis_server_plugin` ベースの実装様式
- `packages/eqmonitor_lints/lib/main.dart` に登録
- **既存違反の猶予**: 現状 UI 層で API 型を使用している 20 ファイルへ `// ignore_for_file: avoid_eqmonitor_api_in_ui` を付与（`dart analyze` の「no warnings」を維持）。各ファイルの移行は別タスクで段階的に実施。

## 補足

- この repo の custom lint（`analysis_server_plugin` ベース）は **IDE/LSP の analysis server 上で動作**します。`dart analyze` CLI では既存ルール含めロードされない既知の挙動のため、ルールの動作確認は IDE 文脈で行われます（実装は既存ルールと同一パターン）。

## 関連

設計 spec: `docs/superpowers/specs/2026-06-23-tsunami-telegram-state-tracking-design.md`（UI層レイヤリング規約）