### PR TITLE
fix: 位置トラッキングのstart/stopバグ修正

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart
@@ -2,8 +2,10 @@ import 'package:background_location_tracker/background_location_tracker.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/location/data/background_location_monitoring_lifecycle.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart';
 import 'package:riverpod/experimental/mutation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -62,8 +64,17 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
   Future<void> deleteCurrentLocation() async {
     final repo = await ref.read(notificationSlotRepositoryProvider.future);
     await repo.deleteCurrentLocation();
-    // invalidateSelf前にトラッキング停止を試みる（stale state回避）
-    await _stopLocationTrackingIfNeeded();
+    final currentSlots = ref.read(notificationSlotsProvider).value ?? [];
+    final slotsWithoutCurrentLocation = currentSlots
+        .where((s) => s.slotType != NotificationSlotType.currentLocation)
+        .toList();
+    final shakeDetectionState =
+        ref.read(shakeDetectionSettingsProvider).value;
+    const lifecycle = BackgroundLocationMonitoringLifecycle();
+    await lifecycle.stopIfUnused(
+      slots: slotsWithoutCurrentLocation,
+      shakeDetectionState: shakeDetectionState,
+    );
     ref.invalidateSelf();
   }
 
@@ -166,19 +177,17 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
     if (existing == null || existing.regionId == regionCode) {
       return false;
     }
+    final repo = await ref.read(notificationSlotRepositoryProvider.future);
+    await repo.putCurrentLocation(
+      eewEnabled: existing.eewEnabled,
+      eewMinIntensity: existing.eewMinIntensity,
+      eewOverrides: existing.eewOverrides,
+      earthquakeEnabled: existing.earthquakeEnabled,
+      earthquakeMinIntensity: existing.earthquakeMinIntensity,
+      earthquakeOverrides: existing.earthquakeOverrides,
+    );
     ref.invalidateSelf();
     return true;
   }
 
-  Future<void> _stopLocationTrackingIfNeeded() async {
-    try {
-      await BackgroundLocationTracker.stopMonitoring();
-    } on Object catch (e, st) {
-      talker.error(
-        '[NotificationSlots] BackgroundLocationTracker.stopMonitoring',
-        e,
-        st,
-      );
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- `updateCurrentLocationRegion` が `ref.invalidateSelf()` のみでAPIを呼んでいなかったバグを修正。既存スロット設定を保持しつつ `repo.putCurrentLocation()` でサーバーに送信するように変更
- `deleteCurrentLocation` が揺れ検知のcurrent_locationエントリを無視して無条件に `stopMonitoring` を呼んでいたバグを修正。`BackgroundLocationMonitoringLifecycle.stopIfUnused()` パターンに統一

closes #1375

## Test plan
- [ ] バックグラウンド位置更新時にサーバー側のregionが正しく更新されることを確認
- [ ] current_locationスロット削除時、揺れ検知のcurrent_locationエントリが存在すれば位置監視が継続することを確認
- [ ] 両方のcurrent_location（スロット+揺れ検知）が無い場合のみstopMonitoringが呼ばれることを確認