### PR TITLE
feat: 推計震度分布図の初回表示時に注意ダイアログを表示

### DIFF
--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -28,6 +28,7 @@ enum SharedPreferencesKey {
   autoReturnToRealtime('auto_return_to_realtime'),
   earthquakeHistoryMapLayerParameter('earthquake_history_map_layer_parameter'),
   homeMapLabelParameter('home_map_label_parameter'),
+  estimatedIntensityNoticeShown('estimated_intensity_notice_shown'),
   ;
 
   const SharedPreferencesKey(this.key);

--- a/app/lib/feature/earthquake_history/data/notifier/estimated_intensity_notice_notifier.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/estimated_intensity_notice_notifier.dart
@@ -1,0 +1,24 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'estimated_intensity_notice_notifier.g.dart';
+
+@riverpod
+class EstimatedIntensityNoticeShown extends _$EstimatedIntensityNoticeShown {
+  @override
+  bool build() {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    return prefs.getBool(
+          SharedPreferencesKey.estimatedIntensityNoticeShown.key,
+        ) ??
+        false;
+  }
+
+  Future<void> markShown() async {
+    state = true;
+    await ref
+        .read(sharedPreferencesProvider)
+        .setBool(SharedPreferencesKey.estimatedIntensityNoticeShown.key, true);
+  }
+}

--- a/app/lib/feature/earthquake_history/data/notifier/estimated_intensity_notice_notifier.g.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/estimated_intensity_notice_notifier.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'estimated_intensity_notice_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EstimatedIntensityNoticeShown)
+final estimatedIntensityNoticeShownProvider =
+    EstimatedIntensityNoticeShownProvider._();
+
+final class EstimatedIntensityNoticeShownProvider
+    extends $NotifierProvider<EstimatedIntensityNoticeShown, bool> {
+  EstimatedIntensityNoticeShownProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'estimatedIntensityNoticeShownProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$estimatedIntensityNoticeShownHash();
+
+  @$internal
+  @override
+  EstimatedIntensityNoticeShown create() => EstimatedIntensityNoticeShown();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$estimatedIntensityNoticeShownHash() =>
+    r'90dafe2a98fc50f35ad8f26ecd9df3eab121ea6f';
+
+abstract class _$EstimatedIntensityNoticeShown extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/components/modal/estimated_intensity_notice_dialog.dart
+++ b/app/lib/feature/earthquake_history/ui/components/modal/estimated_intensity_notice_dialog.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class EstimatedIntensityNoticeDialog extends StatelessWidget {
+  const EstimatedIntensityNoticeDialog({super.key});
+
+  static Future<void> show(BuildContext context) => showDialog<void>(
+        context: context,
+        builder: (context) => const EstimatedIntensityNoticeDialog(),
+      );
+
+  static const _jmaUrl =
+      'https://www.jma.go.jp/jma/kishou/know/jishin/suikei/kaisetsu.html';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AlertDialog(
+      title: const Text('推計震度分布図について'),
+      content: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _BulletText(
+              '推計震度分布図で示すメッシュの震度は、'
+              'それぞれの震度の矩形内が同一震度であることを示すものではなく、'
+              'メッシュの境界線が震度の境界でもありません。',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            _BulletText(
+              '推計震度の値は1階級程度異なる場合があります。',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            _BulletText(
+              '大きな震度の面的な広がり具合やその形状に着目することが重要です。'
+              '地震発生直後に応急対応すべき優先箇所の判別や'
+              '避難ルート・避難場所の選定等に活用頂けます。',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'EQMonitorでは、推計震度分布図(250mメッシュ)を'
+              'サーバで処理し掲載しています。',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            InkWell(
+              onTap: () => launchUrl(Uri.parse(_jmaUrl)),
+              child: Text(
+                '推計震度分布図について - 気象庁',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  decoration: TextDecoration.underline,
+                  decorationColor: theme.colorScheme.primary,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}
+
+class _BulletText extends StatelessWidget {
+  const _BulletText(this.text, {this.style});
+
+  final String text;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('・', style: style),
+        Expanded(child: Text(text, style: style)),
+      ],
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -5,10 +5,12 @@ import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_display_mode.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/estimated_intensity_notice_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/current_location_intensity_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_intensity_card.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/modal/estimated_intensity_notice_dialog.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/similar_earthquake_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -61,13 +63,13 @@ class EarthquakeHistoryDetailsPage extends HookConsumerWidget {
   }
 }
 
-class _LoadedContent extends HookWidget {
+class _LoadedContent extends HookConsumerWidget {
   const _LoadedContent({required this.earthquake});
 
   final Earthquake earthquake;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final hasEstimated = earthquake.estimatedIntensityTileUrl != null;
     final hasLpgm = earthquake.intensity?.maxLpgmIntensity != null;
 
@@ -75,6 +77,26 @@ class _LoadedContent extends HookWidget {
       hasEstimated
           ? IntensityDisplayMode.estimated
           : IntensityDisplayMode.jma,
+    );
+
+    final noticeShown = ref.watch(estimatedIntensityNoticeShownProvider);
+
+    useEffect(
+      () {
+        if (hasEstimated && !noticeShown) {
+          WidgetsBinding.instance.addPostFrameCallback((_) async {
+            if (!context.mounted) {
+              return;
+            }
+            await EstimatedIntensityNoticeDialog.show(context);
+            await ref
+                .read(estimatedIntensityNoticeShownProvider.notifier)
+                .markShown();
+          });
+        }
+        return null;
+      },
+      [hasEstimated, noticeShown],
     );
 
     final availableModes = [


### PR DESCRIPTION
## Summary
- 推計震度分布図レイヤーがある地震の詳細ページを初めて開いた際に、注意事項ダイアログを表示
- メッシュ震度の解釈（矩形内が同一震度ではない、境界線が震度の境界ではない、1階級程度の誤差あり等）を案内
- SharedPreferencesでフラグを永続化し、2回目以降は非表示
- 気象庁の解説ページへのリンクを掲載

## Test plan
- [ ] 推計震度分布図がある地震の詳細ページを開き、注意ダイアログが表示されることを確認
- [ ] OKボタンでダイアログを閉じた後、再度同じページを開いてダイアログが表示されないことを確認
- [ ] 推計震度分布図がない地震の詳細ページではダイアログが表示されないことを確認
- [ ] 気象庁リンクをタップしてブラウザが開くことを確認