### PR TITLE
feat(app): add telemetry events debug viewer

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -48,6 +48,7 @@ import 'package:eqmonitor/feature/settings/children/config/debug/navigation/navi
 import 'package:eqmonitor/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/playground/playground_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/shake_detection/debug_shake_detection_card_page.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/telemetry/debug_telemetry_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/tsunami/debug_tsunami_details_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/tsunami/tsunami_telegram_timeline_debug_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/websocket/debug_websocket_page.dart';
@@ -340,6 +341,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
         TypedGoRoute<DebugAppGroupRoute>(path: 'app-group'),
         TypedGoRoute<DebugLiveActivityTestRoute>(path: 'live-activity-test'),
         TypedGoRoute<DebugIntensityIconRoute>(path: 'intensity-icon'),
+        TypedGoRoute<DebugTelemetryRoute>(path: 'telemetry'),
         TypedGoRoute<DebugTsunamiDetailsRoute>(
           path: 'tsunami-details',
           routes: [
@@ -685,6 +687,15 @@ class DebugIntensityIconRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const IntensityIconDebugPage();
+  }
+}
+
+class DebugTelemetryRoute extends GoRouteData with $DebugTelemetryRoute {
+  const DebugTelemetryRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const DebugTelemetryPage();
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -525,6 +525,10 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           factory: $DebugIntensityIconRoute._fromState,
         ),
         GoRouteData.$route(
+          path: 'telemetry',
+          factory: $DebugTelemetryRoute._fromState,
+        ),
+        GoRouteData.$route(
           path: 'tsunami-details',
           factory: $DebugTsunamiDetailsRoute._fromState,
           routes: [
@@ -1315,6 +1319,27 @@ mixin $DebugIntensityIconRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/settings/debug/intensity-icon');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DebugTelemetryRoute on GoRouteData {
+  static DebugTelemetryRoute _fromState(GoRouterState state) =>
+      const DebugTelemetryRoute();
+
+  @override
+  String get location => GoRouteData.$location('/settings/debug/telemetry');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -126,6 +126,13 @@ class _DebugWidget extends ConsumerWidget {
                   const DebugLiveActivityTestRoute().push<void>(context),
             ),
           ListTile(
+            title: const Text('Telemetry Events'),
+            leading: const Icon(Icons.analytics_outlined),
+            subtitle: const Text('ローカルテレメトリーイベントの閲覧'),
+            onTap: () async =>
+                const DebugTelemetryRoute().push<void>(context),
+          ),
+          ListTile(
             title: const Text('WebSocket'),
             leading: const Icon(Icons.cable),
             subtitle: const Text('WebSocket 接続状況と受信ログ'),

--- a/app/lib/feature/settings/children/config/debug/telemetry/debug_telemetry_page.dart
+++ b/app/lib/feature/settings/children/config/debug/telemetry/debug_telemetry_page.dart
@@ -1,0 +1,308 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_database_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:telemetry_store/telemetry_store.dart';
+
+class DebugTelemetryPage extends HookConsumerWidget {
+  const DebugTelemetryPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final events = useState<List<TelemetryEventRow>>([]);
+    final totalCount = useState(0);
+    final isLoading = useState(true);
+
+    Future<void> refresh() async {
+      isLoading.value = true;
+      final db = ref.read(telemetryDatabaseProvider);
+      final results = await db.getAllEvents();
+      final count = await db.countEvents();
+      events.value = results;
+      totalCount.value = count;
+      isLoading.value = false;
+    }
+
+    useEffect(
+      () {
+        unawaited(refresh());
+        return null;
+      },
+      const [],
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Telemetry Events'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: refresh,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            onPressed: () async {
+              final confirmed = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('全イベントを削除'),
+                  content: Text('${totalCount.value}件のイベントを削除しますか？'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, false),
+                      child: const Text('キャンセル'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, true),
+                      child: const Text('削除'),
+                    ),
+                  ],
+                ),
+              );
+              if (confirmed ?? false) {
+                await ref.read(telemetryDatabaseProvider).deleteAllEvents();
+                await refresh();
+              }
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _SummaryCard(
+            totalCount: totalCount.value,
+            unsyncedCount:
+                events.value.where((e) => !e.synced).length,
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: isLoading.value
+                ? const Center(child: CircularProgressIndicator.adaptive())
+                : events.value.isEmpty
+                    ? const Center(child: Text('イベントはまだありません'))
+                    : ListView.separated(
+                        itemCount: events.value.length,
+                        separatorBuilder: (_, _) => const Divider(height: 1),
+                        itemBuilder: (context, index) =>
+                            _EventTile(event: events.value[index]),
+                      ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({
+    required this.totalCount,
+    required this.unsyncedCount,
+  });
+
+  final int totalCount;
+  final int unsyncedCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '合計: $totalCount件',
+                  style: theme.textTheme.titleMedium,
+                ),
+                Text(
+                  '未送信: $unsyncedCount件',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: unsyncedCount > 0
+                        ? theme.colorScheme.error
+                        : theme.colorScheme.outline,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventTile extends StatelessWidget {
+  const _EventTile({required this.event});
+
+  final TelemetryEventRow event;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final time = DateTime.fromMillisecondsSinceEpoch(event.timestampMs);
+    final timeStr =
+        '${time.month}/${time.day} ${time.hour}:${time.minute.toString().padLeft(2, '0')}:${time.second.toString().padLeft(2, '0')}';
+
+    String prettyPayload;
+    try {
+      final decoded = jsonDecode(event.payload) as Map<String, dynamic>;
+      prettyPayload = const JsonEncoder.withIndent('  ').convert(decoded);
+    } on Object {
+      prettyPayload = event.payload;
+    }
+
+    return ListTile(
+      dense: true,
+      leading: Icon(
+        event.synced ? Icons.cloud_done : Icons.cloud_upload_outlined,
+        size: 20,
+        color: event.synced
+            ? theme.colorScheme.outline
+            : theme.colorScheme.primary,
+      ),
+      title: Text(
+        event.eventType,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          fontFamily: 'monospace',
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            timeStr,
+            style: theme.textTheme.bodySmall,
+          ),
+          if (event.eventId != null)
+            Text(
+              'eventId: ${event.eventId}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+        ],
+      ),
+      onTap: () async {
+        await showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          builder: (context) => DraggableScrollableSheet(
+            initialChildSize: 0.6,
+            minChildSize: 0.3,
+            maxChildSize: 0.9,
+            expand: false,
+            builder: (context, scrollController) => Column(
+              children: [
+                AppBar(
+                  title: Text(event.eventType),
+                  automaticallyImplyLeading: false,
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.copy),
+                      onPressed: () async {
+                        await Clipboard.setData(
+                          ClipboardData(text: prettyPayload),
+                        );
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('コピーしました')),
+                          );
+                        }
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () => Navigator.pop(context),
+                    ),
+                  ],
+                ),
+                Expanded(
+                  child: SingleChildScrollView(
+                    controller: scrollController,
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _DetailRow('ID', '${event.id}'),
+                        _DetailRow('Type', event.eventType),
+                        _DetailRow('Time', time.toIso8601String()),
+                        _DetailRow('Event ID', event.eventId ?? '(null)'),
+                        _DetailRow('Synced', event.synced ? 'Yes' : 'No'),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Payload:',
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+                        const SizedBox(height: 4),
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: SelectableText(
+                            prettyPayload,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              fontFamily: 'monospace',
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow(this.label, this.value);
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontFamily: 'monospace',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/telemetry_store/lib/src/database/telemetry_database.dart
+++ b/packages/telemetry_store/lib/src/database/telemetry_database.dart
@@ -62,4 +62,22 @@ class TelemetryDatabase extends _$TelemetryDatabase {
                   t.createdAtMs.isSmallerThanValue(beforeMs),
             ))
           .go();
+
+  Future<List<TelemetryEventRow>> getAllEvents({
+    int limit = 200,
+    int offset = 0,
+  }) =>
+      (select(telemetryEvents)
+            ..orderBy([(t) => OrderingTerm.desc(t.createdAtMs)])
+            ..limit(limit, offset: offset))
+          .get();
+
+  Future<int> countEvents() async {
+    final count = telemetryEvents.id.count();
+    final query = selectOnly(telemetryEvents)..addColumns([count]);
+    final row = await query.getSingle();
+    return row.read(count)!;
+  }
+
+  Future<int> deleteAllEvents() => delete(telemetryEvents).go();
 }


### PR DESCRIPTION
## Summary

- デバッグメニューに「Telemetry Events」ページを追加
- ローカルの `telemetry_events` テーブルの内容を閲覧可能
- イベント種別、タイムスタンプ、同期状態、JSON payload を表示
- タップで詳細展開（コピーボタン付き）
- 全件削除ボタン（確認ダイアログ付き）

#1335 のフォローアップ

## Test plan

- [ ] Debug Page → Telemetry Events でページが開く
- [ ] イベント一覧が表示される（まだイベントがない場合は空メッセージ）
- [ ] タップで詳細 bottom sheet が開く
- [ ] コピーボタンでペイロードがクリップボードにコピーされる