### PR TITLE
feat: Feed画面の実装とホームシートへの統合

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -14,6 +14,7 @@ import 'package:eqmonitor/feature/earthquake_search/data/model/earthquake_search
 import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_page.dart';
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
 import 'package:eqmonitor/feature/eew_history/ui/eew_history_page.dart';
+import 'package:eqmonitor/feature/feed/ui/page/feed_page.dart';
 import 'package:eqmonitor/feature/home/ui/page/home_map_layer_page.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/intensity_history_page.dart';
 import 'package:eqmonitor/feature/knet_waveform/data/model/knet_station_result.dart';
@@ -850,6 +851,15 @@ class ChangelogRoute extends GoRouteData with $ChangelogRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const ChangelogPage();
+}
+
+@TypedGoRoute<FeedRoute>(path: '/feed')
+class FeedRoute extends GoRouteData with $FeedRoute {
+  const FeedRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const FeedPage();
 }
 
 @TypedGoRoute<TsunamiDetailsRoute>(path: '/tsunami/:tsunamiId')

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -23,6 +23,7 @@ List<RouteBase> get $appRoutes => [
   $homeRoute,
   $talkerRoute,
   $settingsRoute,
+  $feedRoute,
   $tsunamiDetailsRoute,
   $paywallRoute,
   $subscriptionSettingsRoute,
@@ -1663,6 +1664,29 @@ bool _$boolConverter(String value) {
     default:
       throw UnsupportedError('Cannot convert "$value" into a bool.');
   }
+}
+
+RouteBase get $feedRoute =>
+    GoRouteData.$route(path: '/feed', factory: $FeedRoute._fromState);
+
+mixin $FeedRoute on GoRouteData {
+  static FeedRoute _fromState(GoRouterState state) => const FeedRoute();
+
+  @override
+  String get location => GoRouteData.$location('/feed');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
 }
 
 RouteBase get $tsunamiDetailsRoute => GoRouteData.$route(

--- a/app/lib/feature/feed/data/notifier/feed_data_source.dart
+++ b/app/lib/feature/feed/data/notifier/feed_data_source.dart
@@ -1,0 +1,44 @@
+import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:paging_view/paging_view.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feed_data_source.g.dart';
+
+@riverpod
+Future<FeedDataSource> feedDataSource(Ref ref) async {
+  final repository = await ref.watch(feedRepositoryProvider.future);
+  final dataSource = FeedDataSource(repository: repository);
+  ref.onDispose(dataSource.dispose);
+  return dataSource;
+}
+
+class FeedDataSource extends DataSource<String?, api.FeedItem> {
+  FeedDataSource({required FeedRepository repository})
+      : _repository = repository;
+
+  final FeedRepository _repository;
+
+  @override
+  Future<LoadResult<String?, api.FeedItem>> load(
+    LoadAction<String?> action,
+  ) async => switch (action) {
+        Refresh() => await _fetch(null),
+        Append(:final key) => await _fetch(key),
+        Prepend() => const None(),
+      };
+
+  Future<LoadResult<String?, api.FeedItem>> _fetch(String? cursor) async {
+    try {
+      final response = await _repository.fetch(after: cursor);
+      return Success(
+        page: PageData(
+          data: response.feeds,
+          appendKey: response.nextCursor,
+        ),
+      );
+    } on Exception catch (e, st) {
+      return Failure(error: e, stackTrace: st);
+    }
+  }
+}

--- a/app/lib/feature/feed/data/notifier/feed_data_source.g.dart
+++ b/app/lib/feature/feed/data/notifier/feed_data_source.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'feed_data_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(feedDataSource)
+final feedDataSourceProvider = FeedDataSourceProvider._();
+
+final class FeedDataSourceProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<FeedDataSource>,
+          FeedDataSource,
+          FutureOr<FeedDataSource>
+        >
+    with $FutureModifier<FeedDataSource>, $FutureProvider<FeedDataSource> {
+  FeedDataSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'feedDataSourceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$feedDataSourceHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<FeedDataSource> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<FeedDataSource> create(Ref ref) {
+    return feedDataSource(ref);
+  }
+}
+
+String _$feedDataSourceHash() => r'0297b7d14253f2dc8684950041e7b261b6836ad9';

