### PR TITLE
feat: 近傍地震一覧をlat/lng/depth範囲検索に変更

### DIFF
--- a/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.dart
@@ -1,16 +1,35 @@
-import 'package:eqmonitor/feature/earthquake_history/data/model/similar_earthquake_item.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'similar_earthquake_provider.g.dart';
 
 @riverpod
-Future<List<SimilarEarthquakeItem>> similarEarthquake(
+Future<List<EarthquakePartial>> nearbyEarthquake(
   Ref ref,
-  String eventId,
+  String excludeEventId,
+  double latitude,
+  double longitude,
+  int? depth,
+  api.EarthquakeSortBy sortBy,
+  api.SortOrder sortOrder,
 ) async {
   final repository = await ref.watch(
     earthquakeHistoryRepositoryProvider.future,
   );
-  return repository.fetchSimilarEarthquakes(eventId: eventId);
+  final response = await repository.fetchEarthquakeList(
+    latitudeGte: latitude - 0.5,
+    latitudeLte: latitude + 0.5,
+    longitudeGte: longitude - 0.5,
+    longitudeLte: longitude + 0.5,
+    depthGte: depth != null ? (depth - 50).clamp(0, 9999) : null,
+    depthLte: depth != null ? depth + 50 : null,
+    sortBy: sortBy,
+    sortOrder: sortOrder,
+    limit: 50,
+  );
+  return response.items
+      .where((e) => e.eventId != excludeEventId)
+      .toList();
 }

--- a/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.g.dart
@@ -11,55 +11,73 @@ part of 'similar_earthquake_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(similarEarthquake)
-final similarEarthquakeProvider = SimilarEarthquakeFamily._();
+@ProviderFor(nearbyEarthquake)
+final nearbyEarthquakeProvider = NearbyEarthquakeFamily._();
 
-final class SimilarEarthquakeProvider
+final class NearbyEarthquakeProvider
     extends
         $FunctionalProvider<
-          AsyncValue<List<SimilarEarthquakeItem>>,
-          List<SimilarEarthquakeItem>,
-          FutureOr<List<SimilarEarthquakeItem>>
+          AsyncValue<List<EarthquakePartial>>,
+          List<EarthquakePartial>,
+          FutureOr<List<EarthquakePartial>>
         >
     with
-        $FutureModifier<List<SimilarEarthquakeItem>>,
-        $FutureProvider<List<SimilarEarthquakeItem>> {
-  SimilarEarthquakeProvider._({
-    required SimilarEarthquakeFamily super.from,
-    required String super.argument,
+        $FutureModifier<List<EarthquakePartial>>,
+        $FutureProvider<List<EarthquakePartial>> {
+  NearbyEarthquakeProvider._({
+    required NearbyEarthquakeFamily super.from,
+    required (String, double, double, int?, api.EarthquakeSortBy, api.SortOrder)
+    super.argument,
   }) : super(
          retry: null,
-         name: r'similarEarthquakeProvider',
+         name: r'nearbyEarthquakeProvider',
          isAutoDispose: true,
          dependencies: null,
          $allTransitiveDependencies: null,
        );
 
   @override
-  String debugGetCreateSourceHash() => _$similarEarthquakeHash();
+  String debugGetCreateSourceHash() => _$nearbyEarthquakeHash();
 
   @override
   String toString() {
-    return r'similarEarthquakeProvider'
+    return r'nearbyEarthquakeProvider'
         ''
-        '($argument)';
+        '$argument';
   }
 
   @$internal
   @override
-  $FutureProviderElement<List<SimilarEarthquakeItem>> $createElement(
+  $FutureProviderElement<List<EarthquakePartial>> $createElement(
     $ProviderPointer pointer,
   ) => $FutureProviderElement(pointer);
 
   @override
-  FutureOr<List<SimilarEarthquakeItem>> create(Ref ref) {
-    final argument = this.argument as String;
-    return similarEarthquake(ref, argument);
+  FutureOr<List<EarthquakePartial>> create(Ref ref) {
+    final argument =
+        this.argument
+            as (
+              String,
+              double,
+              double,
+              int?,
+              api.EarthquakeSortBy,
+              api.SortOrder,
+            );
+    return nearbyEarthquake(
+      ref,
+      argument.$1,
+      argument.$2,
+      argument.$3,
+      argument.$4,
+      argument.$5,
+      argument.$6,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return other is SimilarEarthquakeProvider && other.argument == argument;
+    return other is NearbyEarthquakeProvider && other.argument == argument;
   }
 
   @override
@@ -68,26 +86,35 @@ final class SimilarEarthquakeProvider
   }
 }
 
-String _$similarEarthquakeHash() => r'484e2ad3e85bc2fdebd8d279ae12fd66f18242e1';
+String _$nearbyEarthquakeHash() => r'2e8fe5b4b86563f9e8fdf6e2c6284137d5d080cd';
 
-final class SimilarEarthquakeFamily extends $Family
+final class NearbyEarthquakeFamily extends $Family
     with
         $FunctionalFamilyOverride<
-          FutureOr<List<SimilarEarthquakeItem>>,
-          String
+          FutureOr<List<EarthquakePartial>>,
+          (String, double, double, int?, api.EarthquakeSortBy, api.SortOrder)
         > {
-  SimilarEarthquakeFamily._()
+  NearbyEarthquakeFamily._()
     : super(
         retry: null,
-        name: r'similarEarthquakeProvider',
+        name: r'nearbyEarthquakeProvider',
         dependencies: null,
         $allTransitiveDependencies: null,
         isAutoDispose: true,
       );
 
-  SimilarEarthquakeProvider call(String eventId) =>
-      SimilarEarthquakeProvider._(argument: eventId, from: this);
+  NearbyEarthquakeProvider call(
+    String excludeEventId,
+    double latitude,
+    double longitude,
+    int? depth,
+    api.EarthquakeSortBy sortBy,
+    api.SortOrder sortOrder,
+  ) => NearbyEarthquakeProvider._(
+    argument: (excludeEventId, latitude, longitude, depth, sortBy, sortOrder),
+    from: this,
+  );
 
   @override
-  String toString() => r'similarEarthquakeProvider';
+  String toString() => r'nearbyEarthquakeProvider';
 }

--- a/app/lib/feature/earthquake_history/ui/components/similar_earthquake_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/similar_earthquake_card.dart
@@ -1,89 +1,72 @@
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
 import 'package:eqmonitor/core/router/router.dart';
-import 'package:eqmonitor/feature/earthquake_history/data/model/similar_earthquake_item.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/similar_earthquake_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
-import 'package:eqmonitor/feature/earthquake_history/ui/components/similarity_score_indicator.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class SimilarEarthquakeCard extends HookConsumerWidget {
   const SimilarEarthquakeCard({
-    required this.eventId,
+    required this.earthquake,
     super.key,
   });
 
-  final String eventId;
+  final Earthquake earthquake;
 
   static const _initialDisplayCount = 5;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncItems = ref.watch(similarEarthquakeProvider(eventId));
-    final intensityColor = ref.watch(intensityColorProvider);
+    final coordinates = earthquake.hypocenter?.coordinates;
+    if (coordinates is! CoordinateLatLng) {
+      return const SizedBox.shrink();
+    }
 
-    return switch (asyncItems) {
-      AsyncLoading() => const Padding(
-        padding: EdgeInsets.symmetric(vertical: 16),
-        child: Center(
-          child: SizedBox(
-            width: 24,
-            height: 24,
-            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-          ),
-        ),
-      ),
-      AsyncError() => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Row(
-          children: [
-            const Icon(Icons.error_outline, size: 16),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                '類似地震の取得に失敗しました',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ),
-            TextButton(
-              onPressed: () => ref.invalidate(
-                similarEarthquakeProvider(eventId),
-              ),
-              child: const Text('再試行'),
-            ),
-          ],
-        ),
-      ),
-      AsyncData(value: final items) when items.isEmpty =>
-        const SizedBox.shrink(),
-      AsyncData(value: final items) => _SimilarEarthquakeList(
-        items: items,
-        intensityColor: intensityColor,
-      ),
+    final depth = switch (earthquake.hypocenter?.depth) {
+      EarthquakeDepthShallow() => 0,
+      EarthquakeDepthValue(:final value) => value,
+      EarthquakeDepthOver700km() => 700,
+      _ => null,
     };
-  }
-}
 
-class _SimilarEarthquakeList extends HookWidget {
-  const _SimilarEarthquakeList({
-    required this.items,
-    required this.intensityColor,
-  });
-
-  final List<SimilarEarthquakeItem> items;
-  final IntensityColorModel intensityColor;
-
-  @override
-  Widget build(BuildContext context) {
+    final sortBy = useState(api.EarthquakeSortBy.originTime);
+    final sortOrder = useState(api.SortOrder.desc);
     final showAll = useState(false);
+    final intensityColor = ref.watch(intensityColorProvider);
     final theme = Theme.of(context);
 
-    final displayItems = showAll.value
-        ? items
-        : items.take(SimilarEarthquakeCard._initialDisplayCount).toList();
-    final hasMore = items.length > SimilarEarthquakeCard._initialDisplayCount;
+    final asyncItems = ref.watch(
+      nearbyEarthquakeProvider(
+        earthquake.eventId,
+        coordinates.latitude,
+        coordinates.longitude,
+        depth,
+        sortBy.value,
+        sortOrder.value,
+      ),
+    );
+
+    void onSortChanged(api.EarthquakeSortBy newSortBy) {
+      if (sortBy.value == newSortBy) {
+        sortOrder.value = sortOrder.value == api.SortOrder.asc
+            ? api.SortOrder.desc
+            : api.SortOrder.asc;
+      } else {
+        sortBy.value = newSortBy;
+        sortOrder.value = switch (newSortBy) {
+          api.EarthquakeSortBy.depth => api.SortOrder.asc,
+          _ => api.SortOrder.desc,
+        };
+        showAll.value = false;
+      }
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -97,11 +80,107 @@ class _SimilarEarthquakeList extends HookWidget {
             ),
           ),
         ),
-        for (final item in displayItems)
-          _SimilarEarthquakeItemTile(
+        _SortButtonRow(
+          sortBy: sortBy.value,
+          sortOrder: sortOrder.value,
+          onSortChanged: onSortChanged,
+        ),
+        const SizedBox(height: 8),
+        switch (asyncItems) {
+          AsyncLoading() => const Padding(
+              padding: EdgeInsets.symmetric(vertical: 16),
+              child: Center(
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                ),
+              ),
+            ),
+          AsyncError() => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  const Icon(Icons.error_outline, size: 16),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '近傍の地震の取得に失敗しました',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => ref.invalidate(
+                      nearbyEarthquakeProvider(
+                        earthquake.eventId,
+                        coordinates.latitude,
+                        coordinates.longitude,
+                        depth,
+                        sortBy.value,
+                        sortOrder.value,
+                      ),
+                    ),
+                    child: const Text('再試行'),
+                  ),
+                ],
+              ),
+            ),
+          AsyncData(value: final items) when items.isEmpty => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+              child: Center(
+                child: Text(
+                  '該当する地震がありません',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
+          AsyncData(value: final items) => _NearbyEarthquakeList(
+              items: items,
+              showAll: showAll,
+              intensityColor: intensityColor,
+            ),
+        },
+      ],
+    );
+  }
+}
+
+class _NearbyEarthquakeList extends StatelessWidget {
+  const _NearbyEarthquakeList({
+    required this.items,
+    required this.showAll,
+    required this.intensityColor,
+  });
+
+  final List<EarthquakePartial> items;
+  final ValueNotifier<bool> showAll;
+  final IntensityColorModel intensityColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayItems = showAll.value
+        ? items
+        : items.take(SimilarEarthquakeCard._initialDisplayCount).toList();
+    final hasMore =
+        items.length > SimilarEarthquakeCard._initialDisplayCount;
+
+    return Column(
+      children: [
+        for (final item in displayItems) ...[
+          EarthquakeHistoryListTile(
             item: item,
             intensityColor: intensityColor,
+            onTap: () => EarthquakeHistoryDetailsRoute(
+              eventId: item.eventId,
+            ).push<void>(context),
+            showBackgroundColor: false,
+            intensityIconSize: 32,
+            dense: true,
           ),
+          const Divider(height: 1, indent: 16, endIndent: 16),
+        ],
         if (hasMore && !showAll.value)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -117,84 +196,59 @@ class _SimilarEarthquakeList extends HookWidget {
   }
 }
 
-class _SimilarEarthquakeItemTile extends HookWidget {
-  const _SimilarEarthquakeItemTile({
-    required this.item,
-    required this.intensityColor,
+class _SortButtonRow extends StatelessWidget {
+  const _SortButtonRow({
+    required this.sortBy,
+    required this.sortOrder,
+    required this.onSortChanged,
   });
 
-  final SimilarEarthquakeItem item;
-  final IntensityColorModel intensityColor;
+  final api.EarthquakeSortBy sortBy;
+  final api.SortOrder sortOrder;
+  final ValueChanged<api.EarthquakeSortBy> onSortChanged;
+
+  static const List<(api.EarthquakeSortBy, String)> _sortOptions = [
+    (api.EarthquakeSortBy.originTime, '日時'),
+    (api.EarthquakeSortBy.magnitude, 'M'),
+    (api.EarthquakeSortBy.maxIntensity, '最大震度'),
+    (api.EarthquakeSortBy.depth, '深さ'),
+  ];
 
   @override
   Widget build(BuildContext context) {
-    final isExpanded = useState(false);
-    final hasGroup = item.groupedEarthquakes.isNotEmpty;
-
-    return Column(
-      children: [
-        Stack(
-          children: [
-            EarthquakeHistoryListTile(
-              item: item.earthquake,
-              intensityColor: intensityColor,
-              onTap: () => EarthquakeHistoryDetailsRoute(
-                eventId: item.earthquake.eventId,
-              ).push<void>(context),
-              showBackgroundColor: false,
-              intensityIconSize: 32,
-              dense: true,
-            ),
-            Positioned(
-              right: 8,
-              top: 8,
-              child: SimilarityScoreIndicator(level: item.level),
-            ),
-          ],
-        ),
-        if (hasGroup)
-          InkWell(
-            onTap: () => isExpanded.value = !isExpanded.value,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-              child: Row(
-                children: [
-                  Icon(
-                    isExpanded.value ? Icons.expand_less : Icons.expand_more,
-                    size: 16,
-                  ),
-                  const SizedBox(width: 4),
-                  Text(
-                    isExpanded.value
-                        ? '閉じる'
-                        : '他${item.groupedEarthquakes.length}件の余震',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                ],
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Row(
+        children: [
+          for (final (value, label) in _sortOptions)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: FilterChip(
+                selected: sortBy == value,
+                showCheckmark: false,
+                label: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(label),
+                    if (sortBy == value) ...[
+                      const SizedBox(width: 2),
+                      Icon(
+                        sortOrder == api.SortOrder.asc
+                            ? Icons.arrow_upward
+                            : Icons.arrow_downward,
+                        size: 14,
+                      ),
+                    ],
+                  ],
+                ),
+                onSelected: (_) => onSortChanged(value),
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
             ),
-          ),
-        if (hasGroup && isExpanded.value)
-          Padding(
-            padding: const EdgeInsets.only(left: 16),
-            child: Column(
-              children: [
-                for (final grouped in item.groupedEarthquakes)
-                  EarthquakeHistoryListTile(
-                    item: grouped,
-                    intensityColor: intensityColor,
-                    onTap: () => EarthquakeHistoryDetailsRoute(
-                      eventId: grouped.eventId,
-                    ).push<void>(context),
-                    showBackgroundColor: false,
-                    intensityIconSize: 28,
-                    dense: true,
-                  ),
-              ],
-            ),
-          ),
-        const Divider(height: 1, indent: 16, endIndent: 16),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -114,7 +114,7 @@ class _LoadedContent extends HookWidget {
                           DateTime.now().difference(earthquake.originTime!) >
                               const Duration(hours: 24))
                         const AdBanner(),
-                      SimilarEarthquakeCard(eventId: earthquake.eventId),
+                      SimilarEarthquakeCard(earthquake: earthquake),
                       _TelegramListButton(eventId: earthquake.eventId),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- 近傍地震一覧で `similar` エンドポイントの代わりに、既存の `fetchEarthquakeList` を使用し、震源の lat/lng ±0.5度・depth ±50km で範囲検索する方式に変更
- ソートボタン（日時・M・最大震度・深さ）を追加。同一キータップで昇順⇔降順トグル、異なるキータップでデフォルト方向に切替
- SimilarityScoreIndicator とグループ化地震の表示を削除

## Test plan
- [ ] 地震詳細画面で「この震源の近傍で発生した地震」セクションが表示されること
- [ ] 各ソートボタンが正しく動作すること（日時降順がデフォルト）
- [ ] ソート切替時にリストが更新されること
- [ ] 震源情報がない地震ではセクションが非表示になること
- [ ] 「すべて表示」ボタンが5件超の場合に表示されること