### PR TITLE
fix: デバイスプロビジョニング直後にFCM/APNsトークンを即時同期

### DIFF
--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
 import 'package:eqmonitor/feature/devices/data/exception/dio_exception_mapper.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/push_token_sync_notifier.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_auth_repository.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_provisioning_repository.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
@@ -89,5 +90,9 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
     });
 
     state = const AsyncData(DeviceProvisioningStatus.notRequired);
+
+    try {
+      await ref.read(pushTokenSyncProvider.notifier).sync();
+    } on Object catch (_) {}
   }
 }


### PR DESCRIPTION
## Summary
- `provision()` 完了後、`state` を `notRequired` に設定した直後にベストエフォートで `pushTokenSyncProvider.notifier.sync()` を呼び出し
- デバイス登録→トークンアップロードの間のギャップを解消し、通知を即座に受け取れるようにする
- 同期失敗時は既存の `pushTokenSyncWiring` リアクティブフローがフォールバックとして機能

## Test plan
- [ ] オンボーディングでデバイス登録直後にFCMトークンがサーバーにアップロードされることを確認
- [ ] トークン同期失敗時もprovision自体は成功し、後続のリアクティブフローで再試行されることを確認