### PR TITLE
feat: 市区町村選択機能（CityPicker）を追加

### DIFF
--- a/app/lib/feature/parameter/data/model/common/parameter_set.freezed.dart
+++ b/app/lib/feature/parameter/data/model/common/parameter_set.freezed.dart
@@ -78,7 +78,7 @@ as ShindoDbStationsParameter,
 @override
 @pragma('vm:prefer-inline')
 $ParameterManifestCopyWith<$Res> get manifest {
-
+  
   return $ParameterManifestCopyWith<$Res>(_self.manifest, (value) {
     return _then(_self.copyWith(manifest: value));
   });
@@ -87,7 +87,7 @@ $ParameterManifestCopyWith<$Res> get manifest {
 @override
 @pragma('vm:prefer-inline')
 $JmaCodeTableParameterCopyWith<$Res> get jmaCodeTable {
-
+  
   return $JmaCodeTableParameterCopyWith<$Res>(_self.jmaCodeTable, (value) {
     return _then(_self.copyWith(jmaCodeTable: value));
   });
@@ -96,7 +96,7 @@ $JmaCodeTableParameterCopyWith<$Res> get jmaCodeTable {
 @override
 @pragma('vm:prefer-inline')
 $KyoshinObservationPointsParameterCopyWith<$Res> get kyoshinObservationPoints {
-
+  
   return $KyoshinObservationPointsParameterCopyWith<$Res>(_self.kyoshinObservationPoints, (value) {
     return _then(_self.copyWith(kyoshinObservationPoints: value));
   });
@@ -105,7 +105,7 @@ $KyoshinObservationPointsParameterCopyWith<$Res> get kyoshinObservationPoints {
 @override
 @pragma('vm:prefer-inline')
 $EarthquakeParameterCopyWith<$Res> get earthquake {
-
+  
   return $EarthquakeParameterCopyWith<$Res>(_self.earthquake, (value) {
     return _then(_self.copyWith(earthquake: value));
   });
@@ -114,7 +114,7 @@ $EarthquakeParameterCopyWith<$Res> get earthquake {
 @override
 @pragma('vm:prefer-inline')
 $TsunamiParameterCopyWith<$Res> get tsunami {
-
+  
   return $TsunamiParameterCopyWith<$Res>(_self.tsunami, (value) {
     return _then(_self.copyWith(tsunami: value));
   });
@@ -123,7 +123,7 @@ $TsunamiParameterCopyWith<$Res> get tsunami {
 @override
 @pragma('vm:prefer-inline')
 $ShindoDbStationsParameterCopyWith<$Res> get shindoDbStations {
-
+  
   return $ShindoDbStationsParameterCopyWith<$Res>(_self.shindoDbStations, (value) {
     return _then(_self.copyWith(shindoDbStations: value));
   });
@@ -266,7 +266,7 @@ return $default(_that.manifest,_that.jmaCodeTable,_that.kyoshinObservationPoints
 
 class _ParameterSet implements ParameterSet {
   const _ParameterSet({required this.manifest, required this.jmaCodeTable, required this.kyoshinObservationPoints, required this.earthquake, required this.tsunami, required this.shindoDbStations});
-
+  
 
 @override final  ParameterManifest manifest;
 @override final  JmaCodeTableParameter jmaCodeTable;
@@ -339,7 +339,7 @@ as ShindoDbStationsParameter,
 @override
 @pragma('vm:prefer-inline')
 $ParameterManifestCopyWith<$Res> get manifest {
-
+  
   return $ParameterManifestCopyWith<$Res>(_self.manifest, (value) {
     return _then(_self.copyWith(manifest: value));
   });
@@ -348,7 +348,7 @@ $ParameterManifestCopyWith<$Res> get manifest {
 @override
 @pragma('vm:prefer-inline')
 $JmaCodeTableParameterCopyWith<$Res> get jmaCodeTable {
-
+  
   return $JmaCodeTableParameterCopyWith<$Res>(_self.jmaCodeTable, (value) {
     return _then(_self.copyWith(jmaCodeTable: value));
   });
@@ -357,7 +357,7 @@ $JmaCodeTableParameterCopyWith<$Res> get jmaCodeTable {
 @override
 @pragma('vm:prefer-inline')
 $KyoshinObservationPointsParameterCopyWith<$Res> get kyoshinObservationPoints {
-
+  
   return $KyoshinObservationPointsParameterCopyWith<$Res>(_self.kyoshinObservationPoints, (value) {
     return _then(_self.copyWith(kyoshinObservationPoints: value));
   });
@@ -366,7 +366,7 @@ $KyoshinObservationPointsParameterCopyWith<$Res> get kyoshinObservationPoints {
 @override
 @pragma('vm:prefer-inline')
 $EarthquakeParameterCopyWith<$Res> get earthquake {
-
+  
   return $EarthquakeParameterCopyWith<$Res>(_self.earthquake, (value) {
     return _then(_self.copyWith(earthquake: value));
   });
@@ -375,7 +375,7 @@ $EarthquakeParameterCopyWith<$Res> get earthquake {
 @override
 @pragma('vm:prefer-inline')
 $TsunamiParameterCopyWith<$Res> get tsunami {
-
+  
   return $TsunamiParameterCopyWith<$Res>(_self.tsunami, (value) {
     return _then(_self.copyWith(tsunami: value));
   });
@@ -384,7 +384,7 @@ $TsunamiParameterCopyWith<$Res> get tsunami {
 @override
 @pragma('vm:prefer-inline')
 $ShindoDbStationsParameterCopyWith<$Res> get shindoDbStations {
-
+  
   return $ShindoDbStationsParameterCopyWith<$Res>(_self.shindoDbStations, (value) {
     return _then(_self.copyWith(shindoDbStations: value));
   });

--- a/app/lib/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart
+++ b/app/lib/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart
@@ -21,6 +21,7 @@ abstract class JmaCodeTableCodeTables with _$JmaCodeTableCodeTables {
   const factory JmaCodeTableCodeTables({
     required List<JmaCodeTableItem> areaForecastLocalEew,
     required List<JmaCodeTableItem> areaInformationPrefectureEarthquake,
+    required List<JmaCodeTableCityItem> areaInformationCity,
     required List<JmaCodeTableItem> areaEpicenter,
     required List<JmaCodeTableItem> areaEpicenterAbbreviation,
     required List<JmaCodeTableItem> areaEpicenterDetail,
@@ -28,6 +29,21 @@ abstract class JmaCodeTableCodeTables with _$JmaCodeTableCodeTables {
 
   factory JmaCodeTableCodeTables.fromJson(Map<String, dynamic> json) =>
       _$JmaCodeTableCodeTablesFromJson(json);
+}
+
+@freezed
+abstract class JmaCodeTableCityItem with _$JmaCodeTableCityItem {
+  const factory JmaCodeTableCityItem({
+    required String code,
+    required LocalizedName name,
+    @JsonKey(name: 'parent_area_forecast_local_eew_code')
+    required String parentAreaForecastLocalEewCode,
+    @JsonKey(name: 'parent_area_information_prefecture_earthquake_code')
+    required String parentAreaInformationPrefectureEarthquakeCode,
+  }) = _JmaCodeTableCityItem;
+
+  factory JmaCodeTableCityItem.fromJson(Map<String, dynamic> json) =>
+      _$JmaCodeTableCityItemFromJson(json);
 }
 
 @freezed

--- a/app/lib/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.freezed.dart
+++ b/app/lib/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.freezed.dart
@@ -317,7 +317,7 @@ $JmaCodeTableCodeTablesCopyWith<$Res> get codeTables {
 /// @nodoc
 mixin _$JmaCodeTableCodeTables {
 
- List<JmaCodeTableItem> get areaForecastLocalEew; List<JmaCodeTableItem> get areaInformationPrefectureEarthquake; List<JmaCodeTableItem> get areaEpicenter; List<JmaCodeTableItem> get areaEpicenterAbbreviation; List<JmaCodeTableItem> get areaEpicenterDetail;
+ List<JmaCodeTableItem> get areaForecastLocalEew; List<JmaCodeTableItem> get areaInformationPrefectureEarthquake; List<JmaCodeTableCityItem> get areaInformationCity; List<JmaCodeTableItem> get areaEpicenter; List<JmaCodeTableItem> get areaEpicenterAbbreviation; List<JmaCodeTableItem> get areaEpicenterDetail;
 /// Create a copy of JmaCodeTableCodeTables
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -330,16 +330,16 @@ $JmaCodeTableCodeTablesCopyWith<JmaCodeTableCodeTables> get copyWith => _$JmaCod
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is JmaCodeTableCodeTables&&const DeepCollectionEquality().equals(other.areaForecastLocalEew, areaForecastLocalEew)&&const DeepCollectionEquality().equals(other.areaInformationPrefectureEarthquake, areaInformationPrefectureEarthquake)&&const DeepCollectionEquality().equals(other.areaEpicenter, areaEpicenter)&&const DeepCollectionEquality().equals(other.areaEpicenterAbbreviation, areaEpicenterAbbreviation)&&const DeepCollectionEquality().equals(other.areaEpicenterDetail, areaEpicenterDetail));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JmaCodeTableCodeTables&&const DeepCollectionEquality().equals(other.areaForecastLocalEew, areaForecastLocalEew)&&const DeepCollectionEquality().equals(other.areaInformationPrefectureEarthquake, areaInformationPrefectureEarthquake)&&const DeepCollectionEquality().equals(other.areaInformationCity, areaInformationCity)&&const DeepCollectionEquality().equals(other.areaEpicenter, areaEpicenter)&&const DeepCollectionEquality().equals(other.areaEpicenterAbbreviation, areaEpicenterAbbreviation)&&const DeepCollectionEquality().equals(other.areaEpicenterDetail, areaEpicenterDetail));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(areaForecastLocalEew),const DeepCollectionEquality().hash(areaInformationPrefectureEarthquake),const DeepCollectionEquality().hash(areaEpicenter),const DeepCollectionEquality().hash(areaEpicenterAbbreviation),const DeepCollectionEquality().hash(areaEpicenterDetail));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(areaForecastLocalEew),const DeepCollectionEquality().hash(areaInformationPrefectureEarthquake),const DeepCollectionEquality().hash(areaInformationCity),const DeepCollectionEquality().hash(areaEpicenter),const DeepCollectionEquality().hash(areaEpicenterAbbreviation),const DeepCollectionEquality().hash(areaEpicenterDetail));
 
 @override
 String toString() {
-  return 'JmaCodeTableCodeTables(areaForecastLocalEew: $areaForecastLocalEew, areaInformationPrefectureEarthquake: $areaInformationPrefectureEarthquake, areaEpicenter: $areaEpicenter, areaEpicenterAbbreviation: $areaEpicenterAbbreviation, areaEpicenterDetail: $areaEpicenterDetail)';
+  return 'JmaCodeTableCodeTables(areaForecastLocalEew: $areaForecastLocalEew, areaInformationPrefectureEarthquake: $areaInformationPrefectureEarthquake, areaInformationCity: $areaInformationCity, areaEpicenter: $areaEpicenter, areaEpicenterAbbreviation: $areaEpicenterAbbreviation, areaEpicenterDetail: $areaEpicenterDetail)';
 }
 
 
@@ -350,7 +350,7 @@ abstract mixin class $JmaCodeTableCodeTablesCopyWith<$Res>  {
   factory $JmaCodeTableCodeTablesCopyWith(JmaCodeTableCodeTables value, $Res Function(JmaCodeTableCodeTables) _then) = _$JmaCodeTableCodeTablesCopyWithImpl;
 @useResult
 $Res call({
- List<JmaCodeTableItem> areaForecastLocalEew, List<JmaCodeTableItem> areaInformationPrefectureEarthquake, List<JmaCodeTableItem> areaEpicenter, List<JmaCodeTableItem> areaEpicenterAbbreviation, List<JmaCodeTableItem> areaEpicenterDetail
+ List<JmaCodeTableItem> areaForecastLocalEew, List<JmaCodeTableItem> areaInformationPrefectureEarthquake, List<JmaCodeTableCityItem> areaInformationCity, List<JmaCodeTableItem> areaEpicenter, List<JmaCodeTableItem> areaEpicenterAbbreviation, List<JmaCodeTableItem> areaEpicenterDetail
 });
 
 
@@ -367,11 +367,12 @@ class _$JmaCodeTableCodeTablesCopyWithImpl<$Res>
 
 /// Create a copy of JmaCodeTableCodeTables
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? areaForecastLocalEew = null,Object? areaInformationPrefectureEarthquake = null,Object? areaEpicenter = null,Object? areaEpicenterAbbreviation = null,Object? areaEpicenterDetail = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? areaForecastLocalEew = null,Object? areaInformationPrefectureEarthquake = null,Object? areaInformationCity = null,Object? areaEpicenter = null,Object? areaEpicenterAbbreviation = null,Object? areaEpicenterDetail = null,}) {
   return _then(_self.copyWith(
 areaForecastLocalEew: null == areaForecastLocalEew ? _self.areaForecastLocalEew : areaForecastLocalEew // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,areaInformationPrefectureEarthquake: null == areaInformationPrefectureEarthquake ? _self.areaInformationPrefectureEarthquake : areaInformationPrefectureEarthquake // ignore: cast_nullable_to_non_nullable
-as List<JmaCodeTableItem>,areaEpicenter: null == areaEpicenter ? _self.areaEpicenter : areaEpicenter // ignore: cast_nullable_to_non_nullable
+as List<JmaCodeTableItem>,areaInformationCity: null == areaInformationCity ? _self.areaInformationCity : areaInformationCity // ignore: cast_nullable_to_non_nullable
+as List<JmaCodeTableCityItem>,areaEpicenter: null == areaEpicenter ? _self.areaEpicenter : areaEpicenter // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,areaEpicenterAbbreviation: null == areaEpicenterAbbreviation ? _self.areaEpicenterAbbreviation : areaEpicenterAbbreviation // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,areaEpicenterDetail: null == areaEpicenterDetail ? _self.areaEpicenterDetail : areaEpicenterDetail // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,
@@ -459,10 +460,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<JmaCodeTableItem> areaForecastLocalEew,  List<JmaCodeTableItem> areaInformationPrefectureEarthquake,  List<JmaCodeTableItem> areaEpicenter,  List<JmaCodeTableItem> areaEpicenterAbbreviation,  List<JmaCodeTableItem> areaEpicenterDetail)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<JmaCodeTableItem> areaForecastLocalEew,  List<JmaCodeTableItem> areaInformationPrefectureEarthquake,  List<JmaCodeTableCityItem> areaInformationCity,  List<JmaCodeTableItem> areaEpicenter,  List<JmaCodeTableItem> areaEpicenterAbbreviation,  List<JmaCodeTableItem> areaEpicenterDetail)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _JmaCodeTableCodeTables() when $default != null:
-return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthquake,_that.areaEpicenter,_that.areaEpicenterAbbreviation,_that.areaEpicenterDetail);case _:
+return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthquake,_that.areaInformationCity,_that.areaEpicenter,_that.areaEpicenterAbbreviation,_that.areaEpicenterDetail);case _:
   return orElse();
 
 }
@@ -480,10 +481,10 @@ return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthq
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<JmaCodeTableItem> areaForecastLocalEew,  List<JmaCodeTableItem> areaInformationPrefectureEarthquake,  List<JmaCodeTableItem> areaEpicenter,  List<JmaCodeTableItem> areaEpicenterAbbreviation,  List<JmaCodeTableItem> areaEpicenterDetail)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<JmaCodeTableItem> areaForecastLocalEew,  List<JmaCodeTableItem> areaInformationPrefectureEarthquake,  List<JmaCodeTableCityItem> areaInformationCity,  List<JmaCodeTableItem> areaEpicenter,  List<JmaCodeTableItem> areaEpicenterAbbreviation,  List<JmaCodeTableItem> areaEpicenterDetail)  $default,) {final _that = this;
 switch (_that) {
 case _JmaCodeTableCodeTables():
-return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthquake,_that.areaEpicenter,_that.areaEpicenterAbbreviation,_that.areaEpicenterDetail);case _:
+return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthquake,_that.areaInformationCity,_that.areaEpicenter,_that.areaEpicenterAbbreviation,_that.areaEpicenterDetail);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -500,10 +501,10 @@ return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthq
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<JmaCodeTableItem> areaForecastLocalEew,  List<JmaCodeTableItem> areaInformationPrefectureEarthquake,  List<JmaCodeTableItem> areaEpicenter,  List<JmaCodeTableItem> areaEpicenterAbbreviation,  List<JmaCodeTableItem> areaEpicenterDetail)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<JmaCodeTableItem> areaForecastLocalEew,  List<JmaCodeTableItem> areaInformationPrefectureEarthquake,  List<JmaCodeTableCityItem> areaInformationCity,  List<JmaCodeTableItem> areaEpicenter,  List<JmaCodeTableItem> areaEpicenterAbbreviation,  List<JmaCodeTableItem> areaEpicenterDetail)?  $default,) {final _that = this;
 switch (_that) {
 case _JmaCodeTableCodeTables() when $default != null:
-return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthquake,_that.areaEpicenter,_that.areaEpicenterAbbreviation,_that.areaEpicenterDetail);case _:
+return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthquake,_that.areaInformationCity,_that.areaEpicenter,_that.areaEpicenterAbbreviation,_that.areaEpicenterDetail);case _:
   return null;
 
 }
@@ -515,7 +516,7 @@ return $default(_that.areaForecastLocalEew,_that.areaInformationPrefectureEarthq
 @JsonSerializable()
 
 class _JmaCodeTableCodeTables implements JmaCodeTableCodeTables {
-  const _JmaCodeTableCodeTables({required final  List<JmaCodeTableItem> areaForecastLocalEew, required final  List<JmaCodeTableItem> areaInformationPrefectureEarthquake, required final  List<JmaCodeTableItem> areaEpicenter, required final  List<JmaCodeTableItem> areaEpicenterAbbreviation, required final  List<JmaCodeTableItem> areaEpicenterDetail}): _areaForecastLocalEew = areaForecastLocalEew,_areaInformationPrefectureEarthquake = areaInformationPrefectureEarthquake,_areaEpicenter = areaEpicenter,_areaEpicenterAbbreviation = areaEpicenterAbbreviation,_areaEpicenterDetail = areaEpicenterDetail;
+  const _JmaCodeTableCodeTables({required final  List<JmaCodeTableItem> areaForecastLocalEew, required final  List<JmaCodeTableItem> areaInformationPrefectureEarthquake, required final  List<JmaCodeTableCityItem> areaInformationCity, required final  List<JmaCodeTableItem> areaEpicenter, required final  List<JmaCodeTableItem> areaEpicenterAbbreviation, required final  List<JmaCodeTableItem> areaEpicenterDetail}): _areaForecastLocalEew = areaForecastLocalEew,_areaInformationPrefectureEarthquake = areaInformationPrefectureEarthquake,_areaInformationCity = areaInformationCity,_areaEpicenter = areaEpicenter,_areaEpicenterAbbreviation = areaEpicenterAbbreviation,_areaEpicenterDetail = areaEpicenterDetail;
   factory _JmaCodeTableCodeTables.fromJson(Map<String, dynamic> json) => _$JmaCodeTableCodeTablesFromJson(json);
 
  final  List<JmaCodeTableItem> _areaForecastLocalEew;
@@ -530,6 +531,13 @@ class _JmaCodeTableCodeTables implements JmaCodeTableCodeTables {
   if (_areaInformationPrefectureEarthquake is EqualUnmodifiableListView) return _areaInformationPrefectureEarthquake;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_areaInformationPrefectureEarthquake);
+}
+
+ final  List<JmaCodeTableCityItem> _areaInformationCity;
+@override List<JmaCodeTableCityItem> get areaInformationCity {
+  if (_areaInformationCity is EqualUnmodifiableListView) return _areaInformationCity;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_areaInformationCity);
 }
 
  final  List<JmaCodeTableItem> _areaEpicenter;
@@ -567,16 +575,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JmaCodeTableCodeTables&&const DeepCollectionEquality().equals(other._areaForecastLocalEew, _areaForecastLocalEew)&&const DeepCollectionEquality().equals(other._areaInformationPrefectureEarthquake, _areaInformationPrefectureEarthquake)&&const DeepCollectionEquality().equals(other._areaEpicenter, _areaEpicenter)&&const DeepCollectionEquality().equals(other._areaEpicenterAbbreviation, _areaEpicenterAbbreviation)&&const DeepCollectionEquality().equals(other._areaEpicenterDetail, _areaEpicenterDetail));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JmaCodeTableCodeTables&&const DeepCollectionEquality().equals(other._areaForecastLocalEew, _areaForecastLocalEew)&&const DeepCollectionEquality().equals(other._areaInformationPrefectureEarthquake, _areaInformationPrefectureEarthquake)&&const DeepCollectionEquality().equals(other._areaInformationCity, _areaInformationCity)&&const DeepCollectionEquality().equals(other._areaEpicenter, _areaEpicenter)&&const DeepCollectionEquality().equals(other._areaEpicenterAbbreviation, _areaEpicenterAbbreviation)&&const DeepCollectionEquality().equals(other._areaEpicenterDetail, _areaEpicenterDetail));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_areaForecastLocalEew),const DeepCollectionEquality().hash(_areaInformationPrefectureEarthquake),const DeepCollectionEquality().hash(_areaEpicenter),const DeepCollectionEquality().hash(_areaEpicenterAbbreviation),const DeepCollectionEquality().hash(_areaEpicenterDetail));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_areaForecastLocalEew),const DeepCollectionEquality().hash(_areaInformationPrefectureEarthquake),const DeepCollectionEquality().hash(_areaInformationCity),const DeepCollectionEquality().hash(_areaEpicenter),const DeepCollectionEquality().hash(_areaEpicenterAbbreviation),const DeepCollectionEquality().hash(_areaEpicenterDetail));
 
 @override
 String toString() {
-  return 'JmaCodeTableCodeTables(areaForecastLocalEew: $areaForecastLocalEew, areaInformationPrefectureEarthquake: $areaInformationPrefectureEarthquake, areaEpicenter: $areaEpicenter, areaEpicenterAbbreviation: $areaEpicenterAbbreviation, areaEpicenterDetail: $areaEpicenterDetail)';
+  return 'JmaCodeTableCodeTables(areaForecastLocalEew: $areaForecastLocalEew, areaInformationPrefectureEarthquake: $areaInformationPrefectureEarthquake, areaInformationCity: $areaInformationCity, areaEpicenter: $areaEpicenter, areaEpicenterAbbreviation: $areaEpicenterAbbreviation, areaEpicenterDetail: $areaEpicenterDetail)';
 }
 
 
@@ -587,7 +595,7 @@ abstract mixin class _$JmaCodeTableCodeTablesCopyWith<$Res> implements $JmaCodeT
   factory _$JmaCodeTableCodeTablesCopyWith(_JmaCodeTableCodeTables value, $Res Function(_JmaCodeTableCodeTables) _then) = __$JmaCodeTableCodeTablesCopyWithImpl;
 @override @useResult
 $Res call({
- List<JmaCodeTableItem> areaForecastLocalEew, List<JmaCodeTableItem> areaInformationPrefectureEarthquake, List<JmaCodeTableItem> areaEpicenter, List<JmaCodeTableItem> areaEpicenterAbbreviation, List<JmaCodeTableItem> areaEpicenterDetail
+ List<JmaCodeTableItem> areaForecastLocalEew, List<JmaCodeTableItem> areaInformationPrefectureEarthquake, List<JmaCodeTableCityItem> areaInformationCity, List<JmaCodeTableItem> areaEpicenter, List<JmaCodeTableItem> areaEpicenterAbbreviation, List<JmaCodeTableItem> areaEpicenterDetail
 });
 
 
@@ -604,11 +612,12 @@ class __$JmaCodeTableCodeTablesCopyWithImpl<$Res>
 
 /// Create a copy of JmaCodeTableCodeTables
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? areaForecastLocalEew = null,Object? areaInformationPrefectureEarthquake = null,Object? areaEpicenter = null,Object? areaEpicenterAbbreviation = null,Object? areaEpicenterDetail = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? areaForecastLocalEew = null,Object? areaInformationPrefectureEarthquake = null,Object? areaInformationCity = null,Object? areaEpicenter = null,Object? areaEpicenterAbbreviation = null,Object? areaEpicenterDetail = null,}) {
   return _then(_JmaCodeTableCodeTables(
 areaForecastLocalEew: null == areaForecastLocalEew ? _self._areaForecastLocalEew : areaForecastLocalEew // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,areaInformationPrefectureEarthquake: null == areaInformationPrefectureEarthquake ? _self._areaInformationPrefectureEarthquake : areaInformationPrefectureEarthquake // ignore: cast_nullable_to_non_nullable
-as List<JmaCodeTableItem>,areaEpicenter: null == areaEpicenter ? _self._areaEpicenter : areaEpicenter // ignore: cast_nullable_to_non_nullable
+as List<JmaCodeTableItem>,areaInformationCity: null == areaInformationCity ? _self._areaInformationCity : areaInformationCity // ignore: cast_nullable_to_non_nullable
+as List<JmaCodeTableCityItem>,areaEpicenter: null == areaEpicenter ? _self._areaEpicenter : areaEpicenter // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,areaEpicenterAbbreviation: null == areaEpicenterAbbreviation ? _self._areaEpicenterAbbreviation : areaEpicenterAbbreviation // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,areaEpicenterDetail: null == areaEpicenterDetail ? _self._areaEpicenterDetail : areaEpicenterDetail // ignore: cast_nullable_to_non_nullable
 as List<JmaCodeTableItem>,
@@ -616,6 +625,296 @@ as List<JmaCodeTableItem>,
 }
 
 
+}
+
+
+/// @nodoc
+mixin _$JmaCodeTableCityItem {
+
+ String get code; LocalizedName get name;@JsonKey(name: 'parent_area_forecast_local_eew_code') String get parentAreaForecastLocalEewCode;@JsonKey(name: 'parent_area_information_prefecture_earthquake_code') String get parentAreaInformationPrefectureEarthquakeCode;
+/// Create a copy of JmaCodeTableCityItem
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$JmaCodeTableCityItemCopyWith<JmaCodeTableCityItem> get copyWith => _$JmaCodeTableCityItemCopyWithImpl<JmaCodeTableCityItem>(this as JmaCodeTableCityItem, _$identity);
+
+  /// Serializes this JmaCodeTableCityItem to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JmaCodeTableCityItem&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.parentAreaForecastLocalEewCode, parentAreaForecastLocalEewCode) || other.parentAreaForecastLocalEewCode == parentAreaForecastLocalEewCode)&&(identical(other.parentAreaInformationPrefectureEarthquakeCode, parentAreaInformationPrefectureEarthquakeCode) || other.parentAreaInformationPrefectureEarthquakeCode == parentAreaInformationPrefectureEarthquakeCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,name,parentAreaForecastLocalEewCode,parentAreaInformationPrefectureEarthquakeCode);
+
+@override
+String toString() {
+  return 'JmaCodeTableCityItem(code: $code, name: $name, parentAreaForecastLocalEewCode: $parentAreaForecastLocalEewCode, parentAreaInformationPrefectureEarthquakeCode: $parentAreaInformationPrefectureEarthquakeCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $JmaCodeTableCityItemCopyWith<$Res>  {
+  factory $JmaCodeTableCityItemCopyWith(JmaCodeTableCityItem value, $Res Function(JmaCodeTableCityItem) _then) = _$JmaCodeTableCityItemCopyWithImpl;
+@useResult
+$Res call({
+ String code, LocalizedName name,@JsonKey(name: 'parent_area_forecast_local_eew_code') String parentAreaForecastLocalEewCode,@JsonKey(name: 'parent_area_information_prefecture_earthquake_code') String parentAreaInformationPrefectureEarthquakeCode
+});
+
+
+$LocalizedNameCopyWith<$Res> get name;
+
+}
+/// @nodoc
+class _$JmaCodeTableCityItemCopyWithImpl<$Res>
+    implements $JmaCodeTableCityItemCopyWith<$Res> {
+  _$JmaCodeTableCityItemCopyWithImpl(this._self, this._then);
+
+  final JmaCodeTableCityItem _self;
+  final $Res Function(JmaCodeTableCityItem) _then;
+
+/// Create a copy of JmaCodeTableCityItem
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? code = null,Object? name = null,Object? parentAreaForecastLocalEewCode = null,Object? parentAreaInformationPrefectureEarthquakeCode = null,}) {
+  return _then(_self.copyWith(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as LocalizedName,parentAreaForecastLocalEewCode: null == parentAreaForecastLocalEewCode ? _self.parentAreaForecastLocalEewCode : parentAreaForecastLocalEewCode // ignore: cast_nullable_to_non_nullable
+as String,parentAreaInformationPrefectureEarthquakeCode: null == parentAreaInformationPrefectureEarthquakeCode ? _self.parentAreaInformationPrefectureEarthquakeCode : parentAreaInformationPrefectureEarthquakeCode // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+/// Create a copy of JmaCodeTableCityItem
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LocalizedNameCopyWith<$Res> get name {
+  
+  return $LocalizedNameCopyWith<$Res>(_self.name, (value) {
+    return _then(_self.copyWith(name: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [JmaCodeTableCityItem].
+extension JmaCodeTableCityItemPatterns on JmaCodeTableCityItem {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _JmaCodeTableCityItem value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _JmaCodeTableCityItem() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _JmaCodeTableCityItem value)  $default,){
+final _that = this;
+switch (_that) {
+case _JmaCodeTableCityItem():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _JmaCodeTableCityItem value)?  $default,){
+final _that = this;
+switch (_that) {
+case _JmaCodeTableCityItem() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String code,  LocalizedName name, @JsonKey(name: 'parent_area_forecast_local_eew_code')  String parentAreaForecastLocalEewCode, @JsonKey(name: 'parent_area_information_prefecture_earthquake_code')  String parentAreaInformationPrefectureEarthquakeCode)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _JmaCodeTableCityItem() when $default != null:
+return $default(_that.code,_that.name,_that.parentAreaForecastLocalEewCode,_that.parentAreaInformationPrefectureEarthquakeCode);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String code,  LocalizedName name, @JsonKey(name: 'parent_area_forecast_local_eew_code')  String parentAreaForecastLocalEewCode, @JsonKey(name: 'parent_area_information_prefecture_earthquake_code')  String parentAreaInformationPrefectureEarthquakeCode)  $default,) {final _that = this;
+switch (_that) {
+case _JmaCodeTableCityItem():
+return $default(_that.code,_that.name,_that.parentAreaForecastLocalEewCode,_that.parentAreaInformationPrefectureEarthquakeCode);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String code,  LocalizedName name, @JsonKey(name: 'parent_area_forecast_local_eew_code')  String parentAreaForecastLocalEewCode, @JsonKey(name: 'parent_area_information_prefecture_earthquake_code')  String parentAreaInformationPrefectureEarthquakeCode)?  $default,) {final _that = this;
+switch (_that) {
+case _JmaCodeTableCityItem() when $default != null:
+return $default(_that.code,_that.name,_that.parentAreaForecastLocalEewCode,_that.parentAreaInformationPrefectureEarthquakeCode);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _JmaCodeTableCityItem implements JmaCodeTableCityItem {
+  const _JmaCodeTableCityItem({required this.code, required this.name, @JsonKey(name: 'parent_area_forecast_local_eew_code') required this.parentAreaForecastLocalEewCode, @JsonKey(name: 'parent_area_information_prefecture_earthquake_code') required this.parentAreaInformationPrefectureEarthquakeCode});
+  factory _JmaCodeTableCityItem.fromJson(Map<String, dynamic> json) => _$JmaCodeTableCityItemFromJson(json);
+
+@override final  String code;
+@override final  LocalizedName name;
+@override@JsonKey(name: 'parent_area_forecast_local_eew_code') final  String parentAreaForecastLocalEewCode;
+@override@JsonKey(name: 'parent_area_information_prefecture_earthquake_code') final  String parentAreaInformationPrefectureEarthquakeCode;
+
+/// Create a copy of JmaCodeTableCityItem
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$JmaCodeTableCityItemCopyWith<_JmaCodeTableCityItem> get copyWith => __$JmaCodeTableCityItemCopyWithImpl<_JmaCodeTableCityItem>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$JmaCodeTableCityItemToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JmaCodeTableCityItem&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.parentAreaForecastLocalEewCode, parentAreaForecastLocalEewCode) || other.parentAreaForecastLocalEewCode == parentAreaForecastLocalEewCode)&&(identical(other.parentAreaInformationPrefectureEarthquakeCode, parentAreaInformationPrefectureEarthquakeCode) || other.parentAreaInformationPrefectureEarthquakeCode == parentAreaInformationPrefectureEarthquakeCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,name,parentAreaForecastLocalEewCode,parentAreaInformationPrefectureEarthquakeCode);
+
+@override
+String toString() {
+  return 'JmaCodeTableCityItem(code: $code, name: $name, parentAreaForecastLocalEewCode: $parentAreaForecastLocalEewCode, parentAreaInformationPrefectureEarthquakeCode: $parentAreaInformationPrefectureEarthquakeCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$JmaCodeTableCityItemCopyWith<$Res> implements $JmaCodeTableCityItemCopyWith<$Res> {
+  factory _$JmaCodeTableCityItemCopyWith(_JmaCodeTableCityItem value, $Res Function(_JmaCodeTableCityItem) _then) = __$JmaCodeTableCityItemCopyWithImpl;
+@override @useResult
+$Res call({
+ String code, LocalizedName name,@JsonKey(name: 'parent_area_forecast_local_eew_code') String parentAreaForecastLocalEewCode,@JsonKey(name: 'parent_area_information_prefecture_earthquake_code') String parentAreaInformationPrefectureEarthquakeCode
+});
+
+
+@override $LocalizedNameCopyWith<$Res> get name;
+
+}
+/// @nodoc
+class __$JmaCodeTableCityItemCopyWithImpl<$Res>
+    implements _$JmaCodeTableCityItemCopyWith<$Res> {
+  __$JmaCodeTableCityItemCopyWithImpl(this._self, this._then);
+
+  final _JmaCodeTableCityItem _self;
+  final $Res Function(_JmaCodeTableCityItem) _then;
+
+/// Create a copy of JmaCodeTableCityItem
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? code = null,Object? name = null,Object? parentAreaForecastLocalEewCode = null,Object? parentAreaInformationPrefectureEarthquakeCode = null,}) {
+  return _then(_JmaCodeTableCityItem(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as LocalizedName,parentAreaForecastLocalEewCode: null == parentAreaForecastLocalEewCode ? _self.parentAreaForecastLocalEewCode : parentAreaForecastLocalEewCode // ignore: cast_nullable_to_non_nullable
+as String,parentAreaInformationPrefectureEarthquakeCode: null == parentAreaInformationPrefectureEarthquakeCode ? _self.parentAreaInformationPrefectureEarthquakeCode : parentAreaInformationPrefectureEarthquakeCode // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+/// Create a copy of JmaCodeTableCityItem
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LocalizedNameCopyWith<$Res> get name {
+  
+  return $LocalizedNameCopyWith<$Res>(_self.name, (value) {
+    return _then(_self.copyWith(name: value));
+  });
+}
 }
 
 

--- a/app/lib/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.g.dart
+++ b/app/lib/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.g.dart
@@ -50,6 +50,14 @@ _JmaCodeTableCodeTables _$JmaCodeTableCodeTablesFromJson(
             .map((e) => JmaCodeTableItem.fromJson(e as Map<String, dynamic>))
             .toList(),
       ),
+      areaInformationCity: $checkedConvert(
+        'area_information_city',
+        (v) => (v as List<dynamic>)
+            .map(
+              (e) => JmaCodeTableCityItem.fromJson(e as Map<String, dynamic>),
+            )
+            .toList(),
+      ),
       areaEpicenter: $checkedConvert(
         'area_epicenter',
         (v) => (v as List<dynamic>)
@@ -75,6 +83,7 @@ _JmaCodeTableCodeTables _$JmaCodeTableCodeTablesFromJson(
     'areaForecastLocalEew': 'area_forecast_local_eew',
     'areaInformationPrefectureEarthquake':
         'area_information_prefecture_earthquake',
+    'areaInformationCity': 'area_information_city',
     'areaEpicenter': 'area_epicenter',
     'areaEpicenterAbbreviation': 'area_epicenter_abbreviation',
     'areaEpicenterDetail': 'area_epicenter_detail',
@@ -87,9 +96,51 @@ Map<String, dynamic> _$JmaCodeTableCodeTablesToJson(
   'area_forecast_local_eew': instance.areaForecastLocalEew,
   'area_information_prefecture_earthquake':
       instance.areaInformationPrefectureEarthquake,
+  'area_information_city': instance.areaInformationCity,
   'area_epicenter': instance.areaEpicenter,
   'area_epicenter_abbreviation': instance.areaEpicenterAbbreviation,
   'area_epicenter_detail': instance.areaEpicenterDetail,
+};
+
+_JmaCodeTableCityItem _$JmaCodeTableCityItemFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_JmaCodeTableCityItem',
+  json,
+  ($checkedConvert) {
+    final val = _JmaCodeTableCityItem(
+      code: $checkedConvert('code', (v) => v as String),
+      name: $checkedConvert(
+        'name',
+        (v) => LocalizedName.fromJson(v as Map<String, dynamic>),
+      ),
+      parentAreaForecastLocalEewCode: $checkedConvert(
+        'parent_area_forecast_local_eew_code',
+        (v) => v as String,
+      ),
+      parentAreaInformationPrefectureEarthquakeCode: $checkedConvert(
+        'parent_area_information_prefecture_earthquake_code',
+        (v) => v as String,
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'parentAreaForecastLocalEewCode': 'parent_area_forecast_local_eew_code',
+    'parentAreaInformationPrefectureEarthquakeCode':
+        'parent_area_information_prefecture_earthquake_code',
+  },
+);
+
+Map<String, dynamic> _$JmaCodeTableCityItemToJson(
+  _JmaCodeTableCityItem instance,
+) => <String, dynamic>{
+  'code': instance.code,
+  'name': instance.name,
+  'parent_area_forecast_local_eew_code':
+      instance.parentAreaForecastLocalEewCode,
+  'parent_area_information_prefecture_earthquake_code':
+      instance.parentAreaInformationPrefectureEarthquakeCode,
 };
 
 _JmaCodeTableItem _$JmaCodeTableItemFromJson(Map<String, dynamic> json) =>

--- a/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/city_picker_page.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
+import 'package:eqmonitor/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/experimental/mutation.dart';
+
+class CityPickerPage extends HookConsumerWidget {
+  const CityPickerPage({
+    required this.regionCode,
+    required this.regionName,
+    super.key,
+  });
+
+  final String regionCode;
+  final String regionName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchController = useTextEditingController();
+    final searchText = useState('');
+
+    useEffect(
+      () {
+        void listener() => searchText.value = searchController.text;
+        searchController.addListener(listener);
+        return () => searchController.removeListener(listener);
+      },
+      [searchController],
+    );
+
+    final jmaCodeTableAsync = ref.watch(jmaCodeTableProvider);
+    final cities = jmaCodeTableAsync.value?.codeTables.areaInformationCity;
+
+    final filteredCities =
+        _filterCities(cities, regionCode, searchText.value);
+
+    ref.listen(NotificationSlotsNotifier.addRegionMutation, (_, next) {
+      if (next is MutationError) {
+        final error = next.error;
+        if (error is DioException && error.response?.statusCode == 402) {
+          unawaited(showProUpgradeDialog(context));
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('地域の追加に失敗しました: $error'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      }
+      if (next is MutationSuccess) {
+        Navigator.of(context)
+          ..pop()
+          ..pop();
+      }
+    });
+
+    final isAdding =
+        ref.watch(NotificationSlotsNotifier.addRegionMutation)
+            is MutationPending;
+
+    return Scaffold(
+      appBar: AppBar(title: Text('$regionName - 市区町村を選択')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: SearchBar(
+              controller: searchController,
+              hintText: '市区町村名で検索',
+              leading: const Padding(
+                padding: EdgeInsets.only(left: 8),
+                child: Icon(Icons.search),
+              ),
+              trailing: [
+                if (searchText.value.isNotEmpty)
+                  IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      searchController.clear();
+                      searchText.value = '';
+                    },
+                  ),
+              ],
+            ),
+          ),
+          if (isAdding) const LinearProgressIndicator(),
+          Expanded(
+            child: switch (jmaCodeTableAsync) {
+              AsyncLoading() => const Center(
+                child: CircularProgressIndicator.adaptive(),
+              ),
+              AsyncError(:final error) => Center(
+                child: Text('読み込みに失敗しました: $error'),
+              ),
+              _ when filteredCities != null => ListView.builder(
+                itemCount: filteredCities.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == 0) {
+                    return _WholeRegionTile(
+                      regionCode: regionCode,
+                      regionName: regionName,
+                      enabled: !isAdding,
+                    );
+                  }
+                  final city = filteredCities[index - 1];
+                  return _CityListTile(
+                    city: city,
+                    regionCode: regionCode,
+                    enabled: !isAdding,
+                  );
+                },
+              ),
+              _ => const SizedBox.shrink(),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  static List<JmaCodeTableCityItem>? _filterCities(
+    List<JmaCodeTableCityItem>? cities,
+    String regionCode,
+    String query,
+  ) {
+    if (cities == null) {
+      return null;
+    }
+    final regionCities = cities
+        .where((c) => c.parentAreaForecastLocalEewCode == regionCode)
+        .toList();
+    if (query.isEmpty) {
+      return regionCities;
+    }
+    final lowerQuery = query.toLowerCase();
+    return regionCities.where((item) {
+      return item.name.ja.toLowerCase().contains(lowerQuery);
+    }).toList();
+  }
+}
+
+class _WholeRegionTile extends ConsumerWidget {
+  const _WholeRegionTile({
+    required this.regionCode,
+    required this.regionName,
+    required this.enabled,
+  });
+
+  final String regionCode;
+  final String regionName;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      enabled: enabled,
+      leading: const Icon(Icons.select_all),
+      title: Text('$regionName 全域'),
+      subtitle: const Text('この地域全体の通知を受け取ります'),
+      trailing: const Icon(Icons.add),
+      onTap: enabled
+          ? () async {
+              await NotificationSlotsNotifier.addRegionMutation.run(
+                ref,
+                (tsx) async {
+                  await tsx
+                      .get(notificationSlotsProvider.notifier)
+                      .addRegion(
+                        regionId: int.parse(regionCode),
+                        regionName: regionName,
+                      );
+                },
+              );
+            }
+          : null,
+    );
+  }
+}
+
+class _CityListTile extends ConsumerWidget {
+  const _CityListTile({
+    required this.city,
+    required this.regionCode,
+    required this.enabled,
+  });
+
+  final JmaCodeTableCityItem city;
+  final String regionCode;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      enabled: enabled,
+      title: Text(city.name.ja),
+      subtitle: Text(city.code),
+      trailing: const Icon(Icons.add),
+      onTap: enabled
+          ? () async {
+              await NotificationSlotsNotifier.addRegionMutation.run(
+                ref,
+                (tsx) async {
+                  await tsx
+                      .get(notificationSlotsProvider.notifier)
+                      .addRegion(
+                        regionId: int.parse(regionCode),
+                        cityCode: city.code,
+                        cityName: city.name.ja,
+                      );
+                },
+              );
+            }
+          : null,
+    );
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/region_picker_page.dart
@@ -1,14 +1,9 @@
-import 'dart:async';
-
-import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/provider/jma_code_table_provider.dart';
 import 'package:eqmonitor/feature/parameter/data/model/jma_code_table/jma_code_table_parameter.dart';
-import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
-import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_upgrade_dialog.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/city_picker_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:riverpod/experimental/mutation.dart';
 
 class RegionPickerPage extends HookConsumerWidget {
   const RegionPickerPage({super.key});
@@ -31,29 +26,6 @@ class RegionPickerPage extends HookConsumerWidget {
     final regions = jmaCodeTableAsync.value?.codeTables.areaForecastLocalEew;
 
     final filteredRegions = _filterRegions(regions, searchText.value);
-
-    ref.listen(NotificationSlotsNotifier.addRegionMutation, (_, next) {
-      if (next is MutationError) {
-        final error = next.error;
-        if (error is DioException && error.response?.statusCode == 402) {
-          unawaited(showProUpgradeDialog(context));
-        } else {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('地域の追加に失敗しました: $error'),
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-          );
-        }
-      }
-      if (next is MutationSuccess) {
-        Navigator.of(context).pop();
-      }
-    });
-
-    final isAdding =
-        ref.watch(NotificationSlotsNotifier.addRegionMutation)
-            is MutationPending;
 
     return Scaffold(
       appBar: AppBar(title: const Text('地域を選択')),
@@ -80,7 +52,6 @@ class RegionPickerPage extends HookConsumerWidget {
               ],
             ),
           ),
-          if (isAdding) const LinearProgressIndicator(),
           Expanded(
             child: switch (jmaCodeTableAsync) {
               AsyncLoading() => const Center(
@@ -95,18 +66,14 @@ class RegionPickerPage extends HookConsumerWidget {
                   final region = filteredRegions[index];
                   return _RegionListTile(
                     region: region,
-                    enabled: !isAdding,
                     onTap: () async {
-                      await NotificationSlotsNotifier.addRegionMutation.run(
-                        ref,
-                        (tsx) async {
-                          await tsx
-                              .get(notificationSlotsProvider.notifier)
-                              .addRegion(
-                                regionId: int.parse(region.code),
-                                regionName: region.name.ja,
-                              );
-                        },
+                      await Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => CityPickerPage(
+                            regionCode: region.code,
+                            regionName: region.name.ja,
+                          ),
+                        ),
                       );
                     },
                   );
@@ -142,22 +109,19 @@ class RegionPickerPage extends HookConsumerWidget {
 class _RegionListTile extends StatelessWidget {
   const _RegionListTile({
     required this.region,
-    required this.enabled,
     required this.onTap,
   });
 
   final JmaCodeTableItem region;
-  final bool enabled;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      enabled: enabled,
       title: Text(region.name.ja),
       subtitle: Text(region.code),
-      trailing: const Icon(Icons.add),
-      onTap: enabled ? onTap : null,
+      trailing: const Icon(Icons.chevron_right),
+      onTap: onTap,
     );
   }
 }


### PR DESCRIPTION
## Summary
- アプリ側に `JmaCodeTableCityItem` モデルを追加し、`JmaCodeTableCodeTables.areaInformationCity` フィールドを追加
- `CityPickerPage` を新規作成: 地域全域 or 市区町村単位で通知スロットを追加可能
- `RegionPickerPage` を2ステップナビゲーションに変更: 地域一覧 → 市区町村一覧（+ 全域オプション）

## Test plan
- [ ] 地域一覧が表示され、タップで市区町村一覧に遷移すること
- [ ] 市区町村一覧に「全域」オプションが表示されること
- [ ] 市区町村を選択して通知スロットが正常に追加されること
- [ ] 全域を選択して通知スロットが正常に追加されること
- [ ] 検索フィルタが地域・市区町村名で動作すること
- [ ] Freeプランでスロット上限超過時にProアップグレードダイアログが表示されること

https://claude.ai/code/session_01QyGpLpJ7FaoZykkDhAChcR