### PR TITLE
feat: オンボーディングカスタム選択時にcurrent_locationスロット自動作成

### DIFF
--- a/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
@@ -11,17 +11,21 @@ class _NotificationSettingsStepPage extends HookConsumerWidget {
     final saveError = useState<String?>(null);
     final isProcessing = useState(false);
 
+    Future<void> createCurrentLocationSlot() async {
+      final notifier = ref.read(notificationSlotsProvider.notifier);
+      await notifier.putCurrentLocation(
+        eewEnabled: true,
+        eewMinIntensity: JmaIntensity.four,
+        earthquakeEnabled: true,
+        earthquakeMinIntensity: JmaIntensity.one,
+      );
+    }
+
     Future<void> saveRecommendedSettings() async {
       isProcessing.value = true;
       saveError.value = null;
       try {
-        final notifier = ref.read(notificationSlotsProvider.notifier);
-        await notifier.putCurrentLocation(
-          eewEnabled: true,
-          eewMinIntensity: JmaIntensity.four,
-          earthquakeEnabled: true,
-          earthquakeMinIntensity: JmaIntensity.one,
-        );
+        await createCurrentLocationSlot();
         if (context.mounted) {
           isProcessing.value = false;
           await scope.nextPage();
@@ -39,9 +43,21 @@ class _NotificationSettingsStepPage extends HookConsumerWidget {
         case .recommended:
           await saveRecommendedSettings();
         case .custom:
+          isProcessing.value = true;
+          saveError.value = null;
+          try {
+            await createCurrentLocationSlot();
+          } on Exception catch (e) {
+            if (context.mounted) {
+              isProcessing.value = false;
+              saveError.value = e.toString();
+            }
+            return;
+          }
           if (!context.mounted) {
             return;
           }
+          isProcessing.value = false;
           await Navigator.of(context).push<void>(
             MaterialPageRoute<void>(
               builder: (_) => const _OnboardingCustomSettingsWrapper(),


### PR DESCRIPTION
## Summary
- オンボーディングでカスタム設定を選択した場合、スロットを1つも作成せずに完了できてしまう問題を修正
- カスタム選択時にも推奨設定と同じcurrent_locationスロットを自動作成してからカスタム設定画面に遷移するように変更
- `createCurrentLocationSlot()` ヘルパーを抽出し、推奨/カスタム両方で再利用

closes #1382

## Test plan
- [ ] オンボーディングでカスタムを選択→カスタム設定画面表示前にcurrent_locationスロットが作成されることを確認
- [ ] スロット作成失敗時にエラーメッセージが表示され、カスタム設定画面に遷移しないことを確認
- [ ] 推奨設定の動作が変わっていないことを確認