### PR TITLE
fix(api): APNs kind casing 修正 & dynamic 型 lint 検出の有効化

### DIFF
--- a/app/lib/feature/devices/data/model/apns_token_kind.dart
+++ b/app/lib/feature/devices/data/model/apns_token_kind.dart
@@ -4,8 +4,8 @@ part 'apns_token_kind.g.dart';
 
 @JsonEnum(alwaysCreate: true, valueField: 'json')
 enum ApnsTokenKind {
-  notification('notification'),
-  liveActivityStart('liveActivityStart');
+  notification('NOTIFICATION'),
+  liveActivityStart('LIVE_ACTIVITY_START');
 
   const ApnsTokenKind(this.json);
 

--- a/app/test/feature/devices/device_repository_apns_kind_test.dart
+++ b/app/test/feature/devices/device_repository_apns_kind_test.dart
@@ -24,8 +24,8 @@ void main() {
     );
 
     expect(adapter.requests.map((request) => request.path), [
-      '/v2/device/me/apns/notification',
-      '/v2/device/me/apns/liveActivityStart',
+      '/v2/device/me/apns/NOTIFICATION',
+      '/v2/device/me/apns/LIVE_ACTIVITY_START',
     ]);
     expect(adapter.requests.map((request) => request.data), [
       {'token': 'apns-token'},

--- a/packages/eqmonitor_api/analysis_options.yaml
+++ b/packages/eqmonitor_api/analysis_options.yaml
@@ -2,4 +2,21 @@ include: package:eqmonitor_lints/analysis_options.yaml
 
 analyzer:
   exclude:
-    - "**/*"
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+  errors:
+    # 生成コードで重要なルールだけ error にし、その他は抑制する
+    avoid_annotating_with_dynamic: error
+    # 以下は swagger_parser 生成コードで不可避なため抑制
+    unnecessary_ignore: ignore
+    always_use_package_imports: ignore
+    directives_ordering: ignore
+    prefer_single_quotes: ignore
+    use_raw_strings: ignore
+    unnecessary_cast: ignore
+    unintended_html_in_doc_comment: ignore
+    avoid_unused_constructor_parameters: ignore
+
+linter:
+  rules:
+    avoid_annotating_with_dynamic: true

--- a/packages/eqmonitor_api/bin/generate.dart
+++ b/packages/eqmonitor_api/bin/generate.dart
@@ -114,6 +114,10 @@ void main(List<String> args) async {
     _patchStatusesQueryInApiClients(libDir);
   });
 
+  await _step('anyOf 由来の dynamic パスパラメータを String にパッチ', () async {
+    _patchDynamicPathParameters(libDir);
+  });
+
   await _step('anyOf 由来の dynamic クエリパラメータを String? にパッチ', () async {
     _patchDynamicQueryParameters(libDir);
   });
@@ -149,6 +153,10 @@ void main(List<String> args) async {
     _patchOriginTimeDateTimeToString(libDir);
   });
 
+  await _step('生成ファイルから type=lint を除去（lint 検出を有効化）', () async {
+    _stripTypeLintFromGeneratedHeaders(libDir);
+  });
+
   await _step('build_runner で Freezed / Retrofit コードを生成', () async {
     await _run('dart', [
       'run',
@@ -156,6 +164,10 @@ void main(List<String> args) async {
       'build',
       '--delete-conflicting-outputs',
     ], packageDir.path);
+  });
+
+  await _step('残存 dynamic の検出', () async {
+    _validateNoDynamic(libDir);
   });
 
   /// 契約 drift テスト用の fixtures を backend submodule からコピーする。
@@ -790,6 +802,102 @@ void _patchOriginTimeDateTimeToString(Directory libDir) {
       entity.writeAsStringSync(content);
       stdout.writeln('  Patched: ${entity.path}');
     }
+  }
+}
+
+/// swagger_parser が `anyOf` のパスパラメータを `dynamic` として生成する問題を修正。
+/// `@Path('xxx') required dynamic yyy` → `@Path('xxx') required String yyy`。
+void _patchDynamicPathParameters(Directory libDir) {
+  final clientsDir = Directory('${libDir.path}/clients');
+  if (!clientsDir.existsSync()) return;
+
+  final pattern = RegExp(r"@Path\('(\w+)'\)\s+required\s+dynamic\s+(\w+)");
+
+  for (final entity in clientsDir.listSync()) {
+    if (entity is! File || !entity.path.endsWith('_api_client.dart')) continue;
+
+    var content = entity.readAsStringSync();
+    final original = content;
+
+    content = content.replaceAllMapped(pattern, (m) {
+      final pathName = m[1];
+      final paramName = m[2];
+      return "@Path('$pathName') required String $paramName";
+    });
+
+    if (content != original) {
+      entity.writeAsStringSync(content);
+      stdout.writeln('  Patched dynamic path params: ${entity.path}');
+    }
+  }
+}
+
+/// swagger_parser が生成する `// ignore_for_file: type=lint, ...` から
+/// `type=lint` を除去する。これにより `avoid_annotating_with_dynamic` 等の
+/// lint ルールがコード生成結果に対して有効になる。
+///
+/// `.g.dart` / `.freezed.dart` はビルドランナー生成で独自に `type=lint` を
+/// 持つため対象外。
+void _stripTypeLintFromGeneratedHeaders(Directory libDir) {
+  final dartFiles = libDir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where(
+        (f) =>
+            f.path.endsWith('.dart') &&
+            !f.path.endsWith('.g.dart') &&
+            !f.path.endsWith('.freezed.dart'),
+      );
+
+  for (final file in dartFiles) {
+    var content = file.readAsStringSync();
+    final original = content;
+
+    content = content.replaceAll(
+      RegExp(r'type=lint,?\s*'),
+      '',
+    );
+    // 末尾にカンマ+空白だけ残った場合を整理
+    content = content.replaceAll(
+      RegExp(r'// ignore_for_file:\s*\n'),
+      '',
+    );
+
+    if (content != original) {
+      file.writeAsStringSync(content);
+      stdout.writeln('  Stripped type=lint: ${file.path}');
+    }
+  }
+}
+
+/// 生成後に `*.dart`（`*.g.dart`, `*.freezed.dart` を除く）に残った
+/// `dynamic` 型注釈を検出して警告する。
+void _validateNoDynamic(Directory libDir) {
+  final pattern = RegExp(r'\bdynamic\b');
+  final dartFiles = libDir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where(
+        (f) =>
+            f.path.endsWith('.dart') &&
+            !f.path.endsWith('.g.dart') &&
+            !f.path.endsWith('.freezed.dart'),
+      );
+
+  var count = 0;
+  for (final file in dartFiles) {
+    final lines = file.readAsLinesSync();
+    for (var i = 0; i < lines.length; i++) {
+      if (pattern.hasMatch(lines[i])) {
+        stderr.writeln(
+          '  ⚠️  dynamic detected: ${file.path}:${i + 1}: ${lines[i].trim()}',
+        );
+        count++;
+      }
+    }
+  }
+  if (count > 0) {
+    stderr.writeln('  ⚠️  $count dynamic annotation(s) remaining');
   }
 }
 

