### PR TITLE
[codex] 通知スロット有効化時に最小震度を補完

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
@@ -10,6 +10,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'notification_slot_repository.g.dart';
 
+const JmaIntensity defaultNotificationSlotMinIntensity = JmaIntensity.three;
+
 @Riverpod(keepAlive: true)
 Future<NotificationSlotRepository> notificationSlotRepository(Ref ref) async =>
     NotificationSlotRepository(await ref.watch(apiClientProvider.future));
@@ -34,18 +36,27 @@ class NotificationSlotRepository {
     JmaIntensity? earthquakeMinIntensity,
     List<NotificationOverride>? earthquakeOverrides,
   }) async {
-    final response =
-        await _api.device.putV2DeviceMeSettingsSlotsCurrentLocation(
-      body: api.UpsertSingletonSlotRequest(
-        eewEnabled: eewEnabled,
-        eewMinIntensity: eewMinIntensity?.toApiJmaIntensity,
-        eewOverrides: eewOverrides?.map((o) => o.toApiSlotOverride()).toList(),
-        earthquakeEnabled: earthquakeEnabled,
-        earthquakeMinIntensity: earthquakeMinIntensity?.toApiJmaIntensity,
-        earthquakeOverrides:
-            earthquakeOverrides?.map((o) => o.toApiSlotOverride()).toList(),
-      ),
-    );
+    final response = await _api.device
+        .putV2DeviceMeSettingsSlotsCurrentLocation(
+          body: api.UpsertSingletonSlotRequest(
+            eewEnabled: eewEnabled,
+            eewMinIntensity: resolveNotificationSlotMinIntensity(
+              enabled: eewEnabled,
+              minIntensity: eewMinIntensity,
+            )?.toApiJmaIntensity,
+            eewOverrides: eewOverrides
+                ?.map((o) => o.toApiSlotOverride())
+                .toList(),
+            earthquakeEnabled: earthquakeEnabled,
+            earthquakeMinIntensity: resolveNotificationSlotMinIntensity(
+              enabled: earthquakeEnabled,
+              minIntensity: earthquakeMinIntensity,
+            )?.toApiJmaIntensity,
+            earthquakeOverrides: earthquakeOverrides
+                ?.map((o) => o.toApiSlotOverride())
+                .toList(),
+          ),
+        );
     return response.data.toNotificationSlot();
   }
 
@@ -64,12 +75,19 @@ class NotificationSlotRepository {
     final response = await _api.device.putV2DeviceMeSettingsSlotsNationwide(
       body: api.UpsertSingletonSlotRequest(
         eewEnabled: eewEnabled,
-        eewMinIntensity: eewMinIntensity?.toApiJmaIntensity,
+        eewMinIntensity: resolveNotificationSlotMinIntensity(
+          enabled: eewEnabled,
+          minIntensity: eewMinIntensity,
+        )?.toApiJmaIntensity,
         eewOverrides: eewOverrides?.map((o) => o.toApiSlotOverride()).toList(),
         earthquakeEnabled: earthquakeEnabled,
-        earthquakeMinIntensity: earthquakeMinIntensity?.toApiJmaIntensity,
-        earthquakeOverrides:
-            earthquakeOverrides?.map((o) => o.toApiSlotOverride()).toList(),
+        earthquakeMinIntensity: resolveNotificationSlotMinIntensity(
+          enabled: earthquakeEnabled,
+          minIntensity: earthquakeMinIntensity,
+        )?.toApiJmaIntensity,
+        earthquakeOverrides: earthquakeOverrides
+            ?.map((o) => o.toApiSlotOverride())
+            .toList(),
       ),
     );
     return response.data.toNotificationSlot();
@@ -98,12 +116,19 @@ class NotificationSlotRepository {
         cityCode: cityCode,
         cityName: cityName,
         eewEnabled: eewEnabled,
-        eewMinIntensity: eewMinIntensity?.toApiJmaIntensity,
+        eewMinIntensity: resolveNotificationSlotMinIntensity(
+          enabled: eewEnabled,
+          minIntensity: eewMinIntensity,
+        )?.toApiJmaIntensity,
         eewOverrides: eewOverrides?.map((o) => o.toApiSlotOverride()).toList(),
         earthquakeEnabled: earthquakeEnabled,
-        earthquakeMinIntensity: earthquakeMinIntensity?.toApiJmaIntensity,
-        earthquakeOverrides:
-            earthquakeOverrides?.map((o) => o.toApiSlotOverride()).toList(),
+        earthquakeMinIntensity: resolveNotificationSlotMinIntensity(
+          enabled: earthquakeEnabled,
+          minIntensity: earthquakeMinIntensity,
+        )?.toApiJmaIntensity,
+        earthquakeOverrides: earthquakeOverrides
+            ?.map((o) => o.toApiSlotOverride())
+            .toList(),
       ),
     );
     return response.data.toNotificationSlot();
