### PR TITLE
feat(earthquake): 地震履歴詳細画面の震源近傍で発生した地震の探索パラメータをユーザが調整できるようにする

### DIFF
--- a/app/lib/core/gen/assets.gen.dart
+++ b/app/lib/core/gen/assets.gen.dart
@@ -37,10 +37,6 @@ class $AssetsDocsGen {
   List<String> get values => [aboutThisApp, privacyPolicy, termOfService];
 }
 
-class $AssetsFontsGen {
-  const $AssetsFontsGen();
-}
-
 class $AssetsImagesGen {
   const $AssetsImagesGen();
 
@@ -150,7 +146,6 @@ class Assets {
       'assets/KyoshinShindoColorMap.json';
   static const $AssetsDebugGen debug = $AssetsDebugGen();
   static const $AssetsDocsGen docs = $AssetsDocsGen();
-  static const $AssetsFontsGen fonts = $AssetsFontsGen();
   static const AssetGenImage header = AssetGenImage('assets/header.png');
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const String jmaCodeTable = 'assets/jma_code_table.pb';

--- a/app/lib/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart
+++ b/app/lib/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'nearby_earthquake_parameter.freezed.dart';
+
+/// 震源近傍の地震探索パラメータ
+@freezed
+abstract class NearbyEarthquakeParameter with _$NearbyEarthquakeParameter {
+  const factory NearbyEarthquakeParameter({
+    /// 緯度オフセット (度): ±この値の範囲を検索
+    @Default(0.5) double latitudeOffset,
+
+    /// 経度オフセット (度): ±この値の範囲を検索
+    @Default(0.5) double longitudeOffset,
+
+    /// 深さオフセット (km): ±この値の範囲を検索
+    @Default(50) int depthOffset,
+  }) = _NearbyEarthquakeParameter;
+}

--- a/app/lib/feature/earthquake_history/data/model/nearby_earthquake_parameter.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/nearby_earthquake_parameter.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'nearby_earthquake_parameter.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$NearbyEarthquakeParameter {
+
+/// 緯度オフセット (度): ±この値の範囲を検索
+ double get latitudeOffset;/// 経度オフセット (度): ±この値の範囲を検索
+ double get longitudeOffset;/// 深さオフセット (km): ±この値の範囲を検索
+ int get depthOffset;
+/// Create a copy of NearbyEarthquakeParameter
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NearbyEarthquakeParameterCopyWith<NearbyEarthquakeParameter> get copyWith => _$NearbyEarthquakeParameterCopyWithImpl<NearbyEarthquakeParameter>(this as NearbyEarthquakeParameter, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NearbyEarthquakeParameter&&(identical(other.latitudeOffset, latitudeOffset) || other.latitudeOffset == latitudeOffset)&&(identical(other.longitudeOffset, longitudeOffset) || other.longitudeOffset == longitudeOffset)&&(identical(other.depthOffset, depthOffset) || other.depthOffset == depthOffset));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,latitudeOffset,longitudeOffset,depthOffset);
+
+@override
+String toString() {
+  return 'NearbyEarthquakeParameter(latitudeOffset: $latitudeOffset, longitudeOffset: $longitudeOffset, depthOffset: $depthOffset)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NearbyEarthquakeParameterCopyWith<$Res>  {
+  factory $NearbyEarthquakeParameterCopyWith(NearbyEarthquakeParameter value, $Res Function(NearbyEarthquakeParameter) _then) = _$NearbyEarthquakeParameterCopyWithImpl;
+@useResult
+$Res call({
+ double latitudeOffset, double longitudeOffset, int depthOffset
+});
+
+
+
+
+}
+/// @nodoc
+class _$NearbyEarthquakeParameterCopyWithImpl<$Res>
+    implements $NearbyEarthquakeParameterCopyWith<$Res> {
+  _$NearbyEarthquakeParameterCopyWithImpl(this._self, this._then);
+
+  final NearbyEarthquakeParameter _self;
+  final $Res Function(NearbyEarthquakeParameter) _then;
+
+/// Create a copy of NearbyEarthquakeParameter
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? latitudeOffset = null,Object? longitudeOffset = null,Object? depthOffset = null,}) {
+  return _then(_self.copyWith(
+latitudeOffset: null == latitudeOffset ? _self.latitudeOffset : latitudeOffset // ignore: cast_nullable_to_non_nullable
+as double,longitudeOffset: null == longitudeOffset ? _self.longitudeOffset : longitudeOffset // ignore: cast_nullable_to_non_nullable
+as double,depthOffset: null == depthOffset ? _self.depthOffset : depthOffset // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [NearbyEarthquakeParameter].
+extension NearbyEarthquakeParameterPatterns on NearbyEarthquakeParameter {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NearbyEarthquakeParameter value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NearbyEarthquakeParameter() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NearbyEarthquakeParameter value)  $default,){
+final _that = this;
+switch (_that) {
+case _NearbyEarthquakeParameter():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NearbyEarthquakeParameter value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NearbyEarthquakeParameter() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double latitudeOffset,  double longitudeOffset,  int depthOffset)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NearbyEarthquakeParameter() when $default != null:
+return $default(_that.latitudeOffset,_that.longitudeOffset,_that.depthOffset);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double latitudeOffset,  double longitudeOffset,  int depthOffset)  $default,) {final _that = this;
+switch (_that) {
+case _NearbyEarthquakeParameter():
+return $default(_that.latitudeOffset,_that.longitudeOffset,_that.depthOffset);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double latitudeOffset,  double longitudeOffset,  int depthOffset)?  $default,) {final _that = this;
+switch (_that) {
+case _NearbyEarthquakeParameter() when $default != null:
+return $default(_that.latitudeOffset,_that.longitudeOffset,_that.depthOffset);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _NearbyEarthquakeParameter implements NearbyEarthquakeParameter {
+  const _NearbyEarthquakeParameter({this.latitudeOffset = 0.5, this.longitudeOffset = 0.5, this.depthOffset = 50});
+  
+
+/// 緯度オフセット (度): ±この値の範囲を検索
+@override@JsonKey() final  double latitudeOffset;
+/// 経度オフセット (度): ±この値の範囲を検索
+@override@JsonKey() final  double longitudeOffset;
+/// 深さオフセット (km): ±この値の範囲を検索
+@override@JsonKey() final  int depthOffset;
+
+/// Create a copy of NearbyEarthquakeParameter
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NearbyEarthquakeParameterCopyWith<_NearbyEarthquakeParameter> get copyWith => __$NearbyEarthquakeParameterCopyWithImpl<_NearbyEarthquakeParameter>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NearbyEarthquakeParameter&&(identical(other.latitudeOffset, latitudeOffset) || other.latitudeOffset == latitudeOffset)&&(identical(other.longitudeOffset, longitudeOffset) || other.longitudeOffset == longitudeOffset)&&(identical(other.depthOffset, depthOffset) || other.depthOffset == depthOffset));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,latitudeOffset,longitudeOffset,depthOffset);
+
+@override
+String toString() {
+  return 'NearbyEarthquakeParameter(latitudeOffset: $latitudeOffset, longitudeOffset: $longitudeOffset, depthOffset: $depthOffset)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$NearbyEarthquakeParameterCopyWith<$Res> implements $NearbyEarthquakeParameterCopyWith<$Res> {
+  factory _$NearbyEarthquakeParameterCopyWith(_NearbyEarthquakeParameter value, $Res Function(_NearbyEarthquakeParameter) _then) = __$NearbyEarthquakeParameterCopyWithImpl;
+@override @useResult
+$Res call({
+ double latitudeOffset, double longitudeOffset, int depthOffset
+});
+
+
+
+
+}
+/// @nodoc
+class __$NearbyEarthquakeParameterCopyWithImpl<$Res>
+    implements _$NearbyEarthquakeParameterCopyWith<$Res> {
+  __$NearbyEarthquakeParameterCopyWithImpl(this._self, this._then);
+
+  final _NearbyEarthquakeParameter _self;
+  final $Res Function(_NearbyEarthquakeParameter) _then;
+
+/// Create a copy of NearbyEarthquakeParameter
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? latitudeOffset = null,Object? longitudeOffset = null,Object? depthOffset = null,}) {
+  return _then(_NearbyEarthquakeParameter(
+latitudeOffset: null == latitudeOffset ? _self.latitudeOffset : latitudeOffset // ignore: cast_nullable_to_non_nullable
+as double,longitudeOffset: null == longitudeOffset ? _self.longitudeOffset : longitudeOffset // ignore: cast_nullable_to_non_nullable
+as double,depthOffset: null == depthOffset ? _self.depthOffset : depthOffset // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.dart
@@ -1,4 +1,5 @@
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -14,20 +15,23 @@ Future<List<EarthquakePartial>> nearbyEarthquake(
   int? depth,
   api.EarthquakeSortBy sortBy,
   api.SortOrder sortOrder,
+  NearbyEarthquakeParameter parameter,
 ) async {
   final repository = await ref.watch(
     earthquakeHistoryRepositoryProvider.future,
   );
   final response = await repository.fetchEarthquakeList(
-    latitudeGte: latitude - 0.5,
-    latitudeLte: latitude + 0.5,
-    longitudeGte: longitude - 0.5,
-    longitudeLte: longitude + 0.5,
-    depthGte: depth != null ? (depth - 50).clamp(0, 9999) : null,
-    depthLte: depth != null ? depth + 50 : null,
+    latitudeGte: latitude - parameter.latitudeOffset,
+    latitudeLte: latitude + parameter.latitudeOffset,
+    longitudeGte: longitude - parameter.longitudeOffset,
+    longitudeLte: longitude + parameter.longitudeOffset,
+    depthGte: depth != null
+        ? (depth - parameter.depthOffset).clamp(0, 9999)
+        : null,
+    depthLte: depth != null ? depth + parameter.depthOffset : null,
     sortBy: sortBy,
     sortOrder: sortOrder,
-    limit: 50,
+    limit: 5,
   );
   return response.items
       .where((e) => e.eventId != excludeEventId)

--- a/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/similar_earthquake_provider.g.dart
@@ -26,7 +26,15 @@ final class NearbyEarthquakeProvider
         $FutureProvider<List<EarthquakePartial>> {
   NearbyEarthquakeProvider._({
     required NearbyEarthquakeFamily super.from,
-    required (String, double, double, int?, api.EarthquakeSortBy, api.SortOrder)
+    required (
+      String,
+      double,
+      double,
+      int?,
+      api.EarthquakeSortBy,
+      api.SortOrder,
+      NearbyEarthquakeParameter,
+    )
     super.argument,
   }) : super(
          retry: null,
@@ -63,6 +71,7 @@ final class NearbyEarthquakeProvider
               int?,
               api.EarthquakeSortBy,
               api.SortOrder,
+              NearbyEarthquakeParameter,
             );
     return nearbyEarthquake(
       ref,
@@ -72,6 +81,7 @@ final class NearbyEarthquakeProvider
       argument.$4,
       argument.$5,
       argument.$6,
+      argument.$7,
     );
   }
 
@@ -86,13 +96,21 @@ final class NearbyEarthquakeProvider
   }
 }
 
-String _$nearbyEarthquakeHash() => r'2e8fe5b4b86563f9e8fdf6e2c6284137d5d080cd';
+String _$nearbyEarthquakeHash() => r'9acd54d1431d49138ec6e08a200d2b2cb4c29447';
 
 final class NearbyEarthquakeFamily extends $Family
     with
         $FunctionalFamilyOverride<
           FutureOr<List<EarthquakePartial>>,
-          (String, double, double, int?, api.EarthquakeSortBy, api.SortOrder)
+          (
+            String,
+            double,
+            double,
+            int?,
+            api.EarthquakeSortBy,
+            api.SortOrder,
+            NearbyEarthquakeParameter,
+          )
         > {
   NearbyEarthquakeFamily._()
     : super(
@@ -110,8 +128,17 @@ final class NearbyEarthquakeFamily extends $Family
     int? depth,
     api.EarthquakeSortBy sortBy,
     api.SortOrder sortOrder,
+    NearbyEarthquakeParameter parameter,
   ) => NearbyEarthquakeProvider._(
-    argument: (excludeEventId, latitude, longitude, depth, sortBy, sortOrder),
+    argument: (
+      excludeEventId,
+      latitude,
+      longitude,
+      depth,
+      sortBy,
+      sortOrder,
+      parameter,
+    ),
     from: this,
   );
 

--- a/app/lib/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart
+++ b/app/lib/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart
@@ -1,0 +1,165 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
+import 'package:flutter/material.dart';
+
+/// 震源近傍の地震探索パラメータを調整する BottomSheet
+class NearbyEarthquakeParameterSheet extends StatefulWidget {
+  const NearbyEarthquakeParameterSheet({
+    required this.initial,
+    required this.hasDepth,
+    super.key,
+  });
+
+  final NearbyEarthquakeParameter initial;
+
+  /// 深さが判明しているか（false の場合は深さオフセットを非表示）
+  final bool hasDepth;
+
+  @override
+  State<NearbyEarthquakeParameterSheet> createState() =>
+      _NearbyEarthquakeParameterSheetState();
+}
+
+class _NearbyEarthquakeParameterSheetState
+    extends State<NearbyEarthquakeParameterSheet> {
+  late double _latitudeOffset;
+  late double _longitudeOffset;
+  late int _depthOffset;
+
+  @override
+  void initState() {
+    super.initState();
+    _latitudeOffset = widget.initial.latitudeOffset;
+    _longitudeOffset = widget.initial.longitudeOffset;
+    _depthOffset = widget.initial.depthOffset;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.onSurfaceVariant.withValues(
+                    alpha: 0.4,
+                  ),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '探索パラメータの設定',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 20),
+            _SliderRow(
+              label: '緯度範囲',
+              value: _latitudeOffset,
+              min: 0.1,
+              max: 3,
+              divisions: 29,
+              displayText: '±${_latitudeOffset.toStringAsFixed(1)}°',
+              onChanged: (v) => setState(() => _latitudeOffset = v),
+            ),
+            _SliderRow(
+              label: '経度範囲',
+              value: _longitudeOffset,
+              min: 0.1,
+              max: 3,
+              divisions: 29,
+              displayText: '±${_longitudeOffset.toStringAsFixed(1)}°',
+              onChanged: (v) => setState(() => _longitudeOffset = v),
+            ),
+            if (widget.hasDepth)
+              _SliderRow(
+                label: '深さ範囲',
+                value: _depthOffset.toDouble(),
+                min: 10,
+                max: 200,
+                divisions: 19,
+                displayText: '±${_depthOffset}km',
+                onChanged: (v) => setState(() => _depthOffset = v.round()),
+              ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(
+                NearbyEarthquakeParameter(
+                  latitudeOffset: _latitudeOffset,
+                  longitudeOffset: _longitudeOffset,
+                  depthOffset: _depthOffset,
+                ),
+              ),
+              style: FilledButton.styleFrom(
+                minimumSize: const Size(double.infinity, 48),
+              ),
+              child: const Text('適用'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.displayText,
+    required this.onChanged,
+  });
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final String displayText;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(label, style: theme.textTheme.bodyMedium),
+            ),
+            Text(
+              displayText,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ],
+        ),
+        Slider(
+          value: value,
+          min: min,
+          max: max,
+          divisions: divisions,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/similar_earthquake_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/similar_earthquake_card.dart
@@ -5,9 +5,14 @@ import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/provider/similar_earthquake_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -20,8 +25,6 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
   });
 
   final Earthquake earthquake;
-
-  static const _initialDisplayCount = 5;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -39,7 +42,7 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
 
     final sortBy = useState(api.EarthquakeSortBy.originTime);
     final sortOrder = useState(api.SortOrder.desc);
-    final showAll = useState(false);
+    final searchParam = useState(const NearbyEarthquakeParameter());
     final intensityColor = ref.watch(intensityColorProvider);
     final theme = Theme.of(context);
 
@@ -51,6 +54,7 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
         depth,
         sortBy.value,
         sortOrder.value,
+        searchParam.value,
       ),
     );
 
