### PR TITLE
fix: 問い合わせ機能のコードレビュー指摘修正

### DIFF
--- a/app/lib/feature/settings/data/contact/contact_action.dart
+++ b/app/lib/feature/settings/data/contact/contact_action.dart
@@ -7,20 +7,14 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-typedef ContactUrlLauncher = Future<bool> Function(Uri url);
-
 final contactTargetPlatformProvider = Provider<TargetPlatform>(
   (_) => defaultTargetPlatform,
-);
-
-final contactUrlBuilderProvider = Provider<ContactUrlBuilder>(
-  (_) => const ContactUrlBuilder(),
 );
 
 final contactUrlProvider = FutureProvider<Uri>((ref) async {
   final deviceId = await ref.read(deviceIdProvider.future);
   final packageInfo = ref.read(packageInfoProvider);
-  final builder = ref.read(contactUrlBuilderProvider);
+  const builder = ContactUrlBuilder();
 
   return switch (ref.read(contactTargetPlatformProvider)) {
     TargetPlatform.android => builder.buildForAndroid(
@@ -39,22 +33,27 @@ final contactUrlProvider = FutureProvider<Uri>((ref) async {
   };
 });
 
-final contactUrlLauncherProvider = Provider<ContactUrlLauncher>(
-  (_) =>
-      (url) => launchUrl(url, mode: LaunchMode.externalApplication),
+final contactUrlLauncherProvider = Provider<Future<bool> Function(Uri)>(
+  (_) => (url) => launchUrl(url, mode: LaunchMode.externalApplication),
 );
 
-final contactActionProvider = Provider<ContactAction>(
-  (_) => const ContactAction(),
+final openContactProvider =
+    Provider<Future<void> Function(WidgetRef, BuildContext)>(
+  (_) => openContactPage,
 );
 
-class ContactAction {
-  const ContactAction();
-
-  Future<void> open(WidgetRef ref, BuildContext context) async {
+Future<void> openContactPage(WidgetRef ref, BuildContext context) async {
+  try {
     final url = await ref.read(contactUrlProvider.future);
     final launched = await ref.read(contactUrlLauncherProvider)(url);
     if (!context.mounted || launched) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('問い合わせページを開けませんでした')),
+    );
+  } on Exception {
+    if (!context.mounted) {
       return;
     }
     ScaffoldMessenger.of(context).showSnackBar(

--- a/app/lib/feature/settings/data/contact/contact_url_builder.dart
+++ b/app/lib/feature/settings/data/contact/contact_url_builder.dart
@@ -11,14 +11,16 @@ class ContactUrlBuilder {
     required String buildNumber,
     required IosDeviceInfo deviceInfo,
   }) {
-    return build(
+    return _build(
       deviceId: deviceId,
       appVersion: appVersion,
       buildNumber: buildNumber,
       os: 'iOS ${deviceInfo.systemVersion}',
       deviceInfo: {
         'platform': 'ios',
-        ...deviceInfo.data,
+        'modelName': deviceInfo.modelName,
+        'machine': deviceInfo.utsname.machine,
+        'isPhysicalDevice': deviceInfo.isPhysicalDevice,
       },
     );
   }
@@ -29,39 +31,35 @@ class ContactUrlBuilder {
     required String buildNumber,
     required AndroidDeviceInfo deviceInfo,
   }) {
-    return build(
+    return _build(
       deviceId: deviceId,
       appVersion: appVersion,
       buildNumber: buildNumber,
       os: 'Android ${deviceInfo.version.release}',
       deviceInfo: {
         'platform': 'android',
-        ...deviceInfo.data,
+        'brand': deviceInfo.brand,
+        'model': deviceInfo.model,
+        'manufacturer': deviceInfo.manufacturer,
+        'sdkInt': deviceInfo.version.sdkInt,
+        'isPhysicalDevice': deviceInfo.isPhysicalDevice,
       },
     );
   }
 
-  Uri build({
+  Uri _build({
     required String deviceId,
     required String appVersion,
     required String buildNumber,
     required String os,
     required Map<String, Object?> deviceInfo,
   }) {
-    final parameters = {
+    return Uri.https('eqmonitor.app', '/contact', {
       'deviceId': deviceId,
       'appVersion': appVersion,
       'buildNumber': buildNumber,
       'os': os,
       'deviceInfo': jsonEncode(deviceInfo),
-    };
-    final query = parameters.entries
-        .map(
-          (entry) =>
-              '${Uri.encodeComponent(entry.key)}='
-              '${Uri.encodeComponent(entry.value)}',
-        )
-        .join('&');
-    return Uri.parse('https://eqmonitor.app/contact?$query');
+    });
   }
 }

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -97,7 +97,7 @@ class SettingsPage extends ConsumerWidget {
                   subtitle: const Text('アプリ情報を付与して問い合わせページを開きます'),
                   leading: const Icon(Icons.contact_support_outlined),
                   onTap: () async =>
-                      ref.read(contactActionProvider).open(ref, context),
+                      ref.read(openContactProvider)(ref, context),
                 ),
                 AppSwitchListTile(
                   title: '広告を非表示',

--- a/app/test/feature/settings/data/contact/contact_url_builder_test.dart
+++ b/app/test/feature/settings/data/contact/contact_url_builder_test.dart
@@ -5,42 +5,7 @@ import 'package:eqmonitor/feature/settings/data/contact/contact_url_builder.dart
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('builds contact URL with app and encoded iOS device metadata', () {
-    const builder = ContactUrlBuilder();
-
-    final url = builder.build(
-      deviceId: 'device-uuid',
-      appVersion: '1.2.3',
-      buildNumber: '456',
-      os: 'iOS 18.0',
-      deviceInfo: const {
-        'platform': 'ios',
-        'model': 'iPhone 16 Pro',
-        'machine': 'iPhone17,1',
-        'isPhysicalDevice': true,
-      },
-    );
-
-    expect(url.scheme, 'https');
-    expect(url.host, 'eqmonitor.app');
-    expect(url.path, '/contact');
-    expect(url.queryParameters, {
-      'deviceId': 'device-uuid',
-      'appVersion': '1.2.3',
-      'buildNumber': '456',
-      'os': 'iOS 18.0',
-      'deviceInfo': jsonEncode({
-        'platform': 'ios',
-        'model': 'iPhone 16 Pro',
-        'machine': 'iPhone17,1',
-        'isPhysicalDevice': true,
-      }),
-    });
-    expect(url.toString(), contains('os=iOS%2018.0'));
-    expect(url.toString(), contains('deviceInfo=%7B'));
-  });
-
-  test('builds contact URL from iOS device info', () {
+  test('builds contact URL from iOS device info with selected fields', () {
     const builder = ContactUrlBuilder();
     final ios = IosDeviceInfo.fromMap({
       'name': 'iPhone',
@@ -72,18 +37,24 @@ void main() {
       buildNumber: '456',
       deviceInfo: ios,
     );
-    final deviceInfo = jsonDecode(url.queryParameters['deviceInfo']!);
+    final deviceInfo =
+        jsonDecode(url.queryParameters['deviceInfo']!) as Map<String, dynamic>;
 
+    expect(url.scheme, 'https');
+    expect(url.host, 'eqmonitor.app');
+    expect(url.path, '/contact');
+    expect(url.queryParameters['deviceId'], 'device-uuid');
+    expect(url.queryParameters['appVersion'], '1.2.3');
+    expect(url.queryParameters['buildNumber'], '456');
     expect(url.queryParameters['os'], 'iOS 18.0');
     expect(deviceInfo, containsPair('platform', 'ios'));
     expect(deviceInfo, containsPair('modelName', 'iPhone 16 Pro'));
-    expect(
-      deviceInfo,
-      containsPair('utsname', containsPair('machine', 'iPhone17,1')),
-    );
+    expect(deviceInfo, containsPair('machine', 'iPhone17,1'));
+    expect(deviceInfo, containsPair('isPhysicalDevice', true));
+    expect(deviceInfo, hasLength(4));
   });
 
-  test('builds contact URL from Android device info', () {
+  test('builds contact URL from Android device info with selected fields', () {
     const builder = ContactUrlBuilder();
     final android = AndroidDeviceInfo.fromMap({
       'version': {
@@ -128,11 +99,16 @@ void main() {
       buildNumber: '456',
       deviceInfo: android,
     );
-    final deviceInfo = jsonDecode(url.queryParameters['deviceInfo']!);
+    final deviceInfo =
+        jsonDecode(url.queryParameters['deviceInfo']!) as Map<String, dynamic>;
 
     expect(url.queryParameters['os'], 'Android 15');
     expect(deviceInfo, containsPair('platform', 'android'));
+    expect(deviceInfo, containsPair('brand', 'Google'));
     expect(deviceInfo, containsPair('model', 'Pixel 9 Pro'));
-    expect(deviceInfo, containsPair('version', containsPair('sdkInt', 35)));
+    expect(deviceInfo, containsPair('manufacturer', 'Google'));
+    expect(deviceInfo, containsPair('sdkInt', 35));
+    expect(deviceInfo, containsPair('isPhysicalDevice', true));
+    expect(deviceInfo, hasLength(6));
   });
 }

--- a/app/test/feature/settings/settings_page_contact_test.dart
+++ b/app/test/feature/settings/settings_page_contact_test.dart
@@ -46,12 +46,12 @@ void main() {
     expect(find.text('問い合わせ'), findsOneWidget);
   });
 
-  testWidgets('contact tile delegates opening to ContactAction', (
+  testWidgets('contact tile delegates to openContactProvider', (
     tester,
   ) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
-    final action = _RecordingContactAction();
+    var opened = false;
 
     await tester.pumpWidget(
       ProviderScope(
@@ -64,7 +64,9 @@ void main() {
           ),
           adsOptOutProvider.overrideWithValue(false),
           buildConfigProvider.overrideWithValue(_buildConfig),
-          contactActionProvider.overrideWithValue(action),
+          openContactProvider.overrideWithValue(
+            (_, __) async => opened = true,
+          ),
           packageInfoProvider.overrideWithValue(_packageInfo),
         ],
         child: const _TestApp(home: SettingsPage()),
@@ -79,7 +81,7 @@ void main() {
     );
     await tester.tap(find.text('問い合わせ'));
 
-    expect(action._opened, true);
+    expect(opened, true);
   });
 }
 
@@ -104,15 +106,6 @@ final _packageInfo = PackageInfo(
   version: '1.2.3',
   buildNumber: '456',
 );
-
-class _RecordingContactAction extends ContactAction {
-  var _opened = false;
-
-  @override
-  Future<void> open(WidgetRef ref, BuildContext context) async {
-    _opened = true;
-  }
-}
 
 class _TestApp extends StatelessWidget {
   const _TestApp({required this.home});


### PR DESCRIPTION
## Summary
- `deviceInfo.data`の全フィールド展開を廃止し、必要最低限のフィールドのみ選択（Android URL長超過問題を解消）
- `ContactAction.open()`に`try-catch`を追加し、例外時のユーザフィードバックを確保
- 手動クエリ文字列エンコーディングを`Uri.https`に置換
- `typedef ContactUrlLauncher`を削除（コードスタイル規約違反）
- `ContactAction`クラスを削除し、トップレベル関数`openContactPage` + `openContactProvider`に簡素化
- `build()`メソッドをprivateに変更

## Test plan
- [x] `contact_url_builder_test.dart` — iOS/Androidの選択フィールドとURL構造を検証（2件パス）
- [x] `contact_action_test.dart` — `contactUrlProvider`のURL構築を検証（1件パス）
- [x] `dart analyze` — 警告・エラーなし