--- a/app/lib/feature/feed/data/notifier/feed_notifier.dart
+++ b/app/lib/feature/feed/data/notifier/feed_notifier.dart
@@ -1,0 +1,49 @@
+import 'package:eqmonitor/core/extension/async_value.dart';
+import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feed_notifier.g.dart';
+
+typedef FeedNotifierState = ({
+  List<api.FeedItem> items,
+  String? nextCursor,
+});
+
+@riverpod
+class FeedNotifier extends _$FeedNotifier {
+  @override
+  Future<FeedNotifierState> build() async {
+    final repository = await ref.read(feedRepositoryProvider.future);
+    final response = await repository.fetch();
+    return (
+      items: response.feeds,
+      nextCursor: response.nextCursor,
+    );
+  }
+
+  Future<void> fetchNextData() async {
+    if (state.isRefreshing || state.isReloading) {
+      return;
+    }
+    final currentState = state.value;
+    if (currentState == null || currentState.nextCursor == null) {
+      return;
+    }
+
+    state = await state.guardPlus(() async {
+      final repository = await ref.read(feedRepositoryProvider.future);
+      final response = await repository.fetch(
+        after: currentState.nextCursor,
+      );
+      return (
+        items: [...currentState.items, ...response.feeds],
+        nextCursor: response.nextCursor,
+      );
+    });
+  }
+}
+
+extension FeedNotifierStateEx on FeedNotifierState {
+  bool get hasNext => nextCursor != null;
+}

--- a/app/lib/feature/feed/data/notifier/feed_notifier.g.dart
+++ b/app/lib/feature/feed/data/notifier/feed_notifier.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'feed_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(FeedNotifier)
+final feedProvider = FeedNotifierProvider._();
+
+final class FeedNotifierProvider
+    extends $AsyncNotifierProvider<FeedNotifier, FeedNotifierState> {
+  FeedNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'feedProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$feedNotifierHash();
+
+  @$internal
+  @override
+  FeedNotifier create() => FeedNotifier();
+}
+
+String _$feedNotifierHash() => r'25469433435c72f308a62362821a40a0737a3357';
+
+abstract class _$FeedNotifier extends $AsyncNotifier<FeedNotifierState> {
+  FutureOr<FeedNotifierState> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<AsyncValue<FeedNotifierState>, FeedNotifierState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<FeedNotifierState>, FeedNotifierState>,
+              AsyncValue<FeedNotifierState>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/feed/data/repository/feed_repository.dart
+++ b/app/lib/feature/feed/data/repository/feed_repository.dart
@@ -1,0 +1,22 @@
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feed_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<FeedRepository> feedRepository(Ref ref) async {
+  final client = await ref.watch(apiClientProvider.future);
+  return FeedRepository(api: client);
+}
+
+class FeedRepository {
+  FeedRepository({required api.ApiClient api}) : _api = api;
+
+  final api.ApiClient _api;
+
+  Future<api.FeedListResponse> fetch({String? after}) async {
+    final response = await _api.feed.getV2Feeds(after: after);
+    return response.data;
+  }
+}

--- a/app/lib/feature/feed/data/repository/feed_repository.g.dart
+++ b/app/lib/feature/feed/data/repository/feed_repository.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'feed_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(feedRepository)
+final feedRepositoryProvider = FeedRepositoryProvider._();
+
+final class FeedRepositoryProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<FeedRepository>,
+          FeedRepository,
+          FutureOr<FeedRepository>
+        >
+    with $FutureModifier<FeedRepository>, $FutureProvider<FeedRepository> {
+  FeedRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'feedRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$feedRepositoryHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<FeedRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<FeedRepository> create(Ref ref) {
+    return feedRepository(ref);
+  }
+}
+
+String _$feedRepositoryHash() => r'7955fb003e2452cf2aae157ac23926620b7e1721';

