### PR TITLE
fix: 通知設定v2 レビュー指摘対応

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart
@@ -4,15 +4,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'eew_warning_settings.freezed.dart';
 
-enum EewWarningTarget {
-  currentLocationOnly,
-  currentLocationAndNationwide;
-
-  String get label => switch (this) {
-    .currentLocationOnly => '現在地のみ',
-    .currentLocationAndNationwide => '現在地＋全国',
-  };
-}
+enum EewWarningTarget { currentLocationOnly, currentLocationAndNationwide }
 
 @freezed
 abstract class EewWarningSettings with _$EewWarningSettings {
@@ -32,15 +24,14 @@ extension ApiEewWarningConfigResponseConverter on api.EewWarningConfigResponse {
 
 extension ApiTargetConverter on api.Target {
   EewWarningTarget get toAppTarget => switch (this) {
-    .currentLocationOnly => EewWarningTarget.currentLocationOnly,
-    .currentLocationAndNationwide =>
-      EewWarningTarget.currentLocationAndNationwide,
+    .currentLocationOnly => .currentLocationOnly,
+    .currentLocationAndNationwide => .currentLocationAndNationwide,
   };
 }
 
 extension EewWarningTargetToApi on EewWarningTarget {
   api.Target get toApiTarget => switch (this) {
-    .currentLocationOnly => api.Target.currentLocationOnly,
-    .currentLocationAndNationwide => api.Target.currentLocationAndNationwide,
+    .currentLocationOnly => .currentLocationOnly,
+    .currentLocationAndNationwide => .currentLocationAndNationwide,
   };
 }

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
@@ -16,19 +16,7 @@ abstract class NotificationOverride with _$NotificationOverride {
 // InterruptionLevel のアプリ側 enum
 // API の InterruptionLevel / DefaultInterruptionLevel / NationwideInterruptionLevel
 // をアプリ内で統一的に扱う
-enum InterruptionLevel {
-  passive,
-  active,
-  timeSensitive,
-  critical;
-
-  String get label => switch (this) {
-    .passive => 'サイレント',
-    .active => '通常',
-    .timeSensitive => '即時',
-    .critical => '重大な通知',
-  };
-}
+enum InterruptionLevel { passive, active, timeSensitive, critical }
 
 extension ApiSlotOverrideConverter on api.SlotOverride {
   NotificationOverride toNotificationOverride() => NotificationOverride(
@@ -40,42 +28,42 @@ extension ApiSlotOverrideConverter on api.SlotOverride {
 
 extension ApiInterruptionLevelConverter on api.InterruptionLevel {
   InterruptionLevel get toAppInterruptionLevel => switch (this) {
-    .passive => InterruptionLevel.passive,
-    .active => InterruptionLevel.active,
-    .timeSensitive => InterruptionLevel.timeSensitive,
-    .critical => InterruptionLevel.critical,
+    .passive => .passive,
+    .active => .active,
+    .timeSensitive => .timeSensitive,
+    .critical => .critical,
   };
 }
 
 extension ApiDefaultInterruptionLevelConverter on api.DefaultInterruptionLevel {
   InterruptionLevel get toAppInterruptionLevel => switch (this) {
-    .passive => InterruptionLevel.passive,
-    .active => InterruptionLevel.active,
-    .timeSensitive => InterruptionLevel.timeSensitive,
-    .critical => InterruptionLevel.critical,
+    .passive => .passive,
+    .active => .active,
+    .timeSensitive => .timeSensitive,
+    .critical => .critical,
   };
 }
 
 extension ApiNationwideInterruptionLevelConverter
     on api.NationwideInterruptionLevel {
   InterruptionLevel get toAppInterruptionLevel => switch (this) {
-    .passive => InterruptionLevel.passive,
-    .active => InterruptionLevel.active,
+    .passive => .passive,
+    .active => .active,
   };
 }
 
 extension InterruptionLevelToApi on InterruptionLevel {
   api.InterruptionLevel get toApiInterruptionLevel => switch (this) {
-    .passive => api.InterruptionLevel.passive,
-    .active => api.InterruptionLevel.active,
-    .timeSensitive => api.InterruptionLevel.timeSensitive,
-    .critical => api.InterruptionLevel.critical,
+    .passive => .passive,
+    .active => .active,
+    .timeSensitive => .timeSensitive,
+    .critical => .critical,
   };
 
   api.NationwideInterruptionLevel? get toApiNationwideInterruptionLevel =>
       switch (this) {
-        .passive => api.NationwideInterruptionLevel.passive,
-        .active => api.NationwideInterruptionLevel.active,
+        .passive => .passive,
+        .active => .active,
         _ => null,
       };
 }
@@ -83,7 +71,8 @@ extension InterruptionLevelToApi on InterruptionLevel {
 extension NotificationOverrideToApi on NotificationOverride {
   api.SlotOverride toApiSlotOverride() => api.SlotOverride(
     minJmaIntensity:
-        minJmaIntensity.toApiMinJmaIntensity ?? api.MinJmaIntensity.value4,
+        minJmaIntensity.toApiMinJmaIntensity ??
+        (throw StateError('unknown intensity cannot be serialized')),
     sound: sound,
     interruptionLevel: interruptionLevel.toApiInterruptionLevel,
   );

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_slot.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_slot.dart
@@ -5,17 +5,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'notification_slot.freezed.dart';
 
-enum NotificationSlotType {
-  currentLocation,
-  nationwide,
-  region;
-
-  String get label => switch (this) {
-    .currentLocation => '現在地',
-    .nationwide => '全国',
-    .region => '地域',
-  };
-}
+enum NotificationSlotType { currentLocation, nationwide, region }
 
 @freezed
 abstract class NotificationSlot with _$NotificationSlot {
@@ -47,9 +37,7 @@ extension ApiSlotResponseConverter on api.SlotResponse {
     displayOrder: displayOrder.toInt(),
     eewEnabled: eewEnabled,
     eewMinIntensity: eewMinIntensity?.toJmaIntensity,
-    eewOverrides: eewOverrides
-        ?.map((o) => o.toNotificationOverride())
-        .toList(),
+    eewOverrides: eewOverrides?.map((o) => o.toNotificationOverride()).toList(),
     earthquakeEnabled: earthquakeEnabled,
     earthquakeMinIntensity: earthquakeMinIntensity?.toJmaIntensity,
     earthquakeOverrides: earthquakeOverrides
@@ -60,8 +48,8 @@ extension ApiSlotResponseConverter on api.SlotResponse {
 
 extension ApiSlotTypeConverter on api.SlotType {
   NotificationSlotType get toAppSlotType => switch (this) {
-    .currentLocation => NotificationSlotType.currentLocation,
-    .nationwide => NotificationSlotType.nationwide,
-    .region => NotificationSlotType.region,
+    .currentLocation => .currentLocation,
+    .nationwide => .nationwide,
+    .region => .region,
   };
 }

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart
@@ -9,17 +9,17 @@ part 'eew_warning_config_notifier.g.dart';
 
 @Riverpod(keepAlive: true)
 class EewWarningConfigNotifier extends _$EewWarningConfigNotifier {
-  static final updateMutation = Mutation<void>();
-
   @override
   Future<EewWarningSettings> build() async {
     final status = await ref.watch(deviceProvisioningProvider.future);
-    if (status != DeviceProvisioningStatus.notRequired) {
+    if (status != .notRequired) {
       throw StateError('Device not provisioned');
     }
     final repo = await ref.watch(notificationSlotRepositoryProvider.future);
     return repo.getEewWarningConfig();
   }
+
+  static final updateConfigMutation = Mutation<void>();
 
   Future<void> updateConfig({
     EewWarningTarget? target,

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart
@@ -12,23 +12,17 @@ part 'notification_slots_notifier.g.dart';
 
 @Riverpod(keepAlive: true)
 class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
-  static final putCurrentLocationMutation = Mutation<void>();
-  static final deleteCurrentLocationMutation = Mutation<void>();
-  static final putNationwideMutation = Mutation<void>();
-  static final deleteNationwideMutation = Mutation<void>();
-  static final addRegionMutation = Mutation<void>();
-  static final updateRegionMutation = Mutation<void>();
-  static final removeRegionMutation = Mutation<void>();
-
   @override
   Future<List<NotificationSlot>> build() async {
     final status = await ref.watch(deviceProvisioningProvider.future);
-    if (status != DeviceProvisioningStatus.notRequired) {
+    if (status != .notRequired) {
       throw StateError('Device not provisioned');
     }
     final repo = await ref.watch(notificationSlotRepositoryProvider.future);
     return repo.getSlots();
   }
+
+  static final putCurrentLocationMutation = Mutation<void>();
 
   Future<void> putCurrentLocation({
     bool? eewEnabled,
@@ -59,6 +53,8 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
     ref.invalidateSelf();
   }
 
+  static final deleteCurrentLocationMutation = Mutation<void>();
+
   Future<void> deleteCurrentLocation() async {
     final repo = await ref.read(notificationSlotRepositoryProvider.future);
     await repo.deleteCurrentLocation();
@@ -66,6 +62,8 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
     await _stopLocationTrackingIfNeeded();
     ref.invalidateSelf();
   }
+
+  static final putNationwideMutation = Mutation<void>();
 
   Future<void> putNationwide({
     bool? eewEnabled,
@@ -87,11 +85,15 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
     ref.invalidateSelf();
   }
 
+  static final deleteNationwideMutation = Mutation<void>();
+
   Future<void> deleteNationwide() async {
     final repo = await ref.read(notificationSlotRepositoryProvider.future);
     await repo.deleteNationwide();
     ref.invalidateSelf();
   }
+
+  static final addRegionMutation = Mutation<void>();
 
   Future<void> addRegion({
     required int regionId,
@@ -121,6 +123,8 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
     ref.invalidateSelf();
   }
 
+  static final updateRegionMutation = Mutation<void>();
+
   Future<void> updateRegion({
     required String slotId,
     String? regionName,
@@ -149,6 +153,8 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
     ref.invalidateSelf();
   }
 
+  static final removeRegionMutation = Mutation<void>();
+
   Future<void> removeRegion({required String slotId}) async {
     final repo = await ref.read(notificationSlotRepositoryProvider.future);
     await repo.removeRegion(slotId: slotId);
@@ -161,7 +167,7 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
   }) async {
     final current = await future;
     final existing = current
-        .where((s) => s.slotType == NotificationSlotType.currentLocation)
+        .where((s) => s.slotType == .currentLocation)
         .firstOrNull;
     if (existing == null || existing.regionId == regionCode) {
       return false;

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart
@@ -1,0 +1,48 @@
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/component/error/error_message_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+Future<void> showNotificationSettingsErrorDialog({
+  required BuildContext context,
+  required Object error,
+  required ErrorMessageBuilder errorMessageBuilder,
+}) async {
+  final message = errorMessageBuilder.build(error: error);
+  final statusCode = error is DioException ? error.response?.statusCode : null;
+  final title = statusCode != null
+      ? 'エラーが発生しました ($statusCode)'
+      : error is DioException &&
+          error.type == DioExceptionType.connectionError
+      ? 'ネットワークエラー'
+      : 'エラーが発生しました';
+
+  if (!context.mounted) {
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () async {
+            await Clipboard.setData(ClipboardData(text: message));
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('エラー内容をコピーしました')),
+              );
+            }
+          },
+          child: const Text('コピー'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('閉じる'),
+        ),
+      ],
+    ),
+  );
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -656,7 +656,7 @@ class _EewWarningSettingsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen(EewWarningConfigNotifier.updateMutation, (_, next) {
+    ref.listen(EewWarningConfigNotifier.updateConfigMutation, (_, next) {
       if (next is MutationError) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -670,7 +670,7 @@ class _EewWarningSettingsPage extends ConsumerWidget {
     final target = ref.watch(eewWarningConfigProvider).value?.target;
 
     Future<void> select(EewWarningTarget value) async {
-      await EewWarningConfigNotifier.updateMutation.run(ref, (tsx) async {
+      await EewWarningConfigNotifier.updateConfigMutation.run(ref, (tsx) async {
         await tsx
             .get(eewWarningConfigProvider.notifier)
             .updateConfig(target: value);
@@ -1139,4 +1139,11 @@ class _AndroidNotificationSettingsTile extends StatelessWidget {
       ),
     );
   }
+}
+
+extension on EewWarningTarget {
+  String get label => switch (this) {
+    .currentLocationOnly => '現在地のみ',
+    .currentLocationAndNationwide => '現在地＋全国',
+  };
 }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -1,5 +1,7 @@
 import 'package:app_settings/app_settings.dart';
+import 'package:eqmonitor/core/component/error/error_message_builder.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
@@ -48,12 +50,11 @@ class _Body extends HookConsumerWidget {
     final maxRegions = constraints?.maxRegions.toInt() ?? 1;
 
     ref.listen(NotificationSlotsNotifier.putCurrentLocationMutation, (_, next) {
-      if (next is MutationError) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('設定の保存に失敗しました: ${next.error}'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
+      if (next is MutationError && context.mounted) {
+        showNotificationSettingsErrorDialog(
+          context: context,
+          error: next.error,
+          errorMessageBuilder: ref.read(errorMessageBuilderProvider),
         );
       }
     });
@@ -657,12 +658,11 @@ class _EewWarningSettingsPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listen(EewWarningConfigNotifier.updateConfigMutation, (_, next) {
-      if (next is MutationError) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('設定の保存に失敗しました: ${next.error}'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
+      if (next is MutationError && context.mounted) {
+        showNotificationSettingsErrorDialog(
+          context: context,
+          error: next.error,
+          errorMessageBuilder: ref.read(errorMessageBuilderProvider),
         );
       }
     });

--- a/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
@@ -8,19 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod/experimental/mutation.dart';
 
-const List<JmaIntensity> _selectableIntensities = [
-  JmaIntensity.zero,
-  JmaIntensity.one,
-  JmaIntensity.two,
-  JmaIntensity.three,
-  JmaIntensity.four,
-  JmaIntensity.fiveLower,
-  JmaIntensity.fiveUpper,
-  JmaIntensity.sixLower,
-  JmaIntensity.sixUpper,
-  JmaIntensity.seven,
-];
-
 class SlotDetailPage extends HookConsumerWidget {
   const SlotDetailPage({
     required this.slotId,
@@ -28,16 +15,29 @@ class SlotDetailPage extends HookConsumerWidget {
     super.key,
   });
 
+  static const List<JmaIntensity> _selectableIntensities = [
+    JmaIntensity.zero,
+    JmaIntensity.one,
+    JmaIntensity.two,
+    JmaIntensity.three,
+    JmaIntensity.four,
+    JmaIntensity.fiveLower,
+    JmaIntensity.fiveUpper,
+    JmaIntensity.sixLower,
+    JmaIntensity.sixUpper,
+    JmaIntensity.seven,
+  ];
+
   final String slotId;
   final bool isPro;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final slot = ref
-        .watch(notificationSlotsProvider)
-        .value
-        ?.where((s) => s.id == slotId)
-        .firstOrNull;
+    final slot = ref.watch(
+      notificationSlotsProvider.select(
+        (v) => v.value?.where((s) => s.id == slotId).firstOrNull,
+      ),
+    );
 
     void listenError(Mutation<void> mutation, String message) {
       ref.listen(mutation, (_, next) {
@@ -69,7 +69,16 @@ class SlotDetailPage extends HookConsumerWidget {
       '地域の削除に失敗しました',
     );
 
-    final title = slot == null ? '通知設定' : '${_slotName(slot)}の通知設定';
+    final String title;
+    if (slot == null) {
+      title = '通知設定';
+    } else {
+      final slotName = switch (slot.slotType) {
+        NotificationSlotType.region => slot.regionName ?? slot.slotType.label,
+        _ => slot.slotType.label,
+      };
+      title = '$slotNameの通知設定';
+    }
 
     return Scaffold(
       appBar: AppBar(title: Text(title)),
@@ -121,83 +130,86 @@ class SlotDetailPage extends HookConsumerWidget {
             ),
     );
   }
+
+  Future<void> _updateSlot(
+    WidgetRef ref,
+    NotificationSlot slot, {
+    bool? eewEnabled,
+    JmaIntensity? eewMinIntensity,
+    bool? earthquakeEnabled,
+    JmaIntensity? earthquakeMinIntensity,
+  }) async {
+    final resolvedEewEnabled = eewEnabled ?? slot.eewEnabled;
+    final resolvedEewMinIntensity = eewMinIntensity ?? slot.eewMinIntensity;
+    final resolvedEarthquakeEnabled =
+        earthquakeEnabled ?? slot.earthquakeEnabled;
+    final resolvedEarthquakeMinIntensity =
+        earthquakeMinIntensity ?? slot.earthquakeMinIntensity;
+
+    try {
+      switch (slot.slotType) {
+        case NotificationSlotType.currentLocation:
+          await NotificationSlotsNotifier.putCurrentLocationMutation.run(
+            ref,
+            (tsx) async {
+              await tsx
+                  .get(notificationSlotsProvider.notifier)
+                  .putCurrentLocation(
+                    eewEnabled: resolvedEewEnabled,
+                    eewMinIntensity: resolvedEewMinIntensity,
+                    eewOverrides: slot.eewOverrides,
+                    earthquakeEnabled: resolvedEarthquakeEnabled,
+                    earthquakeMinIntensity: resolvedEarthquakeMinIntensity,
+                    earthquakeOverrides: slot.earthquakeOverrides,
+                  );
+            },
+          );
+        case NotificationSlotType.nationwide:
+          await NotificationSlotsNotifier.putNationwideMutation.run(
+            ref,
+            (tsx) async {
+              await tsx
+                  .get(notificationSlotsProvider.notifier)
+                  .putNationwide(
+                    eewEnabled: resolvedEewEnabled,
+                    eewMinIntensity: resolvedEewMinIntensity,
+                    eewOverrides: slot.eewOverrides,
+                    earthquakeEnabled: resolvedEarthquakeEnabled,
+                    earthquakeMinIntensity: resolvedEarthquakeMinIntensity,
+                    earthquakeOverrides: slot.earthquakeOverrides,
+                  );
+            },
+          );
+        case NotificationSlotType.region:
+          await NotificationSlotsNotifier.updateRegionMutation.run(
+            ref,
+            (tsx) async {
+              await tsx
+                  .get(notificationSlotsProvider.notifier)
+                  .updateRegion(
+                    slotId: slot.id,
+                    eewEnabled: resolvedEewEnabled,
+                    eewMinIntensity: resolvedEewMinIntensity,
+                    eewOverrides: slot.eewOverrides,
+                    earthquakeEnabled: resolvedEarthquakeEnabled,
+                    earthquakeMinIntensity: resolvedEarthquakeMinIntensity,
+                    earthquakeOverrides: slot.earthquakeOverrides,
+                  );
+            },
+          );
+      }
+    } on Object {
+      return;
+    }
+  }
 }
 
-String _slotName(NotificationSlot slot) => switch (slot.slotType) {
-  NotificationSlotType.currentLocation => '現在地',
-  NotificationSlotType.nationwide => '全国',
-  NotificationSlotType.region => slot.regionName ?? '地域',
-};
-
-Future<void> _updateSlot(
-  WidgetRef ref,
-  NotificationSlot slot, {
-  bool? eewEnabled,
-  JmaIntensity? eewMinIntensity,
-  bool? earthquakeEnabled,
-  JmaIntensity? earthquakeMinIntensity,
-}) async {
-  final resolvedEewEnabled = eewEnabled ?? slot.eewEnabled;
-  final resolvedEewMinIntensity = eewMinIntensity ?? slot.eewMinIntensity;
-  final resolvedEarthquakeEnabled = earthquakeEnabled ?? slot.earthquakeEnabled;
-  final resolvedEarthquakeMinIntensity =
-      earthquakeMinIntensity ?? slot.earthquakeMinIntensity;
-
-  try {
-    switch (slot.slotType) {
-      case NotificationSlotType.currentLocation:
-        await NotificationSlotsNotifier.putCurrentLocationMutation.run(
-          ref,
-          (tsx) async {
-            await tsx
-                .get(notificationSlotsProvider.notifier)
-                .putCurrentLocation(
-                  eewEnabled: resolvedEewEnabled,
-                  eewMinIntensity: resolvedEewMinIntensity,
-                  eewOverrides: slot.eewOverrides,
-                  earthquakeEnabled: resolvedEarthquakeEnabled,
-                  earthquakeMinIntensity: resolvedEarthquakeMinIntensity,
-                  earthquakeOverrides: slot.earthquakeOverrides,
-                );
-          },
-        );
-      case NotificationSlotType.nationwide:
-        await NotificationSlotsNotifier.putNationwideMutation.run(
-          ref,
-          (tsx) async {
-            await tsx
-                .get(notificationSlotsProvider.notifier)
-                .putNationwide(
-                  eewEnabled: resolvedEewEnabled,
-                  eewMinIntensity: resolvedEewMinIntensity,
-                  eewOverrides: slot.eewOverrides,
-                  earthquakeEnabled: resolvedEarthquakeEnabled,
-                  earthquakeMinIntensity: resolvedEarthquakeMinIntensity,
-                  earthquakeOverrides: slot.earthquakeOverrides,
-                );
-          },
-        );
-      case NotificationSlotType.region:
-        await NotificationSlotsNotifier.updateRegionMutation.run(
-          ref,
-          (tsx) async {
-            await tsx
-                .get(notificationSlotsProvider.notifier)
-                .updateRegion(
-                  slotId: slot.id,
-                  eewEnabled: resolvedEewEnabled,
-                  eewMinIntensity: resolvedEewMinIntensity,
-                  eewOverrides: slot.eewOverrides,
-                  earthquakeEnabled: resolvedEarthquakeEnabled,
-                  earthquakeMinIntensity: resolvedEarthquakeMinIntensity,
-                  earthquakeOverrides: slot.earthquakeOverrides,
-                );
-          },
-        );
-    }
-  } on Object {
-    return;
-  }
+extension NotificationSlotTypeLabel on NotificationSlotType {
+  String get label => switch (this) {
+    .currentLocation => '現在地',
+    .nationwide => '全国',
+    .region => '地域',
+  };
 }
 
 class _NotificationConditionCard extends StatelessWidget {
@@ -279,25 +291,26 @@ class _IntensityDropdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final resolved = value != null && _selectableIntensities.contains(value)
+    final resolved =
+        value != null && SlotDetailPage._selectableIntensities.contains(value)
         ? value
         : JmaIntensity.three;
 
-    return DropdownButton<JmaIntensity>(
-      value: resolved,
-      underline: const SizedBox.shrink(),
-      onChanged: enabled
-          ? (next) {
-              if (next != null) {
-                onChanged(next);
-              }
-            }
-          : null,
-      items: [
-        for (final intensity in _selectableIntensities)
-          DropdownMenuItem(
+    return DropdownMenu<JmaIntensity>(
+      initialSelection: resolved,
+      enabled: enabled,
+      requestFocusOnTap: false,
+      width: 160,
+      onSelected: (next) {
+        if (next != null) {
+          onChanged(next);
+        }
+      },
+      dropdownMenuEntries: [
+        for (final intensity in SlotDetailPage._selectableIntensities)
+          DropdownMenuEntry(
             value: intensity,
-            child: Text('震度${intensity.label}'),
+            label: '震度${intensity.label}',
           ),
       ],
     );

--- a/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
@@ -1,4 +1,6 @@
+import 'package:eqmonitor/core/component/error/error_message_builder.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
@@ -39,35 +41,22 @@ class SlotDetailPage extends HookConsumerWidget {
       ),
     );
 
-    void listenError(Mutation<void> mutation, String message) {
+    void listenMutationError(Mutation<void> mutation) {
       ref.listen(mutation, (_, next) {
-        if (next is MutationError) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('$message: ${next.error}'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
+        if (next is MutationError && context.mounted) {
+          showNotificationSettingsErrorDialog(
+            context: context,
+            error: next.error,
+            errorMessageBuilder: ref.read(errorMessageBuilderProvider),
           );
         }
       });
     }
 
-    listenError(
-      NotificationSlotsNotifier.putCurrentLocationMutation,
-      '設定の保存に失敗しました',
-    );
-    listenError(
-      NotificationSlotsNotifier.putNationwideMutation,
-      '設定の保存に失敗しました',
-    );
-    listenError(
-      NotificationSlotsNotifier.updateRegionMutation,
-      '設定の保存に失敗しました',
-    );
-    listenError(
-      NotificationSlotsNotifier.removeRegionMutation,
-      '地域の削除に失敗しました',
-    );
+    listenMutationError(NotificationSlotsNotifier.putCurrentLocationMutation);
+    listenMutationError(NotificationSlotsNotifier.putNationwideMutation);
+    listenMutationError(NotificationSlotsNotifier.updateRegionMutation);
+    listenMutationError(NotificationSlotsNotifier.removeRegionMutation);
 
     final String title;
     if (slot == null) {

--- a/app/test/feature/settings/features/notification_settings/eew_warning_settings_model_test.dart
+++ b/app/test/feature/settings/features/notification_settings/eew_warning_settings_model_test.dart
@@ -34,14 +34,6 @@ void main() {
   });
 
   group('EewWarningTarget', () {
-    test('label returns correct Japanese text', () {
-      expect(EewWarningTarget.currentLocationOnly.label, '現在地のみ');
-      expect(
-        EewWarningTarget.currentLocationAndNationwide.label,
-        '現在地＋全国',
-      );
-    });
-
     test('toApiTarget roundtrips correctly', () {
       expect(
         EewWarningTarget.currentLocationOnly.toApiTarget,

--- a/app/test/feature/settings/features/notification_settings/notification_override_model_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_override_model_test.dart
@@ -128,12 +128,4 @@ void main() {
     });
   });
 
-  group('InterruptionLevel.label', () {
-    test('returns correct Japanese labels', () {
-      expect(InterruptionLevel.passive.label, 'サイレント');
-      expect(InterruptionLevel.active.label, '通常');
-      expect(InterruptionLevel.timeSensitive.label, '即時');
-      expect(InterruptionLevel.critical.label, '重大な通知');
-    });
-  });
 }

--- a/app/test/feature/settings/features/notification_settings/notification_slot_model_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_slot_model_test.dart
@@ -131,11 +131,4 @@ void main() {
     });
   });
 
-  group('NotificationSlotType.label', () {
-    test('returns correct labels', () {
-      expect(NotificationSlotType.currentLocation.label, '現在地');
-      expect(NotificationSlotType.nationwide.label, '全国');
-      expect(NotificationSlotType.region.label, '地域');
-    });
-  });
 }


### PR DESCRIPTION
## Summary
- PR #1371〜#1373 のレビュー指摘を一括修正
- データ層: label→UI層移動、dot-shorthand適用、Mutation命名規則、StateError fallback
- UI層: グローバル変数/関数禁止対応、DropdownMenu(M3)、select()でリビルド抑制
- テスト: 削除済みlabel getterのテスト除去

## Test plan
- [x] `flutter analyze`: No issues found!
- [x] 全29テストパス
- [ ] エラーハンドリング改善（ErrorMessageBuilder活用、ダイアログ表示、コピー可能）は次のコミットで対応予定

## 次の対応予定（このPR内で追加コミット）
- エラー時のダイアログ表示（ErrorMessageBuilder活用）
- ネットワークエラー/HTTP status code表示
- エラー内容コピー可能
- rollback（ref.invalidateSelf）

https://claude.ai/code/session_01AsTkKtJyyLBhz8HSEVYPgN