### PR TITLE
fix: オンボーディングのデバイス登録中にローディング表示を追加

### DIFF
--- a/app/lib/feature/onboarding/ui/components/onboarding_bottom_bar.dart
+++ b/app/lib/feature/onboarding/ui/components/onboarding_bottom_bar.dart
@@ -7,6 +7,7 @@ class _OnboardingBottomBar extends StatelessWidget {
     required this.buttonLabel,
     required this.isNextEnabled,
     required this.isBackEnabled,
+    required this.isProcessing,
     required this.onNext,
     required this.onPrevious,
   });
@@ -16,6 +17,7 @@ class _OnboardingBottomBar extends StatelessWidget {
   final String buttonLabel;
   final bool isNextEnabled;
   final bool isBackEnabled;
+  final bool isProcessing;
   final Future<void> Function() onNext;
   final Future<void> Function()? onPrevious;
 
@@ -88,14 +90,37 @@ class _OnboardingBottomBar extends StatelessWidget {
                       vertical: designSystem.spacing.md,
                     ),
                   ),
-                  child: Text(
-                    buttonLabel,
-                    style: designSystem.typography.titleSmall.copyWith(
-                      color: isNextEnabled
-                          ? designSystem.textColor.inverse
-                          : designSystem.textColor.secondary,
-                    ),
-                  ),
+                  child: isProcessing
+                    ? Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        spacing: designSystem.spacing.sm,
+                        children: [
+                          SizedBox.square(
+                            dimension: 16,
+                            child: CircularProgressIndicator.adaptive(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation(
+                                designSystem.textColor.secondary,
+                              ),
+                            ),
+                          ),
+                          Text(
+                            'デバイスを登録しています...',
+                            style:
+                                designSystem.typography.titleSmall.copyWith(
+                                  color: designSystem.textColor.secondary,
+                                ),
+                          ),
+                        ],
+                      )
+                    : Text(
+                        buttonLabel,
+                        style: designSystem.typography.titleSmall.copyWith(
+                          color: isNextEnabled
+                              ? designSystem.textColor.inverse
+                              : designSystem.textColor.secondary,
+                        ),
+                      ),
                 ),
               ),
             ],

--- a/app/lib/feature/onboarding/ui/page/onboarding_page.dart
+++ b/app/lib/feature/onboarding/ui/page/onboarding_page.dart
@@ -121,6 +121,7 @@ class OnboardingPage extends HookConsumerWidget {
                 buttonLabel: navigation.buttonLabel,
                 isNextEnabled: navigation.isNextEnabled,
                 isBackEnabled: isBackEnabled,
+                isProcessing: navigation.isProcessing,
                 onNext: goToNext,
                 onPrevious: showBack ? goToPrevious : null,
               ),


### PR DESCRIPTION
## Summary
- デバイス登録中（`isProcessing = true`）のとき、「次へ」ボタンの代わりに「デバイスを登録しています...」テキストと `CircularProgressIndicator.adaptive` を表示
- `isProcessing` を `_StepNavigationState` から `_OnboardingBottomBar` に伝搬

## Test plan
- [ ] オンボーディング画面を開き、デバイス登録中にボタンがローディング表示になることを確認
- [ ] デバイス登録完了後、「次へ」ボタンが有効になり押せることを確認
- [ ] デバイス登録エラー時、エラーダイアログが正しく表示されることを確認