### PR TITLE
fix: 通知設定v2 レビュー指摘3件修正

### DIFF
--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -575,6 +575,8 @@ class _NotificationSettingsSection extends HookConsumerWidget {
     );
     final settings = settingsAsync.value;
     final isBusy = useState(false);
+    final notificationEnabled =
+        useState(settings?.notificationEnabled ?? true);
     final tsunami = useState(settings?.tsunamiEnabled ?? false);
     final training = useState(settings?.trainingEnabled ?? false);
     final nankaiExtraordinary = useState(
@@ -587,6 +589,8 @@ class _NotificationSettingsSection extends HookConsumerWidget {
 
     ref.listen(_notificationSettingsProvider(deviceId), (_, next) {
       if (next.value != null) {
+        notificationEnabled.value =
+            next.requireValue.notificationEnabled;
         tsunami.value = next.requireValue.tsunamiEnabled;
         training.value = next.requireValue.trainingEnabled;
         nankaiExtraordinary.value =
@@ -608,6 +612,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
       final result = await notificationRepository.patchNotificationSettings(
         deviceId: deviceId,
         settings: GeneralNotificationSettings(
+          notificationEnabled: notificationEnabled.value,
           tsunamiEnabled: tsunami.value,
           trainingEnabled: training.value,
           nankaiExtraordinaryEnabled: nankaiExtraordinary.value,

--- a/app/lib/feature/notification/data/model/general_notification_settings.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.dart
@@ -6,6 +6,7 @@ part 'general_notification_settings.freezed.dart';
 @freezed
 abstract class GeneralNotificationSettings with _$GeneralNotificationSettings {
   const factory GeneralNotificationSettings({
+    required bool notificationEnabled,
     required bool tsunamiEnabled,
     required bool trainingEnabled,
     required bool nankaiExtraordinaryEnabled,
@@ -18,6 +19,7 @@ extension GeneralNotificationSettingsApiExtension
     on api.NotificationSettingsResponse {
   GeneralNotificationSettings get toGeneralNotificationSettings =>
       GeneralNotificationSettings(
+        notificationEnabled: notificationEnabled,
         tsunamiEnabled: tsunamiEnabled,
         trainingEnabled: trainingEnabled,
         nankaiExtraordinaryEnabled: nankaiExtraordinaryEnabled,

--- a/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GeneralNotificationSettings {
 
- bool get tsunamiEnabled; bool get trainingEnabled; bool get nankaiExtraordinaryEnabled; bool get nankaiRegularEnabled; bool get hokkaido3renOffshoreEnabled;
+ bool get notificationEnabled; bool get tsunamiEnabled; bool get trainingEnabled; bool get nankaiExtraordinaryEnabled; bool get nankaiRegularEnabled; bool get hokkaido3renOffshoreEnabled;
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $GeneralNotificationSettingsCopyWith<GeneralNotificationSettings> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $GeneralNotificationSettingsCopyWith<$Res>  {
   factory $GeneralNotificationSettingsCopyWith(GeneralNotificationSettings value, $Res Function(GeneralNotificationSettings) _then) = _$GeneralNotificationSettingsCopyWithImpl;
 @useResult
 $Res call({
- bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
+ bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
 });
 
 
@@ -62,9 +62,10 @@ class _$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
   return _then(_self.copyWith(
-tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
+as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
@@ -154,10 +155,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return orElse();
 
 }
@@ -175,10 +176,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings():
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -195,10 +196,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return null;
 
 }
@@ -210,9 +211,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 
 
 class _GeneralNotificationSettings implements GeneralNotificationSettings {
-  const _GeneralNotificationSettings({required this.tsunamiEnabled, required this.trainingEnabled, required this.nankaiExtraordinaryEnabled, required this.nankaiRegularEnabled, required this.hokkaido3renOffshoreEnabled});
+  const _GeneralNotificationSettings({required this.notificationEnabled, required this.tsunamiEnabled, required this.trainingEnabled, required this.nankaiExtraordinaryEnabled, required this.nankaiRegularEnabled, required this.hokkaido3renOffshoreEnabled});
   
 
+@override final  bool notificationEnabled;
 @override final  bool tsunamiEnabled;
 @override final  bool trainingEnabled;
 @override final  bool nankaiExtraordinaryEnabled;
@@ -229,16 +231,16 @@ _$GeneralNotificationSettingsCopyWith<_GeneralNotificationSettings> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -249,7 +251,7 @@ abstract mixin class _$GeneralNotificationSettingsCopyWith<$Res> implements $Gen
   factory _$GeneralNotificationSettingsCopyWith(_GeneralNotificationSettings value, $Res Function(_GeneralNotificationSettings) _then) = __$GeneralNotificationSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
+ bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
 });
 
 
@@ -266,9 +268,10 @@ class __$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
   return _then(_GeneralNotificationSettings(
-tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
+as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable

--- a/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
+++ b/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
@@ -29,6 +29,7 @@ class GeneralNotificationSettingsNotifier
   }
 
   Future<void> updateSettings({
+    bool? notificationEnabled,
     bool? tsunamiEnabled,
     bool? trainingEnabled,
     bool? nankaiExtraordinaryEnabled,
@@ -41,6 +42,8 @@ class GeneralNotificationSettingsNotifier
     final result = await repo.patchNotificationSettings(
       deviceId: deviceId,
       settings: current.copyWith(
+        notificationEnabled:
+            notificationEnabled ?? current.notificationEnabled,
         tsunamiEnabled: tsunamiEnabled ?? current.tsunamiEnabled,
         trainingEnabled: trainingEnabled ?? current.trainingEnabled,
         nankaiExtraordinaryEnabled:

--- a/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.g.dart
+++ b/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.g.dart
@@ -43,7 +43,7 @@ final class GeneralNotificationSettingsNotifierProvider
 }
 
 String _$generalNotificationSettingsNotifierHash() =>
-    r'e12d6797267f136155fb407fe510b97948527fcf';
+    r'41f8811624256234e65ad6c39287d14ad13b1385';
 
 abstract class _$GeneralNotificationSettingsNotifier
     extends $AsyncNotifier<GeneralNotificationSettings> {

--- a/app/lib/feature/notification/data/repository/push_notification_repository.dart
+++ b/app/lib/feature/notification/data/repository/push_notification_repository.dart
@@ -30,6 +30,7 @@ class PushNotificationRepository {
   }) => Result.capture(() async {
     final response = await _api.device.patchV2DeviceMeSettingsNotification(
       body: api.NotificationSettingsRequest(
+        notificationEnabled: settings.notificationEnabled,
         tsunamiEnabled: settings.tsunamiEnabled,
         trainingEnabled: settings.trainingEnabled,
         nankaiExtraordinaryEnabled: settings.nankaiExtraordinaryEnabled,

--- a/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
@@ -28,6 +28,9 @@ class _NotificationSettingsStepPage extends HookConsumerWidget {
         await createCurrentLocationSlot();
         if (context.mounted) {
           isProcessing.value = false;
+          ref
+              .read(notificationPresetProvider.notifier)
+              .select(NotificationPreset.recommended);
           await scope.nextPage();
         }
       } on Exception catch (e) {
@@ -58,6 +61,9 @@ class _NotificationSettingsStepPage extends HookConsumerWidget {
             return;
           }
           isProcessing.value = false;
+          ref
+              .read(notificationPresetProvider.notifier)
+              .select(NotificationPreset.custom);
           await Navigator.of(context).push<void>(
             MaterialPageRoute<void>(
               builder: (_) => const _OnboardingCustomSettingsWrapper(),

--- a/app/lib/feature/onboarding/ui/page/onboarding_page.dart
+++ b/app/lib/feature/onboarding/ui/page/onboarding_page.dart
@@ -11,6 +11,7 @@ import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exc
 import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
 import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.dart';
 import 'package:eqmonitor/feature/onboarding/ui/component/onboarding_provisioning_error_details_dialog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -130,6 +130,8 @@ class _Body extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isBusy = useState(false);
+    final notificationEnabled =
+        useState(settings?.notificationEnabled ?? true);
     final tsunami = useState(settings?.tsunamiEnabled ?? false);
     final training = useState(settings?.trainingEnabled ?? false);
     final nankaiExtraordinary = useState(
@@ -141,6 +143,7 @@ class _Body extends HookConsumerWidget {
     );
 
     useEffect(() {
+      notificationEnabled.value = settings?.notificationEnabled ?? true;
       tsunami.value = settings?.tsunamiEnabled ?? false;
       training.value = settings?.trainingEnabled ?? false;
       nankaiExtraordinary.value =
@@ -262,6 +265,7 @@ class _Body extends HookConsumerWidget {
         final result = await repo.patchNotificationSettings(
           deviceId: deviceId,
           settings: GeneralNotificationSettings(
+            notificationEnabled: notificationEnabled.value,
             tsunamiEnabled: tsunami.value,
             trainingEnabled: training.value,
             nankaiExtraordinaryEnabled: nankaiExtraordinary.value,

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
@@ -44,7 +44,7 @@ final class NotificationPresetNotifierProvider
 }
 
 String _$notificationPresetNotifierHash() =>
-    r'14576500bcf5e44676c8d81b0904d3d71dfa4086';
+    r'4816373a945f603adeab097a03d4ddbce7cab7b5';
 
 abstract class _$NotificationPresetNotifier
     extends $Notifier<NotificationPreset> {

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -10,6 +10,7 @@ import 'package:eqmonitor/feature/notification/data/notifier/general_notificatio
 import 'package:eqmonitor/feature/notification/data/repository/push_notification_repository.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_warning_settings.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.dart';
@@ -42,7 +43,10 @@ class _Body extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final notificationsEnabled = useState(true);
+    final notificationsEnabled = ref.watch(
+      generalNotificationSettingsProvider
+          .select((s) => s.value?.notificationEnabled ?? true),
+    );
     final selectedPreset = ref.watch(notificationPresetProvider);
 
     final constraints = ref.watch(startProvider).value?.planConstraints.free;
@@ -77,10 +81,19 @@ class _Body extends HookConsumerWidget {
       padding: const EdgeInsets.only(top: 16, bottom: 24),
       children: [
         _MasterNotificationControl(
-          value: notificationsEnabled.value,
-          onChanged: (value) => notificationsEnabled.value = value,
+          value: notificationsEnabled,
+          onChanged: (value) async {
+            await GeneralNotificationSettingsNotifier.updateSettingsMutation.run(
+              ref,
+              (tsx) async {
+                await tsx
+                    .get(generalNotificationSettingsProvider.notifier)
+                    .updateSettings(notificationEnabled: value);
+              },
+            );
+          },
         ),
-        if (notificationsEnabled.value) ...[
+        if (notificationsEnabled) ...[
           const SettingsSectionHeader(text: '通知条件'),
           _PresetOptionGroup(
             selectedPreset: selectedPreset,
@@ -664,13 +677,27 @@ class _EewWarningSettingsPage extends ConsumerWidget {
       }
     });
 
-    final target = ref.watch(eewWarningConfigProvider).value?.target;
+    final config = ref.watch(eewWarningConfigProvider).value;
+    final target = config?.target;
+    final nationwideLevel = config?.nationwideInterruptionLevel;
 
     Future<void> select(EewWarningTarget value) async {
       await EewWarningConfigNotifier.updateConfigMutation.run(ref, (tsx) async {
+        await tsx.get(eewWarningConfigProvider.notifier).updateConfig(
+          target: value,
+          nationwideInterruptionLevel:
+              value == EewWarningTarget.currentLocationAndNationwide
+                  ? InterruptionLevel.active
+                  : null,
+        );
+      });
+    }
+
+    Future<void> updateNationwideLevel(InterruptionLevel value) async {
+      await EewWarningConfigNotifier.updateConfigMutation.run(ref, (tsx) async {
         await tsx
             .get(eewWarningConfigProvider.notifier)
-            .updateConfig(target: value);
+            .updateConfig(nationwideInterruptionLevel: value);
       });
     }
 
@@ -695,6 +722,25 @@ class _EewWarningSettingsPage extends ConsumerWidget {
             onTap: () async =>
                 select(EewWarningTarget.currentLocationAndNationwide),
           ),
+          if (target == EewWarningTarget.currentLocationAndNationwide) ...[
+            const SettingsSectionHeader(text: '全国の割り込みレベル'),
+            RadioGroup<InterruptionLevel>(
+              groupValue: nationwideLevel,
+              onChanged: (v) async => updateNationwideLevel(v!),
+              child: const Column(
+                children: [
+                  RadioListTile<InterruptionLevel>(
+                    title: Text('通常'),
+                    value: InterruptionLevel.active,
+                  ),
+                  RadioListTile<InterruptionLevel>(
+                    title: Text('サイレント'),
+                    value: InterruptionLevel.passive,
+                  ),
+                ],
+              ),
+            ),
+          ],
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: Text(

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -1,7 +1,6 @@
 import 'package:app_settings/app_settings.dart';
 import 'package:eqmonitor/core/component/error/error_message_builder.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
-import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
@@ -17,6 +16,7 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/n
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/region_picker_page.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';

--- a/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/slot_detail_page.dart
@@ -1,12 +1,12 @@
 import 'package:eqmonitor/core/component/error/error_message_builder.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
-import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_error_dialog.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/override_edit_page.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_request.dart
@@ -10,6 +10,8 @@ part 'notification_settings_request.g.dart';
 @Freezed()
 abstract class NotificationSettingsRequest with _$NotificationSettingsRequest {
   const factory NotificationSettingsRequest({
+    @JsonKey(includeIfNull: false,name: 'notification_enabled')
+    bool? notificationEnabled,
     @JsonKey(includeIfNull: false,name: 'tsunami_enabled')
     bool? tsunamiEnabled,
     @JsonKey(includeIfNull: false,name: 'training_enabled')

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_request.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NotificationSettingsRequest {
 
-@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? get tsunamiEnabled;@JsonKey(includeIfNull: false, name: 'training_enabled') bool? get trainingEnabled;@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? get nankaiExtraordinaryEnabled;@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? get nankaiRegularEnabled;@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? get hokkaido3renOffshoreEnabled;
+@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? get notificationEnabled;@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? get tsunamiEnabled;@JsonKey(includeIfNull: false, name: 'training_enabled') bool? get trainingEnabled;@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? get nankaiExtraordinaryEnabled;@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? get nankaiRegularEnabled;@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? get hokkaido3renOffshoreEnabled;
 /// Create a copy of NotificationSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $NotificationSettingsRequestCopyWith<NotificationSettingsRequest> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsRequest&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsRequest&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsRequest(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsRequest(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $NotificationSettingsRequestCopyWith<$Res>  {
   factory $NotificationSettingsRequestCopyWith(NotificationSettingsRequest value, $Res Function(NotificationSettingsRequest) _then) = _$NotificationSettingsRequestCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? hokkaido3renOffshoreEnabled
+@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? notificationEnabled,@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? hokkaido3renOffshoreEnabled
 });
 
 
@@ -65,9 +65,10 @@ class _$NotificationSettingsRequestCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? hokkaido3renOffshoreEnabled = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = freezed,Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? hokkaido3renOffshoreEnabled = freezed,}) {
   return _then(_self.copyWith(
-tsunamiEnabled: freezed == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+notificationEnabled: freezed == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
+as bool?,tsunamiEnabled: freezed == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,trainingEnabled: freezed == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiExtraordinaryEnabled: freezed == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiRegularEnabled: freezed == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
@@ -157,10 +158,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NotificationSettingsRequest() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return orElse();
 
 }
@@ -178,10 +179,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsRequest():
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -198,10 +199,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsRequest() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return null;
 
 }
@@ -213,9 +214,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 @JsonSerializable()
 
 class _NotificationSettingsRequest implements NotificationSettingsRequest {
-  const _NotificationSettingsRequest({@JsonKey(includeIfNull: false, name: 'tsunami_enabled') this.tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled') this.trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') this.nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') this.nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') this.hokkaido3renOffshoreEnabled});
+  const _NotificationSettingsRequest({@JsonKey(includeIfNull: false, name: 'notification_enabled') this.notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled') this.tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled') this.trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') this.nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') this.nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') this.hokkaido3renOffshoreEnabled});
   factory _NotificationSettingsRequest.fromJson(Map<String, dynamic> json) => _$NotificationSettingsRequestFromJson(json);
 
+@override@JsonKey(includeIfNull: false, name: 'notification_enabled') final  bool? notificationEnabled;
 @override@JsonKey(includeIfNull: false, name: 'tsunami_enabled') final  bool? tsunamiEnabled;
 @override@JsonKey(includeIfNull: false, name: 'training_enabled') final  bool? trainingEnabled;
 @override@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') final  bool? nankaiExtraordinaryEnabled;
@@ -235,16 +237,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsRequest&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsRequest&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsRequest(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsRequest(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -255,7 +257,7 @@ abstract mixin class _$NotificationSettingsRequestCopyWith<$Res> implements $Not
   factory _$NotificationSettingsRequestCopyWith(_NotificationSettingsRequest value, $Res Function(_NotificationSettingsRequest) _then) = __$NotificationSettingsRequestCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? hokkaido3renOffshoreEnabled
+@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? notificationEnabled,@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? hokkaido3renOffshoreEnabled
 });
 
 
@@ -272,9 +274,10 @@ class __$NotificationSettingsRequestCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? hokkaido3renOffshoreEnabled = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = freezed,Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? hokkaido3renOffshoreEnabled = freezed,}) {
   return _then(_NotificationSettingsRequest(
-tsunamiEnabled: freezed == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+notificationEnabled: freezed == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
+as bool?,tsunamiEnabled: freezed == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,trainingEnabled: freezed == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiExtraordinaryEnabled: freezed == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiRegularEnabled: freezed == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_request.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_request.g.dart
@@ -15,6 +15,10 @@ _NotificationSettingsRequest _$NotificationSettingsRequestFromJson(
   json,
   ($checkedConvert) {
     final val = _NotificationSettingsRequest(
+      notificationEnabled: $checkedConvert(
+        'notification_enabled',
+        (v) => v as bool?,
+      ),
       tsunamiEnabled: $checkedConvert('tsunami_enabled', (v) => v as bool?),
       trainingEnabled: $checkedConvert('training_enabled', (v) => v as bool?),
       nankaiExtraordinaryEnabled: $checkedConvert(
@@ -33,6 +37,7 @@ _NotificationSettingsRequest _$NotificationSettingsRequestFromJson(
     return val;
   },
   fieldKeyMap: const {
+    'notificationEnabled': 'notification_enabled',
     'tsunamiEnabled': 'tsunami_enabled',
     'trainingEnabled': 'training_enabled',
     'nankaiExtraordinaryEnabled': 'nankai_extraordinary_enabled',
@@ -44,6 +49,7 @@ _NotificationSettingsRequest _$NotificationSettingsRequestFromJson(
 Map<String, dynamic> _$NotificationSettingsRequestToJson(
   _NotificationSettingsRequest instance,
 ) => <String, dynamic>{
+  'notification_enabled': ?instance.notificationEnabled,
   'tsunami_enabled': ?instance.tsunamiEnabled,
   'training_enabled': ?instance.trainingEnabled,
   'nankai_extraordinary_enabled': ?instance.nankaiExtraordinaryEnabled,

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_response.dart
@@ -10,6 +10,8 @@ part 'notification_settings_response.g.dart';
 @Freezed()
 abstract class NotificationSettingsResponse with _$NotificationSettingsResponse {
   const factory NotificationSettingsResponse({
+    @JsonKey(name: 'notification_enabled')
+    required bool notificationEnabled,
     @JsonKey(name: 'tsunami_enabled')
     required bool tsunamiEnabled,
     @JsonKey(name: 'training_enabled')

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_response.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NotificationSettingsResponse {
 
-@JsonKey(name: 'tsunami_enabled') bool get tsunamiEnabled;@JsonKey(name: 'training_enabled') bool get trainingEnabled;@JsonKey(name: 'nankai_extraordinary_enabled') bool get nankaiExtraordinaryEnabled;@JsonKey(name: 'nankai_regular_enabled') bool get nankaiRegularEnabled;@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool get hokkaido3renOffshoreEnabled;
+@JsonKey(name: 'notification_enabled') bool get notificationEnabled;@JsonKey(name: 'tsunami_enabled') bool get tsunamiEnabled;@JsonKey(name: 'training_enabled') bool get trainingEnabled;@JsonKey(name: 'nankai_extraordinary_enabled') bool get nankaiExtraordinaryEnabled;@JsonKey(name: 'nankai_regular_enabled') bool get nankaiRegularEnabled;@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool get hokkaido3renOffshoreEnabled;
 /// Create a copy of NotificationSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $NotificationSettingsResponseCopyWith<NotificationSettingsResponse> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsResponse&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsResponse&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsResponse(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsResponse(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $NotificationSettingsResponseCopyWith<$Res>  {
   factory $NotificationSettingsResponseCopyWith(NotificationSettingsResponse value, $Res Function(NotificationSettingsResponse) _then) = _$NotificationSettingsResponseCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool hokkaido3renOffshoreEnabled
+@JsonKey(name: 'notification_enabled') bool notificationEnabled,@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool hokkaido3renOffshoreEnabled
 });
 
 
@@ -65,9 +65,10 @@ class _$NotificationSettingsResponseCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
   return _then(_self.copyWith(
-tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
+as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
@@ -157,10 +158,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NotificationSettingsResponse() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return orElse();
 
 }
@@ -178,10 +179,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsResponse():
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -198,10 +199,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsResponse() when $default != null:
-return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
   return null;
 
 }
@@ -213,9 +214,10 @@ return $default(_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordi
 @JsonSerializable()
 
 class _NotificationSettingsResponse implements NotificationSettingsResponse {
-  const _NotificationSettingsResponse({@JsonKey(name: 'tsunami_enabled') required this.tsunamiEnabled, @JsonKey(name: 'training_enabled') required this.trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled') required this.nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled') required this.nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled') required this.hokkaido3renOffshoreEnabled});
+  const _NotificationSettingsResponse({@JsonKey(name: 'notification_enabled') required this.notificationEnabled, @JsonKey(name: 'tsunami_enabled') required this.tsunamiEnabled, @JsonKey(name: 'training_enabled') required this.trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled') required this.nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled') required this.nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled') required this.hokkaido3renOffshoreEnabled});
   factory _NotificationSettingsResponse.fromJson(Map<String, dynamic> json) => _$NotificationSettingsResponseFromJson(json);
 
+@override@JsonKey(name: 'notification_enabled') final  bool notificationEnabled;
 @override@JsonKey(name: 'tsunami_enabled') final  bool tsunamiEnabled;
 @override@JsonKey(name: 'training_enabled') final  bool trainingEnabled;
 @override@JsonKey(name: 'nankai_extraordinary_enabled') final  bool nankaiExtraordinaryEnabled;
@@ -235,16 +237,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsResponse&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsResponse&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsResponse(tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsResponse(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
 }
 
 
@@ -255,7 +257,7 @@ abstract mixin class _$NotificationSettingsResponseCopyWith<$Res> implements $No
   factory _$NotificationSettingsResponseCopyWith(_NotificationSettingsResponse value, $Res Function(_NotificationSettingsResponse) _then) = __$NotificationSettingsResponseCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool hokkaido3renOffshoreEnabled
+@JsonKey(name: 'notification_enabled') bool notificationEnabled,@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool hokkaido3renOffshoreEnabled
 });
 
 
@@ -272,9 +274,10 @@ class __$NotificationSettingsResponseCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
   return _then(_NotificationSettingsResponse(
-tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
+notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
+as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_response.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_response.g.dart
@@ -15,6 +15,10 @@ _NotificationSettingsResponse _$NotificationSettingsResponseFromJson(
   json,
   ($checkedConvert) {
     final val = _NotificationSettingsResponse(
+      notificationEnabled: $checkedConvert(
+        'notification_enabled',
+        (v) => v as bool,
+      ),
       tsunamiEnabled: $checkedConvert('tsunami_enabled', (v) => v as bool),
       trainingEnabled: $checkedConvert('training_enabled', (v) => v as bool),
       nankaiExtraordinaryEnabled: $checkedConvert(
@@ -33,6 +37,7 @@ _NotificationSettingsResponse _$NotificationSettingsResponseFromJson(
     return val;
   },
   fieldKeyMap: const {
+    'notificationEnabled': 'notification_enabled',
     'tsunamiEnabled': 'tsunami_enabled',
     'trainingEnabled': 'training_enabled',
     'nankaiExtraordinaryEnabled': 'nankai_extraordinary_enabled',
@@ -44,6 +49,7 @@ _NotificationSettingsResponse _$NotificationSettingsResponseFromJson(
 Map<String, dynamic> _$NotificationSettingsResponseToJson(
   _NotificationSettingsResponse instance,
 ) => <String, dynamic>{
+  'notification_enabled': instance.notificationEnabled,
   'tsunami_enabled': instance.tsunamiEnabled,
   'training_enabled': instance.trainingEnabled,
   'nankai_extraordinary_enabled': instance.nankaiExtraordinaryEnabled,


### PR DESCRIPTION
## Summary
通知設定v2の実装レビューで発見された3件のバグを修正。

### 1. notification_enabled マスタースイッチ接続
- eqmonitor_apiの `NotificationSettingsResponse/Request` に `notification_enabled` フィールド追加
- `GeneralNotificationSettings` モデル + Repository + Notifier に対応フィールド追加
- `_MasterNotificationControl` の useState を `ref.watch(generalNotificationSettingsProvider)` に置換、API連動に変更

### 2. EEW警報 nationwide_interruption_level UI
- `currentLocationAndNationwide` 選択時にデフォルト `InterruptionLevel.active` を送信（400エラー回避）
- 「全国の割り込みレベル」セクション追加（通常/サイレント選択 = active/passive）

### 3. オンボーディング プリセット同期
- 推奨/カスタム選択時に `NotificationPresetNotifier.select()` を呼び出し、SharedPreferencesに永続化
- オンボーディング後に設定画面を開いても選択が保持される

### 追加修正
- `OverrideEditPage`: `interruptionLevel.name` → `.label` に修正（日本語表示）
- デバッグページ2箇所の `GeneralNotificationSettings` 構築に `notificationEnabled` 追加

## Test plan
- [ ] マスタースイッチのON/OFFがAPI PATCHと連動し、画面遷移後も保持
- [ ] マスタースイッチOFF時にサーバーが通知を配信しないことを確認
- [ ] EEW警報で「現在地+全国」選択時に400エラーが出ないことを確認
- [ ] 全国の割り込みレベル（通常/サイレント）の切り替えが保存されること
- [ ] オンボーディングで推奨/カスタム選択後、設定画面でプリセットが保持されること
- [ ] 震度別オーバーライドUIで割り込みレベルが日本語表示されること