### PR TITLE
feat: 一般通知設定UI + プリセット永続化 + GeneralNotificationSettingsNotifier

### DIFF
--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -577,11 +577,22 @@ class _NotificationSettingsSection extends HookConsumerWidget {
     final isBusy = useState(false);
     final tsunami = useState(settings?.tsunamiEnabled ?? false);
     final training = useState(settings?.trainingEnabled ?? false);
+    final nankaiExtraordinary = useState(
+      settings?.nankaiExtraordinaryEnabled ?? false,
+    );
+    final nankaiRegular = useState(settings?.nankaiRegularEnabled ?? false);
+    final hokkaido3ren = useState(
+      settings?.hokkaido3renOffshoreEnabled ?? false,
+    );
 
     ref.listen(_notificationSettingsProvider(deviceId), (_, next) {
       if (next.value != null) {
         tsunami.value = next.requireValue.tsunamiEnabled;
         training.value = next.requireValue.trainingEnabled;
+        nankaiExtraordinary.value =
+            next.requireValue.nankaiExtraordinaryEnabled;
+        nankaiRegular.value = next.requireValue.nankaiRegularEnabled;
+        hokkaido3ren.value = next.requireValue.hokkaido3renOffshoreEnabled;
       }
     });
 
@@ -599,6 +610,9 @@ class _NotificationSettingsSection extends HookConsumerWidget {
         settings: GeneralNotificationSettings(
           tsunamiEnabled: tsunami.value,
           trainingEnabled: training.value,
+          nankaiExtraordinaryEnabled: nankaiExtraordinary.value,
+          nankaiRegularEnabled: nankaiRegular.value,
+          hokkaido3renOffshoreEnabled: hokkaido3ren.value,
         ),
       );
       isBusy.value = false;

--- a/app/lib/feature/notification/data/model/general_notification_settings.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.dart
@@ -8,6 +8,9 @@ abstract class GeneralNotificationSettings with _$GeneralNotificationSettings {
   const factory GeneralNotificationSettings({
     required bool tsunamiEnabled,
     required bool trainingEnabled,
+    required bool nankaiExtraordinaryEnabled,
+    required bool nankaiRegularEnabled,
+    required bool hokkaido3renOffshoreEnabled,
   }) = _GeneralNotificationSettings;
 }
 
@@ -17,5 +20,8 @@ extension GeneralNotificationSettingsApiExtension
       GeneralNotificationSettings(
         tsunamiEnabled: tsunamiEnabled,
         trainingEnabled: trainingEnabled,
+        nankaiExtraordinaryEnabled: nankaiExtraordinaryEnabled,
+        nankaiRegularEnabled: nankaiRegularEnabled,
+        hokkaido3renOffshoreEnabled: hokkaido3renOffshoreEnabled,
       );
 }

--- a/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GeneralNotificationSettings {
 
- bool get tsunamiEnabled; bool get trainingEnabled;
+ bool get tsunamiEnabled; bool get trainingEnabled; bool get nankaiExtraordinaryEnabled; bool get nankaiRegularEnabled; bool get hokkaido3renOffshoreEnabled;
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $GeneralNotificationSettingsCopyWith<GeneralNotificationSettings> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled);
+int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled)';
+  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $GeneralNotificationSettingsCopyWith<$Res>  {
   factory $GeneralNotificationSettingsCopyWith(GeneralNotificationSettings value, $Res Function(GeneralNotificationSettings) _then) = _$GeneralNotificationSettingsCopyWithImpl;
 @useResult
 $Res call({
- bool tsunamiEnabled, bool trainingEnabled
+ bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
 });
 
 
@@ -62,10 +62,13 @@ class _$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
   return _then(_self.copyWith(
 tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
+as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
+as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
+as bool,hokkaido3renOffshoreEnabled: null == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -151,10 +154,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
+return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return orElse();
 
 }
@@ -172,10 +175,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings():
-return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
+return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -192,10 +195,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool tsunamiEnabled,  bool trainingEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
+return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return null;
 
 }
@@ -207,11 +210,14 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled);case _:
 
 
 class _GeneralNotificationSettings implements GeneralNotificationSettings {
-  const _GeneralNotificationSettings({required this.tsunamiEnabled, required this.trainingEnabled});
+  const _GeneralNotificationSettings({required this.tsunamiEnabled, required this.trainingEnabled, required this.nankaiExtraordinaryEnabled, required this.nankaiRegularEnabled, required this.hokkaido3renOffshoreEnabled});
   
 
 @override final  bool tsunamiEnabled;
 @override final  bool trainingEnabled;
+@override final  bool nankaiExtraordinaryEnabled;
+@override final  bool nankaiRegularEnabled;
+@override final  bool hokkaido3renOffshoreEnabled;
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
@@ -223,16 +229,16 @@ _$GeneralNotificationSettingsCopyWith<_GeneralNotificationSettings> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled);
+int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled)';
+  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -243,7 +249,7 @@ abstract mixin class _$GeneralNotificationSettingsCopyWith<$Res> implements $Gen
   factory _$GeneralNotificationSettingsCopyWith(_GeneralNotificationSettings value, $Res Function(_GeneralNotificationSettings) _then) = __$GeneralNotificationSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- bool tsunamiEnabled, bool trainingEnabled
+ bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
 });
 
 
@@ -260,10 +266,13 @@ class __$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
   return _then(_GeneralNotificationSettings(
 tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
+as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
+as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
+as bool,hokkaido3renOffshoreEnabled: null == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
+++ b/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
@@ -1,0 +1,61 @@
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/core/provider/device_id.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/notification/data/model/general_notification_settings.dart';
+import 'package:eqmonitor/feature/notification/data/repository/push_notification_repository.dart';
+import 'package:riverpod/experimental/mutation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'general_notification_settings_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class GeneralNotificationSettingsNotifier
+    extends _$GeneralNotificationSettingsNotifier {
+  static final updateSettingsMutation = Mutation<void>();
+
+  @override
+  Future<GeneralNotificationSettings> build() async {
+    final status = await ref.watch(deviceProvisioningProvider.future);
+    if (status != DeviceProvisioningStatus.notRequired) {
+      throw StateError('Device not provisioned');
+    }
+    final repo = await ref.watch(pushNotificationRepositoryProvider.future);
+    final deviceId = await ref.read(deviceIdProvider.future);
+    final result = await repo.getNotificationSettings(deviceId);
+    return switch (result) {
+      Success(:final value) => value,
+      Failure(:final exception) => throw exception,
+    };
+  }
+
+  Future<void> updateSettings({
+    bool? tsunamiEnabled,
+    bool? trainingEnabled,
+    bool? nankaiExtraordinaryEnabled,
+    bool? nankaiRegularEnabled,
+    bool? hokkaido3renOffshoreEnabled,
+  }) async {
+    final current = state.requireValue;
+    final repo = await ref.read(pushNotificationRepositoryProvider.future);
+    final deviceId = await ref.read(deviceIdProvider.future);
+    final result = await repo.patchNotificationSettings(
+      deviceId: deviceId,
+      settings: current.copyWith(
+        tsunamiEnabled: tsunamiEnabled ?? current.tsunamiEnabled,
+        trainingEnabled: trainingEnabled ?? current.trainingEnabled,
+        nankaiExtraordinaryEnabled:
+            nankaiExtraordinaryEnabled ?? current.nankaiExtraordinaryEnabled,
+        nankaiRegularEnabled:
+            nankaiRegularEnabled ?? current.nankaiRegularEnabled,
+        hokkaido3renOffshoreEnabled:
+            hokkaido3renOffshoreEnabled ?? current.hokkaido3renOffshoreEnabled,
+      ),
+    );
+    state = AsyncData(
+      switch (result) {
+        Success(:final value) => value,
+        Failure(:final exception) => throw exception,
+      },
+    );
+  }
+}

--- a/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.g.dart
+++ b/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.g.dart
@@ -1,0 +1,73 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'general_notification_settings_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(GeneralNotificationSettingsNotifier)
+final generalNotificationSettingsProvider =
+    GeneralNotificationSettingsNotifierProvider._();
+
+final class GeneralNotificationSettingsNotifierProvider
+    extends
+        $AsyncNotifierProvider<
+          GeneralNotificationSettingsNotifier,
+          GeneralNotificationSettings
+        > {
+  GeneralNotificationSettingsNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'generalNotificationSettingsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$generalNotificationSettingsNotifierHash();
+
+  @$internal
+  @override
+  GeneralNotificationSettingsNotifier create() =>
+      GeneralNotificationSettingsNotifier();
+}
+
+String _$generalNotificationSettingsNotifierHash() =>
+    r'e12d6797267f136155fb407fe510b97948527fcf';
+
+abstract class _$GeneralNotificationSettingsNotifier
+    extends $AsyncNotifier<GeneralNotificationSettings> {
+  FutureOr<GeneralNotificationSettings> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<GeneralNotificationSettings>,
+              GeneralNotificationSettings
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<GeneralNotificationSettings>,
+                GeneralNotificationSettings
+              >,
+              AsyncValue<GeneralNotificationSettings>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/notification/data/repository/push_notification_repository.dart
+++ b/app/lib/feature/notification/data/repository/push_notification_repository.dart
@@ -32,6 +32,9 @@ class PushNotificationRepository {
       body: api.NotificationSettingsRequest(
         tsunamiEnabled: settings.tsunamiEnabled,
         trainingEnabled: settings.trainingEnabled,
+        nankaiExtraordinaryEnabled: settings.nankaiExtraordinaryEnabled,
+        nankaiRegularEnabled: settings.nankaiRegularEnabled,
+        hokkaido3renOffshoreEnabled: settings.hokkaido3renOffshoreEnabled,
       ),
     );
     return response.data.toGeneralNotificationSettings;

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -132,10 +132,21 @@ class _Body extends HookConsumerWidget {
     final isBusy = useState(false);
     final tsunami = useState(settings?.tsunamiEnabled ?? false);
     final training = useState(settings?.trainingEnabled ?? false);
+    final nankaiExtraordinary = useState(
+      settings?.nankaiExtraordinaryEnabled ?? false,
+    );
+    final nankaiRegular = useState(settings?.nankaiRegularEnabled ?? false);
+    final hokkaido3ren = useState(
+      settings?.hokkaido3renOffshoreEnabled ?? false,
+    );
 
     useEffect(() {
       tsunami.value = settings?.tsunamiEnabled ?? false;
       training.value = settings?.trainingEnabled ?? false;
+      nankaiExtraordinary.value =
+          settings?.nankaiExtraordinaryEnabled ?? false;
+      nankaiRegular.value = settings?.nankaiRegularEnabled ?? false;
+      hokkaido3ren.value = settings?.hokkaido3renOffshoreEnabled ?? false;
       return null;
     }, [settings]);
 
@@ -253,6 +264,9 @@ class _Body extends HookConsumerWidget {
           settings: GeneralNotificationSettings(
             tsunamiEnabled: tsunami.value,
             trainingEnabled: training.value,
+            nankaiExtraordinaryEnabled: nankaiExtraordinary.value,
+            nankaiRegularEnabled: nankaiRegular.value,
+            hokkaido3renOffshoreEnabled: hokkaido3ren.value,
           ),
         );
         if (!context.mounted) {

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_preset_notifier.g.dart';
+
+enum NotificationPreset { recommended, custom }
+
+@Riverpod(keepAlive: true)
+class NotificationPresetNotifier extends _$NotificationPresetNotifier {
+  static const _key = 'notification_preset';
+
+  @override
+  NotificationPreset build() {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    final stored = prefs.getString(_key);
+    return stored == 'custom'
+        ? NotificationPreset.custom
+        : NotificationPreset.recommended;
+  }
+
+  void select(NotificationPreset preset) {
+    final prefs = ref.read(sharedPreferencesProvider);
+    unawaited(prefs.setString(_key, preset.name));
+    state = preset;
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_preset_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(NotificationPresetNotifier)
+final notificationPresetProvider = NotificationPresetNotifierProvider._();
+
+final class NotificationPresetNotifierProvider
+    extends $NotifierProvider<NotificationPresetNotifier, NotificationPreset> {
+  NotificationPresetNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationPresetProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationPresetNotifierHash();
+
+  @$internal
+  @override
+  NotificationPresetNotifier create() => NotificationPresetNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationPreset value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationPreset>(value),
+    );
+  }
+}
+
+String _$notificationPresetNotifierHash() =>
+    r'14576500bcf5e44676c8d81b0904d3d71dfa4086';
+
+abstract class _$NotificationPresetNotifier
+    extends $Notifier<NotificationPreset> {
+  NotificationPreset build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<NotificationPreset, NotificationPreset>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<NotificationPreset, NotificationPreset>,
+              NotificationPreset,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -7,6 +7,7 @@ import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/notification/data/model/test_notification_delivery.dart';
+import 'package:eqmonitor/feature/notification/data/notifier/general_notification_settings_notifier.dart';
 import 'package:eqmonitor/feature/notification/data/repository/push_notification_repository.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart';
@@ -14,6 +15,7 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/m
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/region_picker_page.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart';
@@ -41,9 +43,8 @@ class _Body extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notificationsEnabled = useState(true);
-    final selectedPreset = useState(_NotificationPreset.recommended);
+    final selectedPreset = ref.watch(notificationPresetProvider);
 
-    // 暫定: Freeプランの制約を使用（RevenueCat統合時にユーザーのプラン状態へ差し替え）
     final constraints = ref.watch(startProvider).value?.planConstraints.free;
     final isPro = constraints?.isPro ?? false;
     final maxRegions = constraints?.maxRegions.toInt() ?? 1;
@@ -58,6 +59,20 @@ class _Body extends HookConsumerWidget {
       }
     });
 
+    ref.listen(
+      GeneralNotificationSettingsNotifier.updateSettingsMutation,
+      (_, next) {
+        if (next is MutationError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('設定の保存に失敗しました: ${next.error}'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      },
+    );
+
     return ListView(
       padding: const EdgeInsets.only(top: 16, bottom: 24),
       children: [
@@ -68,10 +83,11 @@ class _Body extends HookConsumerWidget {
         if (notificationsEnabled.value) ...[
           const SettingsSectionHeader(text: '通知条件'),
           _PresetOptionGroup(
-            selectedPreset: selectedPreset.value,
-            onChanged: (preset) => selectedPreset.value = preset,
+            selectedPreset: selectedPreset,
+            onChanged: (preset) =>
+                ref.read(notificationPresetProvider.notifier).select(preset),
             onCustomSettingsTap: () async {
-              if (selectedPreset.value != _NotificationPreset.custom) {
+              if (selectedPreset != NotificationPreset.custom) {
                 return;
               }
               await Navigator.of(context).push<void>(
@@ -84,6 +100,8 @@ class _Body extends HookConsumerWidget {
               );
             },
           ),
+          const SettingsSectionHeader(text: 'その他の通知'),
+          const _GeneralNotificationSettingsSection(),
         ],
         const SettingsSectionHeader(text: 'ツール'),
         const _NotificationHistoryTile(),
@@ -92,11 +110,6 @@ class _Body extends HookConsumerWidget {
       ],
     );
   }
-}
-
-enum _NotificationPreset {
-  recommended,
-  custom,
 }
 
 
@@ -162,8 +175,8 @@ class _PresetOptionGroup extends StatelessWidget {
     required this.onCustomSettingsTap,
   });
 
-  final _NotificationPreset selectedPreset;
-  final ValueChanged<_NotificationPreset> onChanged;
+  final NotificationPreset selectedPreset;
+  final ValueChanged<NotificationPreset> onChanged;
   final VoidCallback onCustomSettingsTap;
 
   @override
@@ -193,17 +206,17 @@ class _PresetOptionGroup extends StatelessWidget {
           _PresetOptionTile(
             title: '推奨設定',
             subtitle: '現在地を中心に、必要な通知を自動で受け取ります',
-            isSelected: selectedPreset == _NotificationPreset.recommended,
-            onTap: () => onChanged(_NotificationPreset.recommended),
+            isSelected: selectedPreset == NotificationPreset.recommended,
+            onTap: () => onChanged(NotificationPreset.recommended),
           ),
           const Divider(height: 1),
           _PresetOptionTile(
             title: 'カスタム',
             subtitle: '通知の種類ごとに条件を細かく設定します',
-            isSelected: selectedPreset == _NotificationPreset.custom,
-            onTap: () => onChanged(_NotificationPreset.custom),
+            isSelected: selectedPreset == NotificationPreset.custom,
+            onTap: () => onChanged(NotificationPreset.custom),
             trailing: _CustomPresetTrailing(
-              enabled: selectedPreset == _NotificationPreset.custom,
+              enabled: selectedPreset == NotificationPreset.custom,
               onTap: onCustomSettingsTap,
             ),
           ),
@@ -989,6 +1002,116 @@ class _SettingValueTile extends StatelessWidget {
     return ListTile(
       title: Text(title),
       subtitle: Text(subtitle),
+    );
+  }
+}
+
+class _GeneralNotificationSettingsSection extends ConsumerWidget {
+  const _GeneralNotificationSettingsSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settingsAsync = ref.watch(generalNotificationSettingsProvider);
+    final settings = settingsAsync.value;
+    if (settings == null) {
+      return const Center(child: CircularProgressIndicator.adaptive());
+    }
+
+    final designSystem = context.designSystem;
+    final color = designSystem.color;
+    final spacing = designSystem.spacing;
+    final shape = designSystem.shape;
+
+    return Card.outlined(
+      margin: EdgeInsets.fromLTRB(
+        spacing.lg,
+        spacing.sm,
+        spacing.lg,
+        spacing.md,
+      ),
+      color: color.surfaceCard,
+      clipBehavior: Clip.antiAlias,
+      elevation: 0,
+      shape: RoundedSuperellipseBorder(
+        borderRadius: BorderRadius.circular(shape.card),
+        side: BorderSide(color: color.outlineSoft),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _InlineSwitchTile(
+            title: '津波通知',
+            subtitle: settings.tsunamiEnabled ? '通知する' : '通知しない',
+            value: settings.tsunamiEnabled,
+            onChanged: ({required value}) async {
+              await GeneralNotificationSettingsNotifier.updateSettingsMutation
+                  .run(ref, (tsx) async {
+                await tsx
+                    .get(generalNotificationSettingsProvider.notifier)
+                    .updateSettings(tsunamiEnabled: value);
+              });
+            },
+          ),
+          const Divider(height: 1),
+          _InlineSwitchTile(
+            title: '訓練通知',
+            subtitle: settings.trainingEnabled ? '通知する' : '通知しない',
+            value: settings.trainingEnabled,
+            onChanged: ({required value}) async {
+              await GeneralNotificationSettingsNotifier.updateSettingsMutation
+                  .run(ref, (tsx) async {
+                await tsx
+                    .get(generalNotificationSettingsProvider.notifier)
+                    .updateSettings(trainingEnabled: value);
+              });
+            },
+          ),
+          const Divider(height: 1),
+          _InlineSwitchTile(
+            title: '南海トラフ臨時情報',
+            subtitle:
+                settings.nankaiExtraordinaryEnabled ? '通知する' : '通知しない',
+            value: settings.nankaiExtraordinaryEnabled,
+            onChanged: ({required value}) async {
+              await GeneralNotificationSettingsNotifier.updateSettingsMutation
+                  .run(ref, (tsx) async {
+                await tsx
+                    .get(generalNotificationSettingsProvider.notifier)
+                    .updateSettings(nankaiExtraordinaryEnabled: value);
+              });
+            },
+          ),
+          const Divider(height: 1),
+          _InlineSwitchTile(
+            title: '南海トラフ定例情報',
+            subtitle: settings.nankaiRegularEnabled ? '通知する' : '通知しない',
+            value: settings.nankaiRegularEnabled,
+            onChanged: ({required value}) async {
+              await GeneralNotificationSettingsNotifier.updateSettingsMutation
+                  .run(ref, (tsx) async {
+                await tsx
+                    .get(generalNotificationSettingsProvider.notifier)
+                    .updateSettings(nankaiRegularEnabled: value);
+              });
+            },
+          ),
+          const Divider(height: 1),
+          _InlineSwitchTile(
+            title: '北海道三連動（十勝沖）',
+            subtitle:
+                settings.hokkaido3renOffshoreEnabled ? '通知する' : '通知しない',
+            value: settings.hokkaido3renOffshoreEnabled,
+            onChanged: ({required value}) async {
+              await GeneralNotificationSettingsNotifier.updateSettingsMutation
+                  .run(ref, (tsx) async {
+                await tsx
+                    .get(generalNotificationSettingsProvider.notifier)
+                    .updateSettings(hokkaido3renOffshoreEnabled: value);
+              });
+            },
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- `GeneralNotificationSettings` に欠落していた3フィールド追加: `nankaiExtraordinaryEnabled`, `nankaiRegularEnabled`, `hokkaido3renOffshoreEnabled`
- `GeneralNotificationSettingsNotifier` を新規作成（keepAlive + Mutationパターン）
- 通知設定画面に「その他の通知」セクション追加: 津波・訓練・南海トラフ臨時/定例・北海道三連動の5項目トグル
- `NotificationPresetNotifier` 新規作成: 推奨/カスタムプリセットをSharedPreferencesで永続化
- マスタースイッチ（notification_enabled）はAPI型未追加のため保留（BE PR #742でサーバー側は対応済み、eqmonitor_apiパッケージの型更新後に接続）
- デバッグページ2箇所の`GeneralNotificationSettings`構築を新フィールド対応に修正

closes #1380
closes #1377

## Test plan
- [ ] 「その他の通知」セクションの各トグルがAPI PATCHと連動
- [ ] 津波・訓練・南海トラフ・北海道三連動の設定が保存・復元される
- [ ] プリセット選択（推奨/カスタム）が画面遷移後も保持される
- [ ] エラー時にSnackBar表示
- [ ] デバッグページでビルドエラーなし