@@ -65,8 +69,25 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
           api.EarthquakeSortBy.depth => api.SortOrder.asc,
           _ => api.SortOrder.desc,
         };
-        showAll.value = false;
       }
+    }
+
+    Future<void> onShowAll() async {
+      final param = searchParam.value;
+      await EarthquakeHistoryRoute(
+        $extra: EarthquakeHistoryParameter(
+          latitudeGte: coordinates.latitude - param.latitudeOffset,
+          latitudeLte: coordinates.latitude + param.latitudeOffset,
+          longitudeGte: coordinates.longitude - param.longitudeOffset,
+          longitudeLte: coordinates.longitude + param.longitudeOffset,
+          depthGte: depth != null
+              ? (depth - param.depthOffset).clamp(0, 9999)
+              : null,
+          depthLte: depth != null ? depth + param.depthOffset : null,
+          sortBy: sortBy.value.toEarthquakeSortBy,
+          sortOrder: sortOrder.value.toSortOrder,
+        ),
+      ).push<void>(context);
     }
 
     return BorderedContainer(
@@ -75,14 +96,43 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
-            child: Text(
-              'この震源の近傍で発生した地震',
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
+            padding: const EdgeInsets.fromLTRB(12, 0, 4, 4),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'この震源の近傍で発生した地震',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.tune, size: 20),
+                  tooltip: '探索パラメータを変更',
+                  visualDensity: VisualDensity.compact,
+                  onPressed: () async {
+                    final result =
+                        await showModalBottomSheet<NearbyEarthquakeParameter>(
+                      context: context,
+                      builder: (_) => NearbyEarthquakeParameterSheet(
+                        initial: searchParam.value,
+                        hasDepth: depth != null,
+                      ),
+                    );
+                    if (result != null) {
+                      searchParam.value = result;
+                    }
+                  },
+                ),
+              ],
             ),
           ),