--- a/packages/eqmonitor_api/lib/src/api_client.dart
+++ b/packages/eqmonitor_api/lib/src/api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 

--- a/packages/eqmonitor_api/lib/src/clients/admin_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/admin_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/changelog_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/changelog_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/device_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/device_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
@@ -61,7 +61,7 @@ abstract class DeviceApiClient {
   /// APNsトークンを更新
   @PATCH(DeviceApiClientUrls.patchV2DeviceMeApnsKind)
   Future<HttpResponse<void>> patchV2DeviceMeApnsKind({
-    @Path('kind') required dynamic kind,
+    @Path('kind') required String kind,
     @Body() required V2DeviceMeApnsKindRequestBody body,
   });
 

--- a/packages/eqmonitor_api/lib/src/clients/device_api_client.g.dart
+++ b/packages/eqmonitor_api/lib/src/clients/device_api_client.g.dart
@@ -155,7 +155,7 @@ class _DeviceApiClient implements DeviceApiClient {
 
   @override
   Future<HttpResponse<void>> patchV2DeviceMeApnsKind({
-    required dynamic kind,
+    required String kind,
     required V2DeviceMeApnsKindRequestBody body,
   }) async {
     final _extra = <String, dynamic>{};

--- a/packages/eqmonitor_api/lib/src/clients/earthquake_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/earthquake_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/eew_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/eew_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/feed_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/feed_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/notification_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/notification_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/parameters_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/parameters_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/realtime_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/realtime_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/start_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/start_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/subscription_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/subscription_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/telegram_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/telegram_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/tsunami_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/tsunami_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/user_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/user_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/clients/webhooks_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/webhooks_api_client.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';

--- a/packages/eqmonitor_api/lib/src/export.dart
+++ b/packages/eqmonitor_api/lib/src/export.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 // Clients
 export 'clients/changelog_api_client.dart';

--- a/packages/eqmonitor_api/lib/src/models/admin_dispatch_summary_detail_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/admin_dispatch_summary_detail_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/admin_dispatch_summary_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/admin_dispatch_summary_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/admin_replay_file_detail_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/admin_replay_file_detail_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/admin_replay_file_detail_response_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/admin_replay_file_detail_response_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/admin_replay_file_download_url_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/admin_replay_file_download_url_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/admin_replay_file_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/admin_replay_file_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/apns_environment.dart
+++ b/packages/eqmonitor_api/lib/src/models/apns_environment.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/app.dart
+++ b/packages/eqmonitor_api/lib/src/models/app.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/bad_request_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/bad_request_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/challenge_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/challenge_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/changelog_bad_request_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/changelog_bad_request_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/changelog_entry.dart
+++ b/packages/eqmonitor_api/lib/src/models/changelog_entry.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/changelog_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/changelog_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/changelog_section.dart
+++ b/packages/eqmonitor_api/lib/src/models/changelog_section.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/code_name.dart
+++ b/packages/eqmonitor_api/lib/src/models/code_name.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/comments.dart
+++ b/packages/eqmonitor_api/lib/src/models/comments.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/comments2.dart
+++ b/packages/eqmonitor_api/lib/src/models/comments2.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/comments3.dart
+++ b/packages/eqmonitor_api/lib/src/models/comments3.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/coordinate.dart
+++ b/packages/eqmonitor_api/lib/src/models/coordinate.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/data.dart
+++ b/packages/eqmonitor_api/lib/src/models/data.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/depth.dart
+++ b/packages/eqmonitor_api/lib/src/models/depth.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/depth_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/depth_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/device_locale.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_locale.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/device_me_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_me_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/device_register_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_register_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/device_register_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_register_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/device_registration_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_registration_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/device_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/device_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/dispatch_summary_detail_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/dispatch_summary_detail_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/dispatch_summary_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/dispatch_summary_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_counts.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_counts.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_counts_telegram_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_counts_telegram_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_datasource.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_datasource.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_detail_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_detail_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_explanation_telegram_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_explanation_telegram_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_info.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_info.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_nankai_telegram_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_nankai_telegram_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_notice_telegram_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_notice_telegram_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_partial.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_partial.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_settings_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_settings_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_settings_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_settings_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_sort_by.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_sort_by.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_station.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_station.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_station_city.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_station_city.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_station_prefecture.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_station_prefecture.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_station_region.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_station_region.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_station_status.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_station_status.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_stations_parameter.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_stations_parameter.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body_intensity_region.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body_intensity_region.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body_intensity_station.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body_intensity_station.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body_quake.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_telegram_body_quake.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_telegram_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_telegram_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/earthquake_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/earthquake_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_accuracy.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_accuracy.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_array_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_array_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_hypocenter.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_hypocenter.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity_lpgm_value.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity_lpgm_value.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_time.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_time.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity_region_arrival_time_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_intensity_value.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_intensity_value.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_item_with_relations.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_item_with_relations.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_latest_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_latest_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_settings_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_settings_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_telegram_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_telegram_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_warning.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/eew_warning_zone_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/eew_warning_zone_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/environment.dart
+++ b/packages/eqmonitor_api/lib/src/models/environment.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/event_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/event_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/feed_create_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_create_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/feed_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/feed_item_data_union.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_item_data_union.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:json_annotation/json_annotation.dart';

--- a/packages/eqmonitor_api/lib/src/models/feed_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/first_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/first_height.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/first_height2.dart
+++ b/packages/eqmonitor_api/lib/src/models/first_height2.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/first_height_condition.dart
+++ b/packages/eqmonitor_api/lib/src/models/first_height_condition.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/forbidden_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/forbidden_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/framework.dart
+++ b/packages/eqmonitor_api/lib/src/models/framework.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/get_v2_subscription_me_response_union.dart
+++ b/packages/eqmonitor_api/lib/src/models/get_v2_subscription_me_response_union.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:json_annotation/json_annotation.dart';

--- a/packages/eqmonitor_api/lib/src/models/hypocenter.dart
+++ b/packages/eqmonitor_api/lib/src/models/hypocenter.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/hypocenter_auxiliary.dart
+++ b/packages/eqmonitor_api/lib/src/models/hypocenter_auxiliary.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/info_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/info_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_city_search_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_city_search_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_city_search_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_city_search_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_partial.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_partial.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_prefecture_search_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_prefecture_search_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_prefecture_search_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_prefecture_search_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_region_search_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_region_search_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_region_search_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_region_search_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_station_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_station_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_station_search_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_station_search_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_station_search_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_station_search_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_tree.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_tree.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/intensity_tree_region_id.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_tree_region_id.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 /// RegionID
 typedef IntensityTreeRegionId = String;

--- a/packages/eqmonitor_api/lib/src/models/intensity_tree_station_id.dart
+++ b/packages/eqmonitor_api/lib/src/models/intensity_tree_station_id.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 /// 観測点ID
 typedef IntensityTreeStationId = String;

--- a/packages/eqmonitor_api/lib/src/models/internal_server_error_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/internal_server_error_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/interruption_level.dart
+++ b/packages/eqmonitor_api/lib/src/models/interruption_level.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/is_active.dart
+++ b/packages/eqmonitor_api/lib/src/models/is_active.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/is_canceled.dart
+++ b/packages/eqmonitor_api/lib/src/models/is_canceled.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/item.dart
+++ b/packages/eqmonitor_api/lib/src/models/item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/item2.dart
+++ b/packages/eqmonitor_api/lib/src/models/item2.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/items.dart
+++ b/packages/eqmonitor_api/lib/src/models/items.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/items2.dart
+++ b/packages/eqmonitor_api/lib/src/models/items2.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/items3.dart
+++ b/packages/eqmonitor_api/lib/src/models/items3.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/items4.dart
+++ b/packages/eqmonitor_api/lib/src/models/items4.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/jma_code_table_area_forecast_local_eew_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_code_table_area_forecast_local_eew_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/jma_code_table_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_code_table_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/jma_code_table_parameter.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_code_table_parameter.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/jma_code_table_parameter_code_tables.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_code_table_parameter_code_tables.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/jma_code_table_parameter_metadata.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_code_table_parameter_metadata.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_intensity.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/jma_lpgm_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/jma_lpgm_intensity.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/kind.dart
+++ b/packages/eqmonitor_api/lib/src/models/kind.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point.dart
+++ b/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point_map_point.dart
+++ b/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point_map_point.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/kyoshin_observation_point_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/kyoshin_observation_points_parameter.dart
+++ b/packages/eqmonitor_api/lib/src/models/kyoshin_observation_points_parameter.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/kyoshin_observation_points_parameter_metadata.dart
+++ b/packages/eqmonitor_api/lib/src/models/kyoshin_observation_points_parameter_metadata.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/latest_telegram.dart
+++ b/packages/eqmonitor_api/lib/src/models/latest_telegram.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/latest_version.dart
+++ b/packages/eqmonitor_api/lib/src/models/latest_version.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/live_activity_event.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_event.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/live_activity_start_trigger.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_start_trigger.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/live_activity_test_scenario_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_test_scenario_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/live_activity_test_scenario_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_test_scenario_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/live_activity_token_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_token_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/live_activity_token_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/live_activity_token_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/localized_name.dart
+++ b/packages/eqmonitor_api/lib/src/models/localized_name.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/lpgm_intensity_tree.dart
+++ b/packages/eqmonitor_api/lib/src/models/lpgm_intensity_tree.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/lpgm_intensity_tree_region_id.dart
+++ b/packages/eqmonitor_api/lib/src/models/lpgm_intensity_tree_region_id.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 /// RegionID
 typedef LpgmIntensityTreeRegionId = String;

--- a/packages/eqmonitor_api/lib/src/models/magnitude.dart
+++ b/packages/eqmonitor_api/lib/src/models/magnitude.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/magnitude_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/magnitude_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/maintenance_info.dart
+++ b/packages/eqmonitor_api/lib/src/models/maintenance_info.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/max_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/max_height.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/min_jma_intensity.dart
+++ b/packages/eqmonitor_api/lib/src/models/min_jma_intensity.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/naming.dart
+++ b/packages/eqmonitor_api/lib/src/models/naming.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/not_found_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/not_found_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_history_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_history_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_log_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_log_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_tiers.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_tiers.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_tiers2.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_tiers2.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_tiers3.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_tiers3.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/notification_tiers4.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_tiers4.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/observation_max_height_condition.dart
+++ b/packages/eqmonitor_api/lib/src/models/observation_max_height_condition.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/origin_time_precision.dart
+++ b/packages/eqmonitor_api/lib/src/models/origin_time_precision.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/parameter_data_response_union.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_data_response_union.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:json_annotation/json_annotation.dart';

--- a/packages/eqmonitor_api/lib/src/models/parameter_location.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_location.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/parameter_manifest_item.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_manifest_item.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/parameter_metadata.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_metadata.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/parameter_point.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_point.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/parameter_service_unavailable_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_service_unavailable_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/parameter_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameter_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/parameters_manifest_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/parameters_manifest_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/post_v2_admin_test_live_event_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/post_v2_admin_test_live_event_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/pre_periods.dart
+++ b/packages/eqmonitor_api/lib/src/models/pre_periods.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/pre_periods2.dart
+++ b/packages/eqmonitor_api/lib/src/models/pre_periods2.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/qualitative_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/qualitative_height.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/realtime_ticket_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/realtime_ticket_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_patch_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/region_setting_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/region_setting_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/region_setting_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/replay_download_service_unavailable.dart
+++ b/packages/eqmonitor_api/lib/src/models/replay_download_service_unavailable.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/replay_forbidden_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/replay_forbidden_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/required_version.dart
+++ b/packages/eqmonitor_api/lib/src/models/required_version.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/result.dart
+++ b/packages/eqmonitor_api/lib/src/models/result.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/revise.dart
+++ b/packages/eqmonitor_api/lib/src/models/revise.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/scenario.dart
+++ b/packages/eqmonitor_api/lib/src/models/scenario.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/service_unavailable_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/service_unavailable_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/session_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/session_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/shake_detection_level.dart
+++ b/packages/eqmonitor_api/lib/src/models/shake_detection_level.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/shake_detection_setting_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/shake_detection_setting_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/shake_detection_setting_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/shake_detection_setting_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/shake_detection_sub_region_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/shake_detection_sub_region_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/sort_order.dart
+++ b/packages/eqmonitor_api/lib/src/models/sort_order.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/start_flags.dart
+++ b/packages/eqmonitor_api/lib/src/models/start_flags.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/start_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/start_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/start_trigger.dart
+++ b/packages/eqmonitor_api/lib/src/models/start_trigger.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/store_url.dart
+++ b/packages/eqmonitor_api/lib/src/models/store_url.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/subscription_active_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/subscription_active_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/subscription_inactive_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/subscription_inactive_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/target_time.dart
+++ b/packages/eqmonitor_api/lib/src/models/target_time.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/target_union.dart
+++ b/packages/eqmonitor_api/lib/src/models/target_union.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:json_annotation/json_annotation.dart';

--- a/packages/eqmonitor_api/lib/src/models/telegram.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegram_body_union.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_body_union.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:json_annotation/json_annotation.dart';

--- a/packages/eqmonitor_api/lib/src/models/telegram_comments.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_comments.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegram_detail.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_detail.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegram_detail_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_detail_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegram_event_details_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_event_details_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegram_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegram_status.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_status.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegram_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegram_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/telegrams.dart
+++ b/packages/eqmonitor_api/lib/src/models/telegrams.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/test_notification_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/test_notification_request.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/test_notification_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/test_notification_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/test_notification_type.dart
+++ b/packages/eqmonitor_api/lib/src/models/test_notification_type.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/translations.dart
+++ b/packages/eqmonitor_api/lib/src/models/translations.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/triggers.dart
+++ b/packages/eqmonitor_api/lib/src/models/triggers.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_list_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_list_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_offshore_station.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_offshore_station.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_region.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_region.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_region_estimation.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_region_estimation.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_region_forecast.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_region_forecast.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_region_forecast_first_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_region_forecast_first_height.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_region_forecast_max_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_region_forecast_max_height.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_region_station.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_region_station.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_state.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_state.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_state_earthquake.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_state_earthquake.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_station.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_station.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_station_area.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_station_area.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_station_forecast.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_station_forecast.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_station_observation.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_station_observation.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_station_observation_first_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_station_observation_first_height.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_station_observation_max_height.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_station_observation_max_height.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_station_prefecture.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_station_prefecture.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_stations_parameter.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_stations_parameter.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_stations_parameter_metadata.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_stations_parameter_metadata.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_telegram_with_state.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_telegram_with_state.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_telegrams_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_telegrams_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/tsunami_warning_kind.dart
+++ b/packages/eqmonitor_api/lib/src/models/tsunami_warning_kind.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/unauthorized_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/unauthorized_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/user_device_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/user_device_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/user_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/user_response.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/v2_admin_test_live_event_request_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/v2_admin_test_live_event_request_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/v2_device_me_apns_kind_request_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/v2_device_me_apns_kind_request_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/v2_device_me_fcm_request_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/v2_device_me_fcm_request_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/v2_feeds_admin_request_body.dart
+++ b/packages/eqmonitor_api/lib/src/models/v2_feeds_admin_request_body.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/values.dart
+++ b/packages/eqmonitor_api/lib/src/models/values.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/version.dart
+++ b/packages/eqmonitor_api/lib/src/models/version.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/warning.dart
+++ b/packages/eqmonitor_api/lib/src/models/warning.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/wave_initial.dart
+++ b/packages/eqmonitor_api/lib/src/models/wave_initial.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/eqmonitor_api/lib/src/models/whats_new.dart
+++ b/packages/eqmonitor_api/lib/src/models/whats_new.dart
@@ -1,6 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 


### PR DESCRIPTION
## Summary
- APNs トークン同期で `kind` パスパラメータが `notification` (小文字) で送信され、API が期待する `NOTIFICATION` (大文字) と不一致で 400 エラーになっていた問題を修正
- `swagger_parser` が `anyOf` のパスパラメータを `dynamic` 型として生成する問題に対し、`generate.dart` に自動パッチステップを追加
- `packages/eqmonitor_api` で `avoid_annotating_with_dynamic` lint を error レベルで有効化し、残存 `dynamic` 72件を検出可能にした

## Changes
- `ApnsTokenKind.json` の値を `NOTIFICATION` / `LIVE_ACTIVITY_START` に変更
- `generate.dart` に3つの新ステップを追加:
  - `_patchDynamicPathParameters`: `@Path` の `dynamic` → `String`
  - `_stripTypeLintFromGeneratedHeaders`: 生成ファイルから `type=lint` 除去
  - `_validateNoDynamic`: 残存 `dynamic` の検出・警告
- `analysis_options.yaml`: `**/*` exclude → `*.g.dart` / `*.freezed.dart` のみ exclude に変更し、`avoid_annotating_with_dynamic: error` を有効化
- テストの期待値を更新

## Test plan
- [x] `device_repository_apns_kind_test.dart` パス確認済み
- [x] `dart analyze lib/src` で `avoid_annotating_with_dynamic` の72件のみが検出されることを確認
- [ ] 実機で APNs トークン同期が 200 で成功することを確認