--- a/app/lib/feature/feed/ui/component/feed_item_card.dart
+++ b/app/lib/feature/feed/ui/component/feed_item_card.dart
@@ -1,0 +1,289 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class FeedItemCard extends StatelessWidget {
+  const FeedItemCard({required this.item, super.key});
+
+  final api.FeedItem item;
+
+  static Future<void> showDetail(BuildContext context, api.FeedItem item) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.6,
+        minChildSize: 0.3,
+        maxChildSize: 0.9,
+        expand: false,
+        builder: (context, scrollController) => _FeedDetailSheet(
+          item: item,
+          scrollController: scrollController,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateStr = _formatPublishedAt(item.publishedAt);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => showDetail(context, item),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  FeedPriorityBadge(priority: item.priority),
+                  const SizedBox(width: 8),
+                  FeedTypeBadge(data: item.data),
+                  const Spacer(),
+                  Text(dateStr, style: theme.textTheme.labelSmall),
+                ],
+              ),
+              if (item.title != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  item.title!,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+              if (item.summary != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  item.summary!,
+                  style: theme.textTheme.bodySmall,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              if (item.title == null && item.summary == null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  dataText(item.data),
+                  style: theme.textTheme.bodySmall,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String dataText(api.FeedItemDataUnion data) => switch (data) {
+        api.FeedItemDataUnionFeedEarthquakeNoticeData(:final text) => text,
+        api.FeedItemDataUnionFeedEarthquakeExplanationData(:final text) => text,
+        api.FeedItemDataUnionFeedEarthquakeCountsData(:final text) =>
+          text ?? '',
+        api.FeedItemDataUnionFeedEarthquakeNankaiData(:final text) =>
+          text ?? '',
+        api.FeedItemDataUnionFeedAppUpdateData(:final version) =>
+          'バージョン ${version ?? ""}',
+        api.FeedItemDataUnionFeedIncidentData() => '障害情報',
+        api.FeedItemDataUnionFeedDeveloperMessageData() => '開発者メッセージ',
+      };
+
+  static String _formatPublishedAt(String publishedAt) {
+    final dt = DateTime.tryParse(publishedAt)?.toLocal();
+    if (dt == null) {
+      return publishedAt;
+    }
+    return DateFormat('yyyy/MM/dd HH:mm').format(dt);
+  }
+}
+
+class FeedItemListTileContent extends StatelessWidget {
+  const FeedItemListTileContent({required this.item, super.key});
+
+  final api.FeedItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateStr = FeedItemCard._formatPublishedAt(item.publishedAt);
+    final title = item.title ?? item.summary ?? FeedItemCard.dataText(item.data);
+
+    return Row(
+      children: [
+        FeedPriorityBadge(priority: item.priority),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              Text(
+                dateStr,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 4),
+        Icon(
+          Icons.chevron_right_rounded,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ],
+    );
+  }
+}
+
+class FeedPriorityBadge extends StatelessWidget {
+  const FeedPriorityBadge({required this.priority, super.key});
+
+  final api.FeedPriority priority;
+
+  @override
+  Widget build(BuildContext context) {
+    final (color, label) = switch (priority) {
+      api.FeedPriority.critical => (Colors.red, '緊急'),
+      api.FeedPriority.high => (Colors.orange, '重要'),
+      api.FeedPriority.normal => (Colors.blue, '通常'),
+      api.FeedPriority.low => (Colors.grey, '低'),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class FeedTypeBadge extends StatelessWidget {
+  const FeedTypeBadge({required this.data, super.key});
+
+  final api.FeedItemDataUnion data;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = switch (data) {
+      api.FeedItemDataUnionFeedEarthquakeNoticeData() => '地震情報',
+      api.FeedItemDataUnionFeedEarthquakeExplanationData() => '地震解説',
+      api.FeedItemDataUnionFeedEarthquakeCountsData() => '地震回数',
+      api.FeedItemDataUnionFeedEarthquakeNankaiData() => '南海トラフ',
+      api.FeedItemDataUnionFeedAppUpdateData() => 'アップデート',
+      api.FeedItemDataUnionFeedIncidentData() => '障害情報',
+      api.FeedItemDataUnionFeedDeveloperMessageData() => 'お知らせ',
+    };
+
+    return Text(
+      label,
+      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+    );
+  }
+}
+
+class _FeedDetailSheet extends StatelessWidget {
+  const _FeedDetailSheet({
+    required this.item,
+    required this.scrollController,
+  });
+
+  final api.FeedItem item;
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final publishedAt = DateTime.tryParse(item.publishedAt)?.toLocal();
+    final dateStr = publishedAt != null
+        ? DateFormat('yyyy年MM月dd日 HH:mm').format(publishedAt)
+        : item.publishedAt;
+
+    return ListView(
+      controller: scrollController,
+      padding: const EdgeInsets.all(24),
+      children: [
+        Center(
+          child: Container(
+            width: 32,
+            height: 4,
+            decoration: BoxDecoration(
+              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        if (item.title != null)
+          Text(
+            item.title!,
+            style: theme.textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            FeedPriorityBadge(priority: item.priority),
+            const SizedBox(width: 8),
+            FeedTypeBadge(data: item.data),
+            const Spacer(),
+            Text(dateStr, style: theme.textTheme.labelSmall),
+          ],
+        ),
+        const SizedBox(height: 16),
+        const Divider(),
+        const SizedBox(height: 16),
+        Text(
+          FeedItemCard.dataText(item.data),
+          style: theme.textTheme.bodyMedium,
+        ),
+        if (item.expiresAt != null) ...[
+          const SizedBox(height: 16),
+          Text(
+            '有効期限: ${_formatExpires(item.expiresAt!)}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  String _formatExpires(String expiresAt) {
+    final dt = DateTime.tryParse(expiresAt)?.toLocal();
+    if (dt == null) {
+      return expiresAt;
+    }
+    return DateFormat('yyyy年MM月dd日 HH:mm').format(dt);
+  }
+}

--- a/app/lib/feature/feed/ui/page/feed_page.dart
+++ b/app/lib/feature/feed/ui/page/feed_page.dart
@@ -1,0 +1,131 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
+import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/feature/feed/data/notifier/feed_data_source.dart';
+import 'package:eqmonitor/feature/feed/ui/component/feed_item_card.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:paging_view/paging_view.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+class FeedPage extends ConsumerWidget {
+  const FeedPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dataSourceAsync = ref.watch(feedDataSourceProvider);
+
+    return Scaffold(
+      body: dataSourceAsync.when(
+        loading: () => const _FeedSkeleton(),
+        error: (error, _) => ErrorCard(
+          error: error,
+          onReload: () async => ref.invalidate(feedDataSourceProvider),
+        ),
+        data: (dataSource) => _PagingBody(dataSource: dataSource),
+      ),
+    );
+  }
+}
+
+class _PagingBody extends StatelessWidget {
+  const _PagingBody({required this.dataSource});
+
+  final FeedDataSource dataSource;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: dataSource.refresh,
+      child: CustomScrollView(
+        slivers: [
+          const SliverAppBar(
+            pinned: true,
+            centerTitle: false,
+            title: Text('お知らせ'),
+          ),
+          SliverPagingList<String?, api.FeedItem>(
+            dataSource: dataSource,
+            builder: (context, item, index) => FeedItemCard(item: item),
+            initialLoadingWidget: const _FeedSkeleton(scrollable: false),
+            appendLoadingWidget: const _FeedSkeleton(
+              itemCount: 2,
+              scrollable: false,
+            ),
+            errorBuilder: (context, error, stackTrace) => ErrorCard(
+              error: error,
+              onReload: () async => dataSource.refresh(),
+            ),
+            emptyWidget: const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: Text('お知らせはありません'),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: AppendLoadStateBuilder(
+              dataSource: dataSource,
+              builder: (context, hasMore, isLoading) =>
+                  !hasMore && !isLoading
+                      ? const Padding(
+                          padding: EdgeInsets.all(16),
+                          child: Center(
+                            child: Text('すべてのお知らせを表示しました'),
+                          ),
+                        )
+                      : const SizedBox.shrink(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeedSkeleton extends StatelessWidget {
+  const _FeedSkeleton({
+    this.itemCount = 5,
+    this.scrollable = true,
+  });
+
+  final int itemCount;
+  final bool scrollable;
+
+  @override
+  Widget build(BuildContext context) {
+    final tiles = [
+      for (var i = 0; i < itemCount; i++)
+        const Card(
+          margin: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    SizedBox(width: 40, height: 16),
+                    SizedBox(width: 8),
+                    SizedBox(width: 60, height: 16),
+                    Spacer(),
+                    SizedBox(width: 80, height: 12),
+                  ],
+                ),
+                SizedBox(height: 8),
+                SizedBox(width: 200, height: 16),
+                SizedBox(height: 4),
+                SizedBox(width: double.infinity, height: 14),
+              ],
+            ),
+          ),
+        ),
+    ];
+
+    return Skeletonizer(
+      child: scrollable
+          ? ListView(children: tiles)
+          : Column(mainAxisSize: MainAxisSize.min, children: tiles),
+    );
+  }
+}

--- a/app/lib/feature/home/ui/component/sheet/home_feed_sheet.dart
+++ b/app/lib/feature/home/ui/component/sheet/home_feed_sheet.dart
@@ -1,0 +1,150 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
+import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/feed/data/notifier/feed_notifier.dart';
+import 'package:eqmonitor/feature/feed/ui/component/feed_item_card.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+class HomeFeedSheet extends ConsumerWidget {
+  const HomeFeedSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final designSystem = context.designSystem;
+    final color = designSystem.color;
+    final spacing = designSystem.spacing;
+    final shape = designSystem.shape;
+    final typography = designSystem.typography;
+    final state = ref.watch(feedProvider);
+
+    return Card.outlined(
+      margin: EdgeInsets.zero,
+      color: color.surfaceCard,
+      clipBehavior: Clip.antiAlias,
+      elevation: 0,
+      shape: RoundedSuperellipseBorder(
+        borderRadius: BorderRadius.circular(shape.card),
+        side: BorderSide(color: color.outlineSoft),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              spacing.lg,
+              spacing.md,
+              spacing.lg,
+              spacing.xs,
+            ),
+            child: Text(
+              'お知らせ',
+              style: typography.titleSmall.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          switch (state) {
+            AsyncData<FeedNotifierState>(:final value) =>
+              value.items.isEmpty
+                  ? Padding(
+                      padding: EdgeInsets.all(spacing.lg),
+                      child: const Center(child: Text('お知らせはありません')),
+                    )
+                  : Column(
+                      children: value.items.take(3).map(
+                        (item) => _HomeFeedListTile(item: item),
+                      ).toList(),
+                    ),
+            AsyncError<FeedNotifierState>(:final error) => ErrorCard(
+                error: error,
+                margin: EdgeInsets.zero,
+                onReload: () async => ref.invalidate(
+                  feedProvider,
+                  asReload: true,
+                ),
+                padding: const EdgeInsets.all(8),
+              ),
+            _ => const _HomeFeedSkeleton(),
+          },
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              spacing.lg,
+              spacing.xs,
+              spacing.lg,
+              spacing.md,
+            ),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () async => const FeedRoute().push<void>(context),
+                child: const Text('さらに表示'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HomeFeedListTile extends StatelessWidget {
+  const _HomeFeedListTile({required this.item});
+
+  final api.FeedItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+    final spacing = designSystem.spacing;
+    final shape = designSystem.shape;
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(shape.md),
+      onTap: () => FeedItemCard.showDetail(context, item),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: spacing.lg,
+          vertical: spacing.sm,
+        ),
+        child: FeedItemListTileContent(item: item),
+      ),
+    );
+  }
+}
+
+class _HomeFeedSkeleton extends StatelessWidget {
+  const _HomeFeedSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = context.designSystem.spacing;
+    final shape = context.designSystem.shape;
+    final color = context.designSystem.color;
+
+    return Padding(
+      padding: EdgeInsets.all(spacing.lg),
+      child: Skeletonizer(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (var i = 0; i < 3; i++) ...[
+              Container(
+                height: 44,
+                decoration: BoxDecoration(
+                  color: color.surfaceRaised,
+                  borderRadius: BorderRadius.circular(shape.md),
+                ),
+              ),
+              if (i != 2) SizedBox(height: spacing.sm),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -12,6 +12,7 @@ import 'package:eqmonitor/feature/home/ui/component/eew/eew_card.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/home_map_view.dart';
 import 'package:eqmonitor/feature/home/ui/component/shake_detection/shake_detection_card.dart';
 import 'package:eqmonitor/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart';
+import 'package:eqmonitor/feature/home/ui/component/sheet/home_feed_sheet.dart';
 import 'package:eqmonitor/feature/location/data/background_location_permission_provider.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
@@ -207,6 +208,8 @@ class _SheetBody extends ConsumerWidget {
                           .toList(),
                     ),
                   const HomeEarthquakeHistorySheet(),
+                  SizedBox(height: spacing.md),
+                  const HomeFeedSheet(),
                   SizedBox(height: spacing.lg),
                   actionsCard,
                 ],


### PR DESCRIPTION
## Summary
- Feed API (`GET /v2/feeds`) を利用したお知らせ一覧画面を新規実装
- `paging_view` による無限スクロール対応のフルページ (`/feed`)
- ホームシートに上位3件のFeedを表示する `HomeFeedSheet` を追加（地震履歴シートの下）
- タップで詳細BottomSheet表示、「さらに表示」ボタンでフルページへ遷移

## 構成
- `feature/feed/data/repository/` — FeedRepository (API呼び出し)
- `feature/feed/data/notifier/` — FeedNotifier (ホーム用) + FeedDataSource (paging_view)
- `feature/feed/ui/` — FeedItemCard, FeedPage
- `feature/home/ui/component/sheet/home_feed_sheet.dart` — ホームシート統合

## Test plan
- [ ] ホーム画面でお知らせセクションが表示されること
- [ ] お知らせアイテムをタップして詳細BottomSheetが表示されること
- [ ] 「さらに表示」ボタンからFeedページ (`/feed`) に遷移すること
- [ ] Feedページで下スクロール時にページネーションが動作すること
- [ ] pull-to-refreshで最新データに更新されること
- [ ] お知らせが0件の場合に空状態が表示されること
- [ ] エラー時にエラーカード+再試行ボタンが表示されること