### PR TITLE
feat: ads_enabledフラグ接続 & Start APIデバッグオーバーライド

### DIFF
--- a/app/lib/feature/ads/data/provider/ads_server_flag_provider.dart
+++ b/app/lib/feature/ads/data/provider/ads_server_flag_provider.dart
@@ -1,7 +1,13 @@
+import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'ads_server_flag_provider.g.dart';
 
-/// Start API実装前のスタブ。サーバから取得した ads_enabled フラグに置き換える。
 @Riverpod(keepAlive: true)
-bool adsServerFlag(Ref ref) => true;
+bool adsServerFlag(Ref ref) {
+  final start = ref.watch(startProvider).value;
+  if (start == null) {
+    return true;
+  }
+  return start.flags.adsEnabled;
+}

--- a/app/lib/feature/ads/data/provider/ads_server_flag_provider.g.dart
+++ b/app/lib/feature/ads/data/provider/ads_server_flag_provider.g.dart
@@ -10,16 +10,12 @@ part of 'ads_server_flag_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Start API実装前のスタブ。サーバから取得した ads_enabled フラグに置き換える。
 
 @ProviderFor(adsServerFlag)
 final adsServerFlagProvider = AdsServerFlagProvider._();
 
-/// Start API実装前のスタブ。サーバから取得した ads_enabled フラグに置き換える。
-
 final class AdsServerFlagProvider extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
-  /// Start API実装前のスタブ。サーバから取得した ads_enabled フラグに置き換える。
   AdsServerFlagProvider._()
     : super(
         from: null,
@@ -53,4 +49,4 @@ final class AdsServerFlagProvider extends $FunctionalProvider<bool, bool, bool>
   }
 }
 
-String _$adsServerFlagHash() => r'0bdda0b35cfe3662737d173f830ff5c8942f832b';
+String _$adsServerFlagHash() => r'16e99704d3100060368507c0b7def5b45942ccfe';

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -15,6 +15,7 @@ import 'package:eqmonitor/feature/settings/children/config/debug/app_check/app_c
 import 'package:eqmonitor/feature/settings/children/config/debug/hypocenter_icon/hypocenter_icon_page.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -584,63 +585,115 @@ class _StartApiDebugSection extends ConsumerWidget {
             title: const Text('エラー'),
             subtitle: Text(error.toString()),
           ),
-          _ when startAsync.hasValue => Column(
-            children: [
-              if (startAsync.hasError)
-                ListTile(
-                  dense: true,
-                  leading: const Icon(Icons.warning_amber),
-                  title: const Text('再検証エラー（stale 表示中）'),
-                  subtitle: Text(startAsync.error.toString()),
-                ),
-              ListTile(
-                dense: true,
-                title: const Text('maintenance.enabled'),
-                trailing: Text(
-                  startAsync.value!.flags.maintenance.enabled.toString(),
-                ),
-              ),
-              if (startAsync.value!.flags.maintenance.message != null)
-                ListTile(
-                  dense: true,
-                  title: const Text('maintenance.message'),
-                  subtitle: Text(startAsync.value!.flags.maintenance.message!),
-                ),
-              ListTile(
-                dense: true,
-                title: const Text('latest.version'),
-                trailing: Text(
-                  startAsync.value!.app.version.latest?.version ?? '(なし)',
-                ),
-              ),
-              ListTile(
-                dense: true,
-                title: const Text('latest.showWhatsNew'),
-                trailing: Text(
-                  startAsync.value!.app.version.latest?.showWhatsNew
-                          .toString() ??
-                      '-',
-                ),
-              ),
-              ListTile(
-                dense: true,
-                title: const Text('requiredVersions'),
-                subtitle: Text(
-                  startAsync.value!.app.version.requiredVersions
-                          .map((r) => r.version)
-                          .join(', ')
-                          .isNotEmpty
-                      ? startAsync.value!.app.version.requiredVersions
-                            .map((r) => r.version)
-                            .join(', ')
-                      : '(なし)',
-                ),
-              ),
-            ],
+          _ when startAsync.hasValue => _StartApiDebugContent(
+            data: startAsync.value!,
+            hasError: startAsync.hasError,
+            error: startAsync.error,
           ),
           _ => const SizedBox.shrink(),
         },
       ],
     );
