### PR TITLE
feat(intensity-history): 地域別 最大震度マップを追加

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -15,6 +15,7 @@ import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
 import 'package:eqmonitor/feature/eew_history/ui/eew_history_page.dart';
 import 'package:eqmonitor/feature/home/ui/page/home_map_layer_page.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/intensity_history_page.dart';
 import 'package:eqmonitor/feature/knet_waveform/data/model/knet_station_result.dart';
 import 'package:eqmonitor/feature/knet_waveform/ui/knet_waveform_page.dart';
 import 'package:eqmonitor/feature/knet_waveform/ui/media/knet_media_page.dart';
@@ -170,6 +171,21 @@ class EewHistoryRoute extends GoRouteData with $EewHistoryRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const EewHistoryPage();
+}
+
+@TypedGoRoute<IntensityHistoryRoute>(path: '/intensity-history')
+class IntensityHistoryRoute extends GoRouteData with $IntensityHistoryRoute {
+  const IntensityHistoryRoute({this.prefectureCode, this.cityCode});
+
+  final String? prefectureCode;
+  final String? cityCode;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      IntensityHistoryPage(
+        initialPrefectureCode: prefectureCode,
+        initialCityCode: cityCode,
+      );
 }
 
 @TypedGoRoute<EarthquakeSearchResultRoute>(

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -14,6 +14,7 @@ List<RouteBase> get $appRoutes => [
   $betaTestingWarningRoute,
   $earthquakeHistoryRoute,
   $eewHistoryRoute,
+  $intensityHistoryRoute,
   $earthquakeSearchResultRoute,
   $earthquakeHistoryDetailsRoute,
   $shakeDetectionHistoryRoute,
@@ -145,6 +146,43 @@ mixin $EewHistoryRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/eew-history');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $intensityHistoryRoute => GoRouteData.$route(
+  path: '/intensity-history',
+  factory: $IntensityHistoryRoute._fromState,
+);
+
+mixin $IntensityHistoryRoute on GoRouteData {
+  static IntensityHistoryRoute _fromState(GoRouterState state) =>
+      IntensityHistoryRoute(
+        prefectureCode: state.uri.queryParameters['prefecture-code'],
+        cityCode: state.uri.queryParameters['city-code'],
+      );
+
+  IntensityHistoryRoute get _self => this as IntensityHistoryRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/intensity-history',
+    queryParams: {
+      if (_self.prefectureCode != null) 'prefecture-code': _self.prefectureCode,
+      if (_self.cityCode != null) 'city-code': _self.cityCode,
+    },
+  );
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
 import 'package:eqmonitor/core/provider/map/jma_map_utility.dart';
+import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
@@ -22,8 +23,10 @@ import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/home_map_options.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:eqmonitor/feature/map/ui/maplibre_event_provider.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -150,6 +153,7 @@ class _MapContent extends HookConsumerWidget {
               if (context.mounted) {
                 await _handleTap(
                   context: context,
+                  ref: ref,
                   event: event,
                   jmaMap: jmaMap,
                 );
@@ -223,6 +227,7 @@ class _MapContent extends HookConsumerWidget {
 
   Future<void> _handleTap({
     required BuildContext context,
+    required WidgetRef ref,
     required MapEventClick event,
     required Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
   }) async {
@@ -269,19 +274,36 @@ class _MapContent extends HookConsumerWidget {
     final code = item.property.code;
     final name = item.property.name;
 
+    // 都道府県コードを解決してディープリンクルートを構築する
+    final prefectures =
+        ref
+            .read(parameterSetProvider)
+            .whenOrNull(data: (p) => p.earthquake.prefectures) ??
+        [];
+
     if (isCity) {
       final cityNode = _findCityByCode(code);
+      final prefCode = prefectureCodeOfCity(code, prefectures);
+      final intensityHistoryRoute = prefCode != null
+          ? IntensityHistoryRoute(prefectureCode: prefCode, cityCode: code)
+          : null;
       await showAreaPopup(
         context,
         areaName: name,
         maxIntensity: cityNode?.maxIntensity,
+        intensityHistoryRoute: intensityHistoryRoute,
       );
     } else {
       final region = _findRegionByCode(code);
+      final prefInfo = prefectureOfRegionCode(code, prefectures);
+      final intensityHistoryRoute = prefInfo != null
+          ? IntensityHistoryRoute(prefectureCode: prefInfo.code)
+          : null;
       await showAreaPopup(
         context,
         areaName: name,
         maxIntensity: region?.maxIntensity,
+        intensityHistoryRoute: intensityHistoryRoute,
       );
     }
   }

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_map_popup.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_map_popup.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
 import 'package:eqmonitor/core/component/intenisty/jma_lpgm_intensity_icon.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
+import 'package:eqmonitor/core/router/router.dart';
 import 'package:flutter/material.dart';
 
 /// 観測点タップ時のポップアップ
@@ -23,10 +26,13 @@ Future<void> showStationPopup(
 }
 
 /// 区域タップ時のポップアップ
+///
+/// [intensityHistoryRoute] を指定すると「この地域の最大震度履歴」ボタンを表示する。
 Future<void> showAreaPopup(
   BuildContext context, {
   required String areaName,
   required JmaIntensity? maxIntensity,
+  IntensityHistoryRoute? intensityHistoryRoute,
 }) {
   return showModalBottomSheet(
     context: context,
@@ -34,6 +40,7 @@ Future<void> showAreaPopup(
     builder: (context) => _AreaPopupBody(
       areaName: areaName,
       maxIntensity: maxIntensity,
+      intensityHistoryRoute: intensityHistoryRoute,
     ),
   );
 }
@@ -116,10 +123,12 @@ class _AreaPopupBody extends StatelessWidget {
   const _AreaPopupBody({
     required this.areaName,
     required this.maxIntensity,
+    this.intensityHistoryRoute,
   });
 
   final String areaName;
   final JmaIntensity? maxIntensity;
+  final IntensityHistoryRoute? intensityHistoryRoute;
 
   @override
   Widget build(BuildContext context) {
@@ -166,6 +175,17 @@ class _AreaPopupBody extends StatelessWidget {
                   color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                 ),
               ),
+            if (intensityHistoryRoute != null) ...[
+              const SizedBox(height: 8),
+              TextButton.icon(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  unawaited(intensityHistoryRoute!.push<void>(context));
+                },
+                icon: const Icon(Icons.bar_chart_outlined),
+                label: const Text('この地域の最大震度履歴'),
+              ),
+            ],
           ],
         ),
       ),

--- a/app/lib/feature/intensity_history/data/model/city_intensity_page.dart
+++ b/app/lib/feature/intensity_history/data/model/city_intensity_page.dart
@@ -1,0 +1,13 @@
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'city_intensity_page.freezed.dart';
+
+/// 市区町村の過去地震一覧ページ。
+@freezed
+abstract class CityIntensityPage with _$CityIntensityPage {
+  const factory CityIntensityPage({
+    required List<IntensityCitySearchItem> items,
+    required String? nextToken,
+  }) = _CityIntensityPage;
+}

--- a/app/lib/feature/intensity_history/data/model/city_intensity_page.freezed.dart
+++ b/app/lib/feature/intensity_history/data/model/city_intensity_page.freezed.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'city_intensity_page.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$CityIntensityPage {
+
+ List<IntensityCitySearchItem> get items; String? get nextToken;
+/// Create a copy of CityIntensityPage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CityIntensityPageCopyWith<CityIntensityPage> get copyWith => _$CityIntensityPageCopyWithImpl<CityIntensityPage>(this as CityIntensityPage, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CityIntensityPage&&const DeepCollectionEquality().equals(other.items, items)&&(identical(other.nextToken, nextToken) || other.nextToken == nextToken));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(items),nextToken);
+
+@override
+String toString() {
+  return 'CityIntensityPage(items: $items, nextToken: $nextToken)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CityIntensityPageCopyWith<$Res>  {
+  factory $CityIntensityPageCopyWith(CityIntensityPage value, $Res Function(CityIntensityPage) _then) = _$CityIntensityPageCopyWithImpl;
+@useResult
+$Res call({
+ List<IntensityCitySearchItem> items, String? nextToken
+});
+
+
+
+
+}
+/// @nodoc
+class _$CityIntensityPageCopyWithImpl<$Res>
+    implements $CityIntensityPageCopyWith<$Res> {
+  _$CityIntensityPageCopyWithImpl(this._self, this._then);
+
+  final CityIntensityPage _self;
+  final $Res Function(CityIntensityPage) _then;
+
+/// Create a copy of CityIntensityPage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? items = null,Object? nextToken = freezed,}) {
+  return _then(_self.copyWith(
+items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+as List<IntensityCitySearchItem>,nextToken: freezed == nextToken ? _self.nextToken : nextToken // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [CityIntensityPage].
+extension CityIntensityPagePatterns on CityIntensityPage {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CityIntensityPage value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CityIntensityPage() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CityIntensityPage value)  $default,){
+final _that = this;
+switch (_that) {
+case _CityIntensityPage():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CityIntensityPage value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CityIntensityPage() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<IntensityCitySearchItem> items,  String? nextToken)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CityIntensityPage() when $default != null:
+return $default(_that.items,_that.nextToken);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<IntensityCitySearchItem> items,  String? nextToken)  $default,) {final _that = this;
+switch (_that) {
+case _CityIntensityPage():
+return $default(_that.items,_that.nextToken);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<IntensityCitySearchItem> items,  String? nextToken)?  $default,) {final _that = this;
+switch (_that) {
+case _CityIntensityPage() when $default != null:
+return $default(_that.items,_that.nextToken);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _CityIntensityPage implements CityIntensityPage {
+  const _CityIntensityPage({required final  List<IntensityCitySearchItem> items, required this.nextToken}): _items = items;
+  
+
+ final  List<IntensityCitySearchItem> _items;
+@override List<IntensityCitySearchItem> get items {
+  if (_items is EqualUnmodifiableListView) return _items;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_items);
+}
+
+@override final  String? nextToken;
+
+/// Create a copy of CityIntensityPage
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CityIntensityPageCopyWith<_CityIntensityPage> get copyWith => __$CityIntensityPageCopyWithImpl<_CityIntensityPage>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CityIntensityPage&&const DeepCollectionEquality().equals(other._items, _items)&&(identical(other.nextToken, nextToken) || other.nextToken == nextToken));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_items),nextToken);
+
+@override
+String toString() {
+  return 'CityIntensityPage(items: $items, nextToken: $nextToken)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CityIntensityPageCopyWith<$Res> implements $CityIntensityPageCopyWith<$Res> {
+  factory _$CityIntensityPageCopyWith(_CityIntensityPage value, $Res Function(_CityIntensityPage) _then) = __$CityIntensityPageCopyWithImpl;
+@override @useResult
+$Res call({
+ List<IntensityCitySearchItem> items, String? nextToken
+});
+
+
+
+
+}
+/// @nodoc
+class __$CityIntensityPageCopyWithImpl<$Res>
+    implements _$CityIntensityPageCopyWith<$Res> {
+  __$CityIntensityPageCopyWithImpl(this._self, this._then);
+
+  final _CityIntensityPage _self;
+  final $Res Function(_CityIntensityPage) _then;
+
+/// Create a copy of CityIntensityPage
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? items = null,Object? nextToken = freezed,}) {
+  return _then(_CityIntensityPage(
+items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
+as List<IntensityCitySearchItem>,nextToken: freezed == nextToken ? _self.nextToken : nextToken // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/intensity_history/data/model/highest_intensity_entry.dart
+++ b/app/lib/feature/intensity_history/data/model/highest_intensity_entry.dart
@@ -1,0 +1,39 @@
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'highest_intensity_entry.freezed.dart';
+
+/// [HighestIntensityItem] の app 用ラッパ。
+///
+/// Lv1(都道府県)・Lv2(市区町村)共通で使用する。
+@freezed
+abstract class HighestIntensityEntry with _$HighestIntensityEntry {
+  const factory HighestIntensityEntry({
+    /// 気象庁防災情報XMLフォーマットの地域コード。
+    required String code,
+
+    /// 地域名。
+    required String name,
+
+    /// 過去最高震度。
+    required JmaIntensity intensity,
+
+    /// 同震度を観測した地震の件数。
+    required int count,
+
+    /// 最高震度を観測した直近の地震イベント。
+    required EarthquakePartial earthquake,
+  }) = _HighestIntensityEntry;
+
+  const HighestIntensityEntry._();
+
+  /// [HighestIntensityItem] から変換する。
+  factory HighestIntensityEntry.fromApi(HighestIntensityItem item) =>
+      HighestIntensityEntry(
+        code: item.code,
+        name: item.name,
+        intensity: item.intensity,
+        count: item.count,
+        earthquake: item.earthquake,
+      );
+}

--- a/app/lib/feature/intensity_history/data/model/highest_intensity_entry.freezed.dart
+++ b/app/lib/feature/intensity_history/data/model/highest_intensity_entry.freezed.dart
@@ -1,0 +1,311 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'highest_intensity_entry.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$HighestIntensityEntry {
+
+/// 気象庁防災情報XMLフォーマットの地域コード。
+ String get code;/// 地域名。
+ String get name;/// 過去最高震度。
+ JmaIntensity get intensity;/// 同震度を観測した地震の件数。
+ int get count;/// 最高震度を観測した直近の地震イベント。
+ EarthquakePartial get earthquake;
+/// Create a copy of HighestIntensityEntry
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HighestIntensityEntryCopyWith<HighestIntensityEntry> get copyWith => _$HighestIntensityEntryCopyWithImpl<HighestIntensityEntry>(this as HighestIntensityEntry, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HighestIntensityEntry&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.intensity, intensity) || other.intensity == intensity)&&(identical(other.count, count) || other.count == count)&&(identical(other.earthquake, earthquake) || other.earthquake == earthquake));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,code,name,intensity,count,earthquake);
+
+@override
+String toString() {
+  return 'HighestIntensityEntry(code: $code, name: $name, intensity: $intensity, count: $count, earthquake: $earthquake)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $HighestIntensityEntryCopyWith<$Res>  {
+  factory $HighestIntensityEntryCopyWith(HighestIntensityEntry value, $Res Function(HighestIntensityEntry) _then) = _$HighestIntensityEntryCopyWithImpl;
+@useResult
+$Res call({
+ String code, String name, JmaIntensity intensity, int count, EarthquakePartial earthquake
+});
+
+
+$EarthquakePartialCopyWith<$Res> get earthquake;
+
+}
+/// @nodoc
+class _$HighestIntensityEntryCopyWithImpl<$Res>
+    implements $HighestIntensityEntryCopyWith<$Res> {
+  _$HighestIntensityEntryCopyWithImpl(this._self, this._then);
+
+  final HighestIntensityEntry _self;
+  final $Res Function(HighestIntensityEntry) _then;
+
+/// Create a copy of HighestIntensityEntry
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? code = null,Object? name = null,Object? intensity = null,Object? count = null,Object? earthquake = null,}) {
+  return _then(_self.copyWith(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,intensity: null == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
+as JmaIntensity,count: null == count ? _self.count : count // ignore: cast_nullable_to_non_nullable
+as int,earthquake: null == earthquake ? _self.earthquake : earthquake // ignore: cast_nullable_to_non_nullable
+as EarthquakePartial,
+  ));
+}
+/// Create a copy of HighestIntensityEntry
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EarthquakePartialCopyWith<$Res> get earthquake {
+  
+  return $EarthquakePartialCopyWith<$Res>(_self.earthquake, (value) {
+    return _then(_self.copyWith(earthquake: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [HighestIntensityEntry].
+extension HighestIntensityEntryPatterns on HighestIntensityEntry {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _HighestIntensityEntry value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _HighestIntensityEntry() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _HighestIntensityEntry value)  $default,){
+final _that = this;
+switch (_that) {
+case _HighestIntensityEntry():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _HighestIntensityEntry value)?  $default,){
+final _that = this;
+switch (_that) {
+case _HighestIntensityEntry() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String code,  String name,  JmaIntensity intensity,  int count,  EarthquakePartial earthquake)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _HighestIntensityEntry() when $default != null:
+return $default(_that.code,_that.name,_that.intensity,_that.count,_that.earthquake);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String code,  String name,  JmaIntensity intensity,  int count,  EarthquakePartial earthquake)  $default,) {final _that = this;
+switch (_that) {
+case _HighestIntensityEntry():
+return $default(_that.code,_that.name,_that.intensity,_that.count,_that.earthquake);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String code,  String name,  JmaIntensity intensity,  int count,  EarthquakePartial earthquake)?  $default,) {final _that = this;
+switch (_that) {
+case _HighestIntensityEntry() when $default != null:
+return $default(_that.code,_that.name,_that.intensity,_that.count,_that.earthquake);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _HighestIntensityEntry extends HighestIntensityEntry {
+  const _HighestIntensityEntry({required this.code, required this.name, required this.intensity, required this.count, required this.earthquake}): super._();
+  
+
+/// 気象庁防災情報XMLフォーマットの地域コード。
+@override final  String code;
+/// 地域名。
+@override final  String name;
+/// 過去最高震度。
+@override final  JmaIntensity intensity;
+/// 同震度を観測した地震の件数。
+@override final  int count;
+/// 最高震度を観測した直近の地震イベント。
+@override final  EarthquakePartial earthquake;
+
+/// Create a copy of HighestIntensityEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HighestIntensityEntryCopyWith<_HighestIntensityEntry> get copyWith => __$HighestIntensityEntryCopyWithImpl<_HighestIntensityEntry>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HighestIntensityEntry&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.intensity, intensity) || other.intensity == intensity)&&(identical(other.count, count) || other.count == count)&&(identical(other.earthquake, earthquake) || other.earthquake == earthquake));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,code,name,intensity,count,earthquake);
+
+@override
+String toString() {
+  return 'HighestIntensityEntry(code: $code, name: $name, intensity: $intensity, count: $count, earthquake: $earthquake)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$HighestIntensityEntryCopyWith<$Res> implements $HighestIntensityEntryCopyWith<$Res> {
+  factory _$HighestIntensityEntryCopyWith(_HighestIntensityEntry value, $Res Function(_HighestIntensityEntry) _then) = __$HighestIntensityEntryCopyWithImpl;
+@override @useResult
+$Res call({
+ String code, String name, JmaIntensity intensity, int count, EarthquakePartial earthquake
+});
+
+
+@override $EarthquakePartialCopyWith<$Res> get earthquake;
+
+}
+/// @nodoc
+class __$HighestIntensityEntryCopyWithImpl<$Res>
+    implements _$HighestIntensityEntryCopyWith<$Res> {
+  __$HighestIntensityEntryCopyWithImpl(this._self, this._then);
+
+  final _HighestIntensityEntry _self;
+  final $Res Function(_HighestIntensityEntry) _then;
+
+/// Create a copy of HighestIntensityEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? code = null,Object? name = null,Object? intensity = null,Object? count = null,Object? earthquake = null,}) {
+  return _then(_HighestIntensityEntry(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,intensity: null == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
+as JmaIntensity,count: null == count ? _self.count : count // ignore: cast_nullable_to_non_nullable
+as int,earthquake: null == earthquake ? _self.earthquake : earthquake // ignore: cast_nullable_to_non_nullable
+as EarthquakePartial,
+  ));
+}
+
+/// Create a copy of HighestIntensityEntry
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EarthquakePartialCopyWith<$Res> get earthquake {
+  
+  return $EarthquakePartialCopyWith<$Res>(_self.earthquake, (value) {
+    return _then(_self.copyWith(earthquake: value));
+  });
+}
+}
+
+// dart format on

--- a/app/lib/feature/intensity_history/data/model/intensity_history_state.dart
+++ b/app/lib/feature/intensity_history/data/model/intensity_history_state.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'intensity_history_state.freezed.dart';
+
+/// 地域別最大震度マップのフォーカス状態。
+///
+/// - [IntensityHistoryStatePrefecture]: Lv1 全都道府県表示。
+/// - [IntensityHistoryStateCity]: Lv2 特定都道府県にフォーカス中。
+@freezed
+sealed class IntensityHistoryState with _$IntensityHistoryState {
+  /// Lv1: 全都道府県表示状態。
+  const factory IntensityHistoryState.prefecture() =
+      IntensityHistoryStatePrefecture;
+
+  /// Lv2: 特定都道府県にフォーカス中の状態。
+  const factory IntensityHistoryState.city({
+    required String prefectureCode,
+    required String prefectureName,
+  }) = IntensityHistoryStateCity;
+}

--- a/app/lib/feature/intensity_history/data/model/intensity_history_state.freezed.dart
+++ b/app/lib/feature/intensity_history/data/model/intensity_history_state.freezed.dart
@@ -1,0 +1,274 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'intensity_history_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$IntensityHistoryState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IntensityHistoryState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'IntensityHistoryState()';
+}
+
+
+}
+
+/// @nodoc
+class $IntensityHistoryStateCopyWith<$Res>  {
+$IntensityHistoryStateCopyWith(IntensityHistoryState _, $Res Function(IntensityHistoryState) __);
+}
+
+
+/// Adds pattern-matching-related methods to [IntensityHistoryState].
+extension IntensityHistoryStatePatterns on IntensityHistoryState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( IntensityHistoryStatePrefecture value)?  prefecture,TResult Function( IntensityHistoryStateCity value)?  city,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case IntensityHistoryStatePrefecture() when prefecture != null:
+return prefecture(_that);case IntensityHistoryStateCity() when city != null:
+return city(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( IntensityHistoryStatePrefecture value)  prefecture,required TResult Function( IntensityHistoryStateCity value)  city,}){
+final _that = this;
+switch (_that) {
+case IntensityHistoryStatePrefecture():
+return prefecture(_that);case IntensityHistoryStateCity():
+return city(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( IntensityHistoryStatePrefecture value)?  prefecture,TResult? Function( IntensityHistoryStateCity value)?  city,}){
+final _that = this;
+switch (_that) {
+case IntensityHistoryStatePrefecture() when prefecture != null:
+return prefecture(_that);case IntensityHistoryStateCity() when city != null:
+return city(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  prefecture,TResult Function( String prefectureCode,  String prefectureName)?  city,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case IntensityHistoryStatePrefecture() when prefecture != null:
+return prefecture();case IntensityHistoryStateCity() when city != null:
+return city(_that.prefectureCode,_that.prefectureName);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  prefecture,required TResult Function( String prefectureCode,  String prefectureName)  city,}) {final _that = this;
+switch (_that) {
+case IntensityHistoryStatePrefecture():
+return prefecture();case IntensityHistoryStateCity():
+return city(_that.prefectureCode,_that.prefectureName);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  prefecture,TResult? Function( String prefectureCode,  String prefectureName)?  city,}) {final _that = this;
+switch (_that) {
+case IntensityHistoryStatePrefecture() when prefecture != null:
+return prefecture();case IntensityHistoryStateCity() when city != null:
+return city(_that.prefectureCode,_that.prefectureName);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class IntensityHistoryStatePrefecture implements IntensityHistoryState {
+  const IntensityHistoryStatePrefecture();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IntensityHistoryStatePrefecture);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'IntensityHistoryState.prefecture()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class IntensityHistoryStateCity implements IntensityHistoryState {
+  const IntensityHistoryStateCity({required this.prefectureCode, required this.prefectureName});
+  
+
+ final  String prefectureCode;
+ final  String prefectureName;
+
+/// Create a copy of IntensityHistoryState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$IntensityHistoryStateCityCopyWith<IntensityHistoryStateCity> get copyWith => _$IntensityHistoryStateCityCopyWithImpl<IntensityHistoryStateCity>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IntensityHistoryStateCity&&(identical(other.prefectureCode, prefectureCode) || other.prefectureCode == prefectureCode)&&(identical(other.prefectureName, prefectureName) || other.prefectureName == prefectureName));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,prefectureCode,prefectureName);
+
+@override
+String toString() {
+  return 'IntensityHistoryState.city(prefectureCode: $prefectureCode, prefectureName: $prefectureName)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $IntensityHistoryStateCityCopyWith<$Res> implements $IntensityHistoryStateCopyWith<$Res> {
+  factory $IntensityHistoryStateCityCopyWith(IntensityHistoryStateCity value, $Res Function(IntensityHistoryStateCity) _then) = _$IntensityHistoryStateCityCopyWithImpl;
+@useResult
+$Res call({
+ String prefectureCode, String prefectureName
+});
+
+
+
+
+}
+/// @nodoc
+class _$IntensityHistoryStateCityCopyWithImpl<$Res>
+    implements $IntensityHistoryStateCityCopyWith<$Res> {
+  _$IntensityHistoryStateCityCopyWithImpl(this._self, this._then);
+
+  final IntensityHistoryStateCity _self;
+  final $Res Function(IntensityHistoryStateCity) _then;
+
+/// Create a copy of IntensityHistoryState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? prefectureCode = null,Object? prefectureName = null,}) {
+  return _then(IntensityHistoryStateCity(
+prefectureCode: null == prefectureCode ? _self.prefectureCode : prefectureCode // ignore: cast_nullable_to_non_nullable
+as String,prefectureName: null == prefectureName ? _self.prefectureName : prefectureName // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/intensity_history/data/model/region_code_mapping.dart
+++ b/app/lib/feature/intensity_history/data/model/region_code_mapping.dart
@@ -62,3 +62,21 @@ List<String> cityCodesOfPrefecture(
   }
   return const [];
 }
+
+/// 細分区域コードから所属都道府県コードと名前を返す。
+///
+/// [regionCode] に一致する `regions[].code` を持つ都道府県を検索する。
+/// 一致する都道府県が存在しない場合は `null` を返す。
+({String code, String name})? prefectureOfRegionCode(
+  String regionCode,
+  List<EarthquakeParameterPrefectureItem> prefectures,
+) {
+  for (final pref in prefectures) {
+    for (final region in pref.regions) {
+      if (region.code == regionCode) {
+        return (code: pref.code, name: pref.name.ja);
+      }
+    }
+  }
+  return null;
+}

--- a/app/lib/feature/intensity_history/data/model/region_code_mapping.dart
+++ b/app/lib/feature/intensity_history/data/model/region_code_mapping.dart
@@ -1,0 +1,64 @@
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+
+// Task 0 調査結論:
+// `prefecture/highest` API の code は都道府県コード（例: `0100` = 北海道）。
+// 地図レイヤ `areaForecastLocalE` のフィーチャは細分区域コード
+// （EarthquakeParameterRegionItem.code）に対応する。
+//
+// `earthquake_intensity.dart` の `forecastLocalEIntensityPairs` では、
+// `pref.cities.isEmpty` の場合に `pref.prefecture.prefecture.code`（都道府県コード）を
+// そのまま `areaForecastLocalE` の code として使用している前例がある。
+// しかし全フィーチャが都道府県コードに対応しているとは限らないため、
+// `regionCodesOfPrefecture` は EarthquakeParameter の regions コード（細分区域）を
+// 返す実装とし、Lv1 塗り分け時は都道府県配下の全細分区域コードに同じ震度色を適用する
+// 方針（安全側）を採用する。
+
+/// 市区町村コードから所属都道府県コードを返す。
+///
+/// city.code の上 2 桁が prefecture.code の上 2 桁と一致する規則を利用する
+/// (`city_selector.dart` の `substring(0,2)` ロジックに準拠)。
+///
+/// 一致する都道府県が存在しない場合は `null` を返す。
+String? prefectureCodeOfCity(
+  String cityCode,
+  List<EarthquakeParameterPrefectureItem> prefectures,
+) {
+  final cityPrefix = cityCode.substring(0, 2);
+  for (final pref in prefectures) {
+    if (pref.code.substring(0, 2) == cityPrefix) {
+      return pref.code;
+    }
+  }
+  return null;
+}
+
+/// 都道府県コードに対応する `areaForecastLocalE` 細分区域コード群を返す。
+///
+/// EarthquakeParameter の `regions[].code` が細分区域コードに対応する。
+/// 存在しない場合は空リストを返す。
+List<String> regionCodesOfPrefecture(
+  String prefectureCode,
+  List<EarthquakeParameterPrefectureItem> prefectures,
+) {
+  for (final pref in prefectures) {
+    if (pref.code == prefectureCode) {
+      return pref.regions.map((r) => r.code).toList();
+    }
+  }
+  return const [];
+}
+
+/// 都道府県コードに対応する市区町村コード群を返す。
+///
+/// 存在しない場合は空リストを返す。
+List<String> cityCodesOfPrefecture(
+  String prefectureCode,
+  List<EarthquakeParameterPrefectureItem> prefectures,
+) {
+  for (final pref in prefectures) {
+    if (pref.code == prefectureCode) {
+      return pref.regions.expand((r) => r.cities.map((c) => c.code)).toList();
+    }
+  }
+  return const [];
+}

--- a/app/lib/feature/intensity_history/data/notifier/city_highest_provider.dart
+++ b/app/lib/feature/intensity_history/data/notifier/city_highest_provider.dart
@@ -1,0 +1,15 @@
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/repository/intensity_highest_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'city_highest_provider.g.dart';
+
+/// 指定都道府県の市区町村ごとの過去最高震度一覧を取得する family provider。
+@riverpod
+Future<List<HighestIntensityEntry>> cityHighest(
+  Ref ref,
+  String prefectureCode,
+) async {
+  final repository = await ref.watch(intensityHighestRepositoryProvider.future);
+  return repository.fetchCityHighest(prefectureCode);
+}

--- a/app/lib/feature/intensity_history/data/notifier/city_highest_provider.g.dart
+++ b/app/lib/feature/intensity_history/data/notifier/city_highest_provider.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'city_highest_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 指定都道府県の市区町村ごとの過去最高震度一覧を取得する family provider。
+
+@ProviderFor(cityHighest)
+final cityHighestProvider = CityHighestFamily._();
+
+/// 指定都道府県の市区町村ごとの過去最高震度一覧を取得する family provider。
+
+final class CityHighestProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<HighestIntensityEntry>>,
+          List<HighestIntensityEntry>,
+          FutureOr<List<HighestIntensityEntry>>
+        >
+    with
+        $FutureModifier<List<HighestIntensityEntry>>,
+        $FutureProvider<List<HighestIntensityEntry>> {
+  /// 指定都道府県の市区町村ごとの過去最高震度一覧を取得する family provider。
+  CityHighestProvider._({
+    required CityHighestFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'cityHighestProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$cityHighestHash();
+
+  @override
+  String toString() {
+    return r'cityHighestProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<HighestIntensityEntry>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<HighestIntensityEntry>> create(Ref ref) {
+    final argument = this.argument as String;
+    return cityHighest(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is CityHighestProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$cityHighestHash() => r'69023c9912d6ad0a9f4e7f36cc81b21062293da9';
+
+/// 指定都道府県の市区町村ごとの過去最高震度一覧を取得する family provider。
+
+final class CityHighestFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<List<HighestIntensityEntry>>,
+          String
+        > {
+  CityHighestFamily._()
+    : super(
+        retry: null,
+        name: r'cityHighestProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// 指定都道府県の市区町村ごとの過去最高震度一覧を取得する family provider。
+
+  CityHighestProvider call(String prefectureCode) =>
+      CityHighestProvider._(argument: prefectureCode, from: this);
+
+  @override
+  String toString() => r'cityHighestProvider';
+}

--- a/app/lib/feature/intensity_history/data/notifier/city_intensity_list_data_source.dart
+++ b/app/lib/feature/intensity_history/data/notifier/city_intensity_list_data_source.dart
@@ -1,0 +1,71 @@
+import 'package:eqmonitor/feature/intensity_history/data/repository/intensity_highest_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:intl/intl.dart';
+import 'package:paging_view/paging_view.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'city_intensity_list_data_source.g.dart';
+
+@riverpod
+Future<CityIntensityListDataSource> cityIntensityListDataSource(
+  Ref ref,
+  String cityCode,
+) async {
+  final repository = await ref.watch(intensityHighestRepositoryProvider.future);
+  final dataSource = CityIntensityListDataSource(
+    repository: repository,
+    cityCode: cityCode,
+  );
+  ref.onDispose(dataSource.dispose);
+  return dataSource;
+}
+
+class CityIntensityListDataSource
+    extends GroupedDataSource<String?, String, IntensityCitySearchItem> {
+  CityIntensityListDataSource({
+    required IntensityHighestRepository repository,
+    required String cityCode,
+  }) : _repository = repository,
+       _cityCode = cityCode;
+
+  final IntensityHighestRepository _repository;
+  final String _cityCode;
+
+  static final _dateFormatter = DateFormat('yyyy/MM/dd');
+
+  @override
+  String groupBy(IntensityCitySearchItem value) {
+    final originTime = value.earthquake.originTime;
+    if (originTime == null) {
+      return '不明';
+    }
+    return _dateFormatter.format(originTime.toLocal());
+  }
+
+  @override
+  Future<LoadResult<String?, IntensityCitySearchItem>> load(
+    LoadAction<String?> action,
+  ) async => switch (action) {
+    Refresh() => await _fetch(null),
+    Append(:final key) => await _fetch(key),
+    Prepend() => const None(),
+  };
+
+  Future<LoadResult<String?, IntensityCitySearchItem>> _fetch(
+    String? cursor,
+  ) async {
+    try {
+      final limit = cursor != null ? 100 : 20;
+      final page = await _repository.fetchCityIntensityList(
+        cityCode: _cityCode,
+        cursor: cursor,
+        limit: limit,
+      );
+      return Success(
+        page: PageData(data: page.items, appendKey: page.nextToken),
+      );
+    } on Exception catch (e, st) {
+      return Failure(error: e, stackTrace: st);
+    }
+  }
+}

--- a/app/lib/feature/intensity_history/data/notifier/city_intensity_list_data_source.g.dart
+++ b/app/lib/feature/intensity_history/data/notifier/city_intensity_list_data_source.g.dart
@@ -1,0 +1,96 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'city_intensity_list_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(cityIntensityListDataSource)
+final cityIntensityListDataSourceProvider =
+    CityIntensityListDataSourceFamily._();
+
+final class CityIntensityListDataSourceProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<CityIntensityListDataSource>,
+          CityIntensityListDataSource,
+          FutureOr<CityIntensityListDataSource>
+        >
+    with
+        $FutureModifier<CityIntensityListDataSource>,
+        $FutureProvider<CityIntensityListDataSource> {
+  CityIntensityListDataSourceProvider._({
+    required CityIntensityListDataSourceFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'cityIntensityListDataSourceProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$cityIntensityListDataSourceHash();
+
+  @override
+  String toString() {
+    return r'cityIntensityListDataSourceProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<CityIntensityListDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<CityIntensityListDataSource> create(Ref ref) {
+    final argument = this.argument as String;
+    return cityIntensityListDataSource(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is CityIntensityListDataSourceProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$cityIntensityListDataSourceHash() =>
+    r'2ca34b78ad73c76ad2ae0a941b961c3377434469';
+
+final class CityIntensityListDataSourceFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<CityIntensityListDataSource>,
+          String
+        > {
+  CityIntensityListDataSourceFamily._()
+    : super(
+        retry: null,
+        name: r'cityIntensityListDataSourceProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  CityIntensityListDataSourceProvider call(String cityCode) =>
+      CityIntensityListDataSourceProvider._(argument: cityCode, from: this);
+
+  @override
+  String toString() => r'cityIntensityListDataSourceProvider';
+}

--- a/app/lib/feature/intensity_history/data/notifier/intensity_history_controller.dart
+++ b/app/lib/feature/intensity_history/data/notifier/intensity_history_controller.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'intensity_history_controller.g.dart';
+
+/// 地域別最大震度マップのフォーカス状態を管理する Notifier。
+///
+/// - 初期状態は [IntensityHistoryStatePrefecture]（Lv1 全都道府県表示）。
+/// - [focusPrefecture] で [IntensityHistoryStateCity]（Lv2）に遷移。
+/// - [backToPrefecture] で Lv1 に戻る。
+@riverpod
+class IntensityHistoryController extends _$IntensityHistoryController {
+  @override
+  IntensityHistoryState build() => const IntensityHistoryState.prefecture();
+
+  /// 指定都道府県にフォーカスする（Lv2 に遷移）。
+  void focusPrefecture({required String code, required String name}) {
+    state = IntensityHistoryState.city(
+      prefectureCode: code,
+      prefectureName: name,
+    );
+  }
+
+  /// 全都道府県表示に戻る（Lv1 に遷移）。
+  void backToPrefecture() {
+    state = const IntensityHistoryState.prefecture();
+  }
+}

--- a/app/lib/feature/intensity_history/data/notifier/intensity_history_controller.g.dart
+++ b/app/lib/feature/intensity_history/data/notifier/intensity_history_controller.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'intensity_history_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 地域別最大震度マップのフォーカス状態を管理する Notifier。
+///
+/// - 初期状態は [IntensityHistoryStatePrefecture]（Lv1 全都道府県表示）。
+/// - [focusPrefecture] で [IntensityHistoryStateCity]（Lv2）に遷移。
+/// - [backToPrefecture] で Lv1 に戻る。
+
+@ProviderFor(IntensityHistoryController)
+final intensityHistoryControllerProvider =
+    IntensityHistoryControllerProvider._();
+
+/// 地域別最大震度マップのフォーカス状態を管理する Notifier。
+///
+/// - 初期状態は [IntensityHistoryStatePrefecture]（Lv1 全都道府県表示）。
+/// - [focusPrefecture] で [IntensityHistoryStateCity]（Lv2）に遷移。
+/// - [backToPrefecture] で Lv1 に戻る。
+final class IntensityHistoryControllerProvider
+    extends
+        $NotifierProvider<IntensityHistoryController, IntensityHistoryState> {
+  /// 地域別最大震度マップのフォーカス状態を管理する Notifier。
+  ///
+  /// - 初期状態は [IntensityHistoryStatePrefecture]（Lv1 全都道府県表示）。
+  /// - [focusPrefecture] で [IntensityHistoryStateCity]（Lv2）に遷移。
+  /// - [backToPrefecture] で Lv1 に戻る。
+  IntensityHistoryControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'intensityHistoryControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$intensityHistoryControllerHash();
+
+  @$internal
+  @override
+  IntensityHistoryController create() => IntensityHistoryController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(IntensityHistoryState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<IntensityHistoryState>(value),
+    );
+  }
+}
+
+String _$intensityHistoryControllerHash() =>
+    r'eea7b62666ba91a423f5868ab25dd8f76a2d4fd0';
+
+/// 地域別最大震度マップのフォーカス状態を管理する Notifier。
+///
+/// - 初期状態は [IntensityHistoryStatePrefecture]（Lv1 全都道府県表示）。
+/// - [focusPrefecture] で [IntensityHistoryStateCity]（Lv2）に遷移。
+/// - [backToPrefecture] で Lv1 に戻る。
+
+abstract class _$IntensityHistoryController
+    extends $Notifier<IntensityHistoryState> {
+  IntensityHistoryState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<IntensityHistoryState, IntensityHistoryState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<IntensityHistoryState, IntensityHistoryState>,
+              IntensityHistoryState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/intensity_history/data/notifier/prefecture_highest_provider.dart
+++ b/app/lib/feature/intensity_history/data/notifier/prefecture_highest_provider.dart
@@ -1,0 +1,12 @@
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/repository/intensity_highest_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'prefecture_highest_provider.g.dart';
+
+/// 全都道府県の過去最高震度一覧をキャッシュする provider。
+@Riverpod(keepAlive: true)
+Future<List<HighestIntensityEntry>> prefectureHighest(Ref ref) async {
+  final repository = await ref.watch(intensityHighestRepositoryProvider.future);
+  return repository.fetchPrefectureHighest();
+}

--- a/app/lib/feature/intensity_history/data/notifier/prefecture_highest_provider.g.dart
+++ b/app/lib/feature/intensity_history/data/notifier/prefecture_highest_provider.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'prefecture_highest_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 全都道府県の過去最高震度一覧をキャッシュする provider。
+
+@ProviderFor(prefectureHighest)
+final prefectureHighestProvider = PrefectureHighestProvider._();
+
+/// 全都道府県の過去最高震度一覧をキャッシュする provider。
+
+final class PrefectureHighestProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<HighestIntensityEntry>>,
+          List<HighestIntensityEntry>,
+          FutureOr<List<HighestIntensityEntry>>
+        >
+    with
+        $FutureModifier<List<HighestIntensityEntry>>,
+        $FutureProvider<List<HighestIntensityEntry>> {
+  /// 全都道府県の過去最高震度一覧をキャッシュする provider。
+  PrefectureHighestProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'prefectureHighestProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$prefectureHighestHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<HighestIntensityEntry>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<HighestIntensityEntry>> create(Ref ref) {
+    return prefectureHighest(ref);
+  }
+}
+
+String _$prefectureHighestHash() => r'd16d052760ebd71add8225510f58077037eefd8f';

--- a/app/lib/feature/intensity_history/data/repository/intensity_highest_repository.dart
+++ b/app/lib/feature/intensity_history/data/repository/intensity_highest_repository.dart
@@ -15,14 +15,14 @@ Future<IntensityHighestRepository> intensityHighestRepository(Ref ref) async {
 /// 最高震度 API をまとめる薄いラッパ。
 class IntensityHighestRepository {
   IntensityHighestRepository({required EarthquakeApiClient earthquake})
-      : _earthquake = earthquake;
+    : _earthquake = earthquake;
 
   final EarthquakeApiClient _earthquake;
 
   /// 全都道府県の過去最高震度一覧を取得する。
   Future<List<HighestIntensityEntry>> fetchPrefectureHighest() async {
-    final response =
-        await _earthquake.getV2EarthquakeIntensityPrefectureHighest();
+    final response = await _earthquake
+        .getV2EarthquakeIntensityPrefectureHighest();
     return response.data.items.map(HighestIntensityEntry.fromApi).toList();
   }
 
@@ -31,7 +31,9 @@ class IntensityHighestRepository {
     String prefectureCode,
   ) async {
     final response = await _earthquake
-        .getV2EarthquakeIntensityPrefectureCodeCityHighest(code: prefectureCode);
+        .getV2EarthquakeIntensityPrefectureCodeCityHighest(
+          code: prefectureCode,
+        );
     return response.data.items.map(HighestIntensityEntry.fromApi).toList();
   }
 

--- a/app/lib/feature/intensity_history/data/repository/intensity_highest_repository.dart
+++ b/app/lib/feature/intensity_history/data/repository/intensity_highest_repository.dart
@@ -1,0 +1,54 @@
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/city_intensity_page.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'intensity_highest_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<IntensityHighestRepository> intensityHighestRepository(Ref ref) async {
+  final apiClient = await ref.watch(apiClientProvider.future);
+  return IntensityHighestRepository(earthquake: apiClient.earthquake);
+}
+
+/// 最高震度 API をまとめる薄いラッパ。
+class IntensityHighestRepository {
+  IntensityHighestRepository({required EarthquakeApiClient earthquake})
+      : _earthquake = earthquake;
+
+  final EarthquakeApiClient _earthquake;
+
+  /// 全都道府県の過去最高震度一覧を取得する。
+  Future<List<HighestIntensityEntry>> fetchPrefectureHighest() async {
+    final response =
+        await _earthquake.getV2EarthquakeIntensityPrefectureHighest();
+    return response.data.items.map(HighestIntensityEntry.fromApi).toList();
+  }
+
+  /// 指定都道府県内の市区町村ごとの過去最高震度一覧を取得する。
+  Future<List<HighestIntensityEntry>> fetchCityHighest(
+    String prefectureCode,
+  ) async {
+    final response = await _earthquake
+        .getV2EarthquakeIntensityPrefectureCodeCityHighest(code: prefectureCode);
+    return response.data.items.map(HighestIntensityEntry.fromApi).toList();
+  }
+
+  /// 指定市区町村の過去地震一覧を取得する（ページネーション）。
+  Future<CityIntensityPage> fetchCityIntensityList({
+    required String cityCode,
+    required int limit,
+    String? cursor,
+  }) async {
+    final response = await _earthquake.getV2EarthquakeIntensityCityCode(
+      code: cityCode,
+      limit: limit.toString(),
+      cursor: cursor,
+    );
+    return CityIntensityPage(
+      items: response.data.items,
+      nextToken: response.data.nextToken,
+    );
+  }
+}

--- a/app/lib/feature/intensity_history/data/repository/intensity_highest_repository.g.dart
+++ b/app/lib/feature/intensity_history/data/repository/intensity_highest_repository.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'intensity_highest_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(intensityHighestRepository)
+final intensityHighestRepositoryProvider =
+    IntensityHighestRepositoryProvider._();
+
+final class IntensityHighestRepositoryProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<IntensityHighestRepository>,
+          IntensityHighestRepository,
+          FutureOr<IntensityHighestRepository>
+        >
+    with
+        $FutureModifier<IntensityHighestRepository>,
+        $FutureProvider<IntensityHighestRepository> {
+  IntensityHighestRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'intensityHighestRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$intensityHighestRepositoryHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<IntensityHighestRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<IntensityHighestRepository> create(Ref ref) {
+    return intensityHighestRepository(ref);
+  }
+}
+
+String _$intensityHighestRepositoryHash() =>
+    r'273f18b2c2cb53292545bf2bb5c4edefabecdc3f';

--- a/app/lib/feature/intensity_history/ui/components/city_detail_modal.dart
+++ b/app/lib/feature/intensity_history/ui/components/city_detail_modal.dart
@@ -1,0 +1,344 @@
+import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/magnitude_text.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_intensity_list_data_source.dart';
+import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:paging_view/paging_view.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+/// 市区町村の詳細モーダルを表示する。
+///
+/// サマリ(地域名・最高震度バッジ・件数・代表地震)と
+/// ページネーション付きの過去地震一覧を表示する。
+Future<void> showCityDetailModal(
+  BuildContext context, {
+  required String cityCode,
+  required String cityName,
+  HighestIntensityEntry? summary,
+}) => showModalBottomSheet<void>(
+  context: context,
+  isScrollControlled: true,
+  clipBehavior: Clip.antiAlias,
+  builder: (context) => _CityDetailModal(
+    cityCode: cityCode,
+    cityName: cityName,
+    summary: summary,
+  ),
+);
+
+class _CityDetailModal extends ConsumerWidget {
+  const _CityDetailModal({
+    required this.cityCode,
+    required this.cityName,
+    required this.summary,
+  });
+
+  final String cityCode;
+  final String cityName;
+  final HighestIntensityEntry? summary;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dataSourceAsync = ref.watch(
+      cityIntensityListDataSourceProvider(cityCode),
+    );
+
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.6,
+      minChildSize: 0.3,
+      maxChildSize: 0.95,
+      builder: (context, scrollController) {
+        return dataSourceAsync.when(
+          loading: () => _buildShell(
+            scrollController: scrollController,
+            context: context,
+            child: const _Skeleton(),
+          ),
+          error: (error, stackTrace) => _buildShell(
+            scrollController: scrollController,
+            context: context,
+            child: SliverToBoxAdapter(
+              child: ErrorCard(error: error),
+            ),
+          ),
+          data: (dataSource) => _buildShell(
+            scrollController: scrollController,
+            context: context,
+            child: _PagingBody(dataSource: dataSource),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildShell({
+    required BuildContext context,
+    required ScrollController scrollController,
+    required Widget child,
+  }) {
+    final theme = Theme.of(context);
+    return CustomScrollView(
+      controller: scrollController,
+      slivers: [
+        // ドラッグハンドル
+        SliverToBoxAdapter(
+          child: Center(
+            child: Container(
+              margin: const EdgeInsets.symmetric(vertical: 8),
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(2),
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
+              ),
+            ),
+          ),
+        ),
+        // サマリ
+        SliverToBoxAdapter(
+          child: _SummarySection(cityName: cityName, summary: summary),
+        ),
+        // 区切り
+        SliverToBoxAdapter(
+          child: Divider(height: 0, color: theme.colorScheme.outlineVariant),
+        ),
+        // 一覧 or ローディング or エラー
+        child,
+        // BottomPadding
+        SliverToBoxAdapter(
+          child: SizedBox(height: MediaQuery.paddingOf(context).bottom + 16),
+        ),
+      ],
+    );
+  }
+}
+
+class _SummarySection extends StatelessWidget {
+  const _SummarySection({
+    required this.cityName,
+    required this.summary,
+  });
+
+  final String cityName;
+  final HighestIntensityEntry? summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormatter = DateFormat('yyyy/MM/dd HH:mm');
+    final eq = summary?.earthquake;
+    final originTime = eq?.originTime;
+    final hypocenter = eq?.hypocenter;
+    final magnitude = hypocenter?.magnitude.toEarthquakeMagnitude;
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              if (summary != null) ...[
+                JmaIntensityIcon(
+                  intensity: summary!.intensity.toJmaIntensity,
+                  type: IntensityIconType.filled,
+                  size: 40,
+                ),
+                const SizedBox(width: 12),
+              ],
+              Expanded(
+                child: Text(
+                  cityName,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (summary != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              '観測件数: ${summary!.count}件',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface,
+              ),
+            ),
+            if (eq != null) ...[
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (originTime != null)
+                          Text(
+                            '代表: ${dateFormatter.format(originTime.toLocal())}発生',
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        if (hypocenter != null)
+                          Text(
+                            hypocenter.name,
+                            style: theme.textTheme.bodySmall,
+                          ),
+                      ],
+                    ),
+                  ),
+                  if (magnitude != null) MagnitudeText(magnitude: magnitude),
+                ],
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PagingBody extends StatelessWidget {
+  const _PagingBody({required this.dataSource});
+
+  final CityIntensityListDataSource dataSource;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SliverGroupedPagingList<String?, String, IntensityCitySearchItem>(
+      dataSource: dataSource,
+      stickyHeader: true,
+      headerBuilder: (_, date, _) => _DateHeader(date: date),
+      itemBuilder: (context, item, globalIndex, localIndex) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _CityIntensityListTile(item: item),
+          Divider(
+            height: 0,
+            thickness: 0,
+            color: theme.colorScheme.onInverseSurface,
+          ),
+        ],
+      ),
+      initialLoadingWidget: const _SkeletonBox(),
+      appendLoadingWidget: const _SkeletonBox(itemCount: 2),
+      errorBuilder: (context, error, stackTrace) => ErrorCard(
+        error: error,
+        onReload: () async => dataSource.refresh(),
+      ),
+      emptyWidget: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(32),
+          child: Text('震度の記録がありません'),
+        ),
+      ),
+    );
+  }
+}
+
+class _CityIntensityListTile extends StatelessWidget {
+  const _CityIntensityListTile({required this.item});
+
+  final IntensityCitySearchItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final eq = item.earthquake;
+    final originTime = eq.originTime;
+    final hypocenter = eq.hypocenter;
+    final dateFormatter = DateFormat('yyyy/MM/dd HH:mm');
+    final magnitude = hypocenter?.magnitude.toEarthquakeMagnitude;
+
+    return ListTile(
+      leading: JmaIntensityIcon(
+        intensity: item.intensity.toJmaIntensity,
+        type: IntensityIconType.filled,
+        size: 36,
+      ),
+      title: Text(
+        hypocenter?.name ?? '震源不明',
+        style: theme.textTheme.titleSmall?.copyWith(
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      subtitle: originTime != null
+          ? Text('${dateFormatter.format(originTime.toLocal())}発生')
+          : null,
+      trailing: magnitude != null ? MagnitudeText(magnitude: magnitude) : null,
+    );
+  }
+}
+
+class _DateHeader extends StatelessWidget {
+  const _DateHeader({required this.date});
+
+  final String date;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      color: theme.colorScheme.surfaceContainer,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Text(
+        date,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: theme.colorScheme.onSurface,
+        ),
+      ),
+    );
+  }
+}
+
+/// Sliver として使うスケルトン（CustomScrollView の slivers 内で使用）。
+class _Skeleton extends StatelessWidget {
+  const _Skeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverSkeletonizer(
+      child: SliverList.builder(
+        itemCount: 5,
+        itemBuilder: (_, _) => const ListTile(
+          leading: CircleAvatar(radius: 18),
+          title: Text('宮城県沖'),
+          subtitle: Text('2026/06/27 12:34発生'),
+          trailing: Text('M6.0'),
+        ),
+      ),
+    );
+  }
+}
+
+/// 通常の Widget として使うスケルトン（SliverGroupedPagingList の loading widget 用）。
+class _SkeletonBox extends StatelessWidget {
+  const _SkeletonBox({this.itemCount = 5});
+
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Skeletonizer(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (var i = 0; i < itemCount; i++)
+            const ListTile(
+              leading: CircleAvatar(radius: 18),
+              title: Text('宮城県沖'),
+              subtitle: Text('2026/06/27 12:34発生'),
+              trailing: Text('M6.0'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/intensity_history/ui/components/intensity_history_legend.dart
+++ b/app/lib/feature/intensity_history/ui/components/intensity_history_legend.dart
@@ -1,0 +1,47 @@
+import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
+import 'package:flutter/material.dart';
+
+/// 震度色の凡例ウィジェット。
+///
+/// 震度0〜7（降順）を横に並べて表示する。
+class IntensityHistoryLegend extends StatelessWidget {
+  const IntensityHistoryLegend({super.key});
+
+  static const List<JmaIntensity> _levels = [
+    JmaIntensity.seven,
+    JmaIntensity.sixUpper,
+    JmaIntensity.sixLower,
+    JmaIntensity.fiveUpper,
+    JmaIntensity.fiveLower,
+    JmaIntensity.four,
+    JmaIntensity.three,
+    JmaIntensity.two,
+    JmaIntensity.one,
+    JmaIntensity.zero,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.85),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 4,
+          children: [
+            for (final level in _levels)
+              JmaIntensityIcon(
+                intensity: level,
+                type: IntensityIconType.filled,
+                size: 28,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/intensity_history/ui/components/region_floating_panel.dart
+++ b/app/lib/feature/intensity_history/ui/components/region_floating_panel.dart
@@ -1,0 +1,117 @@
+import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/prefecture_highest_provider.dart';
+import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 地域別最大震度マップの上部フローティングパネル。
+///
+/// - Lv1(全都道府県表示): 「全国」を表示。
+/// - Lv2(特定都道府県フォーカス): 都道府県名・最高震度バッジ・観測件数を表示。
+class RegionFloatingPanel extends ConsumerWidget {
+  const RegionFloatingPanel({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(intensityHistoryControllerProvider);
+    final theme = Theme.of(context);
+
+    return switch (state) {
+      IntensityHistoryStatePrefecture() => _PrefecturePanel(theme: theme),
+      IntensityHistoryStateCity(:final prefectureCode, :final prefectureName) =>
+        _CityPanel(
+          prefectureCode: prefectureCode,
+          prefectureName: prefectureName,
+          theme: theme,
+        ),
+    };
+  }
+}
+
+class _PrefecturePanel extends StatelessWidget {
+  const _PrefecturePanel({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: theme.colorScheme.surface.withValues(alpha: 0.9),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Text(
+          '全国',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CityPanel extends ConsumerWidget {
+  const _CityPanel({
+    required this.prefectureCode,
+    required this.prefectureName,
+    required this.theme,
+  });
+
+  final String prefectureCode;
+  final String prefectureName;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final prefectureHighestAsync = ref.watch(prefectureHighestProvider);
+    final entry = prefectureHighestAsync.whenOrNull(
+      data: (list) => list
+          .where((e) => e.code == prefectureCode)
+          .firstOrNull,
+    );
+
+    return Card(
+      color: theme.colorScheme.surface.withValues(alpha: 0.9),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (entry != null) ...[
+              JmaIntensityIcon(
+                intensity: entry.intensity.toJmaIntensity,
+                type: IntensityIconType.filled,
+                size: 36,
+              ),
+              const SizedBox(width: 10),
+            ],
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  prefectureName,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (entry != null)
+                  Text(
+                    '${entry.count}件',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/intensity_history/ui/components/region_floating_panel.dart
+++ b/app/lib/feature/intensity_history/ui/components/region_floating_panel.dart
@@ -69,9 +69,7 @@ class _CityPanel extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final prefectureHighestAsync = ref.watch(prefectureHighestProvider);
     final entry = prefectureHighestAsync.whenOrNull(
-      data: (list) => list
-          .where((e) => e.code == prefectureCode)
-          .firstOrNull,
+      data: (list) => list.where((e) => e.code == prefectureCode).firstOrNull,
     );
 
     return Card(

--- a/app/lib/feature/intensity_history/ui/intensity_history_page.dart
+++ b/app/lib/feature/intensity_history/ui/intensity_history_page.dart
@@ -1,0 +1,414 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
+import 'package:eqmonitor/core/provider/map/jma_map_utility.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_highest_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/city_detail_modal.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_legend.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/region_floating_panel.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer.dart';
+import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
+import 'package:eqmonitor/feature/map/utils/map_zoom_calculator.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:jma_map/jma_map.dart';
+import 'package:maplibre/maplibre.dart';
+
+/// 地域別最大震度マップのページ。
+///
+/// - [initialPrefectureCode]: 指定時は起動直後に当該都道府県にフォーカスする(Lv2)。
+/// - [initialCityCode]: 指定時はさらに市区町村詳細モーダルを自動表示する。
+class IntensityHistoryPage extends HookConsumerWidget {
+  const IntensityHistoryPage({
+    this.initialPrefectureCode,
+    this.initialCityCode,
+    super.key,
+  });
+
+  final String? initialPrefectureCode;
+  final String? initialCityCode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mapConfiguration = ref.watch(mapConfigurationProvider);
+
+    return switch (mapConfiguration) {
+      AsyncData(:final value) when value.styleString != null => _MapContent(
+        styleString: value.styleString!,
+        initialPrefectureCode: initialPrefectureCode,
+        initialCityCode: initialCityCode,
+      ),
+      AsyncError(:final error) => Scaffold(
+        appBar: AppBar(title: const Text('都道府県別 最大震度')),
+        body: Center(child: ErrorCard(error: error)),
+      ),
+      _ => const Scaffold(
+        body: Center(child: CircularProgressIndicator.adaptive()),
+      ),
+    };
+  }
+}
+
+class _MapContent extends HookConsumerWidget {
+  const _MapContent({
+    required this.styleString,
+    required this.initialPrefectureCode,
+    required this.initialCityCode,
+  });
+
+  final String styleString;
+  final String? initialPrefectureCode;
+  final String? initialCityCode;
+
+  static const _regionSourceLayerId = 'areaForecastLocalE';
+  static const _citySourceLayerId = 'areaInformationCityQuake';
+
+  // 日本全国の LngLatBounds
+  static const _japanBounds = LngLatBounds(
+    longitudeWest: JapanBounds.minLng,
+    longitudeEast: JapanBounds.maxLng,
+    latitudeSouth: JapanBounds.minLat,
+    latitudeNorth: JapanBounds.maxLat,
+  );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(intensityHistoryControllerProvider);
+    final notifier = ref.read(intensityHistoryControllerProvider.notifier);
+    final isCityState = state is IntensityHistoryStateCity;
+
+    // ディープリンク初期化: 初回レンダリング後に実行
+    useEffect(
+      () {
+        final prefCode = initialPrefectureCode;
+        if (prefCode == null) {
+          return null;
+        }
+
+        final paramAsync = ref.read(parameterSetProvider);
+        final prefectures =
+            paramAsync.whenOrNull(data: (p) => p.earthquake.prefectures);
+        var prefName = prefCode;
+        if (prefectures != null) {
+          final pref =
+              prefectures.where((p) => p.code == prefCode).firstOrNull;
+          if (pref != null) {
+            prefName = pref.name.ja;
+          }
+        }
+        notifier.focusPrefecture(code: prefCode, name: prefName);
+
+        WidgetsBinding.instance.addPostFrameCallback((_) async {
+          if (!context.mounted) {
+            return;
+          }
+          final mapController = MapController.maybeOf(context);
+          if (mapController == null) {
+            return;
+          }
+
+          try {
+            final jmaMap = await ref.read(jmaMapProvider.future);
+            if (!context.mounted) {
+              return;
+            }
+
+            final bounds = _buildPrefectureBounds(
+              prefCode: prefCode,
+              jmaMap: jmaMap,
+              prefectures: prefectures ?? [],
+            );
+            if (bounds != null) {
+              await mapController.fitBounds(
+                bounds: bounds,
+                padding: const EdgeInsets.all(48),
+              );
+            }
+          } on Exception catch (e) {
+            talker.log(e);
+          }
+
+          // cityCode の自動モーダル表示
+          final cityCode = initialCityCode;
+          if (cityCode != null && context.mounted) {
+            await showCityDetailModal(
+              context,
+              cityCode: cityCode,
+              cityName: cityCode,
+            );
+          }
+        });
+
+        return null;
+      },
+      const [],
+    );
+
+    final mapOptions = calculateJapanViewMapOptions(
+      context: context,
+      styleString: styleString,
+    );
+
+    return PopScope(
+      canPop: !isCityState,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && isCityState) {
+          notifier.backToPrefecture();
+          _zoomToJapan(context);
+        }
+      },
+      child: Scaffold(
+        body: Stack(
+          children: [
+            MapLibreMap(
+              options: mapOptions,
+              onEvent: (event) async {
+                if (event is MapEventClick) {
+                  final jmaMap = await ref.read(jmaMapProvider.future);
+                  if (!context.mounted) {
+                    return;
+                  }
+                  await _handleTap(
+                    context: context,
+                    ref: ref,
+                    event: event,
+                    jmaMap: jmaMap,
+                    state: state,
+                  );
+                }
+              },
+              children: const [IntensityFillLayer()],
+            ),
+
+            // フローティングパネル（上部中央）
+            const Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: SafeArea(
+                child: Center(
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 8),
+                    child: RegionFloatingPanel(),
+                  ),
+                ),
+              ),
+            ),
+
+            // 凡例（右下）
+            const Positioned(
+              bottom: 8,
+              right: 8,
+              child: SafeArea(child: IntensityHistoryLegend()),
+            ),
+
+            // 戻るボタン（左上、Lv2のときのみ表示）
+            if (isCityState)
+              Positioned(
+                top: 0,
+                left: 0,
+                child: SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Card(
+                      elevation: 2,
+                      clipBehavior: Clip.hardEdge,
+                      child: InkWell(
+                        onTap: () {
+                          notifier.backToPrefecture();
+                          _zoomToJapan(context);
+                        },
+                        child: const Padding(
+                          padding: EdgeInsets.all(8),
+                          child: Icon(Icons.arrow_back_rounded),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleTap({
+    required BuildContext context,
+    required WidgetRef ref,
+    required MapEventClick event,
+    required Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
+    required IntensityHistoryState state,
+  }) async {
+    final mapController = MapController.maybeOf(context);
+    if (mapController == null) {
+      return;
+    }
+
+    final hits = mapController.queryLayers(event.screenPoint);
+    if (hits.isEmpty) {
+      return;
+    }
+
+    final hitCity = hits.any((h) => h.sourceLayer == _citySourceLayerId);
+    final hitRegion = hits.any((h) => h.sourceLayer == _regionSourceLayerId);
+
+    if (!hitCity && !hitRegion) {
+      return;
+    }
+
+    final latLng = JmaMap_LatLng(lat: event.point.lat, lng: event.point.lon);
+
+    if (hitCity && state is IntensityHistoryStateCity) {
+      // Lv2: 市区町村タップ → 詳細モーダル
+      final mapData = jmaMap.areaInformationCity;
+      final result = JmaMapUtility().findNearestItem(latLng, mapData);
+      final item = result.item;
+      if (item == null) {
+        return;
+      }
+
+      final cityCode = item.property.code;
+      final cityName = item.property.name;
+
+      final prefCode = state.prefectureCode;
+      final cityHighest = ref
+          .read(cityHighestProvider(prefCode))
+          .whenOrNull(data: (v) => v);
+      HighestIntensityEntry? summary;
+      if (cityHighest != null) {
+        summary = cityHighest
+            .where((e) => e.code == cityCode)
+            .firstOrNull;
+      }
+
+      if (!context.mounted) {
+        return;
+      }
+      await showCityDetailModal(
+        context,
+        cityCode: cityCode,
+        cityName: cityName,
+        summary: summary,
+      );
+    } else if (hitRegion && state is IntensityHistoryStatePrefecture) {
+      // Lv1: 細分区域タップ → 都道府県フォーカス
+      final mapData = jmaMap.areaForecastLocalE;
+      final result = JmaMapUtility().findNearestItem(latLng, mapData);
+      final item = result.item;
+      if (item == null) {
+        return;
+      }
+
+      final regionCode = item.property.code;
+
+      final paramAsync = ref.read(parameterSetProvider);
+      final prefectures =
+          paramAsync.whenOrNull(data: (p) => p.earthquake.prefectures) ?? [];
+
+      final prefInfo = prefectureOfRegionCode(regionCode, prefectures);
+      if (prefInfo == null) {
+        return;
+      }
+
+      ref
+          .read(intensityHistoryControllerProvider.notifier)
+          .focusPrefecture(code: prefInfo.code, name: prefInfo.name);
+
+      // 都道府県の bounds へズーム
+      final bounds = _buildPrefectureBounds(
+        prefCode: prefInfo.code,
+        jmaMap: jmaMap,
+        prefectures: prefectures,
+      );
+      if (bounds != null && context.mounted) {
+        final c = MapController.maybeOf(context);
+        if (c != null) {
+          await c.fitBounds(
+            bounds: bounds,
+            padding: const EdgeInsets.all(48),
+          );
+        }
+      }
+    }
+  }
+
+  LngLatBounds? _buildPrefectureBounds({
+    required String prefCode,
+    required Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
+    required List<EarthquakeParameterPrefectureItem> prefectures,
+  }) {
+    final regionCodes = regionCodesOfPrefecture(prefCode, prefectures);
+    if (regionCodes.isEmpty) {
+      return null;
+    }
+
+    final regionSet = Set<String>.from(regionCodes);
+    final items = jmaMap.areaForecastLocalE.data
+        .where(
+          (item) => regionSet.contains(item.property.code) && item.hasBounds(),
+        )
+        .toList();
+
+    if (items.isEmpty) {
+      return null;
+    }
+
+    // 1件目で初期化
+    final firstBounds = items.first.bounds;
+    var minLat = firstBounds.southWest.lat;
+    var minLng = firstBounds.southWest.lng;
+    var maxLat = firstBounds.northEast.lat;
+    var maxLng = firstBounds.northEast.lng;
+
+    for (final item in items.skip(1)) {
+      final b = item.bounds;
+      final swLat = b.southWest.lat;
+      final swLng = b.southWest.lng;
+      final neLat = b.northEast.lat;
+      final neLng = b.northEast.lng;
+
+      if (swLat < minLat) {
+        minLat = swLat;
+      }
+      if (swLng < minLng) {
+        minLng = swLng;
+      }
+      if (neLat > maxLat) {
+        maxLat = neLat;
+      }
+      if (neLng > maxLng) {
+        maxLng = neLng;
+      }
+    }
+
+    return LngLatBounds(
+      longitudeWest: minLng,
+      longitudeEast: maxLng,
+      latitudeSouth: minLat,
+      latitudeNorth: maxLat,
+    );
+  }
+
+  void _zoomToJapan(BuildContext context) {
+    final c = MapController.maybeOf(context);
+    if (c == null) {
+      return;
+    }
+    unawaited(
+      c.fitBounds(
+        bounds: _japanBounds,
+        padding: const EdgeInsets.all(32),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/intensity_history/ui/intensity_history_page.dart
+++ b/app/lib/feature/intensity_history/ui/intensity_history_page.dart
@@ -95,12 +95,12 @@ class _MapContent extends HookConsumerWidget {
         }
 
         final paramAsync = ref.read(parameterSetProvider);
-        final prefectures =
-            paramAsync.whenOrNull(data: (p) => p.earthquake.prefectures);
+        final prefectures = paramAsync.whenOrNull(
+          data: (p) => p.earthquake.prefectures,
+        );
         var prefName = prefCode;
         if (prefectures != null) {
-          final pref =
-              prefectures.where((p) => p.code == prefCode).firstOrNull;
+          final pref = prefectures.where((p) => p.code == prefCode).firstOrNull;
           if (pref != null) {
             prefName = pref.name.ja;
           }
@@ -286,9 +286,7 @@ class _MapContent extends HookConsumerWidget {
           .whenOrNull(data: (v) => v);
       HighestIntensityEntry? summary;
       if (cityHighest != null) {
-        summary = cityHighest
-            .where((e) => e.code == cityCode)
-            .firstOrNull;
+        summary = cityHighest.where((e) => e.code == cityCode).firstOrNull;
       }
 
       if (!context.mounted) {

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_expression.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_expression.dart
@@ -1,0 +1,33 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
+import 'package:eqmonitor/core/util/converter/color_converter.dart';
+
+/// `['match', ['get','code'], code1, color1, ..., 'rgba(0,0,0,0)']` 形式の
+/// MapLibre match 式を構築する純粋関数。
+///
+/// [pairs] に指定した各 code に [IntensityColorModel] から算出した震度背景色を
+/// 割り当てる。該当なし区域は透明(`rgba(0,0,0,0)`)。
+///
+/// `earthquake_history_region_intensity_layer.dart` の `_buildFillColorExpression`
+/// を純粋関数として切り出したもの。
+List<Object> buildIntensityMatchExpression(
+  List<({String code, JmaIntensity intensity})> pairs,
+  IntensityColorModel colorModel,
+) {
+  final args = <Object>[
+    'match',
+    <Object>['get', 'code'],
+  ];
+
+  for (final pair in pairs) {
+    args
+      ..add(pair.code)
+      ..add(
+        colorModel.fromJmaIntensity(pair.intensity).background.toHexStringRGB(),
+      );
+  }
+
+  // 該当なし区域は透明
+  args.add('rgba(0,0,0,0)');
+  return args;
+}

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_expression.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_expression.dart
@@ -2,21 +2,27 @@ import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
 import 'package:eqmonitor/core/util/converter/color_converter.dart';
 
-/// `['match', ['get','code'], code1, color1, ..., 'rgba(0,0,0,0)']` 形式の
+/// `['match', ['get', propertyKey], code1, color1, ..., 'rgba(0,0,0,0)']` 形式の
 /// MapLibre match 式を構築する純粋関数。
 ///
 /// [pairs] に指定した各 code に [IntensityColorModel] から算出した震度背景色を
 /// 割り当てる。該当なし区域は透明(`rgba(0,0,0,0)`)。
 ///
+/// [propertyKey] はフィーチャの照合に使うプロパティ名。
+/// - `areaForecastLocalE`(細分区域): `code`(デフォルト)。
+/// - `areaInformationCityQuake`(市区町村): `regioncode`。
+///   (`earthquake_history_fill_layer.dart` の `cityCodeFilter` 参照)
+///
 /// `earthquake_history_region_intensity_layer.dart` の `_buildFillColorExpression`
 /// を純粋関数として切り出したもの。
 List<Object> buildIntensityMatchExpression(
   List<({String code, JmaIntensity intensity})> pairs,
-  IntensityColorModel colorModel,
-) {
+  IntensityColorModel colorModel, {
+  String propertyKey = 'code',
+}) {
   final args = <Object>[
     'match',
-    <Object>['get', 'code'],
+    <Object>['get', propertyKey],
   ];
 
   for (final pair in pairs) {

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
@@ -143,7 +143,13 @@ class IntensityFillLayer extends HookConsumerWidget {
                   (e) => (code: e.code, intensity: e.intensity.toJmaIntensity),
                 )
                 .toList();
-            final fillColor = buildIntensityMatchExpression(pairs, colorModel);
+            // areaInformationCityQuake のフィーチャ照合プロパティは `regioncode`。
+            // (earthquake_history_fill_layer.dart の cityCodeFilter 参照)
+            final fillColor = buildIntensityMatchExpression(
+              pairs,
+              colorModel,
+              propertyKey: 'regioncode',
+            );
 
             if (disposed) {
               return;

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_highest_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/prefecture_highest_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_expression.dart';
+import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:maplibre/maplibre.dart';
+
+/// 地域別最大震度マップ用の震度 fill レイヤー Widget。
+///
+/// - Lv1(都道府県): `areaForecastLocalE` に都道府県最高震度の match 式で塗り分け。
+/// - Lv2(市区町村): `areaInformationCityQuake` に市区町村最高震度で塗り分け +
+///   非選択都道府県を半透明黒でディム。
+///
+/// `earthquake_history_fill_layer.dart` / `earthquake_history_region_intensity_layer.dart`
+/// の構造に倣い、`useEffect` でレイヤー追加・dispose でレイヤー除去。
+class IntensityFillLayer extends HookConsumerWidget {
+  const IntensityFillLayer({super.key});
+
+  // --- Layer ID 定数 ---
+  static const _lv1FillLayerId = 'intensity-history-lv1-fill';
+  static const _lv2FillLayerId = 'intensity-history-lv2-city-fill';
+  static const _dimFillLayerId = 'intensity-history-lv2-dim-fill';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final styleController = MapController.maybeOf(context)?.style;
+    final colorModel = ref.watch(intensityColorProvider);
+    final state = ref.watch(intensityHistoryControllerProvider);
+
+    // --- パラメーター (AsyncValue) ---
+    final parameterAsync = ref.watch(parameterSetProvider);
+    final prefectures = parameterAsync.whenOrNull(
+      data: (p) => p.earthquake.prefectures,
+    );
+
+    // --- Lv1: 都道府県最高震度 ---
+    final prefectureHighestAsync = ref.watch(prefectureHighestProvider);
+    final prefectureHighest = prefectureHighestAsync.whenOrNull(data: (v) => v);
+
+    // --- Lv2: 市区町村最高震度 (City 状態のときのみ) ---
+    final selectedPrefCode = state is IntensityHistoryStateCity
+        ? state.prefectureCode
+        : null;
+    final cityHighestAsync = selectedPrefCode != null
+        ? ref.watch(cityHighestProvider(selectedPrefCode))
+        : null;
+    final cityHighest = cityHighestAsync?.whenOrNull(data: (v) => v);
+
+    // --- Lv1 fill effect ---
+    useEffect(
+      () {
+        if (styleController == null || prefectures == null) {
+          return null;
+        }
+        if (prefectureHighest == null || prefectureHighest.isEmpty) {
+          return null;
+        }
+
+        var disposed = false;
+
+        unawaited(() async {
+          try {
+            // 都道府県コード → 配下の細分区域コード(areaForecastLocalE)に展開
+            final pairs = <({String code, JmaIntensity intensity})>[];
+            for (final entry in prefectureHighest) {
+              final regionCodes = regionCodesOfPrefecture(
+                entry.code,
+                prefectures,
+              );
+              for (final code in regionCodes) {
+                pairs.add(
+                  (code: code, intensity: entry.intensity.toJmaIntensity),
+                );
+              }
+            }
+
+            final fillColor = buildIntensityMatchExpression(pairs, colorModel);
+
+            if (disposed) {
+              return;
+            }
+            await styleController.addLayer(
+              FillStyleLayer(
+                id: _lv1FillLayerId,
+                sourceId: 'eqmonitor_map',
+                sourceLayerId: 'areaForecastLocalE',
+                paint: {
+                  'fill-color': fillColor,
+                  'fill-opacity': 0.7,
+                },
+              ),
+              belowLayerId: BaseLayer.areaForecastLocalELine.name,
+            );
+          } on Exception catch (e) {
+            talker.log(e);
+          }
+        }());
+
+        return () {
+          disposed = true;
+          unawaited(() async {
+            try {
+              await styleController.removeLayer(_lv1FillLayerId);
+            } on Exception catch (e) {
+              talker.log(e);
+            }
+          }());
+        };
+      },
+      [styleController, prefectures, prefectureHighest, colorModel],
+    );
+
+    // --- Lv2 city fill + dim effect ---
+    useEffect(
+      () {
+        if (styleController == null ||
+            prefectures == null ||
+            selectedPrefCode == null) {
+          return null;
+        }
+        if (cityHighest == null || cityHighest.isEmpty) {
+          return null;
+        }
+
+        var disposed = false;
+
+        unawaited(() async {
+          try {
+            // 市区町村 code → 最高震度 pairs (api.JmaIntensity → app.JmaIntensity 変換)
+            final pairs = cityHighest
+                .map(
+                  (e) => (code: e.code, intensity: e.intensity.toJmaIntensity),
+                )
+                .toList();
+            final fillColor = buildIntensityMatchExpression(pairs, colorModel);
+
+            if (disposed) {
+              return;
+            }
+
+            // Lv2 市区町村 fill
+            await styleController.addLayer(
+              FillStyleLayer(
+                id: _lv2FillLayerId,
+                sourceId: 'eqmonitor_map',
+                sourceLayerId: 'areaInformationCityQuake',
+                paint: {
+                  'fill-color': fillColor,
+                  'fill-opacity': 0.8,
+                },
+              ),
+              belowLayerId: BaseLayer.areaForecastLocalELine.name,
+            );
+
+            if (disposed) {
+              return;
+            }
+            // ディムオーバーレイ: 選択都道府県の細分区域コードを除外した全エリアを半透明黒で覆う
+            final selectedRegionCodes = regionCodesOfPrefecture(
+              selectedPrefCode,
+              prefectures,
+            );
+            final dimFilter = <Object>[
+              '!',
+              <Object>[
+                'in',
+                <Object>['get', 'code'],
+                <Object>['literal', selectedRegionCodes],
+              ],
+            ];
+
+            await styleController.addLayer(
+              FillStyleLayer(
+                id: _dimFillLayerId,
+                sourceId: 'eqmonitor_map',
+                sourceLayerId: 'areaForecastLocalE',
+                filter: dimFilter,
+                paint: const {
+                  'fill-color': '#000000',
+                  'fill-opacity': 0.45,
+                },
+              ),
+              belowLayerId: BaseLayer.areaForecastLocalELine.name,
+            );
+          } on Exception catch (e) {
+            talker.log(e);
+          }
+        }());
+
+        return () {
+          disposed = true;
+          unawaited(() async {
+            for (final id in [_lv2FillLayerId, _dimFillLayerId]) {
+              try {
+                await styleController.removeLayer(id);
+              } on Exception catch (e) {
+                talker.log(e);
+              }
+            }
+          }());
+        };
+      },
+      [
+        styleController,
+        prefectures,
+        selectedPrefCode,
+        cityHighest,
+        colorModel,
+      ],
+    );
+
+    return const SizedBox.shrink();
+  }
+}

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -123,6 +123,17 @@ class _SheetBody extends ConsumerWidget {
       child: Column(
         children: [
           ListTile(
+            leading: const Icon(Icons.bar_chart_outlined),
+            title: Text('都道府県別 最大震度', style: typography.titleSmall),
+            subtitle: Text(
+              '地域ごとの最大震度履歴をマップで確認します',
+              style: typography.bodySmall,
+            ),
+            onTap: () async =>
+                const IntensityHistoryRoute().push<void>(context),
+          ),
+          Divider(height: 1, indent: spacing.xl, endIndent: spacing.xl),
+          ListTile(
             leading: const Icon(Icons.settings_outlined),
             title: Text('設定', style: typography.titleSmall),
             subtitle: Text('表示設定や地図の動作を調整します', style: typography.bodySmall),

--- a/app/test/feature/intensity_history/city_detail_modal_test.dart
+++ b/app/test/feature/intensity_history/city_detail_modal_test.dart
@@ -1,0 +1,91 @@
+import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
+import 'package:eqmonitor/feature/intensity_history/data/model/city_intensity_page.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_intensity_list_data_source.dart';
+import 'package:eqmonitor/feature/intensity_history/data/repository/intensity_highest_repository.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/city_detail_modal.dart';
+import 'package:dio/dio.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// モーダルを pump するための足場。
+///
+/// [showCityDetailModal] は `showModalBottomSheet` を直接呼ぶため、
+/// モーダル本体を Widget として直接ビルドするヘルパーを使う。
+class _ModalWrapper extends ConsumerWidget {
+  const _ModalWrapper({required this.cityCode, required this.cityName});
+
+  final String cityCode;
+  final String cityName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ElevatedButton(
+      onPressed: () =>
+          showCityDetailModal(context, cityCode: cityCode, cityName: cityName),
+      child: const Text('open'),
+    );
+  }
+}
+
+class _FakeEmptyRepository extends IntensityHighestRepository {
+  _FakeEmptyRepository() : super(earthquake: api.ApiClient(Dio()).earthquake);
+
+  @override
+  Future<CityIntensityPage> fetchCityIntensityList({
+    required String cityCode,
+    required int limit,
+    String? cursor,
+  }) async => const CityIntensityPage(items: [], nextToken: null);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('市区町村名がモーダルに表示される', (tester) async {
+    // モーダルのスケルトンリストが収まるよう画面サイズを広くする。
+    await tester.binding.setSurfaceSize(const Size(800, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+
+    final container = ProviderContainer(
+      overrides: [
+        app_prefs.sharedPreferencesProvider.overrideWithValue(
+          app_prefs.SharedPreferencesAsync(preferences),
+        ),
+        cityIntensityListDataSourceProvider('city-1').overrideWith(
+          (ref) async => CityIntensityListDataSource(
+            repository: _FakeEmptyRepository(),
+            cityCode: 'city-1',
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: _ModalWrapper(
+              cityCode: 'city-1',
+              cityName: '仙台市',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // ボタンをタップしてモーダルを開く
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+
+    // 市区町村名が表示されていることを確認
+    expect(find.text('仙台市'), findsOneWidget);
+  });
+}

--- a/app/test/feature/intensity_history/city_intensity_list_data_source_test.dart
+++ b/app/test/feature/intensity_history/city_intensity_list_data_source_test.dart
@@ -1,0 +1,96 @@
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/city_intensity_page.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_intensity_list_data_source.dart';
+import 'package:eqmonitor/feature/intensity_history/data/repository/intensity_highest_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paging_view/paging_view.dart';
+
+IntensityCitySearchItem _item({DateTime? originTime}) =>
+    IntensityCitySearchItem(
+      intensity: JmaIntensity.value1,
+      earthquake: EarthquakePartial(
+        eventId: 'e1',
+        status: TelegramStatus.normal,
+        originTimePrecision: OriginTimePrecision.second,
+        datasource: EarthquakeDatasource.jmaIntensityDatabase,
+        telegramTypes: [],
+        earthquakeType: EarthquakeType.normal,
+        originTime: originTime,
+      ),
+    );
+
+class _FakeCityIntensityRepository extends IntensityHighestRepository {
+  _FakeCityIntensityRepository()
+    : super(earthquake: api.ApiClient(Dio()).earthquake);
+
+  final cursors = <String?>[];
+  String? nextToken;
+  List<IntensityCitySearchItem> items = const [];
+
+  @override
+  Future<CityIntensityPage> fetchCityIntensityList({
+    required String cityCode,
+    required int limit,
+    String? cursor,
+  }) async {
+    cursors.add(cursor);
+    return CityIntensityPage(items: items, nextToken: nextToken);
+  }
+}
+
+void main() {
+  group('CityIntensityListDataSource.groupBy', () {
+    test('originTime をローカル日付 yyyy/MM/dd でグループ化', () {
+      final ds = CityIntensityListDataSource(
+        repository: _FakeCityIntensityRepository(),
+        cityCode: 'city-1',
+      );
+      final key = ds.groupBy(_item(originTime: DateTime.utc(2026, 6, 27)));
+      // ローカルタイムに依存するため、形式(8文字 + 区切り)のみ検証
+      expect(key, matches(r'^\d{4}/\d{2}/\d{2}$'));
+    });
+
+    test('originTime が null のとき "不明" を返す', () {
+      final ds = CityIntensityListDataSource(
+        repository: _FakeCityIntensityRepository(),
+        cityCode: 'city-1',
+      );
+      final key = ds.groupBy(_item());
+      expect(key, '不明');
+    });
+  });
+
+  group('CityIntensityListDataSource.load', () {
+    test('Refresh は cursor=null、Append は受け取った key を渡す', () async {
+      final repo = _FakeCityIntensityRepository()
+        ..items = [_item(originTime: DateTime.utc(2026, 6, 27))]
+        ..nextToken = 'next-1';
+      final ds = CityIntensityListDataSource(
+        repository: repo,
+        cityCode: 'city-1',
+      );
+
+      final refresh = await ds.load(const Refresh());
+      expect(refresh, isA<Success<String?, IntensityCitySearchItem>>());
+      await ds.load(const Append(key: 'next-1'));
+
+      expect(repo.cursors, [null, 'next-1']);
+    });
+
+    test('Success の appendKey に nextToken が入る', () async {
+      final repo = _FakeCityIntensityRepository()
+        ..items = [_item(originTime: DateTime.utc(2026, 6, 27))]
+        ..nextToken = 'tok';
+      final ds = CityIntensityListDataSource(
+        repository: repo,
+        cityCode: 'city-1',
+      );
+      final result = await ds.load(const Refresh());
+      final success = result as Success<String?, IntensityCitySearchItem>;
+      expect(success.page.appendKey, 'tok');
+      expect(success.page.data.single.earthquake.eventId, 'e1');
+    });
+  });
+}

--- a/app/test/feature/intensity_history/intensity_fill_expression_test.dart
+++ b/app/test/feature/intensity_history/intensity_fill_expression_test.dart
@@ -1,0 +1,101 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
+import 'package:eqmonitor/core/util/converter/color_converter.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_expression.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildIntensityMatchExpression', () {
+    late IntensityColorModel colorModel;
+
+    setUp(() {
+      colorModel = IntensityColorModel.jma();
+    });
+
+    test('空の pairs は透明色のみのフォールバックを返す', () {
+      final result = buildIntensityMatchExpression([], colorModel);
+
+      expect(result, hasLength(3));
+      expect(result[0], equals('match'));
+      expect(result[1], equals(<Object>['get', 'code']));
+      expect(result[2], equals('rgba(0,0,0,0)'));
+    });
+
+    test('1 つのペアで match 式が正しく生成される', () {
+      const pairs = [
+        (code: '010', intensity: JmaIntensity.four),
+      ];
+
+      final result = buildIntensityMatchExpression(pairs, colorModel);
+
+      // ['match', ['get', 'code'], '010', '#color', 'rgba(0,0,0,0)']
+      expect(result[0], equals('match'));
+      expect(result[1], equals(<Object>['get', 'code']));
+      expect(result[2], equals('010'));
+      // 色は colorModel.fromJmaIntensity(four).background.toHexStringRGB() と等しい
+      final expectedColor = colorModel
+          .fromJmaIntensity(JmaIntensity.four)
+          .background
+          .toHexStringRGB();
+      expect(result[3], equals(expectedColor));
+      expect(result[4], equals('rgba(0,0,0,0)'));
+      expect(result, hasLength(5));
+    });
+
+    test('複数ペアで各 code と色が正しく並ぶ', () {
+      const pairs = [
+        (code: '010', intensity: JmaIntensity.three),
+        (code: '020', intensity: JmaIntensity.fiveLower),
+        (code: '030', intensity: JmaIntensity.seven),
+      ];
+
+      final result = buildIntensityMatchExpression(pairs, colorModel);
+
+      // ['match', ['get','code'], '010', c1, '020', c2, '030', c3, 'rgba(0,0,0,0)']
+      expect(result, hasLength(2 + pairs.length * 2 + 1));
+      expect(result[0], equals('match'));
+      expect(result[1], equals(<Object>['get', 'code']));
+
+      for (var i = 0; i < pairs.length; i++) {
+        final pair = pairs[i];
+        final offset = 2 + i * 2;
+        expect(result[offset], equals(pair.code));
+        final expectedColor = colorModel
+            .fromJmaIntensity(pair.intensity)
+            .background
+            .toHexStringRGB();
+        expect(result[offset + 1], equals(expectedColor));
+      }
+
+      expect(result.last, equals('rgba(0,0,0,0)'));
+    });
+
+    test('色は #RRGGBB 形式の文字列である', () {
+      const pairs = [
+        (code: 'ABC', intensity: JmaIntensity.sixLower),
+      ];
+
+      final result = buildIntensityMatchExpression(pairs, colorModel);
+
+      final color = result[3] as String;
+      // '#' + 6 hex chars
+      expect(color, matches(RegExp(r'^#[0-9A-Fa-f]{6}$')));
+    });
+
+    test('unknown 震度でも正しく色が返る', () {
+      const pairs = [
+        (code: '000', intensity: JmaIntensity.unknown),
+      ];
+
+      final result = buildIntensityMatchExpression(pairs, colorModel);
+
+      expect(result, hasLength(5));
+      final color = result[3] as String;
+      final expectedColor = colorModel
+          .fromJmaIntensity(JmaIntensity.unknown)
+          .background
+          .toHexStringRGB();
+      expect(color, equals(expectedColor));
+    });
+  });
+}

--- a/app/test/feature/intensity_history/intensity_fill_expression_test.dart
+++ b/app/test/feature/intensity_history/intensity_fill_expression_test.dart
@@ -97,5 +97,45 @@ void main() {
           .toHexStringRGB();
       expect(color, equals(expectedColor));
     });
+
+    test('propertyKey を省略した場合は code が使われる', () {
+      const pairs = [
+        (code: '010', intensity: JmaIntensity.four),
+      ];
+
+      final result = buildIntensityMatchExpression(pairs, colorModel);
+
+      expect(result[1], equals(<Object>['get', 'code']));
+    });
+
+    test('propertyKey に regioncode を指定すると get 式に反映される', () {
+      const pairs = [
+        (code: '0110100', intensity: JmaIntensity.four),
+        (code: '0110200', intensity: JmaIntensity.fiveLower),
+      ];
+
+      final result = buildIntensityMatchExpression(
+        pairs,
+        colorModel,
+        propertyKey: 'regioncode',
+      );
+
+      // ['match', ['get','regioncode'], '0110100', c1, '0110200', c2, 'rgba(0,0,0,0)']
+      expect(result[0], equals('match'));
+      expect(result[1], equals(<Object>['get', 'regioncode']));
+      expect(result[2], equals('0110100'));
+      final expectedColor1 = colorModel
+          .fromJmaIntensity(JmaIntensity.four)
+          .background
+          .toHexStringRGB();
+      expect(result[3], equals(expectedColor1));
+      expect(result[4], equals('0110200'));
+      final expectedColor2 = colorModel
+          .fromJmaIntensity(JmaIntensity.fiveLower)
+          .background
+          .toHexStringRGB();
+      expect(result[5], equals(expectedColor2));
+      expect(result.last, equals('rgba(0,0,0,0)'));
+    });
   });
 }

--- a/app/test/feature/intensity_history/intensity_highest_repository_test.dart
+++ b/app/test/feature/intensity_history/intensity_highest_repository_test.dart
@@ -10,26 +10,25 @@ import 'package:flutter_test/flutter_test.dart';
 // ---------------------------------------------------------------------------
 
 EarthquakePartial _partial(String eventId) => EarthquakePartial(
-      eventId: eventId,
-      status: TelegramStatus.normal,
-      originTimePrecision: OriginTimePrecision.second,
-      datasource: EarthquakeDatasource.jmaDisasterInformationXml,
-      telegramTypes: const [],
-      earthquakeType: EarthquakeType.normal,
-    );
+  eventId: eventId,
+  status: TelegramStatus.normal,
+  originTimePrecision: OriginTimePrecision.second,
+  datasource: EarthquakeDatasource.jmaDisasterInformationXml,
+  telegramTypes: const [],
+  earthquakeType: EarthquakeType.normal,
+);
 
 HighestIntensityItem _item({
   required String code,
   required String name,
   required JmaIntensity intensity,
-}) =>
-    HighestIntensityItem(
-      code: code,
-      name: name,
-      intensity: intensity,
-      count: 3,
-      earthquake: _partial('evt-$code'),
-    );
+}) => HighestIntensityItem(
+  code: code,
+  name: name,
+  intensity: intensity,
+  count: 3,
+  earthquake: _partial('evt-$code'),
+);
 
 IntensityCitySearchItem _citySearchItem(JmaIntensity intensity) =>
     IntensityCitySearchItem(
@@ -43,7 +42,7 @@ IntensityCitySearchItem _citySearchItem(JmaIntensity intensity) =>
 
 class _FakeIntensityHighestRepository extends IntensityHighestRepository {
   _FakeIntensityHighestRepository()
-      : super(earthquake: ApiClient(Dio()).earthquake);
+    : super(earthquake: ApiClient(Dio()).earthquake);
 
   List<HighestIntensityItem> prefectureItems = const [];
   List<HighestIntensityItem> cityItems = const [];
@@ -117,7 +116,11 @@ void main() {
     test('cityItems を HighestIntensityEntry のリストに変換して返す', () async {
       final repo = _FakeIntensityHighestRepository()
         ..cityItems = [
-          _item(code: '0110100', name: '札幌市中央区', intensity: JmaIntensity.value4),
+          _item(
+            code: '0110100',
+            name: '札幌市中央区',
+            intensity: JmaIntensity.value4,
+          ),
         ];
 
       final result = await repo.fetchCityHighest('0100');

--- a/app/test/feature/intensity_history/intensity_highest_repository_test.dart
+++ b/app/test/feature/intensity_history/intensity_highest_repository_test.dart
@@ -1,0 +1,162 @@
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/city_intensity_page.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/repository/intensity_highest_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+EarthquakePartial _partial(String eventId) => EarthquakePartial(
+      eventId: eventId,
+      status: TelegramStatus.normal,
+      originTimePrecision: OriginTimePrecision.second,
+      datasource: EarthquakeDatasource.jmaDisasterInformationXml,
+      telegramTypes: const [],
+      earthquakeType: EarthquakeType.normal,
+    );
+
+HighestIntensityItem _item({
+  required String code,
+  required String name,
+  required JmaIntensity intensity,
+}) =>
+    HighestIntensityItem(
+      code: code,
+      name: name,
+      intensity: intensity,
+      count: 3,
+      earthquake: _partial('evt-$code'),
+    );
+
+IntensityCitySearchItem _citySearchItem(JmaIntensity intensity) =>
+    IntensityCitySearchItem(
+      intensity: intensity,
+      earthquake: _partial('evt-city'),
+    );
+
+// ---------------------------------------------------------------------------
+// Fake repository
+// ---------------------------------------------------------------------------
+
+class _FakeIntensityHighestRepository extends IntensityHighestRepository {
+  _FakeIntensityHighestRepository()
+      : super(earthquake: ApiClient(Dio()).earthquake);
+
+  List<HighestIntensityItem> prefectureItems = const [];
+  List<HighestIntensityItem> cityItems = const [];
+  List<IntensityCitySearchItem> cityIntensityItems = const [];
+  String? nextToken;
+
+  @override
+  Future<List<HighestIntensityEntry>> fetchPrefectureHighest() async {
+    return prefectureItems.map(HighestIntensityEntry.fromApi).toList();
+  }
+
+  @override
+  Future<List<HighestIntensityEntry>> fetchCityHighest(
+    String prefectureCode,
+  ) async {
+    return cityItems.map(HighestIntensityEntry.fromApi).toList();
+  }
+
+  @override
+  Future<CityIntensityPage> fetchCityIntensityList({
+    required String cityCode,
+    required int limit,
+    String? cursor,
+  }) async {
+    return CityIntensityPage(
+      items: cityIntensityItems,
+      nextToken: nextToken,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('HighestIntensityEntry.fromApi', () {
+    test('HighestIntensityItem を HighestIntensityEntry に変換できる', () {
+      final apiItem = _item(
+        code: '010101',
+        name: 'テスト地域',
+        intensity: JmaIntensity.value4,
+      );
+      final entry = HighestIntensityEntry.fromApi(apiItem);
+      expect(entry.code, '010101');
+      expect(entry.name, 'テスト地域');
+      expect(entry.intensity, JmaIntensity.value4);
+      expect(entry.count, 3);
+      expect(entry.earthquake.eventId, 'evt-010101');
+    });
+  });
+
+  group('IntensityHighestRepository.fetchPrefectureHighest', () {
+    test('items を HighestIntensityEntry のリストに変換して返す', () async {
+      final repo = _FakeIntensityHighestRepository()
+        ..prefectureItems = [
+          _item(code: '0100', name: '北海道', intensity: JmaIntensity.value5plus),
+          _item(code: '0200', name: '青森県', intensity: JmaIntensity.value3),
+        ];
+
+      final result = await repo.fetchPrefectureHighest();
+      expect(result.length, 2);
+      expect(result[0].code, '0100');
+      expect(result[0].intensity, JmaIntensity.value5plus);
+      expect(result[1].code, '0200');
+      expect(result[1].intensity, JmaIntensity.value3);
+    });
+  });
+
+  group('IntensityHighestRepository.fetchCityHighest', () {
+    test('cityItems を HighestIntensityEntry のリストに変換して返す', () async {
+      final repo = _FakeIntensityHighestRepository()
+        ..cityItems = [
+          _item(code: '0110100', name: '札幌市中央区', intensity: JmaIntensity.value4),
+        ];
+
+      final result = await repo.fetchCityHighest('0100');
+      expect(result.length, 1);
+      expect(result[0].code, '0110100');
+      expect(result[0].intensity, JmaIntensity.value4);
+    });
+  });
+
+  group('IntensityHighestRepository.fetchCityIntensityList', () {
+    test('items と nextToken を CityIntensityPage に詰めて返す', () async {
+      final repo = _FakeIntensityHighestRepository()
+        ..cityIntensityItems = [
+          _citySearchItem(JmaIntensity.value3),
+          _citySearchItem(JmaIntensity.value4),
+        ]
+        ..nextToken = 'next-cursor';
+
+      final page = await repo.fetchCityIntensityList(
+        cityCode: '0110100',
+        cursor: null,
+        limit: 20,
+      );
+      expect(page.items.length, 2);
+      expect(page.nextToken, 'next-cursor');
+      expect(page.items[0].intensity, JmaIntensity.value3);
+    });
+
+    test('nextToken が null の場合は CityIntensityPage.nextToken が null', () async {
+      final repo = _FakeIntensityHighestRepository()
+        ..cityIntensityItems = []
+        ..nextToken = null;
+
+      final page = await repo.fetchCityIntensityList(
+        cityCode: '0110100',
+        cursor: null,
+        limit: 20,
+      );
+      expect(page.nextToken, isNull);
+    });
+  });
+}

--- a/app/test/feature/intensity_history/intensity_history_controller_test.dart
+++ b/app/test/feature/intensity_history/intensity_history_controller_test.dart
@@ -1,0 +1,65 @@
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('IntensityHistoryController', () {
+    test('初期状態が Prefecture である', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final state = container.read(intensityHistoryControllerProvider);
+      expect(state, isA<IntensityHistoryStatePrefecture>());
+    });
+
+    test('focusPrefecture で City 状態に遷移する', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container
+          .read(intensityHistoryControllerProvider.notifier)
+          .focusPrefecture(code: '0100', name: '北海道');
+
+      final state = container.read(intensityHistoryControllerProvider);
+      expect(state, isA<IntensityHistoryStateCity>());
+      final city = state as IntensityHistoryStateCity;
+      expect(city.prefectureCode, '0100');
+      expect(city.prefectureName, '北海道');
+    });
+
+    test('backToPrefecture で Prefecture 状態に戻る', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container
+          .read(intensityHistoryControllerProvider.notifier)
+          .focusPrefecture(code: '0100', name: '北海道');
+
+      container
+          .read(intensityHistoryControllerProvider.notifier)
+          .backToPrefecture();
+
+      final state = container.read(intensityHistoryControllerProvider);
+      expect(state, isA<IntensityHistoryStatePrefecture>());
+    });
+
+    test('focusPrefecture を複数回呼ぶと最後の都道府県に更新される', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container
+          .read(intensityHistoryControllerProvider.notifier)
+          .focusPrefecture(code: '0100', name: '北海道');
+
+      container
+          .read(intensityHistoryControllerProvider.notifier)
+          .focusPrefecture(code: '0200', name: '青森県');
+
+      final state = container.read(intensityHistoryControllerProvider);
+      final city = state as IntensityHistoryStateCity;
+      expect(city.prefectureCode, '0200');
+      expect(city.prefectureName, '青森県');
+    });
+  });
+}

--- a/app/test/feature/intensity_history/region_code_mapping_test.dart
+++ b/app/test/feature/intensity_history/region_code_mapping_test.dart
@@ -87,6 +87,25 @@ void main() {
     });
   });
 
+  group('prefectureOfRegionCode', () {
+    test('細分区域コードから正しく都道府県コードと名前を返す', () {
+      final result = prefectureOfRegionCode('0110100', _testPrefectures);
+      expect(result?.code, '0100');
+      expect(result?.name, 'pref-0100');
+    });
+
+    test('別の都道府県の細分区域コードも正しく解決できる', () {
+      final result = prefectureOfRegionCode('0210100', _testPrefectures);
+      expect(result?.code, '0200');
+      expect(result?.name, 'pref-0200');
+    });
+
+    test('存在しない細分区域 code の場合は null を返す', () {
+      final result = prefectureOfRegionCode('9999999', _testPrefectures);
+      expect(result, isNull);
+    });
+  });
+
   group('cityCodesOfPrefecture', () {
     test('都道府県配下の全市区町村 code を返す', () {
       final result = cityCodesOfPrefecture('0100', _testPrefectures);

--- a/app/test/feature/intensity_history/region_code_mapping_test.dart
+++ b/app/test/feature/intensity_history/region_code_mapping_test.dart
@@ -10,32 +10,30 @@ import 'package:flutter_test/flutter_test.dart';
 LocalizedName _name(String ja) => LocalizedName(ja: ja, en: ja);
 
 EarthquakeParameterCityItem _city(String code) => EarthquakeParameterCityItem(
-      code: code,
-      name: _name('city-$code'),
-      kana: null,
-      stations: const [],
-    );
+  code: code,
+  name: _name('city-$code'),
+  kana: null,
+  stations: const [],
+);
 
 EarthquakeParameterRegionItem _region(
   String code,
   List<String> cityCodes,
-) =>
-    EarthquakeParameterRegionItem(
-      code: code,
-      name: _name('region-$code'),
-      kana: null,
-      cities: cityCodes.map(_city).toList(),
-    );
+) => EarthquakeParameterRegionItem(
+  code: code,
+  name: _name('region-$code'),
+  kana: null,
+  cities: cityCodes.map(_city).toList(),
+);
 
 EarthquakeParameterPrefectureItem _pref(
   String code,
   List<EarthquakeParameterRegionItem> regions,
-) =>
-    EarthquakeParameterPrefectureItem(
-      code: code,
-      name: _name('pref-$code'),
-      regions: regions,
-    );
+) => EarthquakeParameterPrefectureItem(
+  code: code,
+  name: _name('pref-$code'),
+  regions: regions,
+);
 
 // サンプルデータ:
 //   都道府県 '0100': 細分区域 '0110100', '0110200'

--- a/app/test/feature/intensity_history/region_code_mapping_test.dart
+++ b/app/test/feature/intensity_history/region_code_mapping_test.dart
@@ -1,0 +1,107 @@
+import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_common.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+LocalizedName _name(String ja) => LocalizedName(ja: ja, en: ja);
+
+EarthquakeParameterCityItem _city(String code) => EarthquakeParameterCityItem(
+      code: code,
+      name: _name('city-$code'),
+      kana: null,
+      stations: const [],
+    );
+
+EarthquakeParameterRegionItem _region(
+  String code,
+  List<String> cityCodes,
+) =>
+    EarthquakeParameterRegionItem(
+      code: code,
+      name: _name('region-$code'),
+      kana: null,
+      cities: cityCodes.map(_city).toList(),
+    );
+
+EarthquakeParameterPrefectureItem _pref(
+  String code,
+  List<EarthquakeParameterRegionItem> regions,
+) =>
+    EarthquakeParameterPrefectureItem(
+      code: code,
+      name: _name('pref-$code'),
+      regions: regions,
+    );
+
+// サンプルデータ:
+//   都道府県 '0100': 細分区域 '0110100', '0110200'
+//                   市区町村 '0110101', '0110102' (prefix 01)
+//   都道府県 '0200': 細分区域 '0210100'
+//                   市区町村 '0210101' (prefix 02)
+final _testPrefectures = [
+  _pref('0100', [
+    _region('0110100', ['0110101', '0110102']),
+    _region('0110200', ['0110201']),
+  ]),
+  _pref('0200', [
+    _region('0210100', ['0210101']),
+  ]),
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('prefectureCodeOfCity', () {
+    test('市区町村 code の前 2 桁が都道府県 code の前 2 桁と一致する場合に都道府県 code を返す', () {
+      final result = prefectureCodeOfCity('0110101', _testPrefectures);
+      expect(result, '0100');
+    });
+
+    test('別の都道府県の市区町村コードも正しく解決できる', () {
+      final result = prefectureCodeOfCity('0210101', _testPrefectures);
+      expect(result, '0200');
+    });
+
+    test('一致する都道府県が存在しない場合は null を返す', () {
+      final result = prefectureCodeOfCity('9999999', _testPrefectures);
+      expect(result, isNull);
+    });
+  });
+
+  group('regionCodesOfPrefecture', () {
+    test('都道府県配下の全細分区域 code を返す', () {
+      final result = regionCodesOfPrefecture('0100', _testPrefectures);
+      expect(result, containsAll(['0110100', '0110200']));
+      expect(result.length, 2);
+    });
+
+    test('存在しない都道府県 code の場合は空リストを返す', () {
+      final result = regionCodesOfPrefecture('9999', _testPrefectures);
+      expect(result, isEmpty);
+    });
+  });
+
+  group('cityCodesOfPrefecture', () {
+    test('都道府県配下の全市区町村 code を返す', () {
+      final result = cityCodesOfPrefecture('0100', _testPrefectures);
+      expect(result, containsAll(['0110101', '0110102', '0110201']));
+      expect(result.length, 3);
+    });
+
+    test('別の都道府県でも正しく返す', () {
+      final result = cityCodesOfPrefecture('0200', _testPrefectures);
+      expect(result, ['0210101']);
+    });
+
+    test('存在しない都道府県 code の場合は空リストを返す', () {
+      final result = cityCodesOfPrefecture('9999', _testPrefectures);
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/app/test/feature/intensity_history/region_floating_panel_test.dart
+++ b/app/test/feature/intensity_history/region_floating_panel_test.dart
@@ -1,0 +1,78 @@
+import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
+import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/prefecture_highest_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/region_floating_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Lv1(全国)状態で「全国」が表示される', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+
+    final container = ProviderContainer(
+      overrides: [
+        app_prefs.sharedPreferencesProvider.overrideWithValue(
+          app_prefs.SharedPreferencesAsync(preferences),
+        ),
+        prefectureHighestProvider.overrideWith((_) async => []),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: RegionFloatingPanel(),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('全国'), findsOneWidget);
+  });
+
+  testWidgets('Lv2(都道府県フォーカス)状態で都道府県名が表示される', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+
+    final container = ProviderContainer(
+      overrides: [
+        app_prefs.sharedPreferencesProvider.overrideWithValue(
+          app_prefs.SharedPreferencesAsync(preferences),
+        ),
+        prefectureHighestProvider.overrideWith((_) async => []),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // Lv2 状態に遷移
+    container.read(intensityHistoryControllerProvider.notifier).focusPrefecture(
+      code: '0100',
+      name: '北海道',
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: RegionFloatingPanel(),
+          ),
+        ),
+      ),
+    );
+    // 非同期プロバイダの解決を待つ
+    await tester.pumpAndSettle();
+
+    expect(find.text('北海道'), findsOneWidget);
+    expect(find.text('全国'), findsNothing);
+  });
+}

--- a/app/test/feature/intensity_history/region_floating_panel_test.dart
+++ b/app/test/feature/intensity_history/region_floating_panel_test.dart
@@ -54,10 +54,12 @@ void main() {
     addTearDown(container.dispose);
 
     // Lv2 状態に遷移
-    container.read(intensityHistoryControllerProvider.notifier).focusPrefecture(
-      code: '0100',
-      name: '北海道',
-    );
+    container
+        .read(intensityHistoryControllerProvider.notifier)
+        .focusPrefecture(
+          code: '0100',
+          name: '北海道',
+        );
 
     await tester.pumpWidget(
       UncontrolledProviderScope(

--- a/docs/superpowers/plans/2026-06-28-intensity-history-map.md
+++ b/docs/superpowers/plans/2026-06-28-intensity-history-map.md
@@ -1,0 +1,231 @@
+# 地域別 最大震度マップ 実装プラン
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 過去の地域ごとの最高震度を地図で俯瞰し、都道府県→市区町村→詳細とドリルダウンできる画面を新設する。
+
+**Architecture:** `app/lib/feature/intensity_history/` に `eew_history`/`earthquake_history` 構成を踏襲して新設。既存 `eqmonitor_map`(PMTiles ベクタタイル)に `FillStyleLayer` を動的追加し、`['match',['get','code'],...]` 式で震度色を塗る。状態は Riverpod Notifier で Lv1(都道府県)/Lv2(市区町村)を管理。
+
+**Tech Stack:** Flutter / Riverpod (riverpod_annotation) / Flutter Hooks / Freezed / MapLibre (maplibre) / paging_view / eqmonitor_api(生成済み・再生成しない)。
+
+設計書: `docs/superpowers/specs/2026-06-28-intensity-history-map-design.md`
+
+## Global Constraints
+
+- `dart analyze` 警告ゼロ(CI 必須)。`dart format` 準拠。
+- import は package import を使用(相対 import 不可)。
+- 生成ファイル(`*.g.dart` / `*.freezed.dart`)はコミットする。コード生成は `dart run build_runner build`(worktree 直下 or melos)。
+- **`packages/eqmonitor_api` は再生成しない**(本機能は生成済みクライアントのみ利用)。
+- API クライアント取得は `ref.watch(apiClientProvider.future)` → `apiClient.earthquake`。
+- 色は `ref.watch(intensityColorProvider)`(`IntensityColorModel`)。`colorModel.fromJmaIntensity(jma).background.toHexStringRGB()` で `#RRGGBB`。
+- PR ベースブランチは `develop`、リポジトリは `YumNumm/EQMonitor`。
+
+参照すべき既存実装(パターン元):
+- repository/provider: `app/lib/feature/eew_history/data/repository/eew_list_repository.dart`
+- 動的 FillStyleLayer + match 式 + add/removeLayer: `app/lib/feature/earthquake_history/ui/layer/earthquake_history_region_intensity_layer.dart`
+- queryLayers タップ判定 + fitBounds: `app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart`
+- ページネーション DataSource: `app/lib/feature/eew_history/data/notifier/eew_list_data_source.dart`
+- モーダル: `app/lib/feature/earthquake_history/ui/components/earthquake_history_map_popup.dart`
+- ルート: `app/lib/core/router/router.dart`(`@TypedGoRoute`)
+- HomeSheet 導線: `app/lib/page/home_page.dart` の `_SheetBody`
+- 都道府県/市区町村コード階層: `app/lib/core/component/selector/city_selector.dart`
+- API モデル: `packages/eqmonitor_api/lib/src/models/highest_intensity_item.dart`(`{code,name,intensity,count,earthquake}`)
+
+API シグネチャ(確定):
+- `apiClient.earthquake.getV2EarthquakeIntensityPrefectureHighest()` → `HttpResponse<HighestIntensityResponse>`(`HighestIntensityResponse{ items: List<HighestIntensityItem> }`)
+- `apiClient.earthquake.getV2EarthquakeIntensityPrefectureCodeCityHighest(code: ...)` → 同上
+- `apiClient.earthquake.getV2EarthquakeIntensityCityCode(code:, limit:, cursor:, sortBy:, sortOrder:, ...)` → `HttpResponse<IntensityCitySearchResponse>`(`items: List<IntensityCitySearchItem>`, `nextToken`)
+
+---
+
+## Task 0(検証): 地図コードと API コードの対応を確認
+
+**目的:** `prefecture/highest` の `code` が地図レイヤ `areaForecastLocalE` のフィーチャ `code` と一致するか(=Lv1 を直接 match 塗りできるか)を確定し、不一致なら都道府県→細分区域コード展開の要否を判断する。
+
+**Files:**
+- 調査のみ(コード変更なし)
+
+- [ ] **Step 1:** `forecastLocalEIntensityPairs`(`app/lib/feature/earthquake_history/data/model/earthquake_intensity.dart:52`)と `jma_map.pb` 上の `areaForecastLocalE` フィーチャ `code` の実値、`areaInformationPrefectureEarthquake` コードテーブルの `code` を突き合わせる。`app/lib/core/provider/map/jma_map_provider.dart` の `areaForecastLocalE` getter からフィーチャ code を列挙して確認。
+- [ ] **Step 2:** 結論を Task 3 の match 式構築方針に反映:
+  - **一致する場合** → Lv1 は `prefecture/highest` の code をそのまま match。
+  - **一致しない場合** → `earthquake.prefectures[].code`(都道府県) と `.regions[].code`(細分区域=`areaForecastLocalE`) の対応表を `parameterSetProvider` から構築し、都道府県 code → 配下の細分区域 code 群へ展開して match。
+- [ ] **Step 3:** 判明した対応関係を `intensity_history` ディレクトリ内にコメント or 純粋関数(Task 2)として固定化。
+
+---
+
+## Task 1: API モデルラッパと repository
+
+**Files:**
+- Create: `app/lib/feature/intensity_history/data/model/highest_intensity_entry.dart`
+- Create: `app/lib/feature/intensity_history/data/model/city_intensity_page.dart`
+- Create: `app/lib/feature/intensity_history/data/repository/intensity_highest_repository.dart`
+- Test: `app/test/feature/intensity_history/intensity_highest_repository_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `HighestIntensityEntry { String code; String name; JmaIntensity intensity; int count; EarthquakePartial earthquake }`(`api.JmaIntensity` をそのまま保持。app 側 enum 変換が必要なら `intensityColorProvider` が受け取る型に合わせる)
+  - `CityIntensityPage { List<IntensityCitySearchItem> items; String? nextToken }`
+  - `IntensityHighestRepository.fetchPrefectureHighest() → Future<List<HighestIntensityEntry>>`
+  - `IntensityHighestRepository.fetchCityHighest(String prefectureCode) → Future<List<HighestIntensityEntry>>`
+  - `IntensityHighestRepository.fetchCityIntensityList({required String cityCode, String? cursor, required int limit}) → Future<CityIntensityPage>`
+  - `@Riverpod(keepAlive:true) Future<IntensityHighestRepository> intensityHighestRepository(Ref ref)`
+
+- [ ] **Step 1: 失敗するテストを書く** — `intensity_highest_repository_test.dart`。`api.EarthquakeApiClient` を Fake 化し、`fetchPrefectureHighest()` が `HighestIntensityResponse.items` を `HighestIntensityEntry` に変換して返すこと、`fetchCityIntensityList` が `items`/`nextToken` を `CityIntensityPage` に詰めることを検証(`eew_list_data_source_test.dart` の Fake パターン踏襲)。
+- [ ] **Step 2:** `dart test` で未定義により FAIL を確認。
+- [ ] **Step 3: モデルを実装** — `highest_intensity_entry.dart`(Freezed)。`HighestIntensityItem` → `HighestIntensityEntry` の `factory HighestIntensityEntry.fromApi(api.HighestIntensityItem)` を定義。`city_intensity_page.dart`(Freezed)。
+- [ ] **Step 4: repository を実装** — `eew_list_repository.dart` 同様、`ref.watch(apiClientProvider.future)` → `apiClient.earthquake` を受け取る。各メソッドで API を呼び `.data.items.map(...)` で変換。`fetchCityIntensityList` は `getV2EarthquakeIntensityCityCode(code:, limit: limit.toString(), cursor: cursor)` を呼ぶ。
+- [ ] **Step 5:** `dart run build_runner build` で `.freezed.dart`/`.g.dart` 生成。
+- [ ] **Step 6:** `dart test app/test/feature/intensity_history/intensity_highest_repository_test.dart` PASS を確認。
+- [ ] **Step 7: コミット** — `git add` 後 `feat(intensity-history): 最高震度 API の repository とモデルを追加`。
+
+---
+
+## Task 2: コードマッピング純粋関数
+
+**Files:**
+- Create: `app/lib/feature/intensity_history/data/model/region_code_mapping.dart`
+- Test: `app/test/feature/intensity_history/region_code_mapping_test.dart`
+
+**Interfaces:**
+- Produces:
+  - `String? prefectureCodeOfCity(String cityCode, List<EarthquakeParameterPrefectureItem> prefectures)` — 市区町村 code から所属都道府県 code を返す(`city.code` が `prefecture.code` を接頭辞に持つ規則、`city_selector.dart` の `substring(0,2)` ロジックに準拠)。
+  - `List<String> regionCodesOfPrefecture(String prefectureCode, List<EarthquakeParameterPrefectureItem> prefectures)` — 都道府県配下の `areaForecastLocalE`(細分区域)code 群(Task 0 の結論次第。一致なら `[prefectureCode]` を返す簡易版)。
+  - `List<String> cityCodesOfPrefecture(String prefectureCode, List<EarthquakeParameterPrefectureItem> prefectures)` — 都道府県配下の市区町村 code 群。
+
+- [ ] **Step 1: 失敗するテストを書く** — ダミーの `EarthquakeParameterPrefectureItem`(code/regions/cities)を組み、各関数の戻り値を検証。
+- [ ] **Step 2:** FAIL 確認。
+- [ ] **Step 3: 実装** — Task 0 の結論を反映した純粋関数。
+- [ ] **Step 4:** PASS 確認。
+- [ ] **Step 5: コミット** — `feat(intensity-history): 地域コードマッピングの純粋関数を追加`。
+
+---
+
+## Task 3: フォーカス状態 Notifier と provider 群
+
+**Files:**
+- Create: `app/lib/feature/intensity_history/data/model/intensity_history_state.dart`
+- Create: `app/lib/feature/intensity_history/data/notifier/intensity_history_controller.dart`
+- Create: `app/lib/feature/intensity_history/data/notifier/prefecture_highest_provider.dart`
+- Create: `app/lib/feature/intensity_history/data/notifier/city_highest_provider.dart`
+- Test: `app/test/feature/intensity_history/intensity_history_controller_test.dart`
+
+**Interfaces:**
+- Consumes: Task 1 の `intensityHighestRepository`。
+- Produces:
+  - `IntensityHistoryState`(Freezed union): `Prefecture()` / `City({required String prefectureCode, required String prefectureName})`。
+  - `@riverpod class IntensityHistoryController` — `build()→ const IntensityHistoryState.prefecture()`、`void focusPrefecture(String code, String name)`、`void backToPrefecture()`。
+  - `@riverpod Future<List<HighestIntensityEntry>> prefectureHighest(Ref ref)`(repository 呼び出し、keepAlive)。
+  - `@riverpod Future<List<HighestIntensityEntry>> cityHighest(Ref ref, String prefectureCode)`(family)。
+
+- [ ] **Step 1: 失敗するテストを書く** — `ProviderContainer` で `IntensityHistoryController` の初期状態が `Prefecture`、`focusPrefecture` で `City(...)`、`backToPrefecture` で `Prefecture` に戻ることを検証。
+- [ ] **Step 2:** FAIL 確認。
+- [ ] **Step 3: 実装** — state(Freezed union)+ controller + 2 provider。
+- [ ] **Step 4:** build_runner 生成 → PASS 確認。
+- [ ] **Step 5: コミット** — `feat(intensity-history): フォーカス状態 Notifier と provider を追加`。
+
+---
+
+## Task 4: 震度 fill レイヤ(Lv1/Lv2)
+
+**Files:**
+- Create: `app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart`
+- Create: `app/lib/feature/intensity_history/ui/layer/intensity_fill_expression.dart`(match 式構築の純粋関数)
+- Test: `app/test/feature/intensity_history/intensity_fill_expression_test.dart`
+
+**Interfaces:**
+- Consumes: Task 1 entries、Task 2 マッピング、`intensityColorProvider`。
+- Produces:
+  - `List<Object> buildIntensityMatchExpression(List<({String code, JmaIntensity intensity})> pairs, IntensityColorModel colorModel)` — `['match',['get','code'], code, color, ..., 'rgba(0,0,0,0)']`(`earthquake_history_region_intensity_layer.dart:87-108` を踏襲)。
+  - `IntensityFillLayer`(HookConsumerWidget): `state` に応じて、Lv1 は `areaForecastLocalE` に、Lv2 は `areaInformationCityQuake` に `FillStyleLayer` を add/remove。`useEffect` で add、dispose で `removeLayer`(`earthquake_history_region_intensity_layer.dart` の構造を踏襲)。Lv2 時はディムオーバーレイ用 fill も追加。
+
+- [ ] **Step 1: 失敗するテストを書く** — `buildIntensityMatchExpression` が pairs を `['match',['get','code'], 'A','#...', ..., 'rgba(0,0,0,0)']` 形に変換することを検証。
+- [ ] **Step 2:** FAIL 確認。
+- [ ] **Step 3: 実装** — `intensity_fill_expression.dart` の純粋関数。
+- [ ] **Step 4:** PASS 確認。
+- [ ] **Step 5: レイヤ Widget 実装** — `intensity_fill_layer.dart`。`belowLayerId` は `BaseLayer.areaForecastLocalELine.name` を指定(`earthquake_history` 準拠)。Lv2 のディムは非選択地域を半透明黒で覆う fill か、Lv1 fill の opacity を下げる。
+- [ ] **Step 6:** `dart analyze` で当該ファイル警告ゼロ確認。
+- [ ] **Step 7: コミット** — `feat(intensity-history): 震度 fill レイヤと match 式を追加`。
+
+---
+
+## Task 5: 市区町村詳細モーダル(サマリ + 過去地震一覧)
+
+**Files:**
+- Create: `app/lib/feature/intensity_history/data/notifier/city_intensity_list_data_source.dart`
+- Create: `app/lib/feature/intensity_history/ui/components/city_detail_modal.dart`
+- Test: `app/test/feature/intensity_history/city_detail_modal_test.dart`
+
+**Interfaces:**
+- Consumes: Task 1 `fetchCityIntensityList`、Task 3 `cityHighest`(サマリ用)。
+- Produces:
+  - `CityIntensityListDataSource extends GroupedDataSource<String?, String, IntensityCitySearchItem>`(`eew_list_data_source.dart` 踏襲。`groupBy` は地震 originTime の `yyyy/MM/dd`、`load` で cursor ページング、limit 初回 20 / 追加 100)。
+  - `@riverpod CityIntensityListDataSource cityIntensityListDataSource(Ref ref, String cityCode)`。
+  - `Future<void> showCityDetailModal(BuildContext, {required String cityCode, required HighestIntensityEntry? summary})` — `showModalBottomSheet`(`isScrollControlled: true`)+ `DraggableScrollableSheet`。上部にサマリ(地域名/最高震度バッジ/件数/代表地震)、下部に `SliverGroupedPagingList` で過去地震一覧。
+
+- [ ] **Step 1: 失敗するテストを書く** — DataSource の `groupBy`/`load`(Refresh/Append cursor 受け渡し)を Fake repository で検証(`eew_list_data_source_test.dart` 踏襲)。
+- [ ] **Step 2:** FAIL 確認。
+- [ ] **Step 3: DataSource 実装** → build_runner → PASS。
+- [ ] **Step 4: モーダル Widget 実装** — サマリ + ページングリスト。震度バッジは既存 `intensityColorProvider` 利用。
+- [ ] **Step 5: スモークテスト** — `city_detail_modal_test.dart` で `ProviderScope` override し、サマリの地域名が表示されることを検証(`eew_history_list_tile_test.dart` のセットアップ踏襲、`SharedPreferences.setMockInitialValues({})`)。
+- [ ] **Step 6:** PASS + `dart analyze` 確認。
+- [ ] **Step 7: コミット** — `feat(intensity-history): 市区町村詳細モーダルと過去地震一覧を追加`。
+
+---
+
+## Task 6: ページ本体(地図全面 + フローティングパネル + タップ + 戻る)
+
+**Files:**
+- Create: `app/lib/feature/intensity_history/ui/intensity_history_page.dart`
+- Create: `app/lib/feature/intensity_history/ui/components/region_floating_panel.dart`
+- Create: `app/lib/feature/intensity_history/ui/components/intensity_history_legend.dart`
+
+**Interfaces:**
+- Consumes: Task 3 controller/state/providers、Task 4 `IntensityFillLayer`、Task 5 `showCityDetailModal`、Task 2 マッピング。
+- Produces:
+  - `IntensityHistoryPage extends HookConsumerWidget`(引数 `String? initialPrefectureCode`, `String? initialCityCode`)。
+
+- [ ] **Step 1:** `MapLibreMap`(既存 `map_style_util` のスタイル)を全面表示し `IntensityFillLayer` を重ねる。`Stack` 上部に `RegionFloatingPanel`(現在地域名/最高震度/件数)、隅に `IntensityHistoryLegend`、戻るボタン。
+- [ ] **Step 2:** `onMapClick`/`queryLayers`(`earthquake_history_details_map_view.dart:234` 参照)でタップ地域 code を取得。Lv1 命中 → Task 2 で都道府県 code に正規化 → `controller.focusPrefecture(code,name)`。Lv2 命中(市区町村)→ `showCityDetailModal`。
+- [ ] **Step 3:** Lv2 遷移時に当該都道府県の bounds へ `fitBounds`(`jmaMapProvider` から bounds 算出、`map_camera` の既存 fitBounds 利用)。`backToPrefecture` 時は全国へズームアウト。
+- [ ] **Step 4:** `PopScope` で端末バックを Lv2→Lv1 に割り当て(Lv1 のときは通常 pop)。
+- [ ] **Step 5:** `initialPrefectureCode` 指定時は初期 `focusPrefecture`、`initialCityCode` 指定時はさらに `showCityDetailModal` を `addPostFrameCallback` で自動表示。
+- [ ] **Step 6:** `dart analyze` 警告ゼロ確認。
+- [ ] **Step 7: コミット** — `feat(intensity-history): 地図ページ・フローティングパネル・タップ/戻る制御を追加`。
+
+---
+
+## Task 7: ルーティング + HomeSheet 導線 + ディープリンク
+
+**Files:**
+- Modify: `app/lib/core/router/router.dart`(`@TypedGoRoute<IntensityHistoryRoute>` 追加)
+- Modify: `app/lib/page/home_page.dart`(`_SheetBody` のアクションカードに ListTile 追加)
+- Modify: `app/lib/feature/earthquake_history/ui/components/earthquake_history_map_popup.dart`(「この地域の最大震度履歴」アクション追加)
+
+**Interfaces:**
+- Consumes: Task 6 `IntensityHistoryPage`。
+- Produces: `IntensityHistoryRoute({String? prefectureCode, String? cityCode})`(path `/intensity-history`)。
+
+- [ ] **Step 1:** `router.dart` に `IntensityHistoryRoute` を追加(`prefectureCode`/`cityCode` を query パラメータで受け、`build` で `IntensityHistoryPage(initialPrefectureCode:..., initialCityCode:...)` を返す。`EarthquakeHistoryRoute` の `$extra`/`:param` パターン参照)。
+- [ ] **Step 2:** `dart run build_runner build` で `router.g.dart` 再生成。
+- [ ] **Step 3:** `home_page.dart` の `_SheetBody` アクションカードに `ListTile(leading: Icon(Icons.map...), title: Text('都道府県別 最大震度'), onTap: () => const IntensityHistoryRoute().push(context))` を追加。
+- [ ] **Step 4:** `earthquake_history_map_popup.dart` に「この地域の最大震度履歴」ボタンを追加。市区町村ポップアップなら `IntensityHistoryRoute(prefectureCode: prefCode, cityCode: cityCode)`、地域ポップアップなら `prefectureCode` のみを渡して `push`。
+- [ ] **Step 5:** `dart analyze` 警告ゼロ確認。
+- [ ] **Step 6: コミット** — `feat(intensity-history): ルート・HomeSheet導線・ディープリンクを追加`。
+
+---
+
+## Task 8: 仕上げ(analyze / format / test 全体)
+
+- [ ] **Step 1:** `cd app && dart analyze lib` 警告ゼロ。`dart analyze packages/eqmonitor_api/lib` も確認(変更していないこと)。
+- [ ] **Step 2:** `dart format`(差分のあるファイルのみ)。
+- [ ] **Step 3:** `flutter test test/feature/intensity_history/` 全 PASS。
+- [ ] **Step 4:** 受け入れ条件(設計書 §10)1〜5 を手動チェックリストで確認。
+- [ ] **Step 5: コミット**(差分があれば) — `chore(intensity-history): format と analyze 対応`。
+
+---
+
+## Self-Review チェック結果
+
+- **Spec coverage:** 設計書 §3(レンダリング)=Task 4、§4(構成)=Task 1〜6、§5(状態)=Task 3、§6(ナビ/導線/ディープリンク)=Task 7、§7(エラー/空)=Task 1/5/6 内、§8(テスト)=各 Task の test。漏れなし。
+- **Placeholder scan:** 「適切なエラー処理」等の曖昧表現なし。Task 0 の不確定要素は明示的な検証タスクとして分離。
+- **Type consistency:** `HighestIntensityEntry` / `CityIntensityPage` / `IntensityHistoryState`(`Prefecture`/`City`)/ `focusPrefecture`/`backToPrefecture`/`buildIntensityMatchExpression` を全 Task で統一。


### PR DESCRIPTION
## 概要

過去の地域ごとの最高震度を地図で俯瞰し、都道府県→市区町村→詳細とドリルダウンできる画面「地域別 最大震度マップ」を新設します。

- **Lv1(都道府県)**: 全都道府県を過去最高震度で色分け(`areaForecastLocalE` を所属都道府県の最高震度で `match` 塗り)
- **Lv2(市区町村)**: 都道府県をタップ → 当該都道府県にズーム + 他地域ディム → 市区町村ごとの最高震度を色分け
- **Lv3(詳細)**: 市区町村タップ → モーダルでサマリ(最高震度/件数/代表地震)+ 過去地震一覧(ページネーション)

## 利用API(実装済み・再生成なし)

- `GET /v2/earthquake/intensity/prefecture/highest`(Lv1)
- `GET /v2/earthquake/intensity/prefecture/{code}/city/highest`(Lv2)
- `GET /v2/earthquake/intensity/city/{code}`(Lv3一覧)

## 導線

- HomeSheet アクションカードに「都道府県別 最大震度」リンクを追加
- 地震履歴詳細マップのポップアップから当該地域にフォーカスして直接遷移(ディープリンク)
- ルート `/intensity-history`(optional `prefectureCode` / `cityCode`)

## 設計・プラン

- 設計書: `docs/superpowers/specs/2026-06-28-intensity-history-map-design.md`
- 実装プラン: `docs/superpowers/plans/2026-06-28-intensity-history-map.md`

## テスト

- `app/test/feature/intensity_history/` に 34 テスト(repository変換 / コードマッピング / フォーカス状態controller / match式 / DataSource / モーダル・パネルのスモーク)
- `dart analyze lib` 警告ゼロ

## スコープ外

- `eqmonitor_api` の OpenAPI 3.1 への再生成・同期(別途対応。本PRでは既存の生成済みクライアントのみ利用)
- highest 系のフィルタ(API がクエリ非対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H5y7yz4NoRaXvfFszWicz
