### PR TITLE
fix: WebSocket の再接続・初期同期(ready/baseline)の複数バグを修正

### DIFF
--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_realtime_event_mapper.dart
@@ -15,14 +15,7 @@ class EqMonitorRealtimeEventMapper {
   static const tilesBaseUrl = 'https://tiles.eqmonitor.app';
 
   List<RealtimeEvent> map(WsMessage message) => switch (message) {
-    WsSnapshotMessage(:final data) => [
-      .snapshot(
-        eews: data.eews,
-        earthquakes: data.earthquakes,
-        shakes: data.shakes.map(mapSnapshotShakeEntry).toList(),
-        source: RealtimeSource.eqmonitor,
-      ),
-    ],
+    WsSnapshotMessage() => const <RealtimeEvent>[],
     WsRealtimeMessage(:final data) => switch (data) {
       WsEewRealtimeEvent(:final item) => [
         RealtimeEvent.eewUpsert(item: item, source: RealtimeSource.eqmonitor),
@@ -53,7 +46,27 @@ class EqMonitorRealtimeEventMapper {
           ],
           _ => const <RealtimeEvent>[],
         },
-      WsTsunamiRealtimeEvent() => const <RealtimeEvent>[],
+      WsTsunamiRealtimeEvent(
+        :final operation,
+        :final eventId,
+        :final groupId,
+      ) =>
+        switch (operation) {
+          WsRealtimeOperation.upsert => [
+            RealtimeEvent.tsunamiUpsert(
+              eventId: eventId,
+              groupId: groupId,
+              source: RealtimeSource.eqmonitor,
+            ),
+          ],
+          WsRealtimeOperation.delete => [
+            RealtimeEvent.tsunamiDelete(
+              eventId: eventId,
+              groupId: groupId,
+              source: RealtimeSource.eqmonitor,
+            ),
+          ],
+        },
       WsShakeDetectedRealtimeEvent(
         :final eventId,
         :final createdAt,
@@ -90,20 +103,8 @@ class EqMonitorRealtimeEventMapper {
       ],
     },
     WsPingMessage() => const <RealtimeEvent>[],
-    WsReadyMessage() => const <RealtimeEvent>[],
+    WsReadyMessage() => [
+      const RealtimeEvent.ready(source: RealtimeSource.eqmonitor),
+    ],
   };
-
-  RealtimeShakeData mapSnapshotShakeEntry(WsSnapshotShakeEntry entry) =>
-      RealtimeShakeData(
-        eventId: entry.eventId,
-        createdAt: entry.createdAt,
-        level: entry.level,
-        isReplay: entry.isReplay,
-        pointCount: entry.pointCount,
-        minLat: entry.region.bottomRight.latitude,
-        maxLat: entry.region.topLeft.latitude,
-        minLng: entry.region.topLeft.longitude,
-        maxLng: entry.region.bottomRight.longitude,
-        changeReasons: entry.changeReasons,
-      );
 }

--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/core/provider/app_lifecycle.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:web_socket/web_socket.dart';
 
@@ -24,33 +27,64 @@ final class EqmonitorWebSocketTicketRefreshDelayCalculator {
 
 @Riverpod(keepAlive: true)
 Future<WebSocket> eqmonitorWebSocket(Ref ref) async {
-  // MEMO(YumNumm): WebSocket接続時にticketがあればよく、追従する必要はないので、read
   final ticket = await ref.read(eqmonitorWebSocketTicketProvider.future);
-
-  final ws = await WebSocket.connect(
-    Uri.parse(ticket.url),
-  );
+  final ws = await WebSocket.connect(Uri.parse(ticket.url));
   ref.onDispose(() => ws.close().ignore());
   return ws;
 }
 
 /// WebSocket イベントストリーム。
+///
 /// ws.events は単一サブスクリプションのため、ここが唯一の subscriber。
-/// CloseReceived 検知時に eqmonitorWebSocket を invalidate して再接続をトリガーする。
-@riverpod
-Stream<WebSocketEvent> eqmonitorWsEventStream(Ref ref) async* {
-  final websocket = await ref.watch(eqmonitorWebSocketProvider.future);
-  await for (final event in websocket.events) {
-    yield event;
-    if (event case CloseReceived(:final code, :final reason)) {
-      talker.warning(
-        'EQMonitor WebSocket: closed with code $code and reason $reason',
-      );
-      ref.invalidate(eqmonitorWebSocketProvider, asReload: true);
-      return;
+/// 接続失敗・切断時に指数バックオフ（1s→最大60s）で再接続する。
+/// アプリ resume 時はバックオフをリセットして即座に再接続する。
+@Riverpod(keepAlive: true)
+class EqmonitorWsEventStream extends _$EqmonitorWsEventStream {
+  var _retryCount = 0;
+
+  @override
+  Stream<WebSocketEvent> build() async* {
+    ref.listen(appLifecycleProvider, (_, next) {
+      if (next == AppLifecycleState.resumed) {
+        _retryCount = 0;
+        ref.invalidate(eqmonitorWebSocketTicketProvider, asReload: true);
+        ref.invalidate(eqmonitorWebSocketProvider, asReload: true);
+      }
+    });
+
+    try {
+      final websocket = await ref.watch(eqmonitorWebSocketProvider.future);
+      _retryCount = 0;
+
+      await for (final event in websocket.events) {
+        yield event;
+        if (event case CloseReceived(:final code, :final reason)) {
+          talker.warning(
+            'EQMonitor WebSocket: closed with code=$code reason=$reason',
+          );
+          break;
+        }
+      }
+    } on Exception catch (e) {
+      talker.error('EQMonitor WebSocket: connection failed', e);
     }
+
+    final delaySeconds = math.min(
+      math.pow(2, _retryCount).toInt(),
+      60,
+    );
+    _retryCount++;
+    talker.info(
+      'EQMonitor WebSocket: reconnecting in ${delaySeconds}s '
+      '(attempt $_retryCount)',
+    );
+
+    final timer = Timer(Duration(seconds: delaySeconds), () {
+      ref.invalidate(eqmonitorWebSocketTicketProvider, asReload: true);
+      ref.invalidate(eqmonitorWebSocketProvider, asReload: true);
+    });
+    ref.onDispose(timer.cancel);
   }
-  ref.invalidate(eqmonitorWebSocketProvider, asReload: true);
 }
 
 @riverpod

--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.g.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.g.dart
@@ -51,34 +51,33 @@ String _$eqmonitorWebSocketHash() =>
     r'a2ec95ca93dd52b41d6b11bf833eb20780645400';
 
 /// WebSocket イベントストリーム。
+///
 /// ws.events は単一サブスクリプションのため、ここが唯一の subscriber。
-/// CloseReceived 検知時に eqmonitorWebSocket を invalidate して再接続をトリガーする。
+/// 接続失敗・切断時に指数バックオフ（1s→最大60s）で再接続する。
+/// アプリ resume 時はバックオフをリセットして即座に再接続する。
 
-@ProviderFor(eqmonitorWsEventStream)
+@ProviderFor(EqmonitorWsEventStream)
 final eqmonitorWsEventStreamProvider = EqmonitorWsEventStreamProvider._();
 
 /// WebSocket イベントストリーム。
+///
 /// ws.events は単一サブスクリプションのため、ここが唯一の subscriber。
-/// CloseReceived 検知時に eqmonitorWebSocket を invalidate して再接続をトリガーする。
-
+/// 接続失敗・切断時に指数バックオフ（1s→最大60s）で再接続する。
+/// アプリ resume 時はバックオフをリセットして即座に再接続する。
 final class EqmonitorWsEventStreamProvider
-    extends
-        $FunctionalProvider<
-          AsyncValue<WebSocketEvent>,
-          WebSocketEvent,
-          Stream<WebSocketEvent>
-        >
-    with $FutureModifier<WebSocketEvent>, $StreamProvider<WebSocketEvent> {
+    extends $StreamNotifierProvider<EqmonitorWsEventStream, WebSocketEvent> {
   /// WebSocket イベントストリーム。
+  ///
   /// ws.events は単一サブスクリプションのため、ここが唯一の subscriber。
-  /// CloseReceived 検知時に eqmonitorWebSocket を invalidate して再接続をトリガーする。
+  /// 接続失敗・切断時に指数バックオフ（1s→最大60s）で再接続する。
+  /// アプリ resume 時はバックオフをリセットして即座に再接続する。
   EqmonitorWsEventStreamProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'eqmonitorWsEventStreamProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -88,18 +87,36 @@ final class EqmonitorWsEventStreamProvider
 
   @$internal
   @override
-  $StreamProviderElement<WebSocketEvent> $createElement(
-    $ProviderPointer pointer,
-  ) => $StreamProviderElement(pointer);
-
-  @override
-  Stream<WebSocketEvent> create(Ref ref) {
-    return eqmonitorWsEventStream(ref);
-  }
+  EqmonitorWsEventStream create() => EqmonitorWsEventStream();
 }
 
 String _$eqmonitorWsEventStreamHash() =>
-    r'25b58f12d853328d9ba3d189d1e747cba9dc4dcb';
+    r'5d74667823b05b7eeb6bdfc577fc562e18b4363c';
+
+/// WebSocket イベントストリーム。
+///
+/// ws.events は単一サブスクリプションのため、ここが唯一の subscriber。
+/// 接続失敗・切断時に指数バックオフ（1s→最大60s）で再接続する。
+/// アプリ resume 時はバックオフをリセットして即座に再接続する。
+
+abstract class _$EqmonitorWsEventStream
+    extends $StreamNotifier<WebSocketEvent> {
+  Stream<WebSocketEvent> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<WebSocketEvent>, WebSocketEvent>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<WebSocketEvent>, WebSocketEvent>,
+              AsyncValue<WebSocketEvent>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
 
 @ProviderFor(eqmonitorWebSocketTicket)
 final eqmonitorWebSocketTicketProvider = EqmonitorWebSocketTicketProvider._();

--- a/app/lib/core/realtime/model/realtime_event.dart
+++ b/app/lib/core/realtime/model/realtime_event.dart
@@ -9,12 +9,9 @@ enum RealtimeSource { eqmonitor, dmdata }
 
 @Freezed()
 sealed class RealtimeEvent with _$RealtimeEvent {
-  const factory RealtimeEvent.snapshot({
-    required List<EewItemWithRelations> eews,
-    required List<EarthquakePartial> earthquakes,
-    required List<RealtimeShakeData> shakes,
+  const factory RealtimeEvent.ready({
     required RealtimeSource source,
-  }) = RealtimeSnapshotEvent;
+  }) = RealtimeReadyEvent;
 
   const factory RealtimeEvent.eewUpsert({
     required EewItemWithRelations item,
@@ -30,6 +27,18 @@ sealed class RealtimeEvent with _$RealtimeEvent {
     required String eventId,
     required RealtimeSource source,
   }) = RealtimeEarthquakeDeleteEvent;
+
+  const factory RealtimeEvent.tsunamiUpsert({
+    required String eventId,
+    required RealtimeSource source,
+    String? groupId,
+  }) = RealtimeTsunamiUpsertEvent;
+
+  const factory RealtimeEvent.tsunamiDelete({
+    required String eventId,
+    required RealtimeSource source,
+    String? groupId,
+  }) = RealtimeTsunamiDeleteEvent;
 
   const factory RealtimeEvent.shakeDetected({
     required RealtimeShakeData data,

--- a/app/lib/core/realtime/model/realtime_event.freezed.dart
+++ b/app/lib/core/realtime/model/realtime_event.freezed.dart
@@ -15,8 +15,8 @@ RealtimeEvent _$RealtimeEventFromJson(
   Map<String, dynamic> json
 ) {
         switch (json['runtimeType']) {
-                  case 'snapshot':
-          return RealtimeSnapshotEvent.fromJson(
+                  case 'ready':
+          return RealtimeReadyEvent.fromJson(
             json
           );
                 case 'eewUpsert':
@@ -29,6 +29,14 @@ RealtimeEvent _$RealtimeEventFromJson(
           );
                 case 'earthquakeDelete':
           return RealtimeEarthquakeDeleteEvent.fromJson(
+            json
+          );
+                case 'tsunamiUpsert':
+          return RealtimeTsunamiUpsertEvent.fromJson(
+            json
+          );
+                case 'tsunamiDelete':
+          return RealtimeTsunamiDeleteEvent.fromJson(
             json
           );
                 case 'shakeDetected':
@@ -128,14 +136,16 @@ extension RealtimeEventPatterns on RealtimeEvent {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( RealtimeSnapshotEvent value)?  snapshot,TResult Function( RealtimeEewUpsertEvent value)?  eewUpsert,TResult Function( RealtimeEarthquakeUpsertEvent value)?  earthquakeUpsert,TResult Function( RealtimeEarthquakeDeleteEvent value)?  earthquakeDelete,TResult Function( RealtimeShakeDetectedEvent value)?  shakeDetected,TResult Function( RealtimeEstimatedIntensityUpsertEvent value)?  estimatedIntensityUpsert,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( RealtimeReadyEvent value)?  ready,TResult Function( RealtimeEewUpsertEvent value)?  eewUpsert,TResult Function( RealtimeEarthquakeUpsertEvent value)?  earthquakeUpsert,TResult Function( RealtimeEarthquakeDeleteEvent value)?  earthquakeDelete,TResult Function( RealtimeTsunamiUpsertEvent value)?  tsunamiUpsert,TResult Function( RealtimeTsunamiDeleteEvent value)?  tsunamiDelete,TResult Function( RealtimeShakeDetectedEvent value)?  shakeDetected,TResult Function( RealtimeEstimatedIntensityUpsertEvent value)?  estimatedIntensityUpsert,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
-case RealtimeSnapshotEvent() when snapshot != null:
-return snapshot(_that);case RealtimeEewUpsertEvent() when eewUpsert != null:
+case RealtimeReadyEvent() when ready != null:
+return ready(_that);case RealtimeEewUpsertEvent() when eewUpsert != null:
 return eewUpsert(_that);case RealtimeEarthquakeUpsertEvent() when earthquakeUpsert != null:
 return earthquakeUpsert(_that);case RealtimeEarthquakeDeleteEvent() when earthquakeDelete != null:
-return earthquakeDelete(_that);case RealtimeShakeDetectedEvent() when shakeDetected != null:
+return earthquakeDelete(_that);case RealtimeTsunamiUpsertEvent() when tsunamiUpsert != null:
+return tsunamiUpsert(_that);case RealtimeTsunamiDeleteEvent() when tsunamiDelete != null:
+return tsunamiDelete(_that);case RealtimeShakeDetectedEvent() when shakeDetected != null:
 return shakeDetected(_that);case RealtimeEstimatedIntensityUpsertEvent() when estimatedIntensityUpsert != null:
 return estimatedIntensityUpsert(_that);case _:
   return orElse();
@@ -155,14 +165,16 @@ return estimatedIntensityUpsert(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( RealtimeSnapshotEvent value)  snapshot,required TResult Function( RealtimeEewUpsertEvent value)  eewUpsert,required TResult Function( RealtimeEarthquakeUpsertEvent value)  earthquakeUpsert,required TResult Function( RealtimeEarthquakeDeleteEvent value)  earthquakeDelete,required TResult Function( RealtimeShakeDetectedEvent value)  shakeDetected,required TResult Function( RealtimeEstimatedIntensityUpsertEvent value)  estimatedIntensityUpsert,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( RealtimeReadyEvent value)  ready,required TResult Function( RealtimeEewUpsertEvent value)  eewUpsert,required TResult Function( RealtimeEarthquakeUpsertEvent value)  earthquakeUpsert,required TResult Function( RealtimeEarthquakeDeleteEvent value)  earthquakeDelete,required TResult Function( RealtimeTsunamiUpsertEvent value)  tsunamiUpsert,required TResult Function( RealtimeTsunamiDeleteEvent value)  tsunamiDelete,required TResult Function( RealtimeShakeDetectedEvent value)  shakeDetected,required TResult Function( RealtimeEstimatedIntensityUpsertEvent value)  estimatedIntensityUpsert,}){
 final _that = this;
 switch (_that) {
-case RealtimeSnapshotEvent():
-return snapshot(_that);case RealtimeEewUpsertEvent():
+case RealtimeReadyEvent():
+return ready(_that);case RealtimeEewUpsertEvent():
 return eewUpsert(_that);case RealtimeEarthquakeUpsertEvent():
 return earthquakeUpsert(_that);case RealtimeEarthquakeDeleteEvent():
-return earthquakeDelete(_that);case RealtimeShakeDetectedEvent():
+return earthquakeDelete(_that);case RealtimeTsunamiUpsertEvent():
+return tsunamiUpsert(_that);case RealtimeTsunamiDeleteEvent():
+return tsunamiDelete(_that);case RealtimeShakeDetectedEvent():
 return shakeDetected(_that);case RealtimeEstimatedIntensityUpsertEvent():
 return estimatedIntensityUpsert(_that);}
 }
@@ -178,14 +190,16 @@ return estimatedIntensityUpsert(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( RealtimeSnapshotEvent value)?  snapshot,TResult? Function( RealtimeEewUpsertEvent value)?  eewUpsert,TResult? Function( RealtimeEarthquakeUpsertEvent value)?  earthquakeUpsert,TResult? Function( RealtimeEarthquakeDeleteEvent value)?  earthquakeDelete,TResult? Function( RealtimeShakeDetectedEvent value)?  shakeDetected,TResult? Function( RealtimeEstimatedIntensityUpsertEvent value)?  estimatedIntensityUpsert,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( RealtimeReadyEvent value)?  ready,TResult? Function( RealtimeEewUpsertEvent value)?  eewUpsert,TResult? Function( RealtimeEarthquakeUpsertEvent value)?  earthquakeUpsert,TResult? Function( RealtimeEarthquakeDeleteEvent value)?  earthquakeDelete,TResult? Function( RealtimeTsunamiUpsertEvent value)?  tsunamiUpsert,TResult? Function( RealtimeTsunamiDeleteEvent value)?  tsunamiDelete,TResult? Function( RealtimeShakeDetectedEvent value)?  shakeDetected,TResult? Function( RealtimeEstimatedIntensityUpsertEvent value)?  estimatedIntensityUpsert,}){
 final _that = this;
 switch (_that) {
-case RealtimeSnapshotEvent() when snapshot != null:
-return snapshot(_that);case RealtimeEewUpsertEvent() when eewUpsert != null:
+case RealtimeReadyEvent() when ready != null:
+return ready(_that);case RealtimeEewUpsertEvent() when eewUpsert != null:
 return eewUpsert(_that);case RealtimeEarthquakeUpsertEvent() when earthquakeUpsert != null:
 return earthquakeUpsert(_that);case RealtimeEarthquakeDeleteEvent() when earthquakeDelete != null:
-return earthquakeDelete(_that);case RealtimeShakeDetectedEvent() when shakeDetected != null:
+return earthquakeDelete(_that);case RealtimeTsunamiUpsertEvent() when tsunamiUpsert != null:
+return tsunamiUpsert(_that);case RealtimeTsunamiDeleteEvent() when tsunamiDelete != null:
+return tsunamiDelete(_that);case RealtimeShakeDetectedEvent() when shakeDetected != null:
 return shakeDetected(_that);case RealtimeEstimatedIntensityUpsertEvent() when estimatedIntensityUpsert != null:
 return estimatedIntensityUpsert(_that);case _:
   return null;
@@ -204,13 +218,15 @@ return estimatedIntensityUpsert(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( List<EewItemWithRelations> eews,  List<EarthquakePartial> earthquakes,  List<RealtimeShakeData> shakes,  RealtimeSource source)?  snapshot,TResult Function( EewItemWithRelations item,  RealtimeSource source)?  eewUpsert,TResult Function( EarthquakePartial record,  RealtimeSource source)?  earthquakeUpsert,TResult Function( String eventId,  RealtimeSource source)?  earthquakeDelete,TResult Function( RealtimeShakeData data,  RealtimeSource source)?  shakeDetected,TResult Function( String eventId,  String estimatedIntensityTile,  RealtimeSource source)?  estimatedIntensityUpsert,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( RealtimeSource source)?  ready,TResult Function( EewItemWithRelations item,  RealtimeSource source)?  eewUpsert,TResult Function( EarthquakePartial record,  RealtimeSource source)?  earthquakeUpsert,TResult Function( String eventId,  RealtimeSource source)?  earthquakeDelete,TResult Function( String eventId,  RealtimeSource source,  String? groupId)?  tsunamiUpsert,TResult Function( String eventId,  RealtimeSource source,  String? groupId)?  tsunamiDelete,TResult Function( RealtimeShakeData data,  RealtimeSource source)?  shakeDetected,TResult Function( String eventId,  String estimatedIntensityTile,  RealtimeSource source)?  estimatedIntensityUpsert,required TResult orElse(),}) {final _that = this;
 switch (_that) {
-case RealtimeSnapshotEvent() when snapshot != null:
-return snapshot(_that.eews,_that.earthquakes,_that.shakes,_that.source);case RealtimeEewUpsertEvent() when eewUpsert != null:
+case RealtimeReadyEvent() when ready != null:
+return ready(_that.source);case RealtimeEewUpsertEvent() when eewUpsert != null:
 return eewUpsert(_that.item,_that.source);case RealtimeEarthquakeUpsertEvent() when earthquakeUpsert != null:
 return earthquakeUpsert(_that.record,_that.source);case RealtimeEarthquakeDeleteEvent() when earthquakeDelete != null:
-return earthquakeDelete(_that.eventId,_that.source);case RealtimeShakeDetectedEvent() when shakeDetected != null:
+return earthquakeDelete(_that.eventId,_that.source);case RealtimeTsunamiUpsertEvent() when tsunamiUpsert != null:
+return tsunamiUpsert(_that.eventId,_that.source,_that.groupId);case RealtimeTsunamiDeleteEvent() when tsunamiDelete != null:
+return tsunamiDelete(_that.eventId,_that.source,_that.groupId);case RealtimeShakeDetectedEvent() when shakeDetected != null:
 return shakeDetected(_that.data,_that.source);case RealtimeEstimatedIntensityUpsertEvent() when estimatedIntensityUpsert != null:
 return estimatedIntensityUpsert(_that.eventId,_that.estimatedIntensityTile,_that.source);case _:
   return orElse();
@@ -230,13 +246,15 @@ return estimatedIntensityUpsert(_that.eventId,_that.estimatedIntensityTile,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( List<EewItemWithRelations> eews,  List<EarthquakePartial> earthquakes,  List<RealtimeShakeData> shakes,  RealtimeSource source)  snapshot,required TResult Function( EewItemWithRelations item,  RealtimeSource source)  eewUpsert,required TResult Function( EarthquakePartial record,  RealtimeSource source)  earthquakeUpsert,required TResult Function( String eventId,  RealtimeSource source)  earthquakeDelete,required TResult Function( RealtimeShakeData data,  RealtimeSource source)  shakeDetected,required TResult Function( String eventId,  String estimatedIntensityTile,  RealtimeSource source)  estimatedIntensityUpsert,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( RealtimeSource source)  ready,required TResult Function( EewItemWithRelations item,  RealtimeSource source)  eewUpsert,required TResult Function( EarthquakePartial record,  RealtimeSource source)  earthquakeUpsert,required TResult Function( String eventId,  RealtimeSource source)  earthquakeDelete,required TResult Function( String eventId,  RealtimeSource source,  String? groupId)  tsunamiUpsert,required TResult Function( String eventId,  RealtimeSource source,  String? groupId)  tsunamiDelete,required TResult Function( RealtimeShakeData data,  RealtimeSource source)  shakeDetected,required TResult Function( String eventId,  String estimatedIntensityTile,  RealtimeSource source)  estimatedIntensityUpsert,}) {final _that = this;
 switch (_that) {
-case RealtimeSnapshotEvent():
-return snapshot(_that.eews,_that.earthquakes,_that.shakes,_that.source);case RealtimeEewUpsertEvent():
+case RealtimeReadyEvent():
+return ready(_that.source);case RealtimeEewUpsertEvent():
 return eewUpsert(_that.item,_that.source);case RealtimeEarthquakeUpsertEvent():
 return earthquakeUpsert(_that.record,_that.source);case RealtimeEarthquakeDeleteEvent():
-return earthquakeDelete(_that.eventId,_that.source);case RealtimeShakeDetectedEvent():
+return earthquakeDelete(_that.eventId,_that.source);case RealtimeTsunamiUpsertEvent():
+return tsunamiUpsert(_that.eventId,_that.source,_that.groupId);case RealtimeTsunamiDeleteEvent():
+return tsunamiDelete(_that.eventId,_that.source,_that.groupId);case RealtimeShakeDetectedEvent():
 return shakeDetected(_that.data,_that.source);case RealtimeEstimatedIntensityUpsertEvent():
 return estimatedIntensityUpsert(_that.eventId,_that.estimatedIntensityTile,_that.source);}
 }
@@ -252,13 +270,15 @@ return estimatedIntensityUpsert(_that.eventId,_that.estimatedIntensityTile,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( List<EewItemWithRelations> eews,  List<EarthquakePartial> earthquakes,  List<RealtimeShakeData> shakes,  RealtimeSource source)?  snapshot,TResult? Function( EewItemWithRelations item,  RealtimeSource source)?  eewUpsert,TResult? Function( EarthquakePartial record,  RealtimeSource source)?  earthquakeUpsert,TResult? Function( String eventId,  RealtimeSource source)?  earthquakeDelete,TResult? Function( RealtimeShakeData data,  RealtimeSource source)?  shakeDetected,TResult? Function( String eventId,  String estimatedIntensityTile,  RealtimeSource source)?  estimatedIntensityUpsert,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( RealtimeSource source)?  ready,TResult? Function( EewItemWithRelations item,  RealtimeSource source)?  eewUpsert,TResult? Function( EarthquakePartial record,  RealtimeSource source)?  earthquakeUpsert,TResult? Function( String eventId,  RealtimeSource source)?  earthquakeDelete,TResult? Function( String eventId,  RealtimeSource source,  String? groupId)?  tsunamiUpsert,TResult? Function( String eventId,  RealtimeSource source,  String? groupId)?  tsunamiDelete,TResult? Function( RealtimeShakeData data,  RealtimeSource source)?  shakeDetected,TResult? Function( String eventId,  String estimatedIntensityTile,  RealtimeSource source)?  estimatedIntensityUpsert,}) {final _that = this;
 switch (_that) {
-case RealtimeSnapshotEvent() when snapshot != null:
-return snapshot(_that.eews,_that.earthquakes,_that.shakes,_that.source);case RealtimeEewUpsertEvent() when eewUpsert != null:
+case RealtimeReadyEvent() when ready != null:
+return ready(_that.source);case RealtimeEewUpsertEvent() when eewUpsert != null:
 return eewUpsert(_that.item,_that.source);case RealtimeEarthquakeUpsertEvent() when earthquakeUpsert != null:
 return earthquakeUpsert(_that.record,_that.source);case RealtimeEarthquakeDeleteEvent() when earthquakeDelete != null:
-return earthquakeDelete(_that.eventId,_that.source);case RealtimeShakeDetectedEvent() when shakeDetected != null:
+return earthquakeDelete(_that.eventId,_that.source);case RealtimeTsunamiUpsertEvent() when tsunamiUpsert != null:
+return tsunamiUpsert(_that.eventId,_that.source,_that.groupId);case RealtimeTsunamiDeleteEvent() when tsunamiDelete != null:
+return tsunamiDelete(_that.eventId,_that.source,_that.groupId);case RealtimeShakeDetectedEvent() when shakeDetected != null:
 return shakeDetected(_that.data,_that.source);case RealtimeEstimatedIntensityUpsertEvent() when estimatedIntensityUpsert != null:
 return estimatedIntensityUpsert(_that.eventId,_that.estimatedIntensityTile,_that.source);case _:
   return null;
@@ -271,30 +291,9 @@ return estimatedIntensityUpsert(_that.eventId,_that.estimatedIntensityTile,_that
 /// @nodoc
 @JsonSerializable()
 
-class RealtimeSnapshotEvent implements RealtimeEvent {
-  const RealtimeSnapshotEvent({required final  List<EewItemWithRelations> eews, required final  List<EarthquakePartial> earthquakes, required final  List<RealtimeShakeData> shakes, required this.source, final  String? $type}): _eews = eews,_earthquakes = earthquakes,_shakes = shakes,$type = $type ?? 'snapshot';
-  factory RealtimeSnapshotEvent.fromJson(Map<String, dynamic> json) => _$RealtimeSnapshotEventFromJson(json);
-
- final  List<EewItemWithRelations> _eews;
- List<EewItemWithRelations> get eews {
-  if (_eews is EqualUnmodifiableListView) return _eews;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_eews);
-}
-
- final  List<EarthquakePartial> _earthquakes;
- List<EarthquakePartial> get earthquakes {
-  if (_earthquakes is EqualUnmodifiableListView) return _earthquakes;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_earthquakes);
-}
-
- final  List<RealtimeShakeData> _shakes;
- List<RealtimeShakeData> get shakes {
-  if (_shakes is EqualUnmodifiableListView) return _shakes;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_shakes);
-}
+class RealtimeReadyEvent implements RealtimeEvent {
+  const RealtimeReadyEvent({required this.source, final  String? $type}): $type = $type ?? 'ready';
+  factory RealtimeReadyEvent.fromJson(Map<String, dynamic> json) => _$RealtimeReadyEventFromJson(json);
 
 @override final  RealtimeSource source;
 
@@ -306,36 +305,36 @@ final String $type;
 /// with the given fields replaced by the non-null parameter values.
 @override @JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
-$RealtimeSnapshotEventCopyWith<RealtimeSnapshotEvent> get copyWith => _$RealtimeSnapshotEventCopyWithImpl<RealtimeSnapshotEvent>(this, _$identity);
+$RealtimeReadyEventCopyWith<RealtimeReadyEvent> get copyWith => _$RealtimeReadyEventCopyWithImpl<RealtimeReadyEvent>(this, _$identity);
 
 @override
 Map<String, dynamic> toJson() {
-  return _$RealtimeSnapshotEventToJson(this, );
+  return _$RealtimeReadyEventToJson(this, );
 }
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RealtimeSnapshotEvent&&const DeepCollectionEquality().equals(other._eews, _eews)&&const DeepCollectionEquality().equals(other._earthquakes, _earthquakes)&&const DeepCollectionEquality().equals(other._shakes, _shakes)&&(identical(other.source, source) || other.source == source));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RealtimeReadyEvent&&(identical(other.source, source) || other.source == source));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_eews),const DeepCollectionEquality().hash(_earthquakes),const DeepCollectionEquality().hash(_shakes),source);
+int get hashCode => Object.hash(runtimeType,source);
 
 @override
 String toString() {
-  return 'RealtimeEvent.snapshot(eews: $eews, earthquakes: $earthquakes, shakes: $shakes, source: $source)';
+  return 'RealtimeEvent.ready(source: $source)';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class $RealtimeSnapshotEventCopyWith<$Res> implements $RealtimeEventCopyWith<$Res> {
-  factory $RealtimeSnapshotEventCopyWith(RealtimeSnapshotEvent value, $Res Function(RealtimeSnapshotEvent) _then) = _$RealtimeSnapshotEventCopyWithImpl;
+abstract mixin class $RealtimeReadyEventCopyWith<$Res> implements $RealtimeEventCopyWith<$Res> {
+  factory $RealtimeReadyEventCopyWith(RealtimeReadyEvent value, $Res Function(RealtimeReadyEvent) _then) = _$RealtimeReadyEventCopyWithImpl;
 @override @useResult
 $Res call({
- List<EewItemWithRelations> eews, List<EarthquakePartial> earthquakes, List<RealtimeShakeData> shakes, RealtimeSource source
+ RealtimeSource source
 });
 
 
@@ -343,21 +342,18 @@ $Res call({
 
 }
 /// @nodoc
-class _$RealtimeSnapshotEventCopyWithImpl<$Res>
-    implements $RealtimeSnapshotEventCopyWith<$Res> {
-  _$RealtimeSnapshotEventCopyWithImpl(this._self, this._then);
+class _$RealtimeReadyEventCopyWithImpl<$Res>
+    implements $RealtimeReadyEventCopyWith<$Res> {
+  _$RealtimeReadyEventCopyWithImpl(this._self, this._then);
 
-  final RealtimeSnapshotEvent _self;
-  final $Res Function(RealtimeSnapshotEvent) _then;
+  final RealtimeReadyEvent _self;
+  final $Res Function(RealtimeReadyEvent) _then;
 
 /// Create a copy of RealtimeEvent
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? eews = null,Object? earthquakes = null,Object? shakes = null,Object? source = null,}) {
-  return _then(RealtimeSnapshotEvent(
-eews: null == eews ? _self._eews : eews // ignore: cast_nullable_to_non_nullable
-as List<EewItemWithRelations>,earthquakes: null == earthquakes ? _self._earthquakes : earthquakes // ignore: cast_nullable_to_non_nullable
-as List<EarthquakePartial>,shakes: null == shakes ? _self._shakes : shakes // ignore: cast_nullable_to_non_nullable
-as List<RealtimeShakeData>,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+@override @pragma('vm:prefer-inline') $Res call({Object? source = null,}) {
+  return _then(RealtimeReadyEvent(
+source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
 as RealtimeSource,
   ));
 }
@@ -602,6 +598,160 @@ class _$RealtimeEarthquakeDeleteEventCopyWithImpl<$Res>
 eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
 as RealtimeSource,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class RealtimeTsunamiUpsertEvent implements RealtimeEvent {
+  const RealtimeTsunamiUpsertEvent({required this.eventId, required this.source, this.groupId, final  String? $type}): $type = $type ?? 'tsunamiUpsert';
+  factory RealtimeTsunamiUpsertEvent.fromJson(Map<String, dynamic> json) => _$RealtimeTsunamiUpsertEventFromJson(json);
+
+ final  String eventId;
+@override final  RealtimeSource source;
+ final  String? groupId;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of RealtimeEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RealtimeTsunamiUpsertEventCopyWith<RealtimeTsunamiUpsertEvent> get copyWith => _$RealtimeTsunamiUpsertEventCopyWithImpl<RealtimeTsunamiUpsertEvent>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RealtimeTsunamiUpsertEventToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RealtimeTsunamiUpsertEvent&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.source, source) || other.source == source)&&(identical(other.groupId, groupId) || other.groupId == groupId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,eventId,source,groupId);
+
+@override
+String toString() {
+  return 'RealtimeEvent.tsunamiUpsert(eventId: $eventId, source: $source, groupId: $groupId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RealtimeTsunamiUpsertEventCopyWith<$Res> implements $RealtimeEventCopyWith<$Res> {
+  factory $RealtimeTsunamiUpsertEventCopyWith(RealtimeTsunamiUpsertEvent value, $Res Function(RealtimeTsunamiUpsertEvent) _then) = _$RealtimeTsunamiUpsertEventCopyWithImpl;
+@override @useResult
+$Res call({
+ String eventId, RealtimeSource source, String? groupId
+});
+
+
+
+
+}
+/// @nodoc
+class _$RealtimeTsunamiUpsertEventCopyWithImpl<$Res>
+    implements $RealtimeTsunamiUpsertEventCopyWith<$Res> {
+  _$RealtimeTsunamiUpsertEventCopyWithImpl(this._self, this._then);
+
+  final RealtimeTsunamiUpsertEvent _self;
+  final $Res Function(RealtimeTsunamiUpsertEvent) _then;
+
+/// Create a copy of RealtimeEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? source = null,Object? groupId = freezed,}) {
+  return _then(RealtimeTsunamiUpsertEvent(
+eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as RealtimeSource,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class RealtimeTsunamiDeleteEvent implements RealtimeEvent {
+  const RealtimeTsunamiDeleteEvent({required this.eventId, required this.source, this.groupId, final  String? $type}): $type = $type ?? 'tsunamiDelete';
+  factory RealtimeTsunamiDeleteEvent.fromJson(Map<String, dynamic> json) => _$RealtimeTsunamiDeleteEventFromJson(json);
+
+ final  String eventId;
+@override final  RealtimeSource source;
+ final  String? groupId;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of RealtimeEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RealtimeTsunamiDeleteEventCopyWith<RealtimeTsunamiDeleteEvent> get copyWith => _$RealtimeTsunamiDeleteEventCopyWithImpl<RealtimeTsunamiDeleteEvent>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RealtimeTsunamiDeleteEventToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RealtimeTsunamiDeleteEvent&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.source, source) || other.source == source)&&(identical(other.groupId, groupId) || other.groupId == groupId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,eventId,source,groupId);
+
+@override
+String toString() {
+  return 'RealtimeEvent.tsunamiDelete(eventId: $eventId, source: $source, groupId: $groupId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RealtimeTsunamiDeleteEventCopyWith<$Res> implements $RealtimeEventCopyWith<$Res> {
+  factory $RealtimeTsunamiDeleteEventCopyWith(RealtimeTsunamiDeleteEvent value, $Res Function(RealtimeTsunamiDeleteEvent) _then) = _$RealtimeTsunamiDeleteEventCopyWithImpl;
+@override @useResult
+$Res call({
+ String eventId, RealtimeSource source, String? groupId
+});
+
+
+
+
+}
+/// @nodoc
+class _$RealtimeTsunamiDeleteEventCopyWithImpl<$Res>
+    implements $RealtimeTsunamiDeleteEventCopyWith<$Res> {
+  _$RealtimeTsunamiDeleteEventCopyWithImpl(this._self, this._then);
+
+  final RealtimeTsunamiDeleteEvent _self;
+  final $Res Function(RealtimeTsunamiDeleteEvent) _then;
+
+/// Create a copy of RealtimeEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? source = null,Object? groupId = freezed,}) {
+  return _then(RealtimeTsunamiDeleteEvent(
+eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as RealtimeSource,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/app/lib/core/realtime/model/realtime_event.g.dart
+++ b/app/lib/core/realtime/model/realtime_event.g.dart
@@ -8,46 +8,23 @@ part of 'realtime_event.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-RealtimeSnapshotEvent _$RealtimeSnapshotEventFromJson(
-  Map<String, dynamic> json,
-) => $checkedCreate('RealtimeSnapshotEvent', json, ($checkedConvert) {
-  final val = RealtimeSnapshotEvent(
-    eews: $checkedConvert(
-      'eews',
-      (v) => (v as List<dynamic>)
-          .map((e) => EewItemWithRelations.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    ),
-    earthquakes: $checkedConvert(
-      'earthquakes',
-      (v) => (v as List<dynamic>)
-          .map((e) => EarthquakePartial.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    ),
-    shakes: $checkedConvert(
-      'shakes',
-      (v) => (v as List<dynamic>)
-          .map((e) => RealtimeShakeData.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    ),
-    source: $checkedConvert(
-      'source',
-      (v) => $enumDecode(_$RealtimeSourceEnumMap, v),
-    ),
-    $type: $checkedConvert('runtimeType', (v) => v as String?),
-  );
-  return val;
-}, fieldKeyMap: const {r'$type': 'runtimeType'});
+RealtimeReadyEvent _$RealtimeReadyEventFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('RealtimeReadyEvent', json, ($checkedConvert) {
+      final val = RealtimeReadyEvent(
+        source: $checkedConvert(
+          'source',
+          (v) => $enumDecode(_$RealtimeSourceEnumMap, v),
+        ),
+        $type: $checkedConvert('runtimeType', (v) => v as String?),
+      );
+      return val;
+    }, fieldKeyMap: const {r'$type': 'runtimeType'});
 
-Map<String, dynamic> _$RealtimeSnapshotEventToJson(
-  RealtimeSnapshotEvent instance,
-) => <String, dynamic>{
-  'eews': instance.eews,
-  'earthquakes': instance.earthquakes,
-  'shakes': instance.shakes,
-  'source': _$RealtimeSourceEnumMap[instance.source]!,
-  'runtimeType': instance.$type,
-};
+Map<String, dynamic> _$RealtimeReadyEventToJson(RealtimeReadyEvent instance) =>
+    <String, dynamic>{
+      'source': _$RealtimeSourceEnumMap[instance.source]!,
+      'runtimeType': instance.$type,
+    };
 
 const _$RealtimeSourceEnumMap = {
   RealtimeSource.eqmonitor: 'eqmonitor',
@@ -128,6 +105,72 @@ Map<String, dynamic> _$RealtimeEarthquakeDeleteEventToJson(
 ) => <String, dynamic>{
   'event_id': instance.eventId,
   'source': _$RealtimeSourceEnumMap[instance.source]!,
+  'runtimeType': instance.$type,
+};
+
+RealtimeTsunamiUpsertEvent _$RealtimeTsunamiUpsertEventFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  'RealtimeTsunamiUpsertEvent',
+  json,
+  ($checkedConvert) {
+    final val = RealtimeTsunamiUpsertEvent(
+      eventId: $checkedConvert('event_id', (v) => v as String),
+      source: $checkedConvert(
+        'source',
+        (v) => $enumDecode(_$RealtimeSourceEnumMap, v),
+      ),
+      groupId: $checkedConvert('group_id', (v) => v as String?),
+      $type: $checkedConvert('runtimeType', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'eventId': 'event_id',
+    'groupId': 'group_id',
+    r'$type': 'runtimeType',
+  },
+);
+
+Map<String, dynamic> _$RealtimeTsunamiUpsertEventToJson(
+  RealtimeTsunamiUpsertEvent instance,
+) => <String, dynamic>{
+  'event_id': instance.eventId,
+  'source': _$RealtimeSourceEnumMap[instance.source]!,
+  'group_id': instance.groupId,
+  'runtimeType': instance.$type,
+};
+
+RealtimeTsunamiDeleteEvent _$RealtimeTsunamiDeleteEventFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  'RealtimeTsunamiDeleteEvent',
+  json,
+  ($checkedConvert) {
+    final val = RealtimeTsunamiDeleteEvent(
+      eventId: $checkedConvert('event_id', (v) => v as String),
+      source: $checkedConvert(
+        'source',
+        (v) => $enumDecode(_$RealtimeSourceEnumMap, v),
+      ),
+      groupId: $checkedConvert('group_id', (v) => v as String?),
+      $type: $checkedConvert('runtimeType', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'eventId': 'event_id',
+    'groupId': 'group_id',
+    r'$type': 'runtimeType',
+  },
+);
+
+Map<String, dynamic> _$RealtimeTsunamiDeleteEventToJson(
+  RealtimeTsunamiDeleteEvent instance,
+) => <String, dynamic>{
+  'event_id': instance.eventId,
+  'source': _$RealtimeSourceEnumMap[instance.source]!,
+  'group_id': instance.groupId,
   'runtimeType': instance.$type,
 };
 

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
@@ -72,6 +72,9 @@ Future<EarthquakeHistoryDataSource> earthquakeHistoryDataSource(
     ref.listen(realtimeEventsProvider, (_, next) async {
       if (next case AsyncData(:final value)) {
         switch (value) {
+          case RealtimeReadyEvent():
+            final result = await repository.fetchEarthquakeList(limit: 10);
+            dataSource.upsertItems(result.items);
           case RealtimeEarthquakeUpsertEvent():
             final result = await repository.fetchEarthquakeList(limit: 10);
             dataSource.upsertItems(result.items);

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.g.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.g.dart
@@ -71,7 +71,7 @@ final class EarthquakeHistoryDataSourceProvider
 }
 
 String _$earthquakeHistoryDataSourceHash() =>
-    r'19e34a331e637f239705f593b30308a40bf6ba17';
+    r'398dfcf4a72c1084e08bb460e2a596ee9c971cea';
 
 final class EarthquakeHistoryDataSourceFamily extends $Family
     with

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_map_layer_parameter_notifier.g.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_map_layer_parameter_notifier.g.dart
@@ -43,7 +43,7 @@ final class EarthquakeHistoryMapLayerParameterNotifierProvider
 }
 
 String _$earthquakeHistoryMapLayerParameterNotifierHash() =>
-    r'2fcceaed2f335a0c111c0fb68523f5e481ccf94b';
+    r'8b701b4f09faea950751a9a7bd92becfdb7397c8';
 
 abstract class _$EarthquakeHistoryMapLayerParameterNotifier
     extends $AsyncNotifier<EarthquakeHistoryMapLayerParameter> {

--- a/app/lib/feature/eew/data/eew.dart
+++ b/app/lib/feature/eew/data/eew.dart
@@ -34,8 +34,8 @@ class Eew extends _$Eew {
     ref.listen(realtimeEventsProvider, (_, next) {
       next.whenData((event) {
         switch (event) {
-          case RealtimeSnapshotEvent(:final eews):
-            state = AsyncData(eews.map((e) => e.toEewTelegramItem).toList());
+          case RealtimeReadyEvent():
+            ref.invalidate(_eewRestProvider, asReload: true);
           case RealtimeEewUpsertEvent(:final item):
             _upsert(item.toEewTelegramItem);
           default:

--- a/app/lib/feature/settings/children/config/debug/websocket/debug_websocket_page.dart
+++ b/app/lib/feature/settings/children/config/debug/websocket/debug_websocket_page.dart
@@ -155,21 +155,26 @@ class _WsEventCard extends StatelessWidget {
     final theme = Theme.of(context);
 
     final displayType = switch (event) {
-      RealtimeSnapshotEvent() => 'snapshot',
+      RealtimeReadyEvent() => 'ready',
       RealtimeEewUpsertEvent() => 'eew/upsert',
       RealtimeEarthquakeUpsertEvent() => 'earthquake/upsert',
       RealtimeEarthquakeDeleteEvent() => 'earthquake/delete',
+      RealtimeTsunamiUpsertEvent() => 'tsunami/upsert',
+      RealtimeTsunamiDeleteEvent() => 'tsunami/delete',
       RealtimeShakeDetectedEvent() => 'shake_detected',
       RealtimeEstimatedIntensityUpsertEvent() => 'estimated_intensity/upsert',
     };
 
     final detail = switch (event) {
-      RealtimeSnapshotEvent(:final eews, :final earthquakes, :final shakes) =>
-        'eews=${eews.length} earthquakes=${earthquakes.length} shakes=${shakes.length}',
+      RealtimeReadyEvent(:final source) => 'source=$source',
       RealtimeEewUpsertEvent(:final item) => 'eventId=${item.eventId}',
       RealtimeEarthquakeUpsertEvent(:final record) =>
         'eventId=${record.eventId}',
       RealtimeEarthquakeDeleteEvent(:final eventId) => 'eventId=$eventId',
+      RealtimeTsunamiUpsertEvent(:final eventId, :final groupId) =>
+        'eventId=$eventId groupId=$groupId',
+      RealtimeTsunamiDeleteEvent(:final eventId, :final groupId) =>
+        'eventId=$eventId groupId=$groupId',
       RealtimeShakeDetectedEvent(:final data) => 'eventId=${data.eventId}',
       RealtimeEstimatedIntensityUpsertEvent(:final eventId) =>
         'eventId=$eventId',

--- a/app/lib/feature/shake_detection/data/provider/shake_detection_provider.dart
+++ b/app/lib/feature/shake_detection/data/provider/shake_detection_provider.dart
@@ -35,18 +35,6 @@ class ShakeDetection extends _$ShakeDetection {
 
   void _onRealtimeEvent(RealtimeEvent event) {
     switch (event) {
-      case RealtimeSnapshotEvent(:final shakes):
-        final snapshotEvents = shakes.map(_fromShakeData).toList();
-        final snapshotEventIds = snapshotEvents
-            .map((event) => event.eventId)
-            .toSet();
-        state = [
-          ...state.where(
-            (event) => !snapshotEventIds.contains(event.eventId),
-          ),
-          ...snapshotEvents,
-        ];
-        _cleanup();
       case RealtimeShakeDetectedEvent(:final data):
         _upsert(_fromShakeData(data));
       default:

--- a/app/lib/feature/shake_detection/data/provider/shake_detection_provider.g.dart
+++ b/app/lib/feature/shake_detection/data/provider/shake_detection_provider.g.dart
@@ -43,7 +43,7 @@ final class ShakeDetectionProvider
   }
 }
 
-String _$shakeDetectionHash() => r'1543bceab6470574cba7757b8f69a86bde639a3d';
+String _$shakeDetectionHash() => r'bd1c83377d254d7d8778302c8249595714899ae7';
 
 abstract class _$ShakeDetection extends $Notifier<List<ShakeDetectionEvent>> {
   List<ShakeDetectionEvent> build();

--- a/app/lib/feature/telemetry/data/provider/telemetry_recorder_provider.g.dart
+++ b/app/lib/feature/telemetry/data/provider/telemetry_recorder_provider.g.dart
@@ -56,4 +56,4 @@ final class TelemetryRecorderProvider
   }
 }
 
-String _$telemetryRecorderHash() => r'a7c09f4a2bad1d14f87ec69d6c5d784f2c1c0d27';
+String _$telemetryRecorderHash() => r'a0ac094897646fe3f513b5ccd0bf4c9ed1ad4f48';

--- a/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.dart
+++ b/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.dart
@@ -37,6 +37,7 @@ sealed class RealtimeEventEnvelope with _$RealtimeEventEnvelope {
   const factory RealtimeEventEnvelope.tsunami({
     required WsRealtimeOperation operation,
     @JsonKey(name: 'event_id') required String eventId,
+    @JsonKey(name: 'group_id') String? groupId,
     Map<String, dynamic>? record,
   }) = WsTsunamiRealtimeEvent;
 

--- a/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.freezed.dart
+++ b/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.freezed.dart
@@ -173,13 +173,13 @@ return estimatedIntensity(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( EewItemWithRelations item)?  eew,TResult Function( EarthquakePartial item)?  earthquakeBroadcast,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)?  tsunami,TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  shakeDetected,TResult Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( EewItemWithRelations item)?  eew,TResult Function( EarthquakePartial item)?  earthquakeBroadcast,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'group_id')  String? groupId,  Map<String, dynamic>? record)?  tsunami,TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  shakeDetected,TResult Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case WsEewRealtimeEvent() when eew != null:
 return eew(_that.item);case WsEarthquakeBroadcastEvent() when earthquakeBroadcast != null:
 return earthquakeBroadcast(_that.item);case WsEarthquakeRealtimeEvent() when earthquake != null:
 return earthquake(_that.operation,_that.eventId,_that.record);case WsTsunamiRealtimeEvent() when tsunami != null:
-return tsunami(_that.operation,_that.eventId,_that.record);case WsShakeDetectedRealtimeEvent() when shakeDetected != null:
+return tsunami(_that.operation,_that.eventId,_that.groupId,_that.record);case WsShakeDetectedRealtimeEvent() when shakeDetected != null:
 return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case WsEstimatedIntensityRealtimeEvent() when estimatedIntensity != null:
 return estimatedIntensity(_that.estimatedIntensity);case _:
   return orElse();
@@ -199,13 +199,13 @@ return estimatedIntensity(_that.estimatedIntensity);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( EewItemWithRelations item)  eew,required TResult Function( EarthquakePartial item)  earthquakeBroadcast,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)  earthquake,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)  tsunami,required TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)  shakeDetected,required TResult Function( WsEstimatedIntensityPayload estimatedIntensity)  estimatedIntensity,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( EewItemWithRelations item)  eew,required TResult Function( EarthquakePartial item)  earthquakeBroadcast,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)  earthquake,required TResult Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'group_id')  String? groupId,  Map<String, dynamic>? record)  tsunami,required TResult Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)  shakeDetected,required TResult Function( WsEstimatedIntensityPayload estimatedIntensity)  estimatedIntensity,}) {final _that = this;
 switch (_that) {
 case WsEewRealtimeEvent():
 return eew(_that.item);case WsEarthquakeBroadcastEvent():
 return earthquakeBroadcast(_that.item);case WsEarthquakeRealtimeEvent():
 return earthquake(_that.operation,_that.eventId,_that.record);case WsTsunamiRealtimeEvent():
-return tsunami(_that.operation,_that.eventId,_that.record);case WsShakeDetectedRealtimeEvent():
+return tsunami(_that.operation,_that.eventId,_that.groupId,_that.record);case WsShakeDetectedRealtimeEvent():
 return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case WsEstimatedIntensityRealtimeEvent():
 return estimatedIntensity(_that.estimatedIntensity);}
 }
@@ -221,13 +221,13 @@ return estimatedIntensity(_that.estimatedIntensity);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( EewItemWithRelations item)?  eew,TResult? Function( EarthquakePartial item)?  earthquakeBroadcast,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  Map<String, dynamic>? record)?  tsunami,TResult? Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  shakeDetected,TResult? Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( EewItemWithRelations item)?  eew,TResult? Function( EarthquakePartial item)?  earthquakeBroadcast,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId,  EarthquakePartial? record)?  earthquake,TResult? Function( WsRealtimeOperation operation, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'group_id')  String? groupId,  Map<String, dynamic>? record)?  tsunami,TResult? Function( String eventId,  DateTime createdAt,  String level,  bool isReplay,  int pointCount,  WsShakeRegionPayload region,  List<String> changeReasons,  List<WsShakeObservationPoint> points)?  shakeDetected,TResult? Function( WsEstimatedIntensityPayload estimatedIntensity)?  estimatedIntensity,}) {final _that = this;
 switch (_that) {
 case WsEewRealtimeEvent() when eew != null:
 return eew(_that.item);case WsEarthquakeBroadcastEvent() when earthquakeBroadcast != null:
 return earthquakeBroadcast(_that.item);case WsEarthquakeRealtimeEvent() when earthquake != null:
 return earthquake(_that.operation,_that.eventId,_that.record);case WsTsunamiRealtimeEvent() when tsunami != null:
-return tsunami(_that.operation,_that.eventId,_that.record);case WsShakeDetectedRealtimeEvent() when shakeDetected != null:
+return tsunami(_that.operation,_that.eventId,_that.groupId,_that.record);case WsShakeDetectedRealtimeEvent() when shakeDetected != null:
 return shakeDetected(_that.eventId,_that.createdAt,_that.level,_that.isReplay,_that.pointCount,_that.region,_that.changeReasons,_that.points);case WsEstimatedIntensityRealtimeEvent() when estimatedIntensity != null:
 return estimatedIntensity(_that.estimatedIntensity);case _:
   return null;
@@ -494,11 +494,12 @@ $EarthquakePartialCopyWith<$Res>? get record {
 @JsonSerializable()
 
 class WsTsunamiRealtimeEvent implements RealtimeEventEnvelope {
-  const WsTsunamiRealtimeEvent({required this.operation, @JsonKey(name: 'event_id') required this.eventId, final  Map<String, dynamic>? record, final  String? $type}): _record = record,$type = $type ?? 'tsunami';
+  const WsTsunamiRealtimeEvent({required this.operation, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'group_id') this.groupId, final  Map<String, dynamic>? record, final  String? $type}): _record = record,$type = $type ?? 'tsunami';
   factory WsTsunamiRealtimeEvent.fromJson(Map<String, dynamic> json) => _$WsTsunamiRealtimeEventFromJson(json);
 
  final  WsRealtimeOperation operation;
 @JsonKey(name: 'event_id') final  String eventId;
+@JsonKey(name: 'group_id') final  String? groupId;
  final  Map<String, dynamic>? _record;
  Map<String, dynamic>? get record {
   final value = _record;
@@ -526,16 +527,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsTsunamiRealtimeEvent&&(identical(other.operation, operation) || other.operation == operation)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&const DeepCollectionEquality().equals(other._record, _record));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsTsunamiRealtimeEvent&&(identical(other.operation, operation) || other.operation == operation)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&const DeepCollectionEquality().equals(other._record, _record));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,operation,eventId,const DeepCollectionEquality().hash(_record));
+int get hashCode => Object.hash(runtimeType,operation,eventId,groupId,const DeepCollectionEquality().hash(_record));
 
 @override
 String toString() {
-  return 'RealtimeEventEnvelope.tsunami(operation: $operation, eventId: $eventId, record: $record)';
+  return 'RealtimeEventEnvelope.tsunami(operation: $operation, eventId: $eventId, groupId: $groupId, record: $record)';
 }
 
 
@@ -546,7 +547,7 @@ abstract mixin class $WsTsunamiRealtimeEventCopyWith<$Res> implements $RealtimeE
   factory $WsTsunamiRealtimeEventCopyWith(WsTsunamiRealtimeEvent value, $Res Function(WsTsunamiRealtimeEvent) _then) = _$WsTsunamiRealtimeEventCopyWithImpl;
 @useResult
 $Res call({
- WsRealtimeOperation operation,@JsonKey(name: 'event_id') String eventId, Map<String, dynamic>? record
+ WsRealtimeOperation operation,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'group_id') String? groupId, Map<String, dynamic>? record
 });
 
 
@@ -563,11 +564,12 @@ class _$WsTsunamiRealtimeEventCopyWithImpl<$Res>
 
 /// Create a copy of RealtimeEventEnvelope
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? operation = null,Object? eventId = null,Object? record = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? operation = null,Object? eventId = null,Object? groupId = freezed,Object? record = freezed,}) {
   return _then(WsTsunamiRealtimeEvent(
 operation: null == operation ? _self.operation : operation // ignore: cast_nullable_to_non_nullable
 as WsRealtimeOperation,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
-as String,record: freezed == record ? _self._record : record // ignore: cast_nullable_to_non_nullable
+as String,groupId: freezed == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
+as String?,record: freezed == record ? _self._record : record // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>?,
   ));
 }

--- a/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.g.dart
+++ b/packages/eqmonitor_websocket/lib/src/realtime_event_envelope.g.dart
@@ -91,12 +91,17 @@ WsTsunamiRealtimeEvent _$WsTsunamiRealtimeEventFromJson(
         (v) => $enumDecode(_$WsRealtimeOperationEnumMap, v),
       ),
       eventId: $checkedConvert('event_id', (v) => v as String),
+      groupId: $checkedConvert('group_id', (v) => v as String?),
       record: $checkedConvert('record', (v) => v as Map<String, dynamic>?),
       $type: $checkedConvert('type', (v) => v as String?),
     );
     return val;
   },
-  fieldKeyMap: const {'eventId': 'event_id', r'$type': 'type'},
+  fieldKeyMap: const {
+    'eventId': 'event_id',
+    'groupId': 'group_id',
+    r'$type': 'type',
+  },
 );
 
 Map<String, dynamic> _$WsTsunamiRealtimeEventToJson(
@@ -104,6 +109,7 @@ Map<String, dynamic> _$WsTsunamiRealtimeEventToJson(
 ) => <String, dynamic>{
   'operation': _$WsRealtimeOperationEnumMap[instance.operation]!,
   'event_id': instance.eventId,
+  'group_id': instance.groupId,
   'record': instance.record,
   'type': instance.$type,
 };


### PR DESCRIPTION
## Summary

Closes #1354

WebSocket の `ready` プロトコル対応・再接続の堅牢化・廃止済み `snapshot` コードの除去を行った。

### 🔴 重大バグ修正
- **`ready` 受信時に REST baseline を取得**: `WsReadyMessage` を `RealtimeEvent.ready` にマッピングし、EEW / 地震履歴の各 consumer が `ready` を契機に REST API で初期状態を再取得するように変更。これにより Pub/Sub 購読完了前の隙間でイベントが漏れる問題を解消。
- **再接続後に baseline を再取得**: 再接続のたびに `ready` が配信されるため、自動的に catch-up の REST 再取得が走る。
- **初回接続失敗時の永久停止を修正**: `eqmonitorWsEventStream` を keepAlive StreamNotifier に変換し、`WebSocket.connect` の例外を try-catch で捕捉。接続失敗時もバックオフ付きで再試行を継続する。
- **指数バックオフを導入**: 1s → 2s → 4s → … → 最大60s の指数バックオフで再接続。サーバーデプロイや pong タイムアウト時の再接続ストームを防止。

### 🟡 中（改善）
- **津波 realtime イベントの配管を追加**: `WsTsunamiRealtimeEvent` に `group_id` フィールドを追加し、mapper で `RealtimeEvent.tsunamiUpsert` / `tsunamiDelete` にマッピング。consumer 統合はアーキテクチャ追加が必要なため別 issue で対応（既存のポーリングは継続動作）。
- **アプリ resume 時の再接続**: バックオフをリセットし即座に再接続。

### 🟢 クリーンアップ
- **廃止済み snapshot コードの除去**: `RealtimeEvent.snapshot` / `RealtimeSnapshotEvent` を削除。mapper の `WsSnapshotMessage` は no-op（空リスト）に変更。shake_detection の snapshot 分岐を削除。デバッグ画面の switch 式を更新。

## 変更ファイル
| ファイル | 概要 |
|---|---|
| `packages/eqmonitor_websocket/.../realtime_event_envelope.dart` | `WsTsunamiRealtimeEvent` に `groupId` 追加 |
| `app/.../realtime_event.dart` | `snapshot` 削除、`ready` / `tsunamiUpsert` / `tsunamiDelete` 追加 |
| `app/.../eqmonitor_realtime_event_mapper.dart` | ready / tsunami マッピング実装、snapshot 除去 |
| `app/.../eqmonitor_ws_provider.dart` | keepAlive StreamNotifier 化、指数バックオフ、ライフサイクル連動 |
| `app/.../eew.dart` | `ready` → REST baseline 再取得 |
| `app/.../earthquake_history_data_source.dart` | `ready` → REST baseline 再取得 |
| `app/.../shake_detection_provider.dart` | snapshot 死にコード除去 |
| `app/.../debug_websocket_page.dart` | switch 式を新イベント型に対応 |

## Test plan
- [x] `packages/eqmonitor_websocket` のテスト全通過 (41/41)
- [x] `app` のテスト通過 (450/450, 既存の travel_time 18件の失敗は変更前から存在)
- [x] `dart analyze` で issue なし
- [ ] 手動確認: 起動時オフライン → オンライン復帰後に WS 再接続されること
- [ ] 手動確認: 接続中にネットワーク瞬断 → 再接続後に地震/EEW が補完されること
- [ ] 手動確認: バックグラウンド → フォアグラウンド復帰で再接続されること
- [ ] 手動確認: デバッグ WebSocket 画面で `ready` イベントが表示されること