+  }
+}
+
+class _StartApiDebugContent extends ConsumerWidget {
+  const _StartApiDebugContent({
+    required this.data,
+    required this.hasError,
+    required this.error,
+  });
+
+  final api.StartResponse data;
+  final bool hasError;
+  final Object? error;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      children: [
+        if (hasError)
+          ListTile(
+            dense: true,
+            leading: const Icon(Icons.warning_amber),
+            title: const Text('再検証エラー（stale 表示中）'),
+            subtitle: Text(error.toString()),
+          ),
+        AppSwitchListTile(
+          title: 'maintenance.enabled',
+          subtitle: 'メンテナンスモード',
+          value: data.flags.maintenance.enabled,
+          onChanged: (v) => _override(
+            ref,
+            data.copyWith(
+              flags: data.flags.copyWith(
+                maintenance: data.flags.maintenance.copyWith(enabled: v),
+              ),
+            ),
+          ),
+        ),
+        if (data.flags.maintenance.message != null)
+          ListTile(
+            dense: true,
+            title: const Text('maintenance.message'),
+            subtitle: Text(data.flags.maintenance.message!),
+          ),
+        AppSwitchListTile(
+          title: 'flags.ads_enabled',
+          subtitle: '広告有効フラグ',
+          value: data.flags.adsEnabled,
+          onChanged: (v) => _override(
+            ref,
+            data.copyWith(
+              flags: data.flags.copyWith(adsEnabled: v),
+            ),
+          ),
+        ),
+        ListTile(
+          dense: true,
+          title: const Text('latest.version'),
+          trailing: Text(
+            data.app.version.latest?.version ?? '(なし)',
+          ),
+        ),
+        AppSwitchListTile(
+          title: 'latest.showWhatsNew',
+          subtitle: "What's New バナー表示",
+          value: data.app.version.latest?.showWhatsNew ?? false,
+          onChanged: data.app.version.latest != null
+              ? (v) => _override(
+                    ref,
+                    data.copyWith(
+                      app: data.app.copyWith(
+                        version: data.app.version.copyWith(
+                          latest: data.app.version.latest!.copyWith(
+                            showWhatsNew: v,
+                          ),
+                        ),
+                      ),
+                    ),
+                  )
+              : null,
+        ),
+        ListTile(
+          dense: true,
+          title: const Text('requiredVersions'),
+          subtitle: Text(
+            data.app.version.requiredVersions
+                    .map((r) => r.version)
+                    .join(', ')
+                    .isNotEmpty
+                ? data.app.version.requiredVersions
+                      .map((r) => r.version)
+                      .join(', ')
+                : '(なし)',
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _override(WidgetRef ref, api.StartResponse response) {
+    ref.read(startProvider.notifier).setDebugOverride(response);
   }
 }

--- a/app/lib/feature/start/data/notifier/start_notifier.dart
+++ b/app/lib/feature/start/data/notifier/start_notifier.dart
@@ -13,4 +13,8 @@ class StartNotifier extends _$StartNotifier
 
   @override
   Future<api.StartResponse> build() => cachedBuild();
+
+  void setDebugOverride(api.StartResponse response) {
+    state = AsyncData(response);
+  }
 }

--- a/app/lib/feature/start/data/notifier/start_notifier.g.dart
+++ b/app/lib/feature/start/data/notifier/start_notifier.g.dart
@@ -35,7 +35,7 @@ final class StartNotifierProvider
   StartNotifier create() => StartNotifier();
 }
 
-String _$startNotifierHash() => r'df406add3f047c02ea8659dc5bff5dad049a4f3b';
+String _$startNotifierHash() => r'f634afb86dfe07569d1e9ec4e6453ce20e353958';
 
 abstract class _$StartNotifier extends $AsyncNotifier<api.StartResponse> {
   FutureOr<api.StartResponse> build();


### PR DESCRIPTION
## Summary
- `adsServerFlagProvider`のスタブを解消し、Start APIの`flags.adsEnabled`を参照するよう接続
- `StartNotifier`に`setDebugOverride`メソッドを追加し、デバッグ画面からStart APIのレスポンスを上書き可能に
- デバッグ画面のStart APIセクションに`maintenance.enabled`、`ads_enabled`、`showWhatsNew`のトグルスイッチを追加（「強制再取得」でAPIの実値に戻る）

## Test plan
- [ ] デバッグ画面でmaintenance.enabledをONにし、ホーム画面にメンテナンスバナーが表示されることを確認
- [ ] デバッグ画面でads_enabledをOFFにし、広告が非表示になることを確認
- [ ] デバッグ画面でshowWhatsNewをONにし、What's Newバナーが表示されることを確認
- [ ] 「強制再取得」ボタンでオーバーライドがクリアされAPIの実値に戻ることを確認