+          _ParameterSummary(
+            parameter: searchParam.value,
+            hasDepth: depth != null,
+          ),
+          const SizedBox(height: 4),
           _SortButtonRow(
             sortBy: sortBy.value,
             sortOrder: sortOrder.value,
@@ -122,6 +172,7 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
                           depth,
                           sortBy.value,
                           sortOrder.value,
+                          searchParam.value,
                         ),
                       ),
                       child: const Text('再試行'),
@@ -143,8 +194,8 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
               ),
             AsyncData(value: final items) => _NearbyEarthquakeList(
                 items: items,
-                showAll: showAll,
                 intensityColor: intensityColor,
+                onShowAll: onShowAll,
               ),
           },
         ],
@@ -153,32 +204,54 @@ class SimilarEarthquakeCard extends HookConsumerWidget {
   }
 }
 
-class _NearbyEarthquakeList extends StatelessWidget {
-  const _NearbyEarthquakeList({
-    required this.items,
-    required this.showAll,
-    required this.intensityColor,
+class _ParameterSummary extends StatelessWidget {
+  const _ParameterSummary({
+    required this.parameter,
+    required this.hasDepth,
   });
 
-  final List<EarthquakePartial> items;
-  final ValueNotifier<bool> showAll;
-  final IntensityColorModel intensityColor;
+  final NearbyEarthquakeParameter parameter;
+  final bool hasDepth;
 
   @override
   Widget build(BuildContext context) {
-    final displayItems = showAll.value
-        ? items
-        : items.take(SimilarEarthquakeCard._initialDisplayCount).toList();
-    final hasMore =
-        items.length > SimilarEarthquakeCard._initialDisplayCount;
+    final theme = Theme.of(context);
+    final latStr = '緯度±${parameter.latitudeOffset.toStringAsFixed(1)}°';
+    final lngStr = '経度±${parameter.longitudeOffset.toStringAsFixed(1)}°';
+    final depthStr = hasDepth ? '  深さ±${parameter.depthOffset}km' : '';
 
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Text(
+        '$latStr  $lngStr$depthStr',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeList extends StatelessWidget {
+  const _NearbyEarthquakeList({
+    required this.items,
+    required this.intensityColor,
+    required this.onShowAll,
+  });
+
+  final List<EarthquakePartial> items;
+  final IntensityColorModel intensityColor;
+  final Future<void> Function() onShowAll;
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       children: [
-        for (final item in displayItems) ...[
+        for (final item in items) ...[
           EarthquakeHistoryListTile(
             item: item,
             intensityColor: intensityColor,
-            onTap: () => EarthquakeHistoryDetailsRoute(
+            onTap: () async => EarthquakeHistoryDetailsRoute(
               eventId: item.eventId,
             ).push<void>(context),
             showBackgroundColor: false,
@@ -187,16 +260,13 @@ class _NearbyEarthquakeList extends StatelessWidget {
           ),
           const Divider(height: 1, indent: 12, endIndent: 12),
         ],
-        if (hasMore && !showAll.value)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-            child: TextButton(
-              onPressed: () => showAll.value = true,
-              child: Text(
-                'すべて表示（残り${items.length - SimilarEarthquakeCard._initialDisplayCount}件）',
-              ),
-            ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          child: TextButton(
+            onPressed: onShowAll,
+            child: const Text('すべて表示'),
           ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
Closes #1359

## 変更内容

### 新機能
- 「この震源の近傍で発生した地震」セクションに探索パラメータ調整機能を追加

### 実装詳細

#### `NearbyEarthquakeParameter` モデル (新規)
- `latitudeOffset` (デフォルト 0.5°)
- `longitudeOffset` (デフォルト 0.5°)
- `depthOffset` (デフォルト 50km)

#### `NearbyEarthquakeParameterSheet` BottomSheet (新規)
- 緯度範囲 / 経度範囲スライダー (±0.1〜3.0°)
- 深さ範囲スライダー (±10〜200km、深さ不明の場合は非表示)
- 「適用」ボタンで新パラメータを返す

#### `SimilarEarthquakeCard` 変更
- 現在の探索パラメータ概要を表示（例: `緯度±0.5°  経度±0.5°  深さ±50km`）
- tune アイコンボタンで BottomSheet を開いてパラメータを編集可能
- 「すべて表示」ボタンは `EarthquakeHistoryRoute` へパラメータ付きで push するように変更（インライン展開を廃止）

#### `nearbyEarthquakeProvider` 変更
- 個別パラメータ引数を `NearbyEarthquakeParameter` に集約
- `limit: 50` → `limit: 5` に変更（詳細ページでは少量表示、すべて表示は一覧画面に委譲）