### PR TITLE
feat: LPGM観測点の周期帯別詳細をBottomSheetで表示する

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/lpgm_station_detail_sheet.dart
+++ b/app/lib/feature/earthquake_history/ui/components/lpgm_station_detail_sheet.dart
@@ -1,0 +1,308 @@
+import 'package:eqmonitor/core/component/intenisty/jma_lpgm_intensity_icon.dart';
+import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/intensity_color_provider.dart';
+import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/intensity_color_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_station.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/lpgm_intensity_tree.dart';
+import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class LpgmStationDetailSheet extends ConsumerWidget {
+  const LpgmStationDetailSheet({
+    required this.station,
+    super.key,
+  });
+
+  final StationLpgmIntensityNode station;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final colorModel = ref.watch(intensityColorProvider);
+    final intensity = station.intensity;
+    final prePeriods = intensity?.prePeriods;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 32,
+                height: 4,
+                margin: const EdgeInsets.only(bottom: 12),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.onSurfaceVariant.withValues(
+                    alpha: 0.4,
+                  ),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            _Header(station: station),
+            if (prePeriods != null && prePeriods.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              _PrePeriodsTable(
+                prePeriods: prePeriods,
+                colorModel: colorModel,
+              ),
+            ],
+            const SizedBox(height: 16),
+            const _RelatedLinksCard(),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends ConsumerWidget {
+  const _Header({required this.station});
+
+  final StationLpgmIntensityNode station;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final intensity = station.intensity;
+    final maxLpgmIntensity = intensity?.maxLpgmIntensity;
+    final sva = intensity?.sva;
+
+    return Row(
+      children: [
+        if (maxLpgmIntensity != null) ...[
+          JmaLpgmIntensityIcon(
+            intensity: maxLpgmIntensity,
+            type: IntensityIconType.filled,
+            size: 44,
+          ),
+          const SizedBox(width: 12),
+        ],
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                station.station.name.ja,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  fontFamily: FontFamily.notoSansJP,
+                ),
+              ),
+              if (sva != null)
+                Text(
+                  '最大 ${sva.toStringAsFixed(1)} cm/s',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PrePeriodsTable extends StatelessWidget {
+  const _PrePeriodsTable({
+    required this.prePeriods,
+    required this.colorModel,
+  });
+
+  final List<PrePeriod> prePeriods;
+  final IntensityColorModel colorModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sorted = [...prePeriods]
+      ..sort((a, b) => a.band.compareTo(b.band));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '周期別階級',
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+            fontFamily: FontFamily.notoSansJP,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Table(
+          border: TableBorder.all(
+            color: theme.colorScheme.outlineVariant,
+          ),
+          defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+          children: [
+            TableRow(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+              ),
+              children: [
+                _headerCell('周期', theme),
+                ...sorted.map(
+                  (p) => _headerCell('${p.band.toInt()}秒台', theme),
+                ),
+              ],
+            ),
+            TableRow(
+              children: [
+                _headerCell('階級', theme),
+                ...sorted.map(
+                  (p) => _intensityCell(p.lpgmIntensity, theme),
+                ),
+              ],
+            ),
+            TableRow(
+              children: [
+                _headerCell('SVA', theme),
+                ...sorted.map(
+                  (p) => _svaCell(p.sva, theme),
+                ),
+              ],
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '※ SVA: 絶対速度応答スペクトル (cm/s)',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _headerCell(String text, ThemeData theme) {
+    return TableCell(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        child: Center(
+          child: Text(
+            text,
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              fontFamily: FontFamily.notoSansJP,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _intensityCell(JmaLpgmIntensity intensity, ThemeData theme) {
+    final color = colorModel.fromJmaLpgmIntensity(intensity);
+    return TableCell(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        color: color.background,
+        child: Center(
+          child: Text(
+            intensity.label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: color.foreground,
+              fontFamily: FontFamily.googleSansCode,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _svaCell(double sva, ThemeData theme) {
+    return TableCell(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        child: Center(
+          child: Text(
+            sva.toStringAsFixed(1),
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontFamily: FontFamily.googleSansCode,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RelatedLinksCard extends StatelessWidget {
+  const _RelatedLinksCard();
+
+  static const List<({String title, String url})> _links = [
+    (
+      title: '長周期地震動階級および長周期地震動階級関連解説表について',
+      url:
+          'https://www.jma.go.jp/jma/kishou/know/jishin/ltpgm_explain/about_level.html',
+    ),
+    (
+      title: '固有周期と建物の関係について',
+      url:
+          'https://www.jma.go.jp/jma/kishou/know/jishin/ltpgm_explain/about_period.html',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.open_in_new,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  '気象庁ホームページ',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontFamily: FontFamily.notoSansJP,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ..._links.map(
+              (link) => InkWell(
+                onTap: () => launchUrl(Uri.parse(link.url)),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    link.title,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.primary,
+                      decoration: TextDecoration.underline,
+                      decorationColor: theme.colorScheme.primary,
+                      fontFamily: FontFamily.notoSansJP,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/region_intensity.dart
+++ b/app/lib/feature/earthquake_history/ui/components/region_intensity.dart
@@ -9,6 +9,8 @@ import 'package:eqmonitor/core/provider/config/theme/intensity_color/model/inten
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_tree.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/lpgm_intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/lpgm_station_detail_sheet.dart';
+import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -555,7 +557,7 @@ class _CityTile extends HookWidget {
   }
 }
 
-class _LpgmCityTile extends HookWidget {
+class _LpgmCityTile extends HookConsumerWidget {
   const _LpgmCityTile({
     required this.city,
     required this.eventId,
@@ -565,17 +567,16 @@ class _LpgmCityTile extends HookWidget {
   final String? eventId;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final isExpanded = useState(false);
     final hasStations = city.stations.isNotEmpty;
-
     final trailing = _buildTrailing(
       hasChildren: hasStations,
       isExpanded: isExpanded.value,
     );
 
     return Column(
-      crossAxisAlignment: .start,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         ListTile(
           visualDensity: VisualDensity.compact,
@@ -588,10 +589,60 @@ class _LpgmCityTile extends HookWidget {
         ),
         if (isExpanded.value)
           Padding(
-            padding: const .only(left: 32),
-            child: Text(
-              city.stations.map((s) => s.station.name.ja).join(', '),
-              style: const TextStyle(fontSize: 12),
+            padding: const EdgeInsets.only(left: 32, right: 8, bottom: 4),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: city.stations.map((station) {
+                final hasPeriods =
+                    station.intensity?.prePeriods?.isNotEmpty ?? false;
+                final lpgmIntensity = station.intensity?.maxLpgmIntensity;
+
+                return ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(8),
+                    onTap: hasPeriods
+                        ? () => showModalBottomSheet<void>(
+                              context: context,
+                              clipBehavior: Clip.antiAlias,
+                              builder: (_) => LpgmStationDetailSheet(
+                                station: station,
+                              ),
+                            )
+                        : null,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: Theme.of(context).colorScheme.outlineVariant,
+                        ),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            station.station.name.ja,
+                            style: const TextStyle(fontSize: 12),
+                          ),
+                          if (lpgmIntensity != null) ...[
+                            const SizedBox(width: 4),
+                            JmaLpgmIntensityIcon(
+                              intensity: lpgmIntensity,
+                              type: IntensityIconType.filled,
+                              size: 18,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              }).toList(),
             ),
           )
         else

--- a/docs/superpowers/specs/2026-06-29-lpgm-station-detail-bottomsheet-design.md
+++ b/docs/superpowers/specs/2026-06-29-lpgm-station-detail-bottomsheet-design.md
@@ -1,0 +1,88 @@
+# LPGM観測点詳細BottomSheet
+
+## 概要
+
+地震詳細画面の長周期地震動階級ツリーにおいて、各観測点をタップすると BottomSheet で周期帯別の詳細情報を表示する。
+
+GitHub Issue: #1349
+
+## 背景
+
+現在の LPGM ツリー表示では、市区町村の下に観測点名がカンマ区切りテキストで表示されるのみ。
+データモデル上は各観測点に `sva`（最大絶対速度応答スペクトル）と `prePeriods`（band 1〜7 の周期帯別データ）が存在するが、UI では未使用。
+
+## 変更箇所
+
+### 1. 観測点リストのUI変更
+
+**対象:** `_LpgmCityTile`（`region_intensity.dart`）
+
+現在のカンマ区切り `Text` を、各観測点ごとの個別タップ可能ウィジェットに変更する。
+
+- `Wrap` で横並び＋折り返し配置
+- 各観測点は `ClipRRect`（角丸）→ `InkWell`（リップルエフェクト）でラップ
+- チップ内に観測点名 + 小さい LPGM 階級アイコンを表示
+- タップで `showModalBottomSheet` を呼び出す
+
+### 2. BottomSheet の構成
+
+新規ウィジェット: `LpgmStationDetailSheet`
+
+#### ヘッダー
+
+- 観測点名（`station.name.ja`）
+- 最大 LPGM 階級アイコン（既存 `JmaLpgmIntensityIcon`）
+- 最大 SVA 値（`XX.X cm/s` 形式）
+
+#### 周期帯別テーブル
+
+`Table` ウィジェットで 3行 × 8列（ヘッダー列 + band 1〜7）:
+
+| | 1秒台 | 2秒台 | 3秒台 | 4秒台 | 5秒台 | 6秒台 | 7秒台 |
+|---|---|---|---|---|---|---|---|
+| **階級** | 3 | 2 | 1 | 0 | 0 | 0 | 0 |
+| **SVA** | 26.7 | 29.4 | 10.1 | 6.4 | 3.5 | 2.9 | 2.0 |
+
+- ヘッダー行（周期）: グレー背景
+- 階級行: 各セルの背景色を `IntensityColorModel.fromJmaLpgmIntensity` で着色
+- SVA行: 色なし、小さめフォントで数値のみ（単位 cm/s は行ラベルに含める）
+
+#### 関連リンク Card
+
+`Card` ウィジェットで気象庁の関連ページへのリンクを掲載する。
+
+- ヘッダーに「気象庁ホームページ」と明記
+- リンク一覧:
+  - 「長周期地震動階級および長周期地震動階級関連解説表について」
+    - https://www.jma.go.jp/jma/kishou/know/jishin/ltpgm_explain/about_level.html
+  - 「固有周期と建物の関係について」
+    - https://www.jma.go.jp/jma/kishou/know/jishin/ltpgm_explain/about_period.html
+
+リンクは `url_launcher` パッケージで外部ブラウザを開く。
+
+## データフロー
+
+既存のデータモデルで必要な情報はすべて揃っている。新規 API 呼び出しは不要。
+
+```
+StationLpgmIntensityNode
+  ├── station: EarthquakeParameterStationItem (name, code)
+  └── intensity: IntensityStation
+        ├── sva: double? (最大SVA)
+        ├── maxLpgmIntensity: JmaLpgmIntensity?
+        └── prePeriods: List<PrePeriod>?
+              ├── band: double (1〜7)
+              ├── lpgmIntensity: JmaLpgmIntensity
+              └── sva: double
+```
+
+## ファイル構成
+
+- `region_intensity.dart` — `_LpgmCityTile` の観測点表示を修正
+- `lpgm_station_detail_sheet.dart` — 新規ファイル。BottomSheet のウィジェット
+
+## スコープ外
+
+- JMA 震度ツリー側の観測点詳細表示（今回は LPGM のみ）
+- 地図上の観測点タップからの詳細表示
+- prePeriods が null の場合は BottomSheet を開かない（タップ不可にする）


### PR DESCRIPTION
## Summary
- 長周期地震動階級ツリーの各観測点をタップ可能なチップUIに変更
- タップでBottomSheetを表示し、周期帯別（band 1〜7）のLPGM階級・SVA値をテーブルで表示
- 気象庁ホームページへの関連リンクCardを追加

closes #1349

## Test plan
- [ ] LPGM階級データを持つ地震の詳細画面を開き、長周期地震動階級表示に切り替え
- [ ] 都道府県 → 市区町村を展開し、各観測点が個別のチップとして表示されることを確認
- [ ] 観測点チップをタップしてBottomSheetが表示されることを確認
- [ ] BottomSheet内のテーブルに周期帯別のLPGM階級（色分け）とSVA値が正しく表示されることを確認
- [ ] 関連リンクをタップして気象庁ページが外部ブラウザで開くことを確認
- [ ] prePeriods が null の観測点はタップ不可であることを確認