### PR TITLE
feat: グローバル通知設定Notifier（EEW/地震情報）の実装

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/model/earthquake_global_settings.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/earthquake_global_settings.dart
@@ -1,0 +1,29 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'earthquake_global_settings.freezed.dart';
+
+@freezed
+abstract class EarthquakeGlobalSettings with _$EarthquakeGlobalSettings {
+  const factory EarthquakeGlobalSettings({
+    required bool enabled,
+    required String defaultSound,
+    required InterruptionLevel defaultInterruptionLevel,
+    required bool estimatedIntensityEnabled,
+    required bool collapseNotification,
+  }) = _EarthquakeGlobalSettings;
+}
+
+extension EarthquakeSettingsResponseConverter
+    on api.EarthquakeSettingsResponse {
+  EarthquakeGlobalSettings toEarthquakeGlobalSettings() =>
+      EarthquakeGlobalSettings(
+        enabled: enabled,
+        defaultSound: defaultSound,
+        defaultInterruptionLevel:
+            defaultInterruptionLevel.toAppInterruptionLevel,
+        estimatedIntensityEnabled: estimatedIntensityEnabled,
+        collapseNotification: collapseNotification,
+      );
+}

--- a/app/lib/feature/settings/features/notification_settings/data/model/earthquake_global_settings.freezed.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/earthquake_global_settings.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'earthquake_global_settings.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EarthquakeGlobalSettings {
+
+ bool get enabled; String get defaultSound; InterruptionLevel get defaultInterruptionLevel; bool get estimatedIntensityEnabled; bool get collapseNotification;
+/// Create a copy of EarthquakeGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EarthquakeGlobalSettingsCopyWith<EarthquakeGlobalSettings> get copyWith => _$EarthquakeGlobalSettingsCopyWithImpl<EarthquakeGlobalSettings>(this as EarthquakeGlobalSettings, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeGlobalSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.defaultSound, defaultSound) || other.defaultSound == defaultSound)&&(identical(other.defaultInterruptionLevel, defaultInterruptionLevel) || other.defaultInterruptionLevel == defaultInterruptionLevel)&&(identical(other.estimatedIntensityEnabled, estimatedIntensityEnabled) || other.estimatedIntensityEnabled == estimatedIntensityEnabled)&&(identical(other.collapseNotification, collapseNotification) || other.collapseNotification == collapseNotification));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled,defaultSound,defaultInterruptionLevel,estimatedIntensityEnabled,collapseNotification);
+
+@override
+String toString() {
+  return 'EarthquakeGlobalSettings(enabled: $enabled, defaultSound: $defaultSound, defaultInterruptionLevel: $defaultInterruptionLevel, estimatedIntensityEnabled: $estimatedIntensityEnabled, collapseNotification: $collapseNotification)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EarthquakeGlobalSettingsCopyWith<$Res>  {
+  factory $EarthquakeGlobalSettingsCopyWith(EarthquakeGlobalSettings value, $Res Function(EarthquakeGlobalSettings) _then) = _$EarthquakeGlobalSettingsCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled, String defaultSound, InterruptionLevel defaultInterruptionLevel, bool estimatedIntensityEnabled, bool collapseNotification
+});
+
+
+
+
+}
+/// @nodoc
+class _$EarthquakeGlobalSettingsCopyWithImpl<$Res>
+    implements $EarthquakeGlobalSettingsCopyWith<$Res> {
+  _$EarthquakeGlobalSettingsCopyWithImpl(this._self, this._then);
+
+  final EarthquakeGlobalSettings _self;
+  final $Res Function(EarthquakeGlobalSettings) _then;
+
+/// Create a copy of EarthquakeGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? defaultSound = null,Object? defaultInterruptionLevel = null,Object? estimatedIntensityEnabled = null,Object? collapseNotification = null,}) {
+  return _then(_self.copyWith(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,defaultSound: null == defaultSound ? _self.defaultSound : defaultSound // ignore: cast_nullable_to_non_nullable
+as String,defaultInterruptionLevel: null == defaultInterruptionLevel ? _self.defaultInterruptionLevel : defaultInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as InterruptionLevel,estimatedIntensityEnabled: null == estimatedIntensityEnabled ? _self.estimatedIntensityEnabled : estimatedIntensityEnabled // ignore: cast_nullable_to_non_nullable
+as bool,collapseNotification: null == collapseNotification ? _self.collapseNotification : collapseNotification // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EarthquakeGlobalSettings].
+extension EarthquakeGlobalSettingsPatterns on EarthquakeGlobalSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EarthquakeGlobalSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EarthquakeGlobalSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EarthquakeGlobalSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _EarthquakeGlobalSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EarthquakeGlobalSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EarthquakeGlobalSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enabled,  String defaultSound,  InterruptionLevel defaultInterruptionLevel,  bool estimatedIntensityEnabled,  bool collapseNotification)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EarthquakeGlobalSettings() when $default != null:
+return $default(_that.enabled,_that.defaultSound,_that.defaultInterruptionLevel,_that.estimatedIntensityEnabled,_that.collapseNotification);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enabled,  String defaultSound,  InterruptionLevel defaultInterruptionLevel,  bool estimatedIntensityEnabled,  bool collapseNotification)  $default,) {final _that = this;
+switch (_that) {
+case _EarthquakeGlobalSettings():
+return $default(_that.enabled,_that.defaultSound,_that.defaultInterruptionLevel,_that.estimatedIntensityEnabled,_that.collapseNotification);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enabled,  String defaultSound,  InterruptionLevel defaultInterruptionLevel,  bool estimatedIntensityEnabled,  bool collapseNotification)?  $default,) {final _that = this;
+switch (_that) {
+case _EarthquakeGlobalSettings() when $default != null:
+return $default(_that.enabled,_that.defaultSound,_that.defaultInterruptionLevel,_that.estimatedIntensityEnabled,_that.collapseNotification);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EarthquakeGlobalSettings implements EarthquakeGlobalSettings {
+  const _EarthquakeGlobalSettings({required this.enabled, required this.defaultSound, required this.defaultInterruptionLevel, required this.estimatedIntensityEnabled, required this.collapseNotification});
+  
+
+@override final  bool enabled;
+@override final  String defaultSound;
+@override final  InterruptionLevel defaultInterruptionLevel;
+@override final  bool estimatedIntensityEnabled;
+@override final  bool collapseNotification;
+
+/// Create a copy of EarthquakeGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EarthquakeGlobalSettingsCopyWith<_EarthquakeGlobalSettings> get copyWith => __$EarthquakeGlobalSettingsCopyWithImpl<_EarthquakeGlobalSettings>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeGlobalSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.defaultSound, defaultSound) || other.defaultSound == defaultSound)&&(identical(other.defaultInterruptionLevel, defaultInterruptionLevel) || other.defaultInterruptionLevel == defaultInterruptionLevel)&&(identical(other.estimatedIntensityEnabled, estimatedIntensityEnabled) || other.estimatedIntensityEnabled == estimatedIntensityEnabled)&&(identical(other.collapseNotification, collapseNotification) || other.collapseNotification == collapseNotification));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled,defaultSound,defaultInterruptionLevel,estimatedIntensityEnabled,collapseNotification);
+
+@override
+String toString() {
+  return 'EarthquakeGlobalSettings(enabled: $enabled, defaultSound: $defaultSound, defaultInterruptionLevel: $defaultInterruptionLevel, estimatedIntensityEnabled: $estimatedIntensityEnabled, collapseNotification: $collapseNotification)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EarthquakeGlobalSettingsCopyWith<$Res> implements $EarthquakeGlobalSettingsCopyWith<$Res> {
+  factory _$EarthquakeGlobalSettingsCopyWith(_EarthquakeGlobalSettings value, $Res Function(_EarthquakeGlobalSettings) _then) = __$EarthquakeGlobalSettingsCopyWithImpl;
+@override @useResult
+$Res call({
+ bool enabled, String defaultSound, InterruptionLevel defaultInterruptionLevel, bool estimatedIntensityEnabled, bool collapseNotification
+});
+
+
+
+
+}
+/// @nodoc
+class __$EarthquakeGlobalSettingsCopyWithImpl<$Res>
+    implements _$EarthquakeGlobalSettingsCopyWith<$Res> {
+  __$EarthquakeGlobalSettingsCopyWithImpl(this._self, this._then);
+
+  final _EarthquakeGlobalSettings _self;
+  final $Res Function(_EarthquakeGlobalSettings) _then;
+
+/// Create a copy of EarthquakeGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? defaultSound = null,Object? defaultInterruptionLevel = null,Object? estimatedIntensityEnabled = null,Object? collapseNotification = null,}) {
+  return _then(_EarthquakeGlobalSettings(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,defaultSound: null == defaultSound ? _self.defaultSound : defaultSound // ignore: cast_nullable_to_non_nullable
+as String,defaultInterruptionLevel: null == defaultInterruptionLevel ? _self.defaultInterruptionLevel : defaultInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as InterruptionLevel,estimatedIntensityEnabled: null == estimatedIntensityEnabled ? _self.estimatedIntensityEnabled : estimatedIntensityEnabled // ignore: cast_nullable_to_non_nullable
+as bool,collapseNotification: null == collapseNotification ? _self.collapseNotification : collapseNotification // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_global_settings.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_global_settings.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'eew_global_settings.freezed.dart';
+
+@freezed
+abstract class EewGlobalSettings with _$EewGlobalSettings {
+  const factory EewGlobalSettings({
+    required bool enabled,
+    required String defaultSound,
+    required InterruptionLevel defaultInterruptionLevel,
+    required bool startLiveActivity,
+    required bool collapseNotification,
+    required bool warningEnabled,
+  }) = _EewGlobalSettings;
+}
+
+extension EewSettingsResponseConverter on api.EewSettingsResponse {
+  EewGlobalSettings toEewGlobalSettings() => EewGlobalSettings(
+    enabled: enabled,
+    defaultSound: defaultSound,
+    defaultInterruptionLevel: defaultInterruptionLevel.toAppInterruptionLevel,
+    startLiveActivity: startLiveActivity,
+    collapseNotification: collapseNotification,
+    warningEnabled: warningEnabled,
+  );
+}

--- a/app/lib/feature/settings/features/notification_settings/data/model/eew_global_settings.freezed.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/eew_global_settings.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'eew_global_settings.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EewGlobalSettings {
+
+ bool get enabled; String get defaultSound; InterruptionLevel get defaultInterruptionLevel; bool get startLiveActivity; bool get collapseNotification; bool get warningEnabled;
+/// Create a copy of EewGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EewGlobalSettingsCopyWith<EewGlobalSettings> get copyWith => _$EewGlobalSettingsCopyWithImpl<EewGlobalSettings>(this as EewGlobalSettings, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewGlobalSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.defaultSound, defaultSound) || other.defaultSound == defaultSound)&&(identical(other.defaultInterruptionLevel, defaultInterruptionLevel) || other.defaultInterruptionLevel == defaultInterruptionLevel)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.collapseNotification, collapseNotification) || other.collapseNotification == collapseNotification)&&(identical(other.warningEnabled, warningEnabled) || other.warningEnabled == warningEnabled));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled,defaultSound,defaultInterruptionLevel,startLiveActivity,collapseNotification,warningEnabled);
+
+@override
+String toString() {
+  return 'EewGlobalSettings(enabled: $enabled, defaultSound: $defaultSound, defaultInterruptionLevel: $defaultInterruptionLevel, startLiveActivity: $startLiveActivity, collapseNotification: $collapseNotification, warningEnabled: $warningEnabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EewGlobalSettingsCopyWith<$Res>  {
+  factory $EewGlobalSettingsCopyWith(EewGlobalSettings value, $Res Function(EewGlobalSettings) _then) = _$EewGlobalSettingsCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled, String defaultSound, InterruptionLevel defaultInterruptionLevel, bool startLiveActivity, bool collapseNotification, bool warningEnabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$EewGlobalSettingsCopyWithImpl<$Res>
+    implements $EewGlobalSettingsCopyWith<$Res> {
+  _$EewGlobalSettingsCopyWithImpl(this._self, this._then);
+
+  final EewGlobalSettings _self;
+  final $Res Function(EewGlobalSettings) _then;
+
+/// Create a copy of EewGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,Object? defaultSound = null,Object? defaultInterruptionLevel = null,Object? startLiveActivity = null,Object? collapseNotification = null,Object? warningEnabled = null,}) {
+  return _then(_self.copyWith(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,defaultSound: null == defaultSound ? _self.defaultSound : defaultSound // ignore: cast_nullable_to_non_nullable
+as String,defaultInterruptionLevel: null == defaultInterruptionLevel ? _self.defaultInterruptionLevel : defaultInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as InterruptionLevel,startLiveActivity: null == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool,collapseNotification: null == collapseNotification ? _self.collapseNotification : collapseNotification // ignore: cast_nullable_to_non_nullable
+as bool,warningEnabled: null == warningEnabled ? _self.warningEnabled : warningEnabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EewGlobalSettings].
+extension EewGlobalSettingsPatterns on EewGlobalSettings {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EewGlobalSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EewGlobalSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EewGlobalSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _EewGlobalSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EewGlobalSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EewGlobalSettings() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enabled,  String defaultSound,  InterruptionLevel defaultInterruptionLevel,  bool startLiveActivity,  bool collapseNotification,  bool warningEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EewGlobalSettings() when $default != null:
+return $default(_that.enabled,_that.defaultSound,_that.defaultInterruptionLevel,_that.startLiveActivity,_that.collapseNotification,_that.warningEnabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enabled,  String defaultSound,  InterruptionLevel defaultInterruptionLevel,  bool startLiveActivity,  bool collapseNotification,  bool warningEnabled)  $default,) {final _that = this;
+switch (_that) {
+case _EewGlobalSettings():
+return $default(_that.enabled,_that.defaultSound,_that.defaultInterruptionLevel,_that.startLiveActivity,_that.collapseNotification,_that.warningEnabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enabled,  String defaultSound,  InterruptionLevel defaultInterruptionLevel,  bool startLiveActivity,  bool collapseNotification,  bool warningEnabled)?  $default,) {final _that = this;
+switch (_that) {
+case _EewGlobalSettings() when $default != null:
+return $default(_that.enabled,_that.defaultSound,_that.defaultInterruptionLevel,_that.startLiveActivity,_that.collapseNotification,_that.warningEnabled);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EewGlobalSettings implements EewGlobalSettings {
+  const _EewGlobalSettings({required this.enabled, required this.defaultSound, required this.defaultInterruptionLevel, required this.startLiveActivity, required this.collapseNotification, required this.warningEnabled});
+  
+
+@override final  bool enabled;
+@override final  String defaultSound;
+@override final  InterruptionLevel defaultInterruptionLevel;
+@override final  bool startLiveActivity;
+@override final  bool collapseNotification;
+@override final  bool warningEnabled;
+
+/// Create a copy of EewGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EewGlobalSettingsCopyWith<_EewGlobalSettings> get copyWith => __$EewGlobalSettingsCopyWithImpl<_EewGlobalSettings>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewGlobalSettings&&(identical(other.enabled, enabled) || other.enabled == enabled)&&(identical(other.defaultSound, defaultSound) || other.defaultSound == defaultSound)&&(identical(other.defaultInterruptionLevel, defaultInterruptionLevel) || other.defaultInterruptionLevel == defaultInterruptionLevel)&&(identical(other.startLiveActivity, startLiveActivity) || other.startLiveActivity == startLiveActivity)&&(identical(other.collapseNotification, collapseNotification) || other.collapseNotification == collapseNotification)&&(identical(other.warningEnabled, warningEnabled) || other.warningEnabled == warningEnabled));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled,defaultSound,defaultInterruptionLevel,startLiveActivity,collapseNotification,warningEnabled);
+
+@override
+String toString() {
+  return 'EewGlobalSettings(enabled: $enabled, defaultSound: $defaultSound, defaultInterruptionLevel: $defaultInterruptionLevel, startLiveActivity: $startLiveActivity, collapseNotification: $collapseNotification, warningEnabled: $warningEnabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EewGlobalSettingsCopyWith<$Res> implements $EewGlobalSettingsCopyWith<$Res> {
+  factory _$EewGlobalSettingsCopyWith(_EewGlobalSettings value, $Res Function(_EewGlobalSettings) _then) = __$EewGlobalSettingsCopyWithImpl;
+@override @useResult
+$Res call({
+ bool enabled, String defaultSound, InterruptionLevel defaultInterruptionLevel, bool startLiveActivity, bool collapseNotification, bool warningEnabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$EewGlobalSettingsCopyWithImpl<$Res>
+    implements _$EewGlobalSettingsCopyWith<$Res> {
+  __$EewGlobalSettingsCopyWithImpl(this._self, this._then);
+
+  final _EewGlobalSettings _self;
+  final $Res Function(_EewGlobalSettings) _then;
+
+/// Create a copy of EewGlobalSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,Object? defaultSound = null,Object? defaultInterruptionLevel = null,Object? startLiveActivity = null,Object? collapseNotification = null,Object? warningEnabled = null,}) {
+  return _then(_EewGlobalSettings(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,defaultSound: null == defaultSound ? _self.defaultSound : defaultSound // ignore: cast_nullable_to_non_nullable
+as String,defaultInterruptionLevel: null == defaultInterruptionLevel ? _self.defaultInterruptionLevel : defaultInterruptionLevel // ignore: cast_nullable_to_non_nullable
+as InterruptionLevel,startLiveActivity: null == startLiveActivity ? _self.startLiveActivity : startLiveActivity // ignore: cast_nullable_to_non_nullable
+as bool,collapseNotification: null == collapseNotification ? _self.collapseNotification : collapseNotification // ignore: cast_nullable_to_non_nullable
+as bool,warningEnabled: null == warningEnabled ? _self.warningEnabled : warningEnabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/model/notification_override.dart
@@ -72,6 +72,14 @@ extension InterruptionLevelToApi on InterruptionLevel {
     .critical => api.InterruptionLevel.critical,
   };
 
+  api.DefaultInterruptionLevel get toApiDefaultInterruptionLevel =>
+      switch (this) {
+        .passive => api.DefaultInterruptionLevel.passive,
+        .active => api.DefaultInterruptionLevel.active,
+        .timeSensitive => api.DefaultInterruptionLevel.timeSensitive,
+        .critical => api.DefaultInterruptionLevel.critical,
+      };
+
   api.NationwideInterruptionLevel? get toApiNationwideInterruptionLevel =>
       switch (this) {
         .passive => api.NationwideInterruptionLevel.passive,

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.dart
@@ -1,0 +1,42 @@
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/earthquake_global_settings.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart';
+import 'package:riverpod/experimental/mutation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'earthquake_global_settings_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class EarthquakeGlobalSettingsNotifier
+    extends _$EarthquakeGlobalSettingsNotifier {
+  static final updateSettingsMutation = Mutation<void>();
+
+  @override
+  Future<EarthquakeGlobalSettings> build() async {
+    final status = await ref.watch(deviceProvisioningProvider.future);
+    if (status != DeviceProvisioningStatus.notRequired) {
+      throw StateError('Device not provisioned');
+    }
+    final repo = await ref.watch(notificationSlotRepositoryProvider.future);
+    return repo.getEarthquakeGlobalSettings();
+  }
+
+  Future<void> updateSettings({
+    bool? enabled,
+    String? defaultSound,
+    InterruptionLevel? defaultInterruptionLevel,
+    bool? estimatedIntensityEnabled,
+    bool? collapseNotification,
+  }) async {
+    final repo = await ref.read(notificationSlotRepositoryProvider.future);
+    final result = await repo.patchEarthquakeGlobalSettings(
+      enabled: enabled,
+      defaultSound: defaultSound,
+      defaultInterruptionLevel: defaultInterruptionLevel,
+      estimatedIntensityEnabled: estimatedIntensityEnabled,
+      collapseNotification: collapseNotification,
+    );
+    state = AsyncData(result);
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.g.dart
@@ -1,0 +1,72 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_global_settings_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EarthquakeGlobalSettingsNotifier)
+final earthquakeGlobalSettingsProvider =
+    EarthquakeGlobalSettingsNotifierProvider._();
+
+final class EarthquakeGlobalSettingsNotifierProvider
+    extends
+        $AsyncNotifierProvider<
+          EarthquakeGlobalSettingsNotifier,
+          EarthquakeGlobalSettings
+        > {
+  EarthquakeGlobalSettingsNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'earthquakeGlobalSettingsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$earthquakeGlobalSettingsNotifierHash();
+
+  @$internal
+  @override
+  EarthquakeGlobalSettingsNotifier create() =>
+      EarthquakeGlobalSettingsNotifier();
+}
+
+String _$earthquakeGlobalSettingsNotifierHash() =>
+    r'08b1682a7b3c91453ce16a4b6c2e4faef2baaf29';
+
+abstract class _$EarthquakeGlobalSettingsNotifier
+    extends $AsyncNotifier<EarthquakeGlobalSettings> {
+  FutureOr<EarthquakeGlobalSettings> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<EarthquakeGlobalSettings>,
+              EarthquakeGlobalSettings
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<EarthquakeGlobalSettings>,
+                EarthquakeGlobalSettings
+              >,
+              AsyncValue<EarthquakeGlobalSettings>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.dart
@@ -1,0 +1,43 @@
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_global_settings.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart';
+import 'package:riverpod/experimental/mutation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_global_settings_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class EewGlobalSettingsNotifier extends _$EewGlobalSettingsNotifier {
+  static final updateSettingsMutation = Mutation<void>();
+
+  @override
+  Future<EewGlobalSettings> build() async {
+    final status = await ref.watch(deviceProvisioningProvider.future);
+    if (status != DeviceProvisioningStatus.notRequired) {
+      throw StateError('Device not provisioned');
+    }
+    final repo = await ref.watch(notificationSlotRepositoryProvider.future);
+    return repo.getEewGlobalSettings();
+  }
+
+  Future<void> updateSettings({
+    bool? enabled,
+    String? defaultSound,
+    InterruptionLevel? defaultInterruptionLevel,
+    bool? startLiveActivity,
+    bool? collapseNotification,
+    bool? warningEnabled,
+  }) async {
+    final repo = await ref.read(notificationSlotRepositoryProvider.future);
+    final result = await repo.patchEewGlobalSettings(
+      enabled: enabled,
+      defaultSound: defaultSound,
+      defaultInterruptionLevel: defaultInterruptionLevel,
+      startLiveActivity: startLiveActivity,
+      collapseNotification: collapseNotification,
+      warningEnabled: warningEnabled,
+    );
+    state = AsyncData(result);
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_global_settings_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EewGlobalSettingsNotifier)
+final eewGlobalSettingsProvider = EewGlobalSettingsNotifierProvider._();
+
+final class EewGlobalSettingsNotifierProvider
+    extends
+        $AsyncNotifierProvider<EewGlobalSettingsNotifier, EewGlobalSettings> {
+  EewGlobalSettingsNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewGlobalSettingsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewGlobalSettingsNotifierHash();
+
+  @$internal
+  @override
+  EewGlobalSettingsNotifier create() => EewGlobalSettingsNotifier();
+}
+
+String _$eewGlobalSettingsNotifierHash() =>
+    r'c43f0ca59b9be7fc2684c0bfd8827d5f791f8ae2';
+
+abstract class _$EewGlobalSettingsNotifier
+    extends $AsyncNotifier<EewGlobalSettings> {
+  FutureOr<EewGlobalSettings> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<EewGlobalSettings>, EewGlobalSettings>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<EewGlobalSettings>, EewGlobalSettings>,
+              AsyncValue<EewGlobalSettings>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.g.dart
@@ -41,7 +41,7 @@ final class ShakeDetectionSettingsNotifierProvider
 }
 
 String _$shakeDetectionSettingsNotifierHash() =>
-    r'0c219fc6f2a52c1687887825e1decb79ee146a02';
+    r'ae8afb419933227f926c8e8b3c39ce5dd08c1af2';
 
 abstract class _$ShakeDetectionSettingsNotifier
     extends $AsyncNotifier<ShakeDetectionState> {

--- a/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
@@ -1,5 +1,7 @@
 import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/earthquake_global_settings.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_global_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
@@ -163,5 +165,61 @@ class NotificationSlotRepository {
       ),
     );
     return response.data.toEewWarningSettings();
+  }
+
+  // ─── EEW Global Settings ───
+
+  Future<EewGlobalSettings> getEewGlobalSettings() async {
+    final response = await _api.device.getV2DeviceMeSettingsEew();
+    return response.data.toEewGlobalSettings();
+  }
+
+  Future<EewGlobalSettings> patchEewGlobalSettings({
+    bool? enabled,
+    String? defaultSound,
+    InterruptionLevel? defaultInterruptionLevel,
+    bool? startLiveActivity,
+    bool? collapseNotification,
+    bool? warningEnabled,
+  }) async {
+    final response = await _api.device.patchV2DeviceMeSettingsEew(
+      body: api.EewSettingsRequest(
+        enabled: enabled,
+        defaultSound: defaultSound,
+        defaultInterruptionLevel:
+            defaultInterruptionLevel?.toApiDefaultInterruptionLevel,
+        startLiveActivity: startLiveActivity,
+        collapseNotification: collapseNotification,
+        warningEnabled: warningEnabled,
+      ),
+    );
+    return response.data.toEewGlobalSettings();
+  }
+
+  // ─── Earthquake Global Settings ───
+
+  Future<EarthquakeGlobalSettings> getEarthquakeGlobalSettings() async {
+    final response = await _api.device.getV2DeviceMeSettingsEarthquake();
+    return response.data.toEarthquakeGlobalSettings();
+  }
+
+  Future<EarthquakeGlobalSettings> patchEarthquakeGlobalSettings({
+    bool? enabled,
+    String? defaultSound,
+    InterruptionLevel? defaultInterruptionLevel,
+    bool? estimatedIntensityEnabled,
+    bool? collapseNotification,
+  }) async {
+    final response = await _api.device.patchV2DeviceMeSettingsEarthquake(
+      body: api.EarthquakeSettingsRequest(
+        enabled: enabled,
+        defaultSound: defaultSound,
+        defaultInterruptionLevel:
+            defaultInterruptionLevel?.toApiDefaultInterruptionLevel,
+        estimatedIntensityEnabled: estimatedIntensityEnabled,
+        collapseNotification: collapseNotification,
+      ),
+    );
+    return response.data.toEarthquakeGlobalSettings();
   }
 }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -9,6 +9,8 @@ import 'package:eqmonitor/feature/notification/data/repository/push_notification
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart';
@@ -37,10 +39,6 @@ class _Body extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final notificationsEnabled = useState(true);
     final selectedPreset = useState(_NotificationPreset.recommended);
-    final eewForecastEnabled = useState(true);
-    final earthquakeEnabled = useState(true);
-    final liveActivityEnabled = useState(true);
-    final estimatedIntensityEnabled = useState(true);
 
     // 暫定: Freeプランの制約を使用（RevenueCat統合時にユーザーのプラン状態へ差し替え）
     final constraints = ref.watch(startProvider).value?.planConstraints.free;
@@ -79,21 +77,6 @@ class _Body extends HookConsumerWidget {
                   builder: (_) => _CustomNotificationSettingsPage(
                     isPro: isPro,
                     maxRegions: maxRegions,
-                    settings: _CustomNotificationSettingsDraft(
-                      eewForecastEnabled: eewForecastEnabled.value,
-                      earthquakeEnabled: earthquakeEnabled.value,
-                      liveActivityEnabled: liveActivityEnabled.value,
-                      estimatedIntensityEnabled:
-                          estimatedIntensityEnabled.value,
-                    ),
-                    onEewForecastChanged: (value) =>
-                        eewForecastEnabled.value = value,
-                    onEarthquakeChanged: (value) =>
-                        earthquakeEnabled.value = value,
-                    onLiveActivityChanged: (value) =>
-                        liveActivityEnabled.value = value,
-                    onEstimatedIntensityChanged: (value) =>
-                        estimatedIntensityEnabled.value = value,
                   ),
                 ),
               );
@@ -114,9 +97,6 @@ enum _NotificationPreset {
   custom,
 }
 
-final _notificationSettingsDesignMutation = Mutation<void>();
-
-typedef _BoolSettingChanged = Future<void> Function({required bool value});
 
 class _MasterNotificationControl extends StatelessWidget {
   const _MasterNotificationControl({
@@ -356,46 +336,43 @@ class _CustomPresetTrailing extends StatelessWidget {
   }
 }
 
-class _CustomNotificationSettingsDraft {
-  const _CustomNotificationSettingsDraft({
-    required this.eewForecastEnabled,
-    required this.earthquakeEnabled,
-    required this.liveActivityEnabled,
-    required this.estimatedIntensityEnabled,
-  });
-
-  final bool eewForecastEnabled;
-  final bool earthquakeEnabled;
-  final bool liveActivityEnabled;
-  final bool estimatedIntensityEnabled;
-}
-
-class _CustomNotificationSettingsPage extends HookConsumerWidget {
+class _CustomNotificationSettingsPage extends ConsumerWidget {
   const _CustomNotificationSettingsPage({
     required this.isPro,
     required this.maxRegions,
-    required this.settings,
-    required this.onEewForecastChanged,
-    required this.onEarthquakeChanged,
-    required this.onLiveActivityChanged,
-    required this.onEstimatedIntensityChanged,
   });
 
   final bool isPro;
   final int maxRegions;
-  final _CustomNotificationSettingsDraft settings;
-  final ValueChanged<bool> onEewForecastChanged;
-  final ValueChanged<bool> onEarthquakeChanged;
-  final ValueChanged<bool> onLiveActivityChanged;
-  final ValueChanged<bool> onEstimatedIntensityChanged;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final eewForecastEnabled = useState(settings.eewForecastEnabled);
-    final earthquakeEnabled = useState(settings.earthquakeEnabled);
-    final liveActivityEnabled = useState(settings.liveActivityEnabled);
-    final estimatedIntensityEnabled = useState(
-      settings.estimatedIntensityEnabled,
+    final eewSettings = ref.watch(eewGlobalSettingsProvider).value;
+    final earthquakeSettings =
+        ref.watch(earthquakeGlobalSettingsProvider).value;
+
+    ref.listen(EewGlobalSettingsNotifier.updateSettingsMutation, (_, next) {
+      if (next is MutationError && context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('設定の保存に失敗しました: ${next.error}'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    });
+    ref.listen(
+      EarthquakeGlobalSettingsNotifier.updateSettingsMutation,
+      (_, next) {
+        if (next is MutationError && context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('設定の保存に失敗しました: ${next.error}'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      },
     );
 
     return Scaffold(
@@ -407,43 +384,48 @@ class _CustomNotificationSettingsPage extends HookConsumerWidget {
           const SettingsSectionHeader(text: '通知の種類'),
           _CustomSettingsSection(
             isPro: isPro,
-            eewForecastEnabled: eewForecastEnabled.value,
-            earthquakeEnabled: earthquakeEnabled.value,
-            liveActivityEnabled: liveActivityEnabled.value,
-            estimatedIntensityEnabled: estimatedIntensityEnabled.value,
+            eewForecastEnabled: eewSettings?.enabled ?? true,
+            earthquakeEnabled: earthquakeSettings?.enabled ?? true,
+            liveActivityEnabled: eewSettings?.startLiveActivity ?? true,
+            estimatedIntensityEnabled:
+                earthquakeSettings?.estimatedIntensityEnabled ?? true,
             onEewForecastChanged: ({required value}) async {
-              await _notificationSettingsDesignMutation.run(
+              await EewGlobalSettingsNotifier.updateSettingsMutation.run(
                 ref,
-                (_) async {
-                  eewForecastEnabled.value = value;
-                  onEewForecastChanged(value);
+                (tsx) async {
+                  await tsx
+                      .get(eewGlobalSettingsProvider.notifier)
+                      .updateSettings(enabled: value);
                 },
               );
             },
             onEarthquakeChanged: ({required value}) async {
-              await _notificationSettingsDesignMutation.run(
+              await EarthquakeGlobalSettingsNotifier.updateSettingsMutation.run(
                 ref,
-                (_) async {
-                  earthquakeEnabled.value = value;
-                  onEarthquakeChanged(value);
+                (tsx) async {
+                  await tsx
+                      .get(earthquakeGlobalSettingsProvider.notifier)
+                      .updateSettings(enabled: value);
                 },
               );
             },
             onLiveActivityChanged: ({required value}) async {
-              await _notificationSettingsDesignMutation.run(
+              await EewGlobalSettingsNotifier.updateSettingsMutation.run(
                 ref,
-                (_) async {
-                  liveActivityEnabled.value = value;
-                  onLiveActivityChanged(value);
+                (tsx) async {
+                  await tsx
+                      .get(eewGlobalSettingsProvider.notifier)
+                      .updateSettings(startLiveActivity: value);
                 },
               );
             },
             onEstimatedIntensityChanged: ({required value}) async {
-              await _notificationSettingsDesignMutation.run(
+              await EarthquakeGlobalSettingsNotifier.updateSettingsMutation.run(
                 ref,
-                (_) async {
-                  estimatedIntensityEnabled.value = value;
-                  onEstimatedIntensityChanged(value);
+                (tsx) async {
+                  await tsx
+                      .get(earthquakeGlobalSettingsProvider.notifier)
+                      .updateSettings(estimatedIntensityEnabled: value);
                 },
               );
             },
@@ -474,10 +456,11 @@ class _CustomSettingsSection extends StatelessWidget {
   final bool earthquakeEnabled;
   final bool liveActivityEnabled;
   final bool estimatedIntensityEnabled;
-  final _BoolSettingChanged onEewForecastChanged;
-  final _BoolSettingChanged onEarthquakeChanged;
-  final _BoolSettingChanged onLiveActivityChanged;
-  final _BoolSettingChanged onEstimatedIntensityChanged;
+  final Future<void> Function({required bool value}) onEewForecastChanged;
+  final Future<void> Function({required bool value}) onEarthquakeChanged;
+  final Future<void> Function({required bool value}) onLiveActivityChanged;
+  final Future<void> Function({required bool value})
+      onEstimatedIntensityChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -567,7 +550,7 @@ class _NotificationDetailTile extends StatelessWidget {
   final String title;
   final String subtitle;
   final bool enabled;
-  final _BoolSettingChanged onChanged;
+  final Future<void> Function({required bool value}) onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -599,7 +582,7 @@ class _NotificationConditionDetailPage extends StatelessWidget {
 
   final String title;
   final bool enabled;
-  final _BoolSettingChanged onChanged;
+  final Future<void> Function({required bool value}) onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -721,7 +704,7 @@ class _InlineSwitchTile extends StatelessWidget {
   final String title;
   final String subtitle;
   final bool value;
-  final _BoolSettingChanged onChanged;
+  final Future<void> Function({required bool value}) onChanged;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- `EewGlobalSettings` / `EarthquakeGlobalSettings` Freezedモデルを新規作成し、API型からの変換extensionを実装
- `NotificationSlotRepository` にEEW/地震情報グローバル設定のGET/PATCHメソッドを追加
- `EewGlobalSettingsNotifier` / `EarthquakeGlobalSettingsNotifier` を既存Mutationパターンで実装
- `_CustomNotificationSettingsPage` のuseState管理をNotifier経由に置き換え、API連動に変更
- 不要な `_CustomNotificationSettingsDraft`, `_notificationSettingsDesignMutation`, `_BoolSettingChanged` typedef を削除

closes #1376

## Test plan
- [ ] カスタム設定画面のEEW予報ON/OFFがAPIと連動することを確認
- [ ] 地震情報ON/OFFがAPIと連動することを確認
- [ ] Live ActivityトグルがEEW設定のstartLiveActivityとして保存されることを確認
- [ ] 推計震度トグルがearthquake設定のestimatedIntensityEnabledとして保存されることを確認
- [ ] API呼び出し失敗時にエラー表示されることを確認
- [ ] 画面遷移後も設定が保持されることを確認（useStateからNotifier管理への移行）