### PR TITLE
feat: 震度別オーバーライド設定UI（Pro機能）

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/ui/page/override_edit_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/override_edit_page.dart
@@ -1,0 +1,539 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/experimental/mutation.dart';
+
+enum OverrideType { eew, earthquake }
+
+const _presetSounds = [
+  'default',
+  'eew_warning',
+  'eew_forecast',
+  'earthquake',
+];
+
+const List<JmaIntensity> _overrideIntensities = [
+  JmaIntensity.zero,
+  JmaIntensity.one,
+  JmaIntensity.two,
+  JmaIntensity.three,
+  JmaIntensity.four,
+  JmaIntensity.fiveLower,
+  JmaIntensity.fiveUpper,
+  JmaIntensity.sixLower,
+  JmaIntensity.sixUpper,
+  JmaIntensity.seven,
+];
+
+const _maxOverrides = 12;
+
+class OverrideEditPage extends HookConsumerWidget {
+  const OverrideEditPage({
+    required this.slotId,
+    required this.slotType,
+    required this.overrideType,
+    required this.currentOverrides,
+    super.key,
+  });
+
+  final String slotId;
+  final NotificationSlotType slotType;
+  final OverrideType overrideType;
+  final List<NotificationOverride> currentOverrides;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final slot = ref
+        .watch(notificationSlotsProvider)
+        .value
+        ?.where((s) => s.id == slotId)
+        .firstOrNull;
+
+    final overrides = switch (overrideType) {
+      OverrideType.eew => slot?.eewOverrides,
+      OverrideType.earthquake => slot?.earthquakeOverrides,
+    } ??
+        currentOverrides;
+
+    final sorted = List<NotificationOverride>.of(overrides)
+      ..sort(
+        (a, b) =>
+            a.minJmaIntensity.orderIndex - b.minJmaIntensity.orderIndex,
+      );
+
+    final title = switch (overrideType) {
+      OverrideType.eew => 'EEW 震度別設定',
+      OverrideType.earthquake => '地震情報 震度別設定',
+    };
+
+    void listenError(Mutation<void> mutation, String message) {
+      ref.listen(mutation, (_, next) {
+        if (next is MutationError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('$message: ${next.error}'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      });
+    }
+
+    listenError(
+      NotificationSlotsNotifier.putCurrentLocationMutation,
+      '設定の保存に失敗しました',
+    );
+    listenError(
+      NotificationSlotsNotifier.putNationwideMutation,
+      '設定の保存に失敗しました',
+    );
+    listenError(
+      NotificationSlotsNotifier.updateRegionMutation,
+      '設定の保存に失敗しました',
+    );
+
+    final usedIntensities = sorted.map((o) => o.minJmaIntensity).toSet();
+    final canAdd = sorted.length < _maxOverrides;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      floatingActionButton: canAdd
+          ? FloatingActionButton(
+              onPressed: () => _showAddDialog(
+                context,
+                ref,
+                slot,
+                sorted,
+                usedIntensities,
+              ),
+              child: const Icon(Icons.add),
+            )
+          : null,
+      body: sorted.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.tune,
+                    size: 48,
+                    color: Theme.of(context).disabledColor,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '震度別設定がありません',
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: Theme.of(context).disabledColor,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '右下の＋ボタンから追加できます',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).disabledColor,
+                    ),
+                  ),
+                ],
+              ),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.only(top: 8, bottom: 80),
+              itemCount: sorted.length,
+              itemBuilder: (context, index) {
+                final entry = sorted[index];
+                return _OverrideTile(
+                  entry: entry,
+                  onTap: () => _showEditDialog(
+                    context,
+                    ref,
+                    slot,
+                    sorted,
+                    index,
+                  ),
+                  onDismissed: () => _deleteOverride(
+                    ref,
+                    slot,
+                    sorted,
+                    index,
+                  ),
+                );
+              },
+            ),
+    );
+  }
+
+  Future<void> _showAddDialog(
+    BuildContext context,
+    WidgetRef ref,
+    NotificationSlot? slot,
+    List<NotificationOverride> sorted,
+    Set<JmaIntensity> usedIntensities,
+  ) async {
+    final availableIntensities = _overrideIntensities
+        .where((i) => !usedIntensities.contains(i))
+        .toList();
+
+    if (availableIntensities.isEmpty) {
+      return;
+    }
+
+    final result = await showDialog<NotificationOverride>(
+      context: context,
+      builder: (context) => _OverrideFormDialog(
+        availableIntensities: availableIntensities,
+        initialIntensity: availableIntensities.first,
+      ),
+    );
+
+    if (result == null || slot == null) {
+      return;
+    }
+
+    final updated = [...sorted, result]..sort(
+      (a, b) =>
+          a.minJmaIntensity.orderIndex - b.minJmaIntensity.orderIndex,
+    );
+
+    await _saveOverrides(ref, slot, updated);
+  }
+
+  Future<void> _showEditDialog(
+    BuildContext context,
+    WidgetRef ref,
+    NotificationSlot? slot,
+    List<NotificationOverride> sorted,
+    int index,
+  ) async {
+    final current = sorted[index];
+
+    final result = await showDialog<NotificationOverride>(
+      context: context,
+      builder: (context) => _OverrideFormDialog(
+        availableIntensities: [current.minJmaIntensity],
+        initialIntensity: current.minJmaIntensity,
+        initialSound: current.sound,
+        initialInterruptionLevel: current.interruptionLevel,
+        isEditing: true,
+      ),
+    );
+
+    if (result == null || slot == null) {
+      return;
+    }
+
+    final updated = [...sorted];
+    updated[index] = result;
+
+    await _saveOverrides(ref, slot, updated);
+  }
+
+  Future<void> _deleteOverride(
+    WidgetRef ref,
+    NotificationSlot? slot,
+    List<NotificationOverride> sorted,
+    int index,
+  ) async {
+    if (slot == null) {
+      return;
+    }
+
+    final updated = [...sorted]..removeAt(index);
+    await _saveOverrides(ref, slot, updated);
+  }
+
+  Future<void> _saveOverrides(
+    WidgetRef ref,
+    NotificationSlot slot,
+    List<NotificationOverride> overrides,
+  ) async {
+    final eewOverrides = overrideType == OverrideType.eew
+        ? overrides
+        : slot.eewOverrides;
+    final earthquakeOverrides = overrideType == OverrideType.earthquake
+        ? overrides
+        : slot.earthquakeOverrides;
+
+    try {
+      switch (slotType) {
+        case NotificationSlotType.currentLocation:
+          await NotificationSlotsNotifier.putCurrentLocationMutation.run(
+            ref,
+            (tsx) async {
+              await tsx
+                  .get(notificationSlotsProvider.notifier)
+                  .putCurrentLocation(
+                    eewOverrides: eewOverrides,
+                    earthquakeOverrides: earthquakeOverrides,
+                  );
+            },
+          );
+        case NotificationSlotType.nationwide:
+          await NotificationSlotsNotifier.putNationwideMutation.run(
+            ref,
+            (tsx) async {
+              await tsx
+                  .get(notificationSlotsProvider.notifier)
+                  .putNationwide(
+                    eewOverrides: eewOverrides,
+                    earthquakeOverrides: earthquakeOverrides,
+                  );
+            },
+          );
+        case NotificationSlotType.region:
+          await NotificationSlotsNotifier.updateRegionMutation.run(
+            ref,
+            (tsx) async {
+              await tsx
+                  .get(notificationSlotsProvider.notifier)
+                  .updateRegion(
+                    slotId: slotId,
+                    eewOverrides: eewOverrides,
+                    earthquakeOverrides: earthquakeOverrides,
+                  );
+            },
+          );
+      }
+    } on Object {
+      return;
+    }
+  }
+}
+
+class _OverrideTile extends StatelessWidget {
+  const _OverrideTile({
+    required this.entry,
+    required this.onTap,
+    required this.onDismissed,
+  });
+
+  final NotificationOverride entry;
+  final VoidCallback onTap;
+  final VoidCallback onDismissed;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+    final color = designSystem.color;
+    final spacing = designSystem.spacing;
+    final shape = designSystem.shape;
+
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: spacing.lg,
+        vertical: spacing.xs,
+      ),
+      child: Dismissible(
+        key: ValueKey(entry.minJmaIntensity),
+        direction: DismissDirection.endToStart,
+        onDismissed: (_) => onDismissed(),
+        background: Card(
+          color: Theme.of(context).colorScheme.error,
+          shape: RoundedSuperellipseBorder(
+            borderRadius: BorderRadius.circular(shape.card),
+          ),
+          child: const Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: EdgeInsets.only(right: 24),
+              child: Icon(Icons.delete, color: Colors.white),
+            ),
+          ),
+        ),
+        child: Card.outlined(
+          margin: EdgeInsets.zero,
+          color: color.surfaceCard,
+          clipBehavior: Clip.antiAlias,
+          elevation: 0,
+          shape: RoundedSuperellipseBorder(
+            borderRadius: BorderRadius.circular(shape.card),
+            side: BorderSide(color: color.outlineSoft),
+          ),
+          child: ListTile(
+            onTap: onTap,
+            leading: _IntensityBadge(intensity: entry.minJmaIntensity),
+            title: Text('震度${entry.minJmaIntensity.label}以上'),
+            subtitle: Text(
+              '${_soundLabel(entry.sound)} / ${entry.interruptionLevel.label}',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IntensityBadge extends StatelessWidget {
+  const _IntensityBadge({required this.intensity});
+
+  final JmaIntensity intensity;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        intensity.label,
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          color: colorScheme.onPrimaryContainer,
+        ),
+      ),
+    );
+  }
+}
+
+class _OverrideFormDialog extends StatefulWidget {
+  const _OverrideFormDialog({
+    required this.availableIntensities,
+    required this.initialIntensity,
+    this.initialSound = 'default',
+    this.initialInterruptionLevel = InterruptionLevel.active,
+    this.isEditing = false,
+  });
+
+  final List<JmaIntensity> availableIntensities;
+  final JmaIntensity initialIntensity;
+  final String initialSound;
+  final InterruptionLevel initialInterruptionLevel;
+  final bool isEditing;
+
+  @override
+  State<_OverrideFormDialog> createState() => _OverrideFormDialogState();
+}
+
+class _OverrideFormDialogState extends State<_OverrideFormDialog> {
+  late JmaIntensity _selectedIntensity;
+  late String _selectedSound;
+  late InterruptionLevel _selectedInterruptionLevel;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIntensity = widget.initialIntensity;
+    _selectedSound = widget.initialSound;
+    _selectedInterruptionLevel = widget.initialInterruptionLevel;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.isEditing ? '震度別設定を編集' : '震度別設定を追加'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '最小震度',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 8),
+            DropdownButton<JmaIntensity>(
+              value: _selectedIntensity,
+              isExpanded: true,
+              onChanged: widget.isEditing
+                  ? null
+                  : (next) {
+                      if (next != null) {
+                        setState(() => _selectedIntensity = next);
+                      }
+                    },
+              items: [
+                for (final intensity in widget.availableIntensities)
+                  DropdownMenuItem(
+                    value: intensity,
+                    child: Text('震度${intensity.label}'),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '通知音',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 8),
+            DropdownButton<String>(
+              value: _selectedSound,
+              isExpanded: true,
+              onChanged: (next) {
+                if (next != null) {
+                  setState(() => _selectedSound = next);
+                }
+              },
+              items: [
+                for (final sound in _presetSounds)
+                  DropdownMenuItem(
+                    value: sound,
+                    child: Text(_soundLabel(sound)),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '割り込みレベル',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 8),
+            RadioGroup<InterruptionLevel>(
+              groupValue: _selectedInterruptionLevel,
+              onChanged: (next) {
+                if (next != null) {
+                  setState(() => _selectedInterruptionLevel = next);
+                }
+              },
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (final level in InterruptionLevel.values)
+                    RadioListTile<InterruptionLevel>(
+                      title: Text(level.label),
+                      value: level,
+                      contentPadding: EdgeInsets.zero,
+                      dense: true,
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(
+            NotificationOverride(
+              minJmaIntensity: _selectedIntensity,
+              sound: _selectedSound,
+              interruptionLevel: _selectedInterruptionLevel,
+            ),
+          ),
+          child: Text(widget.isEditing ? '保存' : '追加'),
+        ),
+      ],
+    );
+  }
+}
+
+String _soundLabel(String sound) => switch (sound) {
+  'default' => 'デフォルト',
+  'eew_warning' => 'EEW警報',
+  'eew_forecast' => 'EEW予報',
+  'earthquake' => '地震情報',
+  _ => sound,
+};

--- a/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
@@ -2,8 +2,10 @@ import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/override_edit_page.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod/experimental/mutation.dart';
@@ -83,20 +85,42 @@ class SlotDetailPage extends HookConsumerWidget {
                   enabled: slot.eewEnabled,
                   minIntensity: slot.eewMinIntensity,
                   isPro: isPro,
+                  overrides: slot.eewOverrides ?? [],
                   onEnabledChanged: (next) =>
                       _updateSlot(ref, slot, eewEnabled: next),
                   onMinIntensityChanged: (next) =>
                       _updateSlot(ref, slot, eewMinIntensity: next),
+                  onOverrideTap: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => OverrideEditPage(
+                        slotId: slot.id,
+                        slotType: slot.slotType,
+                        overrideType: OverrideType.eew,
+                        currentOverrides: slot.eewOverrides ?? [],
+                      ),
+                    ),
+                  ),
                 ),
                 const SettingsSectionHeader(text: '地震情報'),
                 _NotificationConditionCard(
                   enabled: slot.earthquakeEnabled,
                   minIntensity: slot.earthquakeMinIntensity,
                   isPro: isPro,
+                  overrides: slot.earthquakeOverrides ?? [],
                   onEnabledChanged: (next) =>
                       _updateSlot(ref, slot, earthquakeEnabled: next),
                   onMinIntensityChanged: (next) =>
                       _updateSlot(ref, slot, earthquakeMinIntensity: next),
+                  onOverrideTap: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => OverrideEditPage(
+                        slotId: slot.id,
+                        slotType: slot.slotType,
+                        overrideType: OverrideType.earthquake,
+                        currentOverrides: slot.earthquakeOverrides ?? [],
+                      ),
+                    ),
+                  ),
                 ),
                 if (slot.slotType == NotificationSlotType.region) ...[
                   const SettingsSectionHeader(text: '削除'),
@@ -205,15 +229,19 @@ class _NotificationConditionCard extends StatelessWidget {
     required this.enabled,
     required this.minIntensity,
     required this.isPro,
+    required this.overrides,
     required this.onEnabledChanged,
     required this.onMinIntensityChanged,
+    required this.onOverrideTap,
   });
 
   final bool enabled;
   final JmaIntensity? minIntensity;
   final bool isPro;
