### PR TITLE
feat: 402 Pro誘導ダイアログ + 地域追加UI（Region Picker）

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart
@@ -1,0 +1,25 @@
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:flutter/material.dart';
+
+Future<void> showProUpgradeDialog(BuildContext context) async {
+  await showDialog<void>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Proプランが必要です'),
+      content: const Text('この機能を利用するにはProプランへのアップグレードが必要です。'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('閉じる'),
+        ),
+        FilledButton(
+          onPressed: () async {
+            Navigator.of(context).pop();
+            await const PaywallRoute().push<void>(context);
+          },
+          child: const Text('Proを見る'),
+        ),
+      ],
+    ),
+  );
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -11,6 +11,7 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/m
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/region_picker_page.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:flutter/material.dart';
@@ -870,11 +871,13 @@ class _SlotListSection extends ConsumerWidget {
           padding: EdgeInsets.fromLTRB(spacing.lg, spacing.sm, spacing.lg, 0),
           child: FilledButton.tonalIcon(
             onPressed: canAddRegion
-                ? () => ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('地域の追加は今後のアップデートで対応予定です'),
-                    ),
-                  )
+                ? () async {
+                    await Navigator.of(context).push<void>(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const RegionPickerPage(),
+                      ),
+                    );
+                  }
                 : null,
             icon: const Icon(Icons.add),
             label: Text(

--- a/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
+import 'package:eqmonitor/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/experimental/mutation.dart';
+
+class RegionPickerPage extends HookConsumerWidget {
+  const RegionPickerPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchController = useTextEditingController();
+    final searchText = useState('');
+
+    useEffect(
+      () {
+        void listener() => searchText.value = searchController.text;
+        searchController.addListener(listener);
+        return () => searchController.removeListener(listener);
+      },
+      [searchController],
+    );
+
+    final jmaCodeTableAsync = ref.watch(jmaCodeTableProvider);
+    final regions = jmaCodeTableAsync.value?.codeTables.areaForecastLocalEew;
+
+    final filteredRegions = _filterRegions(regions, searchText.value);
+
+    ref.listen(NotificationSlotsNotifier.addRegionMutation, (_, next) {
+      if (next is MutationError) {
+        final error = next.error;
+        if (error is DioException && error.response?.statusCode == 402) {
+          unawaited(showProUpgradeDialog(context));
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('地域の追加に失敗しました: $error'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      }
+      if (next is MutationSuccess) {
+        Navigator.of(context).pop();
+      }
+    });
+
+    final isAdding =
+        ref.watch(NotificationSlotsNotifier.addRegionMutation)
+            is MutationPending;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('地域を選択')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: SearchBar(
+              controller: searchController,
+              hintText: '地域名で検索',
+              leading: const Padding(
+                padding: EdgeInsets.only(left: 8),
+                child: Icon(Icons.search),
+              ),
+              trailing: [
+                if (searchText.value.isNotEmpty)
+                  IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      searchController.clear();
+                      searchText.value = '';
+                    },
+                  ),
+              ],
+            ),
+          ),
+          if (isAdding) const LinearProgressIndicator(),
+          Expanded(
+            child: switch (jmaCodeTableAsync) {
+              AsyncLoading() => const Center(
+                child: CircularProgressIndicator.adaptive(),
+              ),
+              AsyncError(:final error) => Center(
+                child: Text('読み込みに失敗しました: $error'),
+              ),
+              _ when filteredRegions != null => ListView.builder(
+                itemCount: filteredRegions.length,
+                itemBuilder: (context, index) {
+                  final region = filteredRegions[index];
+                  return _RegionListTile(
+                    region: region,
+                    enabled: !isAdding,
+                    onTap: () async {
+                      await NotificationSlotsNotifier.addRegionMutation.run(
+                        ref,
+                        (tsx) async {
+                          await tsx
+                              .get(notificationSlotsProvider.notifier)
+                              .addRegion(
+                                regionId: int.parse(region.code),
+                                regionName: region.name.ja,
+                              );
+                        },
+                      );
+                    },
+                  );
+                },
+              ),
+              _ => const SizedBox.shrink(),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  static List<JmaCodeTableItem>? _filterRegions(
+    List<JmaCodeTableItem>? regions,
+    String query,
+  ) {
+    if (regions == null) {
+      return null;
+    }
+    if (query.isEmpty) {
+      return regions;
+    }
+    final lowerQuery = query.toLowerCase();
+    return regions.where((item) {
+      final nameMatch = item.name.ja.toLowerCase().contains(lowerQuery);
+      final kanaMatch = item.kana?.toLowerCase().contains(lowerQuery) ?? false;
+      return nameMatch || kanaMatch;
+    }).toList();
+  }
+}
+
+class _RegionListTile extends StatelessWidget {
+  const _RegionListTile({
+    required this.region,
+    required this.enabled,
+    required this.onTap,
+  });
+
+  final JmaCodeTableItem region;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      enabled: enabled,
+      title: Text(region.name.ja),
+      subtitle: Text(region.code),
+      trailing: const Icon(Icons.add),
+      onTap: enabled ? onTap : null,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- 402 Payment Required時のPro誘導ダイアログ (`showProUpgradeDialog`) を新規作成
  - 「Proを見る」ボタンでPaywallRoute（RevenueCat購入画面）に遷移
- `RegionPickerPage` を新規作成: `areaForecastLocalEew` からEEW予報区を検索・選択
  - 上部SearchBarで `name.ja` / `kana` の部分文字列フィルタリング
  - タップで `addRegion` Mutation実行、成功時にpop
  - 402エラー時はPro誘導ダイアログ表示
- 通知設定画面の「地域を追加」ボタンをRegionPickerPageへの遷移に接続

closes #1381
closes #1378

## Test plan
- [ ] Region Pickerで地域を検索・選択→スロット追加成功→一覧に反映
- [ ] maxRegions上限時にサーバー402→Pro誘導ダイアログ表示
- [ ] Pro誘導ダイアログの「Proを見る」でPaywall画面に遷移
- [ ] 検索バーでかな/漢字の部分文字列検索が動作
- [ ] 追加中のローディング表示