### PR TITLE
feat(home_map): 地域・市区町村ラベル表示とデバッグ調整UI

### DIFF
--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -27,6 +27,7 @@ enum SharedPreferencesKey {
   adsOptOut('ads_opt_out'),
   autoReturnToRealtime('auto_return_to_realtime'),
   earthquakeHistoryMapLayerParameter('earthquake_history_map_layer_parameter'),
+  homeMapLabelParameter('home_map_label_parameter'),
   ;
 
   const SharedPreferencesKey(this.key);

--- a/app/lib/feature/home/data/model/home_map_label_parameter.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'home_map_label_parameter.freezed.dart';
+part 'home_map_label_parameter.g.dart';
+
+@freezed
+abstract class HomeMapLabelParameter with _$HomeMapLabelParameter {
+  const factory HomeMapLabelParameter({
+    @Default(true) bool showRegionLabel,
+    @Default(true) bool showCityLabel,
+    @Default(5.0) double regionLabelMinZoom,
+    @Default(9.0) double cityLabelMinZoom,
+    @Default(14) double regionTextSize,
+    @Default(12) double cityTextSize,
+    @Default(1.0) double textHaloWidth,
+  }) = _HomeMapLabelParameter;
+
+  factory HomeMapLabelParameter.fromJson(Map<String, dynamic> json) =>
+      _$HomeMapLabelParameterFromJson(json);
+}

--- a/app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'home_map_label_parameter.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$HomeMapLabelParameter {
+
+ bool get showRegionLabel; bool get showCityLabel; double get regionLabelMinZoom; double get cityLabelMinZoom; double get regionTextSize; double get cityTextSize; double get textHaloWidth;
+/// Create a copy of HomeMapLabelParameter
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HomeMapLabelParameterCopyWith<HomeMapLabelParameter> get copyWith => _$HomeMapLabelParameterCopyWithImpl<HomeMapLabelParameter>(this as HomeMapLabelParameter, _$identity);
+
+  /// Serializes this HomeMapLabelParameter to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeMapLabelParameter&&(identical(other.showRegionLabel, showRegionLabel) || other.showRegionLabel == showRegionLabel)&&(identical(other.showCityLabel, showCityLabel) || other.showCityLabel == showCityLabel)&&(identical(other.regionLabelMinZoom, regionLabelMinZoom) || other.regionLabelMinZoom == regionLabelMinZoom)&&(identical(other.cityLabelMinZoom, cityLabelMinZoom) || other.cityLabelMinZoom == cityLabelMinZoom)&&(identical(other.regionTextSize, regionTextSize) || other.regionTextSize == regionTextSize)&&(identical(other.cityTextSize, cityTextSize) || other.cityTextSize == cityTextSize)&&(identical(other.textHaloWidth, textHaloWidth) || other.textHaloWidth == textHaloWidth));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,showRegionLabel,showCityLabel,regionLabelMinZoom,cityLabelMinZoom,regionTextSize,cityTextSize,textHaloWidth);
+
+@override
+String toString() {
+  return 'HomeMapLabelParameter(showRegionLabel: $showRegionLabel, showCityLabel: $showCityLabel, regionLabelMinZoom: $regionLabelMinZoom, cityLabelMinZoom: $cityLabelMinZoom, regionTextSize: $regionTextSize, cityTextSize: $cityTextSize, textHaloWidth: $textHaloWidth)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $HomeMapLabelParameterCopyWith<$Res>  {
+  factory $HomeMapLabelParameterCopyWith(HomeMapLabelParameter value, $Res Function(HomeMapLabelParameter) _then) = _$HomeMapLabelParameterCopyWithImpl;
+@useResult
+$Res call({
+ bool showRegionLabel, bool showCityLabel, double regionLabelMinZoom, double cityLabelMinZoom, double regionTextSize, double cityTextSize, double textHaloWidth
+});
+
+
+
+
+}
+/// @nodoc
+class _$HomeMapLabelParameterCopyWithImpl<$Res>
+    implements $HomeMapLabelParameterCopyWith<$Res> {
+  _$HomeMapLabelParameterCopyWithImpl(this._self, this._then);
+
+  final HomeMapLabelParameter _self;
+  final $Res Function(HomeMapLabelParameter) _then;
+
+/// Create a copy of HomeMapLabelParameter
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? showRegionLabel = null,Object? showCityLabel = null,Object? regionLabelMinZoom = null,Object? cityLabelMinZoom = null,Object? regionTextSize = null,Object? cityTextSize = null,Object? textHaloWidth = null,}) {
+  return _then(_self.copyWith(
+showRegionLabel: null == showRegionLabel ? _self.showRegionLabel : showRegionLabel // ignore: cast_nullable_to_non_nullable
+as bool,showCityLabel: null == showCityLabel ? _self.showCityLabel : showCityLabel // ignore: cast_nullable_to_non_nullable
+as bool,regionLabelMinZoom: null == regionLabelMinZoom ? _self.regionLabelMinZoom : regionLabelMinZoom // ignore: cast_nullable_to_non_nullable
+as double,cityLabelMinZoom: null == cityLabelMinZoom ? _self.cityLabelMinZoom : cityLabelMinZoom // ignore: cast_nullable_to_non_nullable
+as double,regionTextSize: null == regionTextSize ? _self.regionTextSize : regionTextSize // ignore: cast_nullable_to_non_nullable
+as double,cityTextSize: null == cityTextSize ? _self.cityTextSize : cityTextSize // ignore: cast_nullable_to_non_nullable
+as double,textHaloWidth: null == textHaloWidth ? _self.textHaloWidth : textHaloWidth // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [HomeMapLabelParameter].
+extension HomeMapLabelParameterPatterns on HomeMapLabelParameter {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HomeMapLabelParameter value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HomeMapLabelParameter() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HomeMapLabelParameter value)  $default,){
+final _that = this;
+switch (_that) {
+case _HomeMapLabelParameter():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HomeMapLabelParameter value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HomeMapLabelParameter() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool showRegionLabel,  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HomeMapLabelParameter() when $default != null:
+return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZoom,_that.cityLabelMinZoom,_that.regionTextSize,_that.cityTextSize,_that.textHaloWidth);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool showRegionLabel,  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)  $default,) {final _that = this;
+switch (_that) {
+case _HomeMapLabelParameter():
+return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZoom,_that.cityLabelMinZoom,_that.regionTextSize,_that.cityTextSize,_that.textHaloWidth);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool showRegionLabel,  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)?  $default,) {final _that = this;
+switch (_that) {
+case _HomeMapLabelParameter() when $default != null:
+return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZoom,_that.cityLabelMinZoom,_that.regionTextSize,_that.cityTextSize,_that.textHaloWidth);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _HomeMapLabelParameter implements HomeMapLabelParameter {
+  const _HomeMapLabelParameter({this.showRegionLabel = true, this.showCityLabel = true, this.regionLabelMinZoom = 5.0, this.cityLabelMinZoom = 9.0, this.regionTextSize = 14, this.cityTextSize = 12, this.textHaloWidth = 1.0});
+  factory _HomeMapLabelParameter.fromJson(Map<String, dynamic> json) => _$HomeMapLabelParameterFromJson(json);
+
+@override@JsonKey() final  bool showRegionLabel;
+@override@JsonKey() final  bool showCityLabel;
+@override@JsonKey() final  double regionLabelMinZoom;
+@override@JsonKey() final  double cityLabelMinZoom;
+@override@JsonKey() final  double regionTextSize;
+@override@JsonKey() final  double cityTextSize;
+@override@JsonKey() final  double textHaloWidth;
+
+/// Create a copy of HomeMapLabelParameter
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HomeMapLabelParameterCopyWith<_HomeMapLabelParameter> get copyWith => __$HomeMapLabelParameterCopyWithImpl<_HomeMapLabelParameter>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$HomeMapLabelParameterToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeMapLabelParameter&&(identical(other.showRegionLabel, showRegionLabel) || other.showRegionLabel == showRegionLabel)&&(identical(other.showCityLabel, showCityLabel) || other.showCityLabel == showCityLabel)&&(identical(other.regionLabelMinZoom, regionLabelMinZoom) || other.regionLabelMinZoom == regionLabelMinZoom)&&(identical(other.cityLabelMinZoom, cityLabelMinZoom) || other.cityLabelMinZoom == cityLabelMinZoom)&&(identical(other.regionTextSize, regionTextSize) || other.regionTextSize == regionTextSize)&&(identical(other.cityTextSize, cityTextSize) || other.cityTextSize == cityTextSize)&&(identical(other.textHaloWidth, textHaloWidth) || other.textHaloWidth == textHaloWidth));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,showRegionLabel,showCityLabel,regionLabelMinZoom,cityLabelMinZoom,regionTextSize,cityTextSize,textHaloWidth);
+
+@override
+String toString() {
+  return 'HomeMapLabelParameter(showRegionLabel: $showRegionLabel, showCityLabel: $showCityLabel, regionLabelMinZoom: $regionLabelMinZoom, cityLabelMinZoom: $cityLabelMinZoom, regionTextSize: $regionTextSize, cityTextSize: $cityTextSize, textHaloWidth: $textHaloWidth)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$HomeMapLabelParameterCopyWith<$Res> implements $HomeMapLabelParameterCopyWith<$Res> {
+  factory _$HomeMapLabelParameterCopyWith(_HomeMapLabelParameter value, $Res Function(_HomeMapLabelParameter) _then) = __$HomeMapLabelParameterCopyWithImpl;
+@override @useResult
+$Res call({
+ bool showRegionLabel, bool showCityLabel, double regionLabelMinZoom, double cityLabelMinZoom, double regionTextSize, double cityTextSize, double textHaloWidth
+});
+
+
+
+
+}
+/// @nodoc
+class __$HomeMapLabelParameterCopyWithImpl<$Res>
+    implements _$HomeMapLabelParameterCopyWith<$Res> {
+  __$HomeMapLabelParameterCopyWithImpl(this._self, this._then);
+
+  final _HomeMapLabelParameter _self;
+  final $Res Function(_HomeMapLabelParameter) _then;
+
+/// Create a copy of HomeMapLabelParameter
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? showRegionLabel = null,Object? showCityLabel = null,Object? regionLabelMinZoom = null,Object? cityLabelMinZoom = null,Object? regionTextSize = null,Object? cityTextSize = null,Object? textHaloWidth = null,}) {
+  return _then(_HomeMapLabelParameter(
+showRegionLabel: null == showRegionLabel ? _self.showRegionLabel : showRegionLabel // ignore: cast_nullable_to_non_nullable
+as bool,showCityLabel: null == showCityLabel ? _self.showCityLabel : showCityLabel // ignore: cast_nullable_to_non_nullable
+as bool,regionLabelMinZoom: null == regionLabelMinZoom ? _self.regionLabelMinZoom : regionLabelMinZoom // ignore: cast_nullable_to_non_nullable
+as double,cityLabelMinZoom: null == cityLabelMinZoom ? _self.cityLabelMinZoom : cityLabelMinZoom // ignore: cast_nullable_to_non_nullable
+as double,regionTextSize: null == regionTextSize ? _self.regionTextSize : regionTextSize // ignore: cast_nullable_to_non_nullable
+as double,cityTextSize: null == cityTextSize ? _self.cityTextSize : cityTextSize // ignore: cast_nullable_to_non_nullable
+as double,textHaloWidth: null == textHaloWidth ? _self.textHaloWidth : textHaloWidth // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/home/data/model/home_map_label_parameter.g.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.g.dart
@@ -1,0 +1,70 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'home_map_label_parameter.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_HomeMapLabelParameter _$HomeMapLabelParameterFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_HomeMapLabelParameter',
+  json,
+  ($checkedConvert) {
+    final val = _HomeMapLabelParameter(
+      showRegionLabel: $checkedConvert(
+        'show_region_label',
+        (v) => v as bool? ?? true,
+      ),
+      showCityLabel: $checkedConvert(
+        'show_city_label',
+        (v) => v as bool? ?? true,
+      ),
+      regionLabelMinZoom: $checkedConvert(
+        'region_label_min_zoom',
+        (v) => (v as num?)?.toDouble() ?? 5.0,
+      ),
+      cityLabelMinZoom: $checkedConvert(
+        'city_label_min_zoom',
+        (v) => (v as num?)?.toDouble() ?? 9.0,
+      ),
+      regionTextSize: $checkedConvert(
+        'region_text_size',
+        (v) => (v as num?)?.toDouble() ?? 14,
+      ),
+      cityTextSize: $checkedConvert(
+        'city_text_size',
+        (v) => (v as num?)?.toDouble() ?? 12,
+      ),
+      textHaloWidth: $checkedConvert(
+        'text_halo_width',
+        (v) => (v as num?)?.toDouble() ?? 1.0,
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'showRegionLabel': 'show_region_label',
+    'showCityLabel': 'show_city_label',
+    'regionLabelMinZoom': 'region_label_min_zoom',
+    'cityLabelMinZoom': 'city_label_min_zoom',
+    'regionTextSize': 'region_text_size',
+    'cityTextSize': 'city_text_size',
+    'textHaloWidth': 'text_halo_width',
+  },
+);
+
+Map<String, dynamic> _$HomeMapLabelParameterToJson(
+  _HomeMapLabelParameter instance,
+) => <String, dynamic>{
+  'show_region_label': instance.showRegionLabel,
+  'show_city_label': instance.showCityLabel,
+  'region_label_min_zoom': instance.regionLabelMinZoom,
+  'city_label_min_zoom': instance.cityLabelMinZoom,
+  'region_text_size': instance.regionTextSize,
+  'city_text_size': instance.cityTextSize,
+  'text_halo_width': instance.textHaloWidth,
+};

--- a/app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.dart
+++ b/app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/feature/home/data/model/home_map_label_parameter.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'home_map_label_parameter_notifier.g.dart';
+
+const _default = HomeMapLabelParameter();
+
+@Riverpod(keepAlive: true)
+class HomeMapLabelParameterNotifier
+    extends _$HomeMapLabelParameterNotifier {
+  @override
+  Future<HomeMapLabelParameter> build() async {
+    final sharedPreferences = await ref.read(
+      sharedPreferencesDataSourceProvider.future,
+    );
+    final jsonString = await sharedPreferences.getString(
+      key: SharedPreferencesKey.homeMapLabelParameter,
+    );
+    if (jsonString == null) {
+      return _default;
+    }
+    try {
+      return HomeMapLabelParameter.fromJson(
+        jsonDecode(jsonString) as Map<String, dynamic>,
+      );
+      // ignore: avoid_catches_without_on_clauses
+    } catch (exception, stackTrace) {
+      talker.error(
+        'load home map label parameter failed: $exception',
+        exception,
+        stackTrace,
+      );
+      return _default;
+    }
+  }
+
+  Future<void> save(HomeMapLabelParameter value) async {
+    state = AsyncValue.data(value);
+    final sharedPreferences = await ref.read(
+      sharedPreferencesDataSourceProvider.future,
+    );
+    await sharedPreferences.setString(
+      key: SharedPreferencesKey.homeMapLabelParameter,
+      value: jsonEncode(value.toJson()),
+    );
+  }
+
+  Future<void> reset() async {
+    await save(_default);
+  }
+}

--- a/app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.g.dart
+++ b/app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.g.dart
@@ -1,0 +1,67 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'home_map_label_parameter_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(HomeMapLabelParameterNotifier)
+final homeMapLabelParameterProvider = HomeMapLabelParameterNotifierProvider._();
+
+final class HomeMapLabelParameterNotifierProvider
+    extends
+        $AsyncNotifierProvider<
+          HomeMapLabelParameterNotifier,
+          HomeMapLabelParameter
+        > {
+  HomeMapLabelParameterNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'homeMapLabelParameterProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$homeMapLabelParameterNotifierHash();
+
+  @$internal
+  @override
+  HomeMapLabelParameterNotifier create() => HomeMapLabelParameterNotifier();
+}
+
+String _$homeMapLabelParameterNotifierHash() =>
+    r'e72d462a41efe247ae9ee3331923dc52c309f574';
+
+abstract class _$HomeMapLabelParameterNotifier
+    extends $AsyncNotifier<HomeMapLabelParameter> {
+  FutureOr<HomeMapLabelParameter> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<AsyncValue<HomeMapLabelParameter>, HomeMapLabelParameter>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<HomeMapLabelParameter>,
+                HomeMapLabelParameter
+              >,
+              AsyncValue<HomeMapLabelParameter>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/home/ui/component/map/home_map_controller_card.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_controller_card.dart
@@ -11,11 +11,13 @@ class HomeMapControllerCard extends StatelessWidget {
     this.onLayerButtonTap,
     this.onLocationButtonTap,
     this.onDebugButtonTap,
+    this.onLabelDebugButtonTap,
   });
 
   final void Function()? onLayerButtonTap;
   final void Function()? onLocationButtonTap;
   final void Function()? onDebugButtonTap;
+  final void Function()? onLabelDebugButtonTap;
 
   @override
   Widget build(BuildContext context) {
@@ -64,6 +66,17 @@ class HomeMapControllerCard extends StatelessWidget {
                         onLocationButtonTap?.call();
                       },
                     ),
+                    if (onLabelDebugButtonTap != null)
+                      InkWell(
+                        child: Padding(
+                          padding: EdgeInsets.all(spacing.sm),
+                          child: const Icon(Icons.label_rounded),
+                        ),
+                        onTap: () async {
+                          await hapticFeedback();
+                          onLabelDebugButtonTap?.call();
+                        },
+                      ),
                     if (onDebugButtonTap != null)
                       InkWell(
                         child: Padding(

--- a/app/lib/feature/home/ui/component/map/home_map_view.dart
+++ b/app/lib/feature/home/ui/component/map/home_map_view.dart
@@ -12,8 +12,10 @@ import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_estimated_inte
 import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/layer/eew_warning_regions_layer.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/layer/home_map_label_layer.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/layer/shake_detection_layer.dart';
+import 'package:eqmonitor/feature/home/ui/component/map/modal/home_map_label_debug_modal.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_monitor_settings.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/components/connection_status_card.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/page/components/kyoshin_monitor_status_card.dart';
@@ -153,6 +155,7 @@ class _MapContent extends ConsumerWidget {
                   eews: ref.watch(eewAliveTelegramProvider) ?? [],
                 ),
               ),
+              const HomeMapLabelLayer(),
               const SafeArea(
                 child: _MapHeader(),
               ),
@@ -206,6 +209,9 @@ class _MapHeader extends ConsumerWidget {
           const HomeMapLayerRoute().push<void>(context),
       onLocationButtonTap: () =>
           ref.read(homeMapCameraStateProvider.notifier).returnToHome(),
+      onLabelDebugButtonTap: isDebug
+          ? () => HomeMapLabelDebugModal.show(context: context)
+          : null,
       onDebugButtonTap: isDebug ? () => PlaybackModeModal.show(context) : null,
     );
 

--- a/app/lib/feature/home/ui/component/map/layer/home_map_label_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/home_map_label_layer.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:eqmonitor/feature/home/data/model/home_map_label_parameter.dart';
+import 'package:eqmonitor/feature/home/data/notifier/home_map_label_parameter_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+
+class HomeMapLabelLayer extends HookConsumerWidget {
+  const HomeMapLabelLayer({super.key});
+
+  static const _regionLabelLayerId = 'home-map-region-label';
+  static const _cityLabelLayerId = 'home-map-city-label';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final styleController = MapController.maybeOf(context)?.style;
+    final paramAsync = ref.watch(homeMapLabelParameterProvider);
+    final param = paramAsync.value ?? const HomeMapLabelParameter();
+
+    final isInitialized = useRef(false);
+    final latestParam = useRef(param);
+    latestParam.value = param;
+
+    useEffect(
+      () {
+        if (styleController == null) {
+          return null;
+        }
+
+        unawaited(() async {
+          await _addLayers(
+            styleController: styleController,
+            param: latestParam.value,
+          );
+          isInitialized.value = true;
+        }());
+
+        return () async {
+          for (final id in [_regionLabelLayerId, _cityLabelLayerId]) {
+            try {
+              await styleController.removeLayer(id);
+            } on Exception catch (_) {}
+          }
+        };
+      },
+      [styleController],
+    );
+
+    useEffect(
+      () {
+        if (styleController == null || !isInitialized.value) {
+          return null;
+        }
+        unawaited(_updateLayers(
+          styleController: styleController,
+          param: param,
+        ));
+        return null;
+      },
+      [styleController, param],
+    );
+
+    return const SizedBox.shrink();
+  }
+
+  static Future<void> _addLayers({
+    required StyleController styleController,
+    required HomeMapLabelParameter param,
+  }) async {
+    if (param.showRegionLabel) {
+      await styleController.addLayer(
+        SymbolStyleLayer(
+          id: _regionLabelLayerId,
+          sourceId: 'eqmonitor_map',
+          sourceLayerId: 'areaForecastLocalE',
+          minZoom: param.regionLabelMinZoom,
+          layout: {
+            'text-field': ['get', 'name'],
+            'text-size': param.regionTextSize,
+            'text-font': ['Noto Sans CJK JP Bold'],
+            'text-allow-overlap': false,
+            'text-ignore-placement': false,
+          },
+          paint: {
+            'text-color': '#ffffff',
+            'text-halo-color': '#000000',
+            'text-halo-width': param.textHaloWidth,
+          },
+        ),
+      );
+    }
+
+    if (param.showCityLabel) {
+      await styleController.addLayer(
+        SymbolStyleLayer(
+          id: _cityLabelLayerId,
+          sourceId: 'eqmonitor_map',
+          sourceLayerId: 'areaInformationCityQuake',
+          minZoom: param.cityLabelMinZoom,
+          layout: {
+            'text-field': ['get', 'name'],
+            'text-size': param.cityTextSize,
+            'text-font': ['Noto Sans CJK JP Regular'],
+            'text-allow-overlap': false,
+            'text-ignore-placement': false,
+          },
+          paint: {
+            'text-color': '#ffffff',
+            'text-halo-color': '#000000',
+            'text-halo-width': param.textHaloWidth,
+          },
+        ),
+      );
+    }
+  }
+
+  static Future<void> _updateLayers({
+    required StyleController styleController,
+    required HomeMapLabelParameter param,
+  }) async {
+    for (final id in [_regionLabelLayerId, _cityLabelLayerId]) {
+      try {
+        await styleController.removeLayer(id);
+      } on Exception catch (_) {}
+    }
+    await _addLayers(styleController: styleController, param: param);
+  }
+}

--- a/app/lib/feature/home/ui/component/map/modal/home_map_label_debug_modal.dart
+++ b/app/lib/feature/home/ui/component/map/modal/home_map_label_debug_modal.dart
@@ -1,0 +1,159 @@
+import 'package:eqmonitor/feature/home/data/notifier/home_map_label_parameter_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class HomeMapLabelDebugModal extends ConsumerWidget {
+  const HomeMapLabelDebugModal._();
+
+  static Future<void> show({required BuildContext context}) =>
+      showModalBottomSheet(
+        context: context,
+        clipBehavior: Clip.antiAlias,
+        isScrollControlled: true,
+        builder: (context) => const HomeMapLabelDebugModal._(),
+      );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final param = ref.watch(homeMapLabelParameterProvider);
+    final notifier = ref.read(
+      homeMapLabelParameterProvider.notifier,
+    );
+
+    final theme = Theme.of(context);
+
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.6,
+      minChildSize: 0.3,
+      maxChildSize: 0.95,
+      builder: (context, scrollController) {
+        return switch (param) {
+          AsyncLoading() => const Center(
+            child: CircularProgressIndicator.adaptive(),
+          ),
+          AsyncError(:final error) => Center(child: Text('Error: $error')),
+          AsyncData(:final value) => ListView(
+            controller: scrollController,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            children: [
+              Center(
+                child: Container(
+                  margin: const EdgeInsets.symmetric(vertical: 8),
+                  width: 36,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(2),
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Row(
+                  children: [
+                    Text(
+                      'マップラベル (Debug)',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const Spacer(),
+                    TextButton(
+                      onPressed: notifier.reset,
+                      child: const Text('リセット'),
+                    ),
+                  ],
+                ),
+              ),
+
+              _header(theme, '表示切替'),
+              SwitchListTile(
+                title: const Text('地域ラベル (areaForecastLocalE)'),
+                value: value.showRegionLabel,
+                onChanged: (v) =>
+                    notifier.save(value.copyWith(showRegionLabel: v)),
+              ),
+              SwitchListTile(
+                title: const Text('市区町村ラベル (areaInformationCityQuake)'),
+                value: value.showCityLabel,
+                onChanged: (v) =>
+                    notifier.save(value.copyWith(showCityLabel: v)),
+              ),
+
+              _header(theme, 'ズーム閾値 (表示開始)'),
+              _slider('地域ラベル', value.regionLabelMinZoom, 1, 15, (v) =>
+                notifier.save(value.copyWith(regionLabelMinZoom: v))),
+              _slider('市区町村ラベル', value.cityLabelMinZoom, 1, 15, (v) =>
+                notifier.save(value.copyWith(cityLabelMinZoom: v))),
+
+              _header(theme, 'テキストサイズ'),
+              _slider('地域', value.regionTextSize, 6, 24, (v) =>
+                notifier.save(value.copyWith(regionTextSize: v))),
+              _slider('市区町村', value.cityTextSize, 6, 24, (v) =>
+                notifier.save(value.copyWith(cityTextSize: v))),
+
+              _header(theme, 'テキストスタイル'),
+              _slider('Halo幅', value.textHaloWidth, 0, 3, (v) =>
+                notifier.save(value.copyWith(textHaloWidth: v))),
+
+              SizedBox(height: MediaQuery.paddingOf(context).bottom),
+            ],
+          ),
+        };
+      },
+    );
+  }
+
+  Widget _header(ThemeData theme, String title) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16, bottom: 4),
+      child: Text(
+        title,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    ValueChanged<double> onChanged,
+  ) {
+    final divisions = max <= 3 ? 30 : 36;
+    final decimals = max <= 3 ? 1 : 1;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 100,
+            child: Text(label, style: const TextStyle(fontSize: 12)),
+          ),
+          Expanded(
+            child: Slider(
+              value: value.clamp(min, max),
+              min: min,
+              max: max,
+              divisions: divisions,
+              label: value.toStringAsFixed(decimals),
+              onChanged: onChanged,
+            ),
+          ),
+          SizedBox(
+            width: 40,
+            child: Text(
+              value.toStringAsFixed(decimals),
+              style: const TextStyle(fontSize: 12),
+              textAlign: TextAlign.end,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/map/data/provider/map_style_util.dart
+++ b/app/lib/feature/map/data/provider/map_style_util.dart
@@ -31,6 +31,7 @@ class MapStyleUtil {
     final json = {
       'version': 8,
       'name': 'EQMonitor Style',
+      'glyphs': 'https://glyphs.geolonia.com/{fontstack}/{range}.pbf',
       'sources': {
         'eqmonitor_map': {
           'type': 'vector',


### PR DESCRIPTION
## Summary
- メインマップにPMTilesの既存`name`プロパティを使った地域名・市区町村名のテキストラベルを表示
- MapLibreスタイルJSONに`glyphs` URL（Geolonia CJKフォント）を追加
- デバッグモードで表示ON/OFF・ズーム閾値・テキストサイズ・Halo幅をリアルタイム調整可能なボトムシート

## 変更内容
- `map_style_util.dart`: glyphs URL追加
- `HomeMapLabelParameter`: Freezedモデル + SharedPreferences永続化
- `HomeMapLabelLayer`: SymbolStyleLayerでラベル描画（HookConsumerWidget）
- `HomeMapLabelDebugModal`: パラメータ調整用ボトムシート
- `HomeMapControllerCard`: ラベルデバッグボタン（`Icons.label_rounded`）追加

## Test plan
- [ ] メインマップでズームイン時に地域名・市区町村名ラベルが表示されることを確認
- [ ] デバッグモードONでラベルアイコン（🏷）ボタンが表示されることを確認
- [ ] デバッグモーダルのスライダーでズーム閾値・テキストサイズが即時反映されることを確認
- [ ] 表示ON/OFFトグルでラベルが切り替わることを確認
- [ ] リセットボタンでデフォルト値に戻ることを確認
- [ ] アプリ再起動後にパラメータが永続化されていることを確認