### PR TITLE
fix(cache): 復元元が無い 304 でExceptionを吐く問題を修正

### DIFF
--- a/packages/cache/lib/src/http/http_cache_interceptor.dart
+++ b/packages/cache/lib/src/http/http_cache_interceptor.dart
@@ -33,15 +33,33 @@ class HttpCacheInterceptor extends Interceptor {
 
     // force-fresh: skip conditional headers, still save on 200
     if (options.extra[kForceFreshExtra] == true) {
+      options.headers.remove('if-none-match');
       handler.next(options);
       return;
     }
 
+    // 条件付きリクエスト(304)を許可する以上、304 が返ってきたら必ず
+    // キャッシュから復元できる状態でなければならない。復元元が無い／壊れて
+    // いる場合に if-none-match を付けると、復元不能な 304 が呼び出し側へ
+    // 漏れてしまうため、その時はヘッダを除去してフルレスポンスを取得する。
+    // 上流(リポジトリ等)が独自に付与した if-none-match もここで一元管理する。
     final cached = await store.read(key);
-    if (cached?.eTag != null) {
-      options.headers['if-none-match'] = cached!.eTag;
+    if (cached?.eTag != null && _isRestorable(options, cached!)) {
+      options.headers['if-none-match'] = cached.eTag;
+    } else {
+      options.headers.remove('if-none-match');
     }
     handler.next(options);
+  }
+
+  /// キャッシュエントリが実際に復元(パース)可能かを検証する。
+  bool _isRestorable(RequestOptions options, HttpCacheEntry entry) {
+    try {
+      restoreResponse(options, entry);
+      return true;
+    } on Object {
+      return false;
+    }
   }
 
   @override

--- a/packages/cache/test/http/http_cache_interceptor_test.dart
+++ b/packages/cache/test/http/http_cache_interceptor_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:cache/cache.dart';
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
@@ -72,6 +75,97 @@ void main() {
     );
     final updated = await dio.get<dynamic>(path);
     expect((updated.data as Map)['v'], 2);
+  });
+
+  test('復元可能なエントリがあれば if-none-match を付与する', () async {
+    const path = '/v2/earthquake';
+    final dio = buildDio();
+    final adapter = DioAdapter(dio: dio);
+
+    adapter.onGet(
+      path,
+      (s) =>
+          s.reply(200, {'items': <dynamic>[]}, headers: jsonHeaders('W/"v1"')),
+    );
+    await dio.get<dynamic>(path);
+
+    adapter.onGet(
+      path,
+      (s) => s.reply(
+        304,
+        '',
+        headers: {
+          'etag': ['W/"v1"'],
+        },
+      ),
+    );
+    final second = await dio.get<dynamic>(path);
+
+    expect(second.requestOptions.headers['if-none-match'], 'W/"v1"');
+    expect((second.data as Map)['items'], <dynamic>[]);
+  });
+
+  test('復元元が無い場合は上流の if-none-match を除去して 200 を取得', () async {
+    const path = '/v2/earthquake';
+    final dio = buildDio();
+    final adapter = DioAdapter(dio: dio);
+
+    // ストアは空。Repository など上流が付与した if-none-match だけが存在する状況。
+    adapter.onGet(
+      path,
+      (s) =>
+          s.reply(200, {'items': <dynamic>[]}, headers: jsonHeaders('W/"v1"')),
+    );
+
+    final res = await dio.get<dynamic>(
+      path,
+      options: Options(headers: {'if-none-match': 'W/"stale"'}),
+    );
+
+    // 復元元が無いので条件付きリクエストにせず、フルの 200 を取得できる。
+    expect((res.data as Map)['items'], <dynamic>[]);
+    expect(res.requestOptions.headers.containsKey('if-none-match'), isFalse);
+  });
+
+  test('ストアの body が壊れている場合も if-none-match を除去', () async {
+    const path = '/v2/earthquake';
+    final store = HttpCacheStore(
+      db: db,
+      schemaVersion: 1,
+      appBuild: '3.0.0+100',
+    );
+    final dio = Dio(BaseOptions(baseUrl: 'https://v2.api.eqmonitor.app'))
+      ..interceptors.add(HttpCacheInterceptor(store));
+    final adapter = DioAdapter(dio: dio);
+
+    // eTag は持つが body が JSON として壊れているエントリを直接書き込む。
+    final key = store.primaryKeyForUrl(
+      RequestOptions(path: path, baseUrl: 'https://v2.api.eqmonitor.app'),
+    );
+    await store.write(
+      HttpCacheEntry(
+        key: key,
+        statusCode: 200,
+        eTag: 'W/"v1"',
+        headers: const {
+          'content-type': ['application/json'],
+        },
+        responseType: 'json',
+        body: Uint8List.fromList(utf8.encode('{ broken json')),
+        updatedAtMs: 0,
+      ),
+    );
+
+    adapter.onGet(
+      path,
+      (s) =>
+          s.reply(200, {'items': <dynamic>[]}, headers: jsonHeaders('W/"v2"')),
+    );
+
+    final res = await dio.get<dynamic>(path);
+
+    expect((res.data as Map)['items'], <dynamic>[]);
+    expect(res.requestOptions.headers.containsKey('if-none-match'), isFalse);
   });
 
   test('schemaVersion 変更で旧 body が復元されない', () async {


### PR DESCRIPTION
## 概要

Changelog API などで `304 Not Modified` を受信した際に `Null check operator used on a null value` (TypeError) でクラッシュする問題を修正します。

```
flutter: [http-response] [GET] https://v2.api.eqmonitor.app/v1/changelog
flutter: Status: 304
flutter: [error] Uncaught async exception
flutter: Null check operator used on a null value
flutter: #0 _ChangelogApiClient.getV1Changelog (changelog_api_client.g.dart:49:55)
```

## 根本原因

キャッシュ機構が二重に存在し、噛み合っていなかった。

| 層 | 仕組み |
|---|---|
| `ChangelogRepository` (5月実装) | ETag/body を **SharedPreferences** に保存し、自前で `if-none-match` を送信 |
| `HttpCacheInterceptor` (6/25実装) | ETag/304 を **drift DB** で透過処理。`onRequest` で `validateStatus` を 304 も成功扱いに変更 |

クラッシュの流れ:

1. Repository が SharedPreferences の ETag で `if-none-match` を送信
2. サーバーが **304** を返す
3. `HttpCacheInterceptor.onResponse` は **自分の drift ストア** を見るが、その ETag は SharedPreferences 由来で drift に無い → `cached == null` → 生の304を素通り
4. `validateStatus` が304を許可しているため `_dio.fetch` は成功扱いで `data == null` を返す
5. 生成コード `ChangelogResponse.fromJson(_result.data!)` で null check → `TypeError`
6. `TypeError` は `Error` のサブクラスで **`Exception` ではない**ため、Repository の `on DioException` / `on Exception` のどちらにも捕まらず Uncaught

## 修正方針

**発生源で断つ。** リクエスト送信前 (`onRequest`) に復元元の有無とパース可否をチェックし、復元可能な場合のみ `if-none-match` を付与する。復元不能なら除去してフルレスポンス (200) を取得する。

```dart
final cached = await store.read(key);
if (cached?.eTag != null && _isRestorable(options, cached!)) {
  options.headers['if-none-match'] = cached.eTag;
} else {
  options.headers.remove('if-none-match'); // 復元不能なら除去
}
```

- `_isRestorable()` は `restoreResponse()` を実際に走らせ、**JSONパースまで成功する場合のみ** true。
- 上流 (Repository) が独自付与した `if-none-match` も interceptor 側で一元管理されるため、二重キャッシュ起因の不整合も解消。
- `force-fresh` 経路でも同様にヘッダを除去するよう統一。

## テスト (TDD)

`packages/cache/test/http/http_cache_interceptor_test.dart` に追加:

- 復元可能なエントリがあれば `if-none-match` を付与する
- 復元元が無い場合は上流の `if-none-match` を除去して 200 を取得
- ストアの body が壊れている場合も `if-none-match` を除去

cache パッケージ全49テスト通過 / `dart analyze` クリーン。

## 残課題 (本PR対象外)

`onResponse` の 304 処理に `cached == null` のとき生の304を通す経路が残存。本PRの `onRequest` 修正で通常フローでは到達不能になるが、リクエスト〜レスポンス間のエビクション競合など稀なケースでは依然クラッシュし得る。別途安全網の追加を検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5KVKE17jGgWRFDSaxoRGr