+  final List<NotificationOverride> overrides;
   final ValueChanged<bool> onEnabledChanged;
   final ValueChanged<JmaIntensity> onMinIntensityChanged;
+  final VoidCallback onOverrideTap;
 
   @override
   Widget build(BuildContext context) {
@@ -255,11 +283,21 @@ class _NotificationConditionCard extends StatelessWidget {
             ),
           ),
           const Divider(height: 1),
-          _LockedSettingTile(
-            title: '震度別設定',
-            subtitle: isPro ? '震度ごとに通知をオーバーライドできます' : 'Proで利用できます',
-            locked: !isPro,
-          ),
+          if (isPro)
+            ListTile(
+              title: const Text('震度別設定'),
+              subtitle: overrides.isEmpty
+                  ? const Text('震度ごとに通知をオーバーライドできます')
+                  : Text('${overrides.length}件の設定'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: onOverrideTap,
+            )
+          else
+            const _LockedSettingTile(
+              title: '震度別設定',
+              subtitle: 'Proで利用できます',
+              locked: true,
+            ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- `OverrideEditPage` を新規作成: 震度別に通知音・割り込みレベルをカスタマイズできるCRUD画面
- `SlotDetailPage` の「震度別設定」タイルをPro時は通常ListTile（件数表示+遷移）に変更
- 追加ダイアログ: 震度選択（使用済み除外）、プリセット音選択、割り込みレベル選択
- スワイプ削除、タップ編集対応
- 制約: 最大12件、震度昇順ソート、重複不可
- EEW/地震情報それぞれ独立した編集画面

closes #1379

## Test plan
- [ ] Pro状態で「震度別設定」タイルをタップ→編集画面に遷移
- [ ] オーバーライドの追加（震度選択→音選択→割り込みレベル選択）が動作
- [ ] 既存オーバーライドの編集が動作
- [ ] スワイプ削除が動作
- [ ] 使用済み震度が追加ダイアログで選択不可
- [ ] 12件上限で追加ボタンが非表示
- [ ] 非Pro時は「Proで利用できます」ロック表示のまま