@@ -121,22 +146,31 @@ class NotificationSlotRepository {
     JmaIntensity? earthquakeMinIntensity,
     List<NotificationOverride>? earthquakeOverrides,
   }) async {
-    final response =
-        await _api.device.patchV2DeviceMeSettingsSlotsRegionsSlotId(
-      slotId: slotId,
-      body: api.UpdateRegionSlotRequest(
-        regionName: regionName,
-        cityCode: cityCode,
-        cityName: cityName,
-        eewEnabled: eewEnabled,
-        eewMinIntensity: eewMinIntensity?.toApiJmaIntensity,
-        eewOverrides: eewOverrides?.map((o) => o.toApiSlotOverride()).toList(),
-        earthquakeEnabled: earthquakeEnabled,
-        earthquakeMinIntensity: earthquakeMinIntensity?.toApiJmaIntensity,
-        earthquakeOverrides:
-            earthquakeOverrides?.map((o) => o.toApiSlotOverride()).toList(),
-      ),
-    );
+    final response = await _api.device
+        .patchV2DeviceMeSettingsSlotsRegionsSlotId(
+          slotId: slotId,
+          body: api.UpdateRegionSlotRequest(
+            regionName: regionName,
+            cityCode: cityCode,
+            cityName: cityName,
+            eewEnabled: eewEnabled,
+            eewMinIntensity: resolveNotificationSlotMinIntensity(
+              enabled: eewEnabled,
+              minIntensity: eewMinIntensity,
+            )?.toApiJmaIntensity,
+            eewOverrides: eewOverrides
+                ?.map((o) => o.toApiSlotOverride())
+                .toList(),
+            earthquakeEnabled: earthquakeEnabled,
+            earthquakeMinIntensity: resolveNotificationSlotMinIntensity(
+              enabled: earthquakeEnabled,
+              minIntensity: earthquakeMinIntensity,
+            )?.toApiJmaIntensity,
+            earthquakeOverrides: earthquakeOverrides
+                ?.map((o) => o.toApiSlotOverride())
+                .toList(),
+          ),
+        );
     return response.data.toNotificationSlot();
   }
 
@@ -222,4 +256,14 @@ class NotificationSlotRepository {
     );
     return response.data.toEarthquakeGlobalSettings();
   }
+}
+
+JmaIntensity? resolveNotificationSlotMinIntensity({
+  required bool? enabled,
+  required JmaIntensity? minIntensity,
+}) {
+  if (enabled != true) {
+    return minIntensity;
+  }
+  return minIntensity ?? defaultNotificationSlotMinIntensity;
 }

--- a/app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart
@@ -64,6 +64,49 @@ void main() {
     });
   });
 
+  group('updateRegion', () {
+    test('sends default eew minimum intensity when enabling eew', () async {
+      await repository.updateRegion(
+        slotId: 'slot-123',
+        eewEnabled: true,
+        earthquakeEnabled: false,
+      );
+
+      expect(adapter.lastRequestBody!['eew_enabled'], isTrue);
+      expect(
+        adapter.lastRequestBody!['eew_min_intensity'],
+        api.JmaIntensity.value3,
+      );
+      expect(adapter.lastRequestBody!['earthquake_enabled'], isFalse);
+      expect(
+        adapter.lastRequestBody!.containsKey('earthquake_min_intensity'),
+        isFalse,
+      );
+    });
+
+    test(
+      'sends default earthquake minimum intensity when enabling earthquake',
+      () async {
+        await repository.updateRegion(
+          slotId: 'slot-123',
+          eewEnabled: false,
+          earthquakeEnabled: true,
+        );
+
+        expect(adapter.lastRequestBody!['eew_enabled'], isFalse);
+        expect(
+          adapter.lastRequestBody!.containsKey('eew_min_intensity'),
+          isFalse,
+        );
+        expect(adapter.lastRequestBody!['earthquake_enabled'], isTrue);
+        expect(
+          adapter.lastRequestBody!['earthquake_min_intensity'],
+          api.JmaIntensity.value3,
+        );
+      },
+    );
+  });
+
   group('removeRegion', () {
     test('sends delete request', () async {
       await repository.removeRegion(slotId: 'slot-123');


### PR DESCRIPTION
## Summary
- 通知スロット request 生成時に、EEW / 地震情報を有効化する payload で最小震度が null の場合は既定の `JmaIntensity.three` を補完します。
- 地域スロット PATCH の回帰テストを追加し、`enabled=true` だけを送って DB CHECK 制約に違反する payload を防ぎます。
- `origin/develop` を取り込み、WebSocket ticket refresh 側の最新変更とも衝突しない状態にしています。

## Root Cause
地域スロット作成時に最小震度が未設定のまま作られ、その後 EEW / 地震情報を有効化すると、PATCH body から最小震度が省略されていました。API 側の CHECK 制約では `enabled=true` の場合に最小震度が必須のため、制約違反になっていました。

## Validation
- `mise exec -- flutter test app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart app/test/core/realtime/eqmonitor_ws_provider_test.dart`
- `mise exec -- flutter analyze app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart app/test/core/realtime/eqmonitor_ws_provider_test.dart`
- `git --no-pager diff --check`