### PR TITLE
feat: 既存ユーザーのオンボーディングで通知設定を引き継ぐ

### DIFF
--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -24,6 +24,7 @@ enum SharedPreferencesKey {
   lastFcmTokenHash('last_fcm_token_hash'),
   lastApnsTokenHash('last_apns_token_hash'),
   lastApnsPushToStartTokenHash('last_apns_push_to_start_token_hash'),
+  deviceMigratedFromLegacy('device_migrated_from_legacy'),
   adsOptOut('ads_opt_out'),
   autoReturnToRealtime('auto_return_to_realtime'),
   earthquakeHistoryMapLayerParameter('earthquake_history_map_layer_parameter'),

--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
@@ -19,6 +19,12 @@ part 'device_provisioning_notifier.g.dart';
 
 enum DeviceProvisioningStatus { required, notRequired }
 
+@riverpod
+bool deviceMigratedFromLegacy(Ref ref) {
+  final repo = ref.watch(deviceProvisioningRepositoryProvider);
+  return repo.wasMigratedFromLegacy();
+}
+
 @Riverpod(keepAlive: true)
 class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
 
@@ -59,6 +65,7 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
             deviceId: deviceId,
             oldDeviceId: legacy,
           );
+          await repo.markMigratedFromLegacy();
         } else {
           final result = await deviceRepo.registerDevice(
             deviceId: deviceId,

--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.g.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.g.dart
@@ -11,6 +11,48 @@ part of 'device_provisioning_notifier.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
+@ProviderFor(deviceMigratedFromLegacy)
+final deviceMigratedFromLegacyProvider = DeviceMigratedFromLegacyProvider._();
+
+final class DeviceMigratedFromLegacyProvider
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  DeviceMigratedFromLegacyProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'deviceMigratedFromLegacyProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$deviceMigratedFromLegacyHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return deviceMigratedFromLegacy(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$deviceMigratedFromLegacyHash() =>
+    r'6cf2db036d78bb2e59bc0cb7b792358465e6968a';
+
 @ProviderFor(DeviceProvisioningNotifier)
 final deviceProvisioningProvider = DeviceProvisioningNotifierProvider._();
 
@@ -40,7 +82,7 @@ final class DeviceProvisioningNotifierProvider
 }
 
 String _$deviceProvisioningNotifierHash() =>
-    r'08246d53590a7abe0ccd84c5a4b08da77e06afe7';
+    r'abfbe9e22dc1335a1eda91d47f41fbefc8b8472c';
 
 abstract class _$DeviceProvisioningNotifier
     extends $AsyncNotifier<DeviceProvisioningStatus> {

--- a/app/lib/feature/devices/data/repository/device_provisioning_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_provisioning_repository.dart
@@ -36,6 +36,12 @@ class DeviceProvisioningRepository {
   String? readLegacyDeviceId() =>
       _prefs.getString(SharedPreferencesKey.legacyDeviceId.key);
 
+  bool wasMigratedFromLegacy() =>
+      _prefs.getBool(SharedPreferencesKey.deviceMigratedFromLegacy.key) ?? false;
+
+  Future<void> markMigratedFromLegacy() =>
+      _prefs.setBool(SharedPreferencesKey.deviceMigratedFromLegacy.key, true);
+
   WorkflowRunner buildRunner() => WorkflowRunner(persistence: _persistence);
 
   /// 現在のトークンと保存済みハッシュを比較して同期スナップショットを返す。

--- a/app/lib/feature/devices/data/repository/device_repository.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/core/provider/dio_provider.dart';
 import 'package:eqmonitor/feature/devices/data/model/notification_token.dart';
 import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
 import 'package:eqmonitor/feature/devices/data/provider/apns_environment.dart';
@@ -17,13 +18,15 @@ part 'device_repository.g.dart';
 Future<DeviceRepository> deviceRepository(Ref ref) async => DeviceRepository(
   await ref.watch(apiClientProvider.future),
   await ref.watch(deviceAuthRepositoryProvider.future),
+  await ref.watch(dioProvider.future),
   apnsEnvironment: ref.watch(apnsEnvironmentProvider),
 );
 
 class DeviceRepository {
   DeviceRepository(
     this._api,
-    this._authRepository, {
+    this._authRepository,
+    this._dio, {
     required api.ApnsEnvironment apnsEnvironment,
     bool? isApplePlatform,
   }) : _apnsEnvironment = apnsEnvironment,
@@ -32,6 +35,7 @@ class DeviceRepository {
 
   final api.ApiClient _api;
   final DeviceAuthRepository _authRepository;
+  final Dio _dio;
   final api.ApnsEnvironment _apnsEnvironment;
 
   /// APNs トークン同期は iOS/macOS でのみ行う。
@@ -141,8 +145,25 @@ class DeviceRepository {
       }
     }
 
-    // Step 3 — migrate endpoint removed; treat as success
-    return const Success(null);
+    // Step 3 — call migration endpoint to transfer Supabase settings
+    return Result.capture(() async {
+      try {
+        await _dio.post<void>(
+          '/v2/device/me/migrate',
+          data: {'old_device_id': oldDeviceId},
+        );
+      } on DioException catch (e) {
+        // 409 = already migrated; treat as idempotent success
+        if (e.response?.statusCode == 409) {
+          return;
+        }
+        // 404 = old device not found in Supabase; non-fatal
+        if (e.response?.statusCode == 404) {
+          return;
+        }
+        rethrow;
+      }
+    });
   }
 
   Future<Result<void, Exception>> syncLiveActivityUpdateToken({

--- a/app/lib/feature/devices/data/repository/device_repository.g.dart
+++ b/app/lib/feature/devices/data/repository/device_repository.g.dart
@@ -48,4 +48,4 @@ final class DeviceRepositoryProvider
   }
 }
 
-String _$deviceRepositoryHash() => r'eaf346da84cc454f50c702ccaf87c2b83eaad191';
+String _$deviceRepositoryHash() => r'6437cccb393c96e7a509bbe719579bee0ac82085';

--- a/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
@@ -5,6 +5,95 @@ class _NotificationSettingsStepPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isMigrated = ref.watch(deviceMigratedFromLegacyProvider);
+    if (isMigrated) {
+      return const _MigratedNotificationSettingsStepPage();
+    }
+    return const _NewUserNotificationSettingsStepPage();
+  }
+}
+
+class _MigratedNotificationSettingsStepPage extends HookConsumerWidget {
+  const _MigratedNotificationSettingsStepPage();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final scope = _OnboardingScope.of(context);
+    final designSystem = Theme.of(context).designSystemThemeExtension;
+
+    useEffect(() {
+      scope.setStepNavigation(
+        step: _OnboardingStep.notificationSettings,
+        state: _StepNavigationState(
+          buttonLabel: '次へ',
+          isNextEnabled: true,
+          isProcessing: false,
+          onNext: scope.nextPage,
+        ),
+      );
+      return null;
+    }, [scope]);
+
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: designSystem.spacing.lg,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(height: designSystem.spacing.xxxxl),
+          Text(
+            '通知設定',
+            style: designSystem.typography.displayMedium,
+          ),
+          SizedBox(height: designSystem.spacing.sm),
+          Text(
+            '前バージョンの通知設定を引き継ぎました',
+            style: designSystem.typography.bodyLarge.copyWith(
+              color: designSystem.textColor.secondary,
+            ),
+          ),
+          SizedBox(height: designSystem.spacing.xl),
+          Container(
+            padding: EdgeInsets.all(designSystem.spacing.md),
+            decoration: BoxDecoration(
+              color: designSystem.color.surfaceCard,
+              borderRadius: BorderRadius.circular(designSystem.shape.card),
+              border: Border.all(
+                color: designSystem.palette.statusSuccess.withValues(alpha: 0.3),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.check_circle_outline,
+                  color: designSystem.palette.statusSuccess,
+                ),
+                SizedBox(width: designSystem.spacing.sm),
+                Expanded(
+                  child: Text(
+                    '通知の地域や震度の設定がそのまま引き継がれています。'
+                    '設定はいつでも変更できます。',
+                    style: designSystem.typography.bodySmall.copyWith(
+                      color: designSystem.textColor.secondary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Spacer(),
+        ],
+      ),
+    );
+  }
+}
+
+class _NewUserNotificationSettingsStepPage extends HookConsumerWidget {
+  const _NewUserNotificationSettingsStepPage();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final scope = _OnboardingScope.of(context);
     final designSystem = Theme.of(context).designSystemThemeExtension;
     final selectedPreset = useState<_NotificationPreset?>(null);

--- a/app/test/feature/devices/device_repository_apns_environment_test.dart
+++ b/app/test/feature/devices/device_repository_apns_environment_test.dart
@@ -30,6 +30,7 @@ void main() {
     final repository = DeviceRepository(
       api.ApiClient(dio),
       _MemoryDeviceAuthRepository(),
+      dio,
       apnsEnvironment: api.ApnsEnvironment.development,
       isApplePlatform: true,
     );

--- a/app/test/feature/devices/device_repository_auth_token_test.dart
+++ b/app/test/feature/devices/device_repository_auth_token_test.dart
@@ -26,6 +26,7 @@ void main() {
       final repository = DeviceRepository(
         api.ApiClient(dio),
         authRepository,
+        dio,
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 
@@ -55,6 +56,7 @@ void main() {
       final repository = DeviceRepository(
         api.ApiClient(dio),
         authRepository,
+        dio,
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 
@@ -95,6 +97,7 @@ void main() {
       final repository = DeviceRepository(
         api.ApiClient(dio),
         authRepository,
+        dio,
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 
@@ -129,6 +132,7 @@ void main() {
       final repository = DeviceRepository(
         api.ApiClient(dio),
         authRepository,
+        dio,
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 
@@ -160,6 +164,7 @@ void main() {
       final repository = DeviceRepository(
         api.ApiClient(dio),
         authRepository,
+        dio,
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 

--- a/app/test/feature/devices/push_token_sync_auth_recovery_test.dart
+++ b/app/test/feature/devices/push_token_sync_auth_recovery_test.dart
@@ -169,6 +169,7 @@ final class _UnauthenticatedDeviceRepository extends DeviceRepository {
     : super(
         api.ApiClient(Dio()),
         _MemoryDeviceAuthRepository(),
+        Dio(),
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 
@@ -193,6 +194,7 @@ final class _RecoveringDeviceRepository extends DeviceRepository {
     : super(
         api.ApiClient(Dio()),
         _MemoryDeviceAuthRepository(),
+        Dio(),
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 

--- a/app/test/feature/devices/push_token_sync_wiring_test.dart
+++ b/app/test/feature/devices/push_token_sync_wiring_test.dart
@@ -62,6 +62,7 @@ final class _RecordingDeviceRepository extends DeviceRepository {
     : super(
         api.ApiClient(Dio()),
         _MemoryDeviceAuthRepository(),
+        Dio(),
         apnsEnvironment: api.ApnsEnvironment.development,
       );
 

--- a/app/test/feature/migration/v3_migration_workflow_test.dart
+++ b/app/test/feature/migration/v3_migration_workflow_test.dart
@@ -254,6 +254,7 @@ class FakeDeviceRepository extends DeviceRepository {
        super(
          api.ApiClient(Dio()),
          _MemoryDeviceAuthRepository(),
+         Dio(),
          apnsEnvironment: api.ApnsEnvironment.development,
        );
 


### PR DESCRIPTION
## Summary
- オンボーディング時に既存ユーザー（v2.6 Supabase）の通知設定をサーバ側に移行
- マイグレーション済みユーザーには通知プリセット選択をスキップし「前バージョンから引き継ぎました」画面を表示

## 変更内容
- `DeviceRepository.migrateFromLegacy` で `POST /v2/device/me/migrate` を実際に呼び出す（409/404は成功扱い）
- `DeviceProvisioningNotifier` でマイグレーション完了フラグを SharedPreferences に保存
- `deviceMigratedFromLegacyProvider` で UI からマイグレーション状態を参照可能に
- オンボーディングの通知設定ステップを新規/マイグレーション済みで分岐

## 依存
- バックエンド: YumNumm/eqmonitor-backend#754 （`POST /v2/device/me/migrate` のマウント）

## Test plan
- [ ] 新規ユーザー: 従来通り「推奨設定/カスタム」プリセット選択が表示される
- [ ] 既存ユーザー（legacyDeviceIdあり）: 「前バージョンから通知設定を引き継ぎました」が表示される
- [ ] マイグレーションAPI失敗時もオンボーディングは完了できる（404/409は成功扱い）
- [ ] `dart analyze` パス、既存テストにリグレッションなし