### PR TITLE
feat(earthquake_history): 類似地震の表示機能を追加

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -10,6 +10,7 @@ import 'package:eqmonitor/feature/devices/ui/page/debug_device_settings_page.dar
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_details_page.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_page.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/similar_earthquake_page.dart';
 import 'package:eqmonitor/feature/earthquake_search/data/model/earthquake_search_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_page.dart';
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
@@ -203,6 +204,20 @@ class EarthquakeHistoryDetailsRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return EarthquakeHistoryDetailsPage(eventId: eventId);
+  }
+}
+
+@TypedGoRoute<SimilarEarthquakeRoute>(
+  path: '/earthquake-history-details/:eventId/similar',
+)
+class SimilarEarthquakeRoute extends GoRouteData with $SimilarEarthquakeRoute {
+  const SimilarEarthquakeRoute({required this.eventId});
+
+  final String eventId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return SimilarEarthquakePage(eventId: eventId);
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -15,6 +15,7 @@ List<RouteBase> get $appRoutes => [
   $earthquakeHistoryRoute,
   $earthquakeSearchResultRoute,
   $earthquakeHistoryDetailsRoute,
+  $similarEarthquakeRoute,
   $shakeDetectionHistoryRoute,
   $shakeDetectionHistoryDetailsRoute,
   $telegramListByEventIdRoute,
@@ -183,6 +184,36 @@ mixin $EarthquakeHistoryDetailsRoute on GoRouteData {
   @override
   String get location => GoRouteData.$location(
     '/earthquake-history-details/${Uri.encodeComponent(_self.eventId)}',
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $similarEarthquakeRoute => GoRouteData.$route(
+  path: '/earthquake-history-details/:eventId/similar',
+  factory: $SimilarEarthquakeRoute._fromState,
+);
+
+mixin $SimilarEarthquakeRoute on GoRouteData {
+  static SimilarEarthquakeRoute _fromState(GoRouterState state) =>
+      SimilarEarthquakeRoute(eventId: state.pathParameters['eventId']!);
+
+  SimilarEarthquakeRoute get _self => this as SimilarEarthquakeRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/earthquake-history-details/${Uri.encodeComponent(_self.eventId)}/similar',
   );
 
   @override

--- a/app/lib/feature/earthquake_history/data/model/similar_earthquake_group.dart
+++ b/app/lib/feature/earthquake_history/data/model/similar_earthquake_group.dart
@@ -1,0 +1,38 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/similarity_grade.dart';
+import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'similar_earthquake_group.freezed.dart';
+
+/// 類似地震グループ。
+///
+/// `representative`はグループ内で最大マグニチュードの代表地震、
+/// `groupedEarthquakes`は代表を除く同一グループの地震。
+/// `score`はグループ内の最小スコア(km相当の距離スコア、小さいほど類似)。
+@freezed
+abstract class SimilarEarthquakeGroup with _$SimilarEarthquakeGroup {
+  const factory SimilarEarthquakeGroup({
+    required EarthquakePartial representative,
+    required num score,
+    required List<EarthquakePartial> groupedEarthquakes,
+  }) = _SimilarEarthquakeGroup;
+
+  const SimilarEarthquakeGroup._();
+
+  /// `score`から導出した類似度グレード。
+  SimilarityGrade get grade => SimilarityGrade.fromScore(score);
+}
+
+extension SimilarEarthquakeItemApiExtension on api.SimilarEarthquakeItem {
+  SimilarEarthquakeGroup toSimilarEarthquakeGroup({
+    required EarthquakeParameter parameter,
+  }) => SimilarEarthquakeGroup(
+    representative: earthquake.toEarthquakePartial(parameter: parameter),
+    score: score,
+    groupedEarthquakes: groupedEarthquakes
+        .map((e) => e.toEarthquakePartial(parameter: parameter))
+        .toList(),
+  );
+}

--- a/app/lib/feature/earthquake_history/data/model/similar_earthquake_group.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/similar_earthquake_group.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'similar_earthquake_group.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$SimilarEarthquakeGroup {
+
+ EarthquakePartial get representative; num get score; List<EarthquakePartial> get groupedEarthquakes;
+/// Create a copy of SimilarEarthquakeGroup
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SimilarEarthquakeGroupCopyWith<SimilarEarthquakeGroup> get copyWith => _$SimilarEarthquakeGroupCopyWithImpl<SimilarEarthquakeGroup>(this as SimilarEarthquakeGroup, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SimilarEarthquakeGroup&&(identical(other.representative, representative) || other.representative == representative)&&(identical(other.score, score) || other.score == score)&&const DeepCollectionEquality().equals(other.groupedEarthquakes, groupedEarthquakes));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,representative,score,const DeepCollectionEquality().hash(groupedEarthquakes));
+
+@override
+String toString() {
+  return 'SimilarEarthquakeGroup(representative: $representative, score: $score, groupedEarthquakes: $groupedEarthquakes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SimilarEarthquakeGroupCopyWith<$Res>  {
+  factory $SimilarEarthquakeGroupCopyWith(SimilarEarthquakeGroup value, $Res Function(SimilarEarthquakeGroup) _then) = _$SimilarEarthquakeGroupCopyWithImpl;
+@useResult
+$Res call({
+ EarthquakePartial representative, num score, List<EarthquakePartial> groupedEarthquakes
+});
+
+
+$EarthquakePartialCopyWith<$Res> get representative;
+
+}
+/// @nodoc
+class _$SimilarEarthquakeGroupCopyWithImpl<$Res>
+    implements $SimilarEarthquakeGroupCopyWith<$Res> {
+  _$SimilarEarthquakeGroupCopyWithImpl(this._self, this._then);
+
+  final SimilarEarthquakeGroup _self;
+  final $Res Function(SimilarEarthquakeGroup) _then;
+
+/// Create a copy of SimilarEarthquakeGroup
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? representative = null,Object? score = null,Object? groupedEarthquakes = null,}) {
+  return _then(_self.copyWith(
+representative: null == representative ? _self.representative : representative // ignore: cast_nullable_to_non_nullable
+as EarthquakePartial,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as num,groupedEarthquakes: null == groupedEarthquakes ? _self.groupedEarthquakes : groupedEarthquakes // ignore: cast_nullable_to_non_nullable
+as List<EarthquakePartial>,
+  ));
+}
+/// Create a copy of SimilarEarthquakeGroup
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EarthquakePartialCopyWith<$Res> get representative {
+  
+  return $EarthquakePartialCopyWith<$Res>(_self.representative, (value) {
+    return _then(_self.copyWith(representative: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [SimilarEarthquakeGroup].
+extension SimilarEarthquakeGroupPatterns on SimilarEarthquakeGroup {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SimilarEarthquakeGroup value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SimilarEarthquakeGroup() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SimilarEarthquakeGroup value)  $default,){
+final _that = this;
+switch (_that) {
+case _SimilarEarthquakeGroup():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SimilarEarthquakeGroup value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SimilarEarthquakeGroup() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( EarthquakePartial representative,  num score,  List<EarthquakePartial> groupedEarthquakes)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SimilarEarthquakeGroup() when $default != null:
+return $default(_that.representative,_that.score,_that.groupedEarthquakes);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( EarthquakePartial representative,  num score,  List<EarthquakePartial> groupedEarthquakes)  $default,) {final _that = this;
+switch (_that) {
+case _SimilarEarthquakeGroup():
+return $default(_that.representative,_that.score,_that.groupedEarthquakes);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( EarthquakePartial representative,  num score,  List<EarthquakePartial> groupedEarthquakes)?  $default,) {final _that = this;
+switch (_that) {
+case _SimilarEarthquakeGroup() when $default != null:
+return $default(_that.representative,_that.score,_that.groupedEarthquakes);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _SimilarEarthquakeGroup extends SimilarEarthquakeGroup {
+  const _SimilarEarthquakeGroup({required this.representative, required this.score, required final  List<EarthquakePartial> groupedEarthquakes}): _groupedEarthquakes = groupedEarthquakes,super._();
+  
+
+@override final  EarthquakePartial representative;
+@override final  num score;
+ final  List<EarthquakePartial> _groupedEarthquakes;
+@override List<EarthquakePartial> get groupedEarthquakes {
+  if (_groupedEarthquakes is EqualUnmodifiableListView) return _groupedEarthquakes;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_groupedEarthquakes);
+}
+
+
+/// Create a copy of SimilarEarthquakeGroup
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SimilarEarthquakeGroupCopyWith<_SimilarEarthquakeGroup> get copyWith => __$SimilarEarthquakeGroupCopyWithImpl<_SimilarEarthquakeGroup>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SimilarEarthquakeGroup&&(identical(other.representative, representative) || other.representative == representative)&&(identical(other.score, score) || other.score == score)&&const DeepCollectionEquality().equals(other._groupedEarthquakes, _groupedEarthquakes));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,representative,score,const DeepCollectionEquality().hash(_groupedEarthquakes));
+
+@override
+String toString() {
+  return 'SimilarEarthquakeGroup(representative: $representative, score: $score, groupedEarthquakes: $groupedEarthquakes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SimilarEarthquakeGroupCopyWith<$Res> implements $SimilarEarthquakeGroupCopyWith<$Res> {
+  factory _$SimilarEarthquakeGroupCopyWith(_SimilarEarthquakeGroup value, $Res Function(_SimilarEarthquakeGroup) _then) = __$SimilarEarthquakeGroupCopyWithImpl;
+@override @useResult
+$Res call({
+ EarthquakePartial representative, num score, List<EarthquakePartial> groupedEarthquakes
+});
+
+
+@override $EarthquakePartialCopyWith<$Res> get representative;
+
+}
+/// @nodoc
+class __$SimilarEarthquakeGroupCopyWithImpl<$Res>
+    implements _$SimilarEarthquakeGroupCopyWith<$Res> {
+  __$SimilarEarthquakeGroupCopyWithImpl(this._self, this._then);
+
+  final _SimilarEarthquakeGroup _self;
+  final $Res Function(_SimilarEarthquakeGroup) _then;
+
+/// Create a copy of SimilarEarthquakeGroup
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? representative = null,Object? score = null,Object? groupedEarthquakes = null,}) {
+  return _then(_SimilarEarthquakeGroup(
+representative: null == representative ? _self.representative : representative // ignore: cast_nullable_to_non_nullable
+as EarthquakePartial,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as num,groupedEarthquakes: null == groupedEarthquakes ? _self._groupedEarthquakes : groupedEarthquakes // ignore: cast_nullable_to_non_nullable
+as List<EarthquakePartial>,
+  ));
+}
+
+/// Create a copy of SimilarEarthquakeGroup
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EarthquakePartialCopyWith<$Res> get representative {
+  
+  return $EarthquakePartialCopyWith<$Res>(_self.representative, (value) {
+    return _then(_self.copyWith(representative: value));
+  });
+}
+}
+
+// dart format on

--- a/app/lib/feature/earthquake_history/data/model/similarity_grade.dart
+++ b/app/lib/feature/earthquake_history/data/model/similarity_grade.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+/// 類似度グレード。
+///
+/// backendが返す`score`(km相当の距離スコア、小さいほど類似)を5段階に分類する。
+enum SimilarityGrade {
+  a,
+  b,
+  c,
+  d,
+  e;
+
+  /// `score`からグレードを導出する。
+  ///
+  /// 閾値: A:`<50` / B:`<100` / C:`<200` / D:`<350` / E:`それ以上`。
+  static SimilarityGrade fromScore(num score) {
+    if (score < 50) {
+      return SimilarityGrade.a;
+    }
+    if (score < 100) {
+      return SimilarityGrade.b;
+    }
+    if (score < 200) {
+      return SimilarityGrade.c;
+    }
+    if (score < 350) {
+      return SimilarityGrade.d;
+    }
+    return SimilarityGrade.e;
+  }
+
+  /// 5セルゲージで点灯するセル数(類似度が高いほど多い)。
+  int get litCells => switch (this) {
+    SimilarityGrade.a => 5,
+    SimilarityGrade.b => 4,
+    SimilarityGrade.c => 3,
+    SimilarityGrade.d => 2,
+    SimilarityGrade.e => 1,
+  };
+
+  String get label => switch (this) {
+    SimilarityGrade.a => 'A',
+    SimilarityGrade.b => 'B',
+    SimilarityGrade.c => 'C',
+    SimilarityGrade.d => 'D',
+    SimilarityGrade.e => 'E',
+  };
+
+  /// グレード色(A:緑 → E:赤)。
+  Color get color => switch (this) {
+    SimilarityGrade.a => const Color(0xFF2E7D32),
+    SimilarityGrade.b => const Color(0xFF689F38),
+    SimilarityGrade.c => const Color(0xFFF9A825),
+    SimilarityGrade.d => const Color(0xFFEF6C00),
+    SimilarityGrade.e => const Color(0xFFC62828),
+  };
+}

--- a/app/lib/feature/earthquake_history/data/notifier/similar_earthquakes_notifier.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/similar_earthquakes_notifier.dart
@@ -1,0 +1,16 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/similar_earthquake_group.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'similar_earthquakes_notifier.g.dart';
+
+@riverpod
+Future<List<SimilarEarthquakeGroup>> similarEarthquakes(
+  Ref ref,
+  String eventId,
+) async {
+  final repository = await ref.watch(
+    earthquakeHistoryRepositoryProvider.future,
+  );
+  return repository.fetchSimilarEarthquakes(eventId: eventId);
+}

--- a/app/lib/feature/earthquake_history/data/notifier/similar_earthquakes_notifier.g.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/similar_earthquakes_notifier.g.dart
@@ -1,0 +1,94 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'similar_earthquakes_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(similarEarthquakes)
+final similarEarthquakesProvider = SimilarEarthquakesFamily._();
+
+final class SimilarEarthquakesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<SimilarEarthquakeGroup>>,
+          List<SimilarEarthquakeGroup>,
+          FutureOr<List<SimilarEarthquakeGroup>>
+        >
+    with
+        $FutureModifier<List<SimilarEarthquakeGroup>>,
+        $FutureProvider<List<SimilarEarthquakeGroup>> {
+  SimilarEarthquakesProvider._({
+    required SimilarEarthquakesFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'similarEarthquakesProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$similarEarthquakesHash();
+
+  @override
+  String toString() {
+    return r'similarEarthquakesProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<SimilarEarthquakeGroup>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<SimilarEarthquakeGroup>> create(Ref ref) {
+    final argument = this.argument as String;
+    return similarEarthquakes(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is SimilarEarthquakesProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$similarEarthquakesHash() =>
+    r'67ecad9ccbbdad4df4e4063f21422d620ded90a2';
+
+final class SimilarEarthquakesFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<List<SimilarEarthquakeGroup>>,
+          String
+        > {
+  SimilarEarthquakesFamily._()
+    : super(
+        retry: null,
+        name: r'similarEarthquakesProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  SimilarEarthquakesProvider call(String eventId) =>
+      SimilarEarthquakesProvider._(argument: eventId, from: this);
+
+  @override
+  String toString() => r'similarEarthquakesProvider';
+}

--- a/app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart
+++ b/app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart
@@ -9,6 +9,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_list_
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_search_response.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/lpgm_intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/similar_earthquake_group.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -139,6 +140,17 @@ class EarthquakeHistoryRepository {
     return response.data.earthquake.toEarthquake(
       parameter: earthquakeParameter,
     );
+  }
+
+  Future<List<SimilarEarthquakeGroup>> fetchSimilarEarthquakes({
+    required String eventId,
+  }) async {
+    final response = await _api.earthquake.getV2EarthquakeEventIdSimilar(
+      eventId: eventId,
+    );
+    return response.data.items
+        .map((e) => e.toSimilarEarthquakeGroup(parameter: earthquakeParameter))
+        .toList();
   }
 
   Future<PaginatedSearchResponse<IntensityAreaSearchItem>> searchByRegion({

--- a/app/lib/feature/earthquake_history/ui/components/similar_earthquake_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/similar_earthquake_card.dart
@@ -1,0 +1,89 @@
+import 'package:eqmonitor/core/component/container/bordered_container.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/similar_earthquakes_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/similar_earthquake_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 詳細画面に表示する「類似地震」Card。
+///
+/// 上位3グループの代表地震を表示し、3件を超える場合は「もっと見る」で
+/// 全画面([SimilarEarthquakeRoute])に遷移する。類似地震が無い場合・取得に
+/// 失敗した場合は非表示にする(詳細画面の主機能を阻害しないため)。
+class SimilarEarthquakeCard extends ConsumerWidget {
+  const SimilarEarthquakeCard({required this.eventId, super.key});
+
+  final String eventId;
+
+  static const _previewCount = 3;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(similarEarthquakesProvider(eventId));
+    final theme = Theme.of(context);
+
+    return state.when(
+      loading: () => BorderedContainer(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _Header(theme: theme),
+            const SizedBox(height: 12),
+            const Center(child: CircularProgressIndicator.adaptive()),
+            const SizedBox(height: 12),
+          ],
+        ),
+      ),
+      error: (_, _) => const SizedBox.shrink(),
+      data: (groups) {
+        if (groups.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        final preview = groups.take(_previewCount).toList();
+        return BorderedContainer(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _Header(theme: theme),
+              const SizedBox(height: 4),
+              for (final group in preview)
+                SimilarEarthquakeTile(
+                  earthquake: group.representative,
+                  grade: group.grade,
+                  dense: true,
+                ),
+              if (groups.length > _previewCount)
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: () => SimilarEarthquakeRoute(
+                      eventId: eventId,
+                    ).push<void>(context),
+                    icon: const Icon(Icons.chevron_right),
+                    label: const Text('もっと見る'),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 4),
+    child: Text(
+      '類似地震',
+      style: theme.textTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+  );
+}

--- a/app/lib/feature/earthquake_history/ui/components/similar_earthquake_gauge.dart
+++ b/app/lib/feature/earthquake_history/ui/components/similar_earthquake_gauge.dart
@@ -1,0 +1,73 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/similarity_grade.dart';
+import 'package:flutter/material.dart';
+
+/// 類似度を5セルのゲージ + グレード文字で表示する。
+///
+/// 類似度が高い(グレードA)ほど多くのセルが点灯する。
+class SimilarEarthquakeGauge extends StatelessWidget {
+  const SimilarEarthquakeGauge({required this.grade, super.key});
+
+  final SimilarityGrade grade;
+
+  static const _cellCount = 5;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '類似度',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(width: 6),
+        for (var i = 0; i < _cellCount; i++)
+          SimilarityGaugeCell(
+            key: ValueKey('gauge-cell-$i'),
+            lit: i < grade.litCells,
+            color: grade.color,
+          ),
+        const SizedBox(width: 6),
+        Text(
+          grade.label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: grade.color,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// ゲージの1セル。点灯時は[color]、消灯時は薄いグレーで塗る。
+@visibleForTesting
+class SimilarityGaugeCell extends StatelessWidget {
+  const SimilarityGaugeCell({
+    required this.lit,
+    required this.color,
+    super.key,
+  });
+
+  final bool lit;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final unlitColor = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: 0.12);
+    return Container(
+      width: 10,
+      height: 14,
+      margin: const EdgeInsets.symmetric(horizontal: 1),
+      decoration: BoxDecoration(
+        color: lit ? color : unlitColor,
+        borderRadius: BorderRadius.circular(3),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/similar_earthquake_tile.dart
+++ b/app/lib/feature/earthquake_history/ui/components/similar_earthquake_tile.dart
@@ -1,0 +1,49 @@
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/similarity_grade.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/similar_earthquake_gauge.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 類似地震の1件を表示するタイル。
+///
+/// 既存の[EarthquakeHistoryListTile]を再利用し、`grade`が指定されていれば
+/// 類似度ゲージを併記する。タップでその地震の詳細画面に遷移する。
+class SimilarEarthquakeTile extends ConsumerWidget {
+  const SimilarEarthquakeTile({
+    required this.earthquake,
+    this.grade,
+    this.dense = false,
+    super.key,
+  });
+
+  final EarthquakePartial earthquake;
+  final SimilarityGrade? grade;
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final intensityColor = ref.watch(intensityColorProvider);
+    final grade = this.grade;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        EarthquakeHistoryListTile(
+          item: earthquake,
+          intensityColor: intensityColor,
+          dense: dense,
+          onTap: () => EarthquakeHistoryDetailsRoute(
+            eventId: earthquake.eventId,
+          ).push<void>(context),
+        ),
+        if (grade != null)
+          Padding(
+            padding: const EdgeInsets.only(left: 16, bottom: 8),
+            child: SimilarEarthquakeGauge(grade: grade),
+          ),
+      ],
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -10,6 +10,7 @@ import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_hi
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_intensity_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_lpgm_intensity_card.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/similar_earthquake_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -72,9 +73,7 @@ class _LoadedContent extends HookWidget {
     final hasLpgm = earthquake.intensity?.maxLpgmIntensity != null;
 
     final displayMode = useState(
-      hasEstimated
-          ? IntensityDisplayMode.estimated
-          : IntensityDisplayMode.jma,
+      hasEstimated ? IntensityDisplayMode.estimated : IntensityDisplayMode.jma,
     );
 
     final availableModes = [
@@ -116,6 +115,7 @@ class _LoadedContent extends HookWidget {
                               const Duration(hours: 24))
                         const AdBanner(),
                       _TelegramListButton(eventId: earthquake.eventId),
+                      SimilarEarthquakeCard(eventId: earthquake.eventId),
                     ],
                   ),
                 ),

--- a/app/lib/feature/earthquake_history/ui/similar_earthquake_page.dart
+++ b/app/lib/feature/earthquake_history/ui/similar_earthquake_page.dart
@@ -1,0 +1,107 @@
+import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/similar_earthquake_group.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/similar_earthquakes_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/similar_earthquake_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 類似地震の全画面一覧。
+///
+/// 全代表地震を一覧し、各行のtoggleで同一グループの他の地震を展開する。
+class SimilarEarthquakePage extends ConsumerWidget {
+  const SimilarEarthquakePage({required this.eventId, super.key});
+
+  final String eventId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(similarEarthquakesProvider(eventId));
+    return Scaffold(
+      appBar: AppBar(title: const Text('類似地震')),
+      body: state.when(
+        loading: () =>
+            const Center(child: CircularProgressIndicator.adaptive()),
+        error: (error, _) => ErrorCard(
+          error: error,
+          onReload: () async =>
+              ref.refresh(similarEarthquakesProvider(eventId)),
+        ),
+        data: (groups) {
+          if (groups.isEmpty) {
+            return const Center(child: Text('類似地震は見つかりませんでした'));
+          }
+          return ListView.builder(
+            itemCount: groups.length,
+            itemBuilder: (context, index) =>
+                _SimilarEarthquakeGroupTile(group: groups[index]),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SimilarEarthquakeGroupTile extends HookConsumerWidget {
+  const _SimilarEarthquakeGroupTile({required this.group});
+
+  final SimilarEarthquakeGroup group;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final expanded = useState(false);
+    final hasChildren = group.groupedEarthquakes.isNotEmpty;
+    final intensityColor = ref.watch(intensityColorProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: SimilarEarthquakeTile(
+                earthquake: group.representative,
+                grade: group.grade,
+              ),
+            ),
+            if (hasChildren)
+              IconButton(
+                onPressed: () => expanded.value = !expanded.value,
+                icon: AnimatedRotation(
+                  turns: expanded.value ? 0.5 : 0,
+                  duration: const Duration(milliseconds: 200),
+                  child: const Icon(Icons.expand_more),
+                ),
+              ),
+          ],
+        ),
+        AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          alignment: Alignment.topCenter,
+          child: (expanded.value && hasChildren)
+              ? Padding(
+                  padding: const EdgeInsets.only(left: 16),
+                  child: Column(
+                    children: [
+                      for (final child in group.groupedEarthquakes)
+                        EarthquakeHistoryListTile(
+                          item: child,
+                          intensityColor: intensityColor,
+                          dense: true,
+                          onTap: () => EarthquakeHistoryDetailsRoute(
+                            eventId: child.eventId,
+                          ).push<void>(context),
+                        ),
+                    ],
+                  ),
+                )
+              : const SizedBox.shrink(),
+        ),
+        const Divider(height: 1),
+      ],
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/similar_earthquake_page.dart
+++ b/app/lib/feature/earthquake_history/ui/similar_earthquake_page.dart
@@ -12,7 +12,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// 類似地震の全画面一覧。
 ///
 /// 全代表地震を一覧し、各行のtoggleで同一グループの他の地震を展開する。
-class SimilarEarthquakePage extends ConsumerWidget {
+/// 展開状態は[ListView.builder]のitemリサイクルで失われないよう、ページ側で
+/// 代表地震のeventId集合として保持する。
+class SimilarEarthquakePage extends HookConsumerWidget {
   const SimilarEarthquakePage({required this.eventId, super.key});
 
   final String eventId;
@@ -20,6 +22,7 @@ class SimilarEarthquakePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(similarEarthquakesProvider(eventId));
+    final expandedIds = useState(<String>{});
     return Scaffold(
       appBar: AppBar(title: const Text('類似地震')),
       body: state.when(
@@ -36,8 +39,21 @@ class SimilarEarthquakePage extends ConsumerWidget {
           }
           return ListView.builder(
             itemCount: groups.length,
-            itemBuilder: (context, index) =>
-                _SimilarEarthquakeGroupTile(group: groups[index]),
+            itemBuilder: (context, index) {
+              final group = groups[index];
+              final id = group.representative.eventId;
+              return _SimilarEarthquakeGroupTile(
+                group: group,
+                expanded: expandedIds.value.contains(id),
+                onToggle: () {
+                  final next = Set<String>.from(expandedIds.value);
+                  if (!next.add(id)) {
+                    next.remove(id);
+                  }
+                  expandedIds.value = next;
+                },
+              );
+            },
           );
         },
       ),
@@ -45,14 +61,19 @@ class SimilarEarthquakePage extends ConsumerWidget {
   }
 }
 
-class _SimilarEarthquakeGroupTile extends HookConsumerWidget {
-  const _SimilarEarthquakeGroupTile({required this.group});
+class _SimilarEarthquakeGroupTile extends ConsumerWidget {
+  const _SimilarEarthquakeGroupTile({
+    required this.group,
+    required this.expanded,
+    required this.onToggle,
+  });
 
   final SimilarEarthquakeGroup group;
+  final bool expanded;
+  final VoidCallback onToggle;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final expanded = useState(false);
     final hasChildren = group.groupedEarthquakes.isNotEmpty;
     final intensityColor = ref.watch(intensityColorProvider);
 
@@ -69,9 +90,9 @@ class _SimilarEarthquakeGroupTile extends HookConsumerWidget {
             ),
             if (hasChildren)
               IconButton(
-                onPressed: () => expanded.value = !expanded.value,
+                onPressed: onToggle,
                 icon: AnimatedRotation(
-                  turns: expanded.value ? 0.5 : 0,
+                  turns: expanded ? 0.5 : 0,
                   duration: const Duration(milliseconds: 200),
                   child: const Icon(Icons.expand_more),
                 ),
@@ -81,7 +102,7 @@ class _SimilarEarthquakeGroupTile extends HookConsumerWidget {
         AnimatedSize(
           duration: const Duration(milliseconds: 200),
           alignment: Alignment.topCenter,
-          child: (expanded.value && hasChildren)
+          child: (expanded && hasChildren)
               ? Padding(
                   padding: const EdgeInsets.only(left: 16),
                   child: Column(

--- a/app/test/feature/earthquake_history/similar_earthquake_gauge_test.dart
+++ b/app/test/feature/earthquake_history/similar_earthquake_gauge_test.dart
@@ -1,0 +1,46 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/similarity_grade.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/similar_earthquake_gauge.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+int _litCount(WidgetTester tester) => tester
+    .widgetList<SimilarityGaugeCell>(find.byType(SimilarityGaugeCell))
+    .where((cell) => cell.lit)
+    .length;
+
+void main() {
+  testWidgets('グレードCは3セル点灯', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SimilarEarthquakeGauge(grade: SimilarityGrade.c),
+        ),
+      ),
+    );
+    expect(find.byType(SimilarityGaugeCell), findsNWidgets(5));
+    expect(_litCount(tester), 3);
+    expect(find.text('C'), findsOneWidget);
+  });
+
+  testWidgets('グレードAは5セル全点灯', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SimilarEarthquakeGauge(grade: SimilarityGrade.a),
+        ),
+      ),
+    );
+    expect(_litCount(tester), 5);
+  });
+
+  testWidgets('グレードEは1セル点灯', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SimilarEarthquakeGauge(grade: SimilarityGrade.e),
+        ),
+      ),
+    );
+    expect(_litCount(tester), 1);
+  });
+}

--- a/app/test/feature/earthquake_history/similar_earthquake_group_test.dart
+++ b/app/test/feature/earthquake_history/similar_earthquake_group_test.dart
@@ -1,0 +1,40 @@
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/similar_earthquake_group.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/similarity_grade.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+EarthquakePartial _dummyPartial(String eventId) => EarthquakePartial(
+  eventId: eventId,
+  status: TelegramStatus.normal,
+  originTime: null,
+  originTimePrecision: OriginTimePrecision.minute,
+  arrivalTime: null,
+  dataSource: EarthquakeDataSource.jmaIntensityDatabase,
+  hypocenter: null,
+  intensity: null,
+  earthquakeType: EarthquakeType.normal,
+  telegramTypes: const [],
+  estimatedIntensityTileUrl: null,
+);
+
+void main() {
+  test('grade は score から導出される', () {
+    final groupA = SimilarEarthquakeGroup(
+      representative: _dummyPartial('20260101000000'),
+      score: 30,
+      groupedEarthquakes: const [],
+    );
+    expect(groupA.grade, SimilarityGrade.a);
+
+    final groupD = SimilarEarthquakeGroup(
+      representative: _dummyPartial('20260101000001'),
+      score: 300,
+      groupedEarthquakes: const [],
+    );
+    expect(groupD.grade, SimilarityGrade.d);
+  });
+}

--- a/app/test/feature/earthquake_history/similarity_grade_test.dart
+++ b/app/test/feature/earthquake_history/similarity_grade_test.dart
@@ -1,0 +1,36 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/similarity_grade.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SimilarityGrade.fromScore', () {
+    test('境界値でグレードが切り替わる', () {
+      expect(SimilarityGrade.fromScore(0), SimilarityGrade.a);
+      expect(SimilarityGrade.fromScore(49.9), SimilarityGrade.a);
+      expect(SimilarityGrade.fromScore(50), SimilarityGrade.b);
+      expect(SimilarityGrade.fromScore(99.9), SimilarityGrade.b);
+      expect(SimilarityGrade.fromScore(100), SimilarityGrade.c);
+      expect(SimilarityGrade.fromScore(199.9), SimilarityGrade.c);
+      expect(SimilarityGrade.fromScore(200), SimilarityGrade.d);
+      expect(SimilarityGrade.fromScore(349.9), SimilarityGrade.d);
+      expect(SimilarityGrade.fromScore(350), SimilarityGrade.e);
+      expect(SimilarityGrade.fromScore(500), SimilarityGrade.e);
+      expect(SimilarityGrade.fromScore(9999), SimilarityGrade.e);
+    });
+
+    test('litCells が A=5..E=1', () {
+      expect(SimilarityGrade.a.litCells, 5);
+      expect(SimilarityGrade.b.litCells, 4);
+      expect(SimilarityGrade.c.litCells, 3);
+      expect(SimilarityGrade.d.litCells, 2);
+      expect(SimilarityGrade.e.litCells, 1);
+    });
+
+    test('label が A..E', () {
+      expect(SimilarityGrade.a.label, 'A');
+      expect(SimilarityGrade.b.label, 'B');
+      expect(SimilarityGrade.c.label, 'C');
+      expect(SimilarityGrade.d.label, 'D');
+      expect(SimilarityGrade.e.label, 'E');
+    });
+  });
+}

--- a/docs/superpowers/plans/2026-06-27-similar-earthquakes-ui.md
+++ b/docs/superpowers/plans/2026-06-27-similar-earthquakes-ui.md
@@ -1,0 +1,47 @@
+# 類似地震 UI 機能 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 地震履歴詳細画面に「類似地震」Card と全画面一覧を追加し、類似度を A→E グレード + 5セルゲージで表示する。
+
+**Architecture:** 既存の `earthquake_history` feature に従い、API レスポンス(`SimilarEarthquakeResponse`)を app モデル(`SimilarEarthquakeGroup`)へ拡張変換 → Repository メソッド → Riverpod FutureProvider(family) → UI(Card / 全画面 Page)。タイルは既存 `EarthquakeHistoryListTile` を再利用。
+
+**Tech Stack:** Flutter, Riverpod (codegen), Freezed, go_router (TypedGoRoute), flutter_hooks。
+
+## Global Constraints
+
+- Dart: `melos run analyze` が警告ゼロで通ること。
+- Formatting: `dart format`。
+- Imports: cross-package は package import。
+- Generated files (`*.g.dart`, `*.freezed.dart`) はコミットする。注釈追加後に `melos run generate`。
+- グレード閾値: A:`score < 50` / B:`50 ≤ score < 100` / C:`100 ≤ score < 200` / D:`200 ≤ score < 350` / E:`350 ≤ score`（500超も E）。
+- ゲージ点灯セル数: A=5, B=4, C=3, D=2, E=1。点灯=グレード色、消灯=薄グレー。
+- 空/エラー時は Card 非表示（`SizedBox.shrink()`）。
+
+---
+
+### Task 1: SimilarityGrade（グレード分類ロジック）
+- score → A〜E、litCells(5..1)、label、color を持つ enum。境界値ユニットテスト。
+
+### Task 2: SimilarEarthquakeGroup モデル + 変換拡張
+- `{representative, score, groupedEarthquakes}` freezed + `grade` getter + `api.SimilarEarthquakeItem.toSimilarEarthquakeGroup`。
+
+### Task 3: Repository メソッド + Provider
+- `fetchSimilarEarthquakes(eventId)` + `similarEarthquakesProvider(eventId)` (FutureProvider family, codegen)。
+
+### Task 4: SimilarEarthquakeGauge widget
+- 5セル + グレード文字。点灯/消灯セルに Key を付与し widget テスト。
+
+### Task 5: SimilarEarthquakeTile widget
+- 既存 `EarthquakeHistoryListTile` 再利用 + ゲージ併記。タップで詳細遷移。
+
+### Task 6: SimilarEarthquakeCard widget
+- 上位3件表示、3件超で「もっと見る」→ 全画面。空/エラーは非表示。
+
+### Task 7: SimilarEarthquakePage（全画面 + toggle展開）
+- 全グループ一覧、代表行に toggle、配下に groupedEarthquakes。子0件は toggle 非表示。
+
+### Task 8: ルート追加 + 詳細画面に Card 配置 + 全体生成/検証
+- `SimilarEarthquakeRoute`(path: `/earthquake-history-details/:eventId/similar`) + Column 末尾に Card + codegen + analyze + test。
+
+詳細な手順・コードは設計書(`docs/superpowers/specs/2026-06-27-similar-earthquakes-ui-design.md`)とコミット履歴に従う。

--- a/docs/superpowers/specs/2026-06-27-similar-earthquakes-ui-design.md
+++ b/docs/superpowers/specs/2026-06-27-similar-earthquakes-ui-design.md
@@ -1,0 +1,191 @@
+# 類似地震 UI 機能 設計書
+
+作成日: 2026-06-27
+対象: Flutter アプリ (`app/`) — 地震履歴詳細画面
+
+## 1. 概要
+
+地震履歴詳細画面の Sheet 末尾に「類似地震」Card を追加する。Card には類似地震グループの上位3件（代表地震）を表示し、「もっと見る」ボタンで全画面に遷移して全代表地震を一覧する。全画面では各代表地震を toggle で展開し、同一グループ内の他の地震（`groupedEarthquakes`）を表示する。
+
+類似度は backend が返す `score`（km 相当の距離スコア、小さいほど類似、500 超は除外）を **A→E の5段階グレード**に分類し、**5セルのゲージ**で視覚表示する。
+
+## 2. 前提（既存実装の調査結果）
+
+### API（実装済み）
+- エンドポイント: `GET /v2/earthquake/{eventId}/similar`
+- Dart クライアント: `packages/eqmonitor_api` の `EarthquakeApiClient.getV2EarthquakeEventIdSimilar({eventId})`
+- レスポンス型:
+  ```dart
+  SimilarEarthquakeResponse { List<SimilarEarthquakeItem> items }
+  SimilarEarthquakeItem {
+    EarthquakePartial earthquake;        // 代表地震（グループ内で最大マグニチュード）
+    num score;                            // km 相当の距離スコア（小さいほど類似、グループ内最小スコア）
+    List<EarthquakePartial> groupedEarthquakes;  // グループ内の他の地震（代表を除く）
+  }
+  ```
+- backend はスコア順（昇順）にソート済み、最大50グループを返却。
+
+### app 側の既存資産（再利用する）
+- `api.EarthquakePartial.toEarthquakePartial({parameter})` 拡張で app の `EarthquakePartial` に変換可能
+  (`app/lib/feature/earthquake_history/data/model/earthquake_partial.dart`)
+- `EarthquakeHistoryListTile`（`app/lib/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart`）が app `EarthquakePartial` を描画（日時・マグニチュード・最大震度・震源地）
+- Repository: `earthquake_history_repository.dart`（`EarthquakeParameter` を保持し変換に渡す）
+- Provider: `@riverpod` codegen + `earthquakeHistoryRepositoryProvider`
+- ルーティング: `go_router` + `TypedGoRoute`。遷移は `EarthquakeHistoryDetailsRoute(eventId:).push(context)`
+- Card 共通スタイル: `BorderedContainer`（`app/lib/core/component/container/bordered_container.dart`）
+- 詳細画面: `earthquake_history_details_page.dart` の Sheet 内 `Column` に Card 群が並ぶ
+
+## 3. 仕様決定事項（ユーザー確認済み）
+
+| 項目 | 決定 |
+|------|------|
+| タイルのタップ挙動 | その地震の詳細画面へ遷移（`EarthquakeHistoryDetailsRoute(eventId:).push`） |
+| タイル表示内容 | 既存 `EarthquakeHistoryListTile` を再利用 + 類似度（A→E グレード + ゲージ）を併記 |
+| 全画面の展開 | 代表行に toggle、配下に `groupedEarthquakes` を展開。子地震0件なら toggle 非表示 |
+| データ取得 | Riverpod FutureProvider (family by eventId) を Card が watch して取得 |
+| Card の件数 | 上位3グループの代表地震のみ（Card 内では toggle なし） |
+| 類似度の表現 | score を A→E の5段階に分類し、5セルゲージで表示 |
+
+### グレード分類（score → グレード）
+| グレード | score 範囲 | ゲージ点灯セル |
+|---------|-----------|--------------|
+| A | 0 〜 50 | ■■■■■ (5) |
+| B | 50 〜 100 | ■■■■□ (4) |
+| C | 100 〜 200 | ■■■□□ (3) |
+| D | 200 〜 350 | ■■□□□ (2) |
+| E | 350 〜 500 | ■□□□□ (1) |
+
+- 境界は下側包含（`score < 50` → A、`50 <= score < 100` → B …、`350 <= score <= 500` → E）。
+- score が 500 を超えるデータは backend が除外済みのため通常届かないが、届いた場合は E 扱い（防御的）。
+
+### ゲージ表現
+- 5個の小さい角丸チップを横並び。
+- 点灯セル = グレード色、消灯セル = 薄いグレー。
+- 「類似度が高いほど多く点灯」（A=5、E=1）。
+- グレード文字（A〜E）も併記。
+- グレード色: A→E で緑→赤系のグラデーション（A:緑, B:黄緑, C:黄, D:橙, E:赤/グレー）。具体色は `Theme` / 既存カラーパレットに合わせて実装時に確定。
+
+## 4. アーキテクチャ
+
+### 4.1 データ層
+
+**新規モデル** `SimilarEarthquakeGroup`
+（`app/lib/feature/earthquake_history/data/model/similar_earthquake_group.dart`）
+```dart
+@freezed
+class SimilarEarthquakeGroup with _$SimilarEarthquakeGroup {
+  const factory SimilarEarthquakeGroup({
+    required EarthquakePartial representative,   // app の EarthquakePartial
+    required num score,
+    required List<EarthquakePartial> groupedEarthquakes,
+  }) = _SimilarEarthquakeGroup;
+}
+```
+
+**グレード分類** `SimilarityGrade`（enum A〜E）と分類ロジック
+- `SimilarityGrade` enum（`a, b, c, d, e`）に `litCells`（点灯セル数 1〜5）と表示文字を持たせる。
+- `SimilarityGrade.fromScore(num score)` で score → グレードに変換。
+- モデル or 専用ファイル（例: `similarity_grade.dart`）に配置。`SimilarEarthquakeGroup.grade` getter で `SimilarityGrade.fromScore(score)` を返す。
+
+**変換拡張**
+```dart
+extension SimilarEarthquakeItemApiExtension on api.SimilarEarthquakeItem {
+  SimilarEarthquakeGroup toSimilarEarthquakeGroup({required EarthquakeParameter parameter}) =>
+    SimilarEarthquakeGroup(
+      representative: earthquake.toEarthquakePartial(parameter: parameter),
+      score: score,
+      groupedEarthquakes: groupedEarthquakes
+          .map((e) => e.toEarthquakePartial(parameter: parameter))
+          .toList(),
+    );
+}
+```
+
+**Repository 追加** （`earthquake_history_repository.dart`）
+```dart
+Future<List<SimilarEarthquakeGroup>> fetchSimilarEarthquakes({required String eventId}) async {
+  final response = await _api.earthquake.getV2EarthquakeEventIdSimilar(eventId: eventId);
+  return response.data.items
+      .map((e) => e.toSimilarEarthquakeGroup(parameter: earthquakeParameter))
+      .toList();
+}
+```
+
+**Provider 追加** （`@riverpod` codegen）
+- `similar_earthquakes_notifier.dart` に `similarEarthquakesProvider(eventId)` (FutureProvider family, autoDispose)。
+- `build` 内で repository を watch して `fetchSimilarEarthquakes(eventId:)` を返す。
+
+### 4.2 UI 層
+
+**`SimilarEarthquakeGauge`**（`.../ui/components/similar_earthquake_gauge.dart`）
+- 入力: `SimilarityGrade grade`
+- 5セルの角丸チップ + グレード文字を描画する純粋な表示 widget。
+
+**`SimilarEarthquakeTile`**（`.../ui/components/similar_earthquake_tile.dart`）
+- 入力: `SimilarEarthquakeGroup group`（または `EarthquakePartial` + `SimilarityGrade`）
+- 既存 `EarthquakeHistoryListTile` を再利用しつつ `SimilarEarthquakeGauge` を併記。
+- タップで `EarthquakeHistoryDetailsRoute(eventId: representative.eventId).push(context)`。
+- レイアウト上、既存タイルにゲージを足す（trailing / サブ行）。既存タイルが行を専有する場合は最小限のラップで対応。
+
+**`SimilarEarthquakeCard`**（`.../ui/components/similar_earthquake_card.dart`）
+- `similarEarthquakesProvider(eventId)` を watch。
+- 状態別:
+  - loading → `BorderedContainer` 内にローディング表示（ヘッダ「類似地震」+ プレースホルダ）
+  - error → 非表示（`SizedBox.shrink()`）
+  - data 空 → 非表示（`SizedBox.shrink()`）
+  - data あり → ヘッダ「類似地震」+ 上位3グループの `SimilarEarthquakeTile`（toggle なし）+ グループが3件超なら「もっと見る」ボタン
+- 詳細画面の `Column` に追加（電文一覧ボタンの後・AdBanner との順序は実装時に既存並びに合わせて調整。基本は最下部付近）。
+
+**`SimilarEarthquakePage`（全画面）**（`.../ui/similar_earthquake_page.dart`）
+- 入力: `eventId`
+- `similarEarthquakesProvider(eventId)` を watch（Card と同じ provider を共有）。
+- 全代表地震を `ListView` で一覧。各行は `SimilarEarthquakeTile` + 展開 toggle。
+  - toggle 状態は `useState`（hooks）で各グループごとに管理。`AnimatedSize` で開閉アニメーション。
+  - 展開時、配下に `groupedEarthquakes` を子タイル（インデント付き）で表示。各子タイルもタップで詳細へ遷移。
+  - `groupedEarthquakes` が空のグループは toggle アイコンを表示しない。
+- AppBar タイトル「類似地震」。
+
+**ルーティング追加** （`app/lib/core/router/router.dart`）
+```dart
+@TypedGoRoute<SimilarEarthquakeRoute>(
+  path: '/earthquake-history-details/:eventId/similar',
+)
+class SimilarEarthquakeRoute extends GoRouteData with $SimilarEarthquakeRoute {
+  const SimilarEarthquakeRoute({required this.eventId});
+  final String eventId;
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      SimilarEarthquakePage(eventId: eventId);
+}
+```
+「もっと見る」から `SimilarEarthquakeRoute(eventId: eventId).push(context)`。
+
+### 4.3 データフロー
+```
+詳細画面 build
+  → SimilarEarthquakeCard が similarEarthquakesProvider(eventId) を watch
+    → Repository.fetchSimilarEarthquakes(eventId)
+      → EarthquakeApiClient.getV2EarthquakeEventIdSimilar
+        → api.SimilarEarthquakeResponse
+          → toSimilarEarthquakeGroup 変換（app モデル）
+  → Card: 上位3件を SimilarEarthquakeTile で描画
+  → 「もっと見る」→ SimilarEarthquakeRoute.push
+    → SimilarEarthquakePage（同 provider をキャッシュ共有）で全件 + toggle 展開
+```
+
+## 5. エッジケース
+- 類似地震 0 件 → Card 自体を非表示（`SizedBox.shrink()`）。
+- API エラー → Card 非表示（詳細画面の主機能を阻害しない）。全画面では遷移経路が「もっと見る」のみのため、データありの状態からのみ到達する。
+- 代表地震の `groupedEarthquakes` が空 → 全画面で toggle アイコン非表示、行はタップで詳細遷移のみ。
+- score が 500 超（防御的）→ E 扱い。
+- 元地震に座標/深さ/マグニチュードが無い → backend が空配列を返す → Card 非表示。
+
+## 6. テスト方針
+- `SimilarityGrade.fromScore` の境界値テスト（0, 49.9, 50, 100, 200, 350, 500, 500超）。Dart ユニットテスト。
+- `toSimilarEarthquakeGroup` 変換のテスト（代表・グループ内地震の件数・score 保持）。
+- ゲージ widget の点灯セル数がグレードに対応することの widget テスト（任意）。
+
+## 7. 影響範囲・非対象
+- 影響: `earthquake_history` feature 配下（data/model, data/repository, data/notifier, ui/components, ui）、`core/router/router.dart`。
+- 非対象: backend（実装済み）、API クライアント生成物（生成済み）、地震履歴一覧画面。
+- code generation: 新規 freezed / riverpod / go_router 注釈を追加するため `melos run generate` が必要。


### PR DESCRIPTION
## 概要

地震履歴詳細画面に **類似地震** 機能を追加しました。実装済みの類似地震検索API (`GET /v2/earthquake/{eventId}/similar`) を利用します。

## 変更内容

- 詳細画面の Sheet 末尾に「類似地震」Card を追加し、類似地震グループの **上位3件（代表地震）** を表示
- **もっと見る** で全画面 (`SimilarEarthquakePage`) に遷移し、全代表地震を一覧。各行の **toggle** で同一グループ内の他の地震 (`groupedEarthquakes`) を展開（子地震が無いグループは toggle 非表示）
- 各タイルはタップでその地震の詳細画面へ遷移（既存 `EarthquakeHistoryListTile` を再利用）
- 類似度を backend の `score`（km相当の距離スコア、小さいほど類似）から **A→E の5段階グレード** に分類し、**5セルゲージ** で表示（A=5セル点灯〜E=1セル、グレード色付き）

### グレード閾値

| グレード | score 範囲 | 点灯セル |
|---|---|---|
| A | `< 50` | 5 |
| B | `< 100` | 4 |
| C | `< 200` | 3 |
| D | `< 350` | 2 |
| E | `≥ 350` | 1 |

## アーキテクチャ

- `SimilarityGrade`（グレード分類）・`SimilarEarthquakeGroup`（appモデル）+ `toSimilarEarthquakeGroup` 変換拡張
- `EarthquakeHistoryRepository.fetchSimilarEarthquakes` + `similarEarthquakesProvider`（FutureProvider family）
- `SimilarEarthquakeGauge` / `SimilarEarthquakeTile` / `SimilarEarthquakeCard` / `SimilarEarthquakePage`
- ルート `SimilarEarthquakeRoute`（`/earthquake-history-details/:eventId/similar`）

## エッジケース

- 類似地震 0 件・取得失敗時は Card 非表示（詳細画面の主機能を阻害しない）
- 子地震 0 件のグループは toggle 非表示
- `score > 500`（防御的）は E 扱い

## テスト

- `SimilarityGrade.fromScore` 境界値、`grade` getter、ゲージ点灯セル数の widget テストを追加
- `melos run analyze` クリーン、新規テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
