### PR TITLE
fix: EEW推計震度が表示されない不具合を修正

### DIFF
--- a/app/lib/core/provider/estimated_intensity/provider/estimated_intensity_provider.dart
+++ b/app/lib/core/provider/estimated_intensity/provider/estimated_intensity_provider.dart
@@ -3,9 +3,10 @@ import 'dart:isolate';
 import 'dart:math' as math;
 
 import 'package:eqmonitor/core/provider/estimated_intensity/data/estimated_intensity_data_source.dart';
-import 'package:eqmonitor/core/provider/jma_parameter/jma_parameter.dart';
+import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshin_observation_points_provider.dart';
 import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/parameter/data/model/kyoshin/kyoshin_observation_points_parameter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -14,8 +15,9 @@ part 'estimated_intensity_provider.g.dart';
 
 typedef _CachedPoint = ({
   String regionCode,
-  String cityCode,
-  EarthquakeParameterStationItem station,
+  double lat,
+  double lon,
+  double arv400,
 });
 
 typedef _EewHypocenterInput = ({
@@ -61,15 +63,17 @@ class EstimatedIntensity extends _$EstimatedIntensity {
   @override
   Future<List<EstimatedIntensityPoint>> build() async {
     ref.listen(eewAliveTelegramProvider, (_, next) async {
-      final parameter = await ref.read(jmaParameterProvider.future);
-      final result = await calcInIsolate(next ?? [], parameter.earthquake);
+      final kyoshinParam =
+          await ref.read(kyoshinObservationPointsProvider.future);
+      final result = await calcInIsolate(next ?? [], kyoshinParam);
       state = AsyncData(result.toList());
     });
-    final parameter = await ref.read(jmaParameterProvider.future);
+    final kyoshinParam =
+        await ref.read(kyoshinObservationPointsProvider.future);
 
     final result = await calcInIsolate(
       ref.read(eewAliveTelegramProvider) ?? [],
-      parameter.earthquake,
+      kyoshinParam,
     );
     return result.toList();
   }
@@ -79,9 +83,9 @@ class EstimatedIntensity extends _$EstimatedIntensity {
 
   List<EstimatedIntensityPoint> calc(
     List<EewTelegramItem> eews,
-    EarthquakeParameter parameter,
+    KyoshinObservationPointsParameter kyoshinParam,
   ) {
-    _cachedPoints ??= _generateCachedPoints(parameter);
+    _cachedPoints ??= _generateCachedPoints(kyoshinParam);
     _calculationPoints ??= _generateCalculationPoints(_cachedPoints!);
 
     final targetEews = eews
@@ -114,8 +118,6 @@ class EstimatedIntensity extends _$EstimatedIntensity {
       for (var i = 0; i < intensities.length; i++)
         EstimatedIntensityPoint(
           regionCode: _cachedPoints![i].regionCode,
-          cityCode: _cachedPoints![i].cityCode,
-          station: _cachedPoints![i].station,
           intensity: intensities[i],
         ),
     ];
@@ -123,9 +125,9 @@ class EstimatedIntensity extends _$EstimatedIntensity {
 
   Future<Iterable<EstimatedIntensityPoint>> calcInIsolate(
     List<EewTelegramItem> eews,
-    EarthquakeParameter parameter,
+    KyoshinObservationPointsParameter kyoshinParam,
   ) async {
-    _cachedPoints ??= _generateCachedPoints(parameter);
+    _cachedPoints ??= _generateCachedPoints(kyoshinParam);
     _calculationPoints ??= _generateCalculationPoints(_cachedPoints!);
 
     final targetEews = eews
@@ -163,27 +165,27 @@ class EstimatedIntensity extends _$EstimatedIntensity {
       for (var i = 0; i < intensities.length; i++)
         EstimatedIntensityPoint(
           regionCode: cachedPoints[i].regionCode,
-          cityCode: cachedPoints[i].cityCode,
-          station: cachedPoints[i].station,
           intensity: intensities[i],
         ),
     ];
   }
 
-  List<_CachedPoint> _generateCachedPoints(EarthquakeParameter earthquake) {
+  List<_CachedPoint> _generateCachedPoints(
+    KyoshinObservationPointsParameter kyoshinParam,
+  ) {
     final result = <_CachedPoint>[];
-    for (final prefecture in earthquake.prefectures) {
-      for (final region in prefecture.regions) {
-        for (final city in region.cities) {
-          for (final station in city.stations) {
-            result.add((
-              regionCode: region.code,
-              cityCode: city.code,
-              station: station,
-            ));
-          }
-        }
+    for (final point in kyoshinParam.points) {
+      if (point.regionCode == null ||
+          point.arv400 == null ||
+          point.isSuspended) {
+        continue;
       }
+      result.add((
+        regionCode: point.regionCode!,
+        lat: point.location.lat,
+        lon: point.location.lon,
+        arv400: point.arv400!,
+      ));
     }
     return result;
   }
@@ -192,30 +194,8 @@ class EstimatedIntensity extends _$EstimatedIntensity {
     Iterable<_CachedPoint> points,
   ) => [
     for (final p in points)
-      if (p.station.arv400 case final arv400?)
-        (
-          lat: p.station.location.lat,
-          lon: p.station.location.lon,
-          arv400: arv400,
-        ),
+      (lat: p.lat, lon: p.lon, arv400: p.arv400),
   ];
-}
-
-@Riverpod(keepAlive: true)
-Stream<Map<String, double>> estimatedIntensityCity(Ref ref) async* {
-  final estimatedIntensity = ref.watch(estimatedIntensityProvider).value;
-  if (estimatedIntensity != null) {
-    final map = <String, double>{};
-    for (final item in estimatedIntensity) {
-      final currentValue = map[item.cityCode];
-      if (currentValue == null) {
-        map[item.cityCode] = item.intensity;
-      } else {
-        map[item.cityCode] = math.max(currentValue, item.intensity);
-      }
-    }
-    yield map;
-  }
 }
 
 @Riverpod(keepAlive: true)
@@ -239,8 +219,6 @@ Stream<Map<String, double>> estimatedIntensityRegion(Ref ref) async* {
 abstract class EstimatedIntensityPoint with _$EstimatedIntensityPoint {
   const factory EstimatedIntensityPoint({
     required String regionCode,
-    required String cityCode,
-    required EarthquakeParameterStationItem station,
     required double intensity,
   }) = _EstimatedIntensityPoint;
 }

--- a/app/lib/core/provider/estimated_intensity/provider/estimated_intensity_provider.freezed.dart
+++ b/app/lib/core/provider/estimated_intensity/provider/estimated_intensity_provider.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EstimatedIntensityPoint {
 
- String get regionCode; String get cityCode; EarthquakeParameterStationItem get station; double get intensity;
+ String get regionCode; double get intensity;
 /// Create a copy of EstimatedIntensityPoint
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $EstimatedIntensityPointCopyWith<EstimatedIntensityPoint> get copyWith => _$Esti
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EstimatedIntensityPoint&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.station, station) || other.station == station)&&(identical(other.intensity, intensity) || other.intensity == intensity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EstimatedIntensityPoint&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.intensity, intensity) || other.intensity == intensity));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,regionCode,cityCode,station,intensity);
+int get hashCode => Object.hash(runtimeType,regionCode,intensity);
 
 @override
 String toString() {
-  return 'EstimatedIntensityPoint(regionCode: $regionCode, cityCode: $cityCode, station: $station, intensity: $intensity)';
+  return 'EstimatedIntensityPoint(regionCode: $regionCode, intensity: $intensity)';
 }
 
 
@@ -45,11 +45,11 @@ abstract mixin class $EstimatedIntensityPointCopyWith<$Res>  {
   factory $EstimatedIntensityPointCopyWith(EstimatedIntensityPoint value, $Res Function(EstimatedIntensityPoint) _then) = _$EstimatedIntensityPointCopyWithImpl;
 @useResult
 $Res call({
- String regionCode, String cityCode, EarthquakeParameterStationItem station, double intensity
+ String regionCode, double intensity
 });
 
 
-$EarthquakeParameterStationItemCopyWith<$Res> get station;
+
 
 }
 /// @nodoc
@@ -62,25 +62,14 @@ class _$EstimatedIntensityPointCopyWithImpl<$Res>
 
 /// Create a copy of EstimatedIntensityPoint
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? regionCode = null,Object? cityCode = null,Object? station = null,Object? intensity = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? regionCode = null,Object? intensity = null,}) {
   return _then(_self.copyWith(
 regionCode: null == regionCode ? _self.regionCode : regionCode // ignore: cast_nullable_to_non_nullable
-as String,cityCode: null == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
-as String,station: null == station ? _self.station : station // ignore: cast_nullable_to_non_nullable
-as EarthquakeParameterStationItem,intensity: null == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
+as String,intensity: null == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
 as double,
   ));
 }
-/// Create a copy of EstimatedIntensityPoint
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$EarthquakeParameterStationItemCopyWith<$Res> get station {
-  
-  return $EarthquakeParameterStationItemCopyWith<$Res>(_self.station, (value) {
-    return _then(_self.copyWith(station: value));
-  });
-}
+
 }
 
 
@@ -162,10 +151,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String regionCode,  String cityCode,  EarthquakeParameterStationItem station,  double intensity)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String regionCode,  double intensity)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EstimatedIntensityPoint() when $default != null:
-return $default(_that.regionCode,_that.cityCode,_that.station,_that.intensity);case _:
+return $default(_that.regionCode,_that.intensity);case _:
   return orElse();
 
 }
@@ -183,10 +172,10 @@ return $default(_that.regionCode,_that.cityCode,_that.station,_that.intensity);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String regionCode,  String cityCode,  EarthquakeParameterStationItem station,  double intensity)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String regionCode,  double intensity)  $default,) {final _that = this;
 switch (_that) {
 case _EstimatedIntensityPoint():
-return $default(_that.regionCode,_that.cityCode,_that.station,_that.intensity);case _:
+return $default(_that.regionCode,_that.intensity);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -203,10 +192,10 @@ return $default(_that.regionCode,_that.cityCode,_that.station,_that.intensity);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String regionCode,  String cityCode,  EarthquakeParameterStationItem station,  double intensity)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String regionCode,  double intensity)?  $default,) {final _that = this;
 switch (_that) {
 case _EstimatedIntensityPoint() when $default != null:
-return $default(_that.regionCode,_that.cityCode,_that.station,_that.intensity);case _:
+return $default(_that.regionCode,_that.intensity);case _:
   return null;
 
 }
@@ -218,12 +207,10 @@ return $default(_that.regionCode,_that.cityCode,_that.station,_that.intensity);c
 
 
 class _EstimatedIntensityPoint implements EstimatedIntensityPoint {
-  const _EstimatedIntensityPoint({required this.regionCode, required this.cityCode, required this.station, required this.intensity});
+  const _EstimatedIntensityPoint({required this.regionCode, required this.intensity});
   
 
 @override final  String regionCode;
-@override final  String cityCode;
-@override final  EarthquakeParameterStationItem station;
 @override final  double intensity;
 
 /// Create a copy of EstimatedIntensityPoint
@@ -236,16 +223,16 @@ _$EstimatedIntensityPointCopyWith<_EstimatedIntensityPoint> get copyWith => __$E
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EstimatedIntensityPoint&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode)&&(identical(other.station, station) || other.station == station)&&(identical(other.intensity, intensity) || other.intensity == intensity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EstimatedIntensityPoint&&(identical(other.regionCode, regionCode) || other.regionCode == regionCode)&&(identical(other.intensity, intensity) || other.intensity == intensity));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,regionCode,cityCode,station,intensity);
+int get hashCode => Object.hash(runtimeType,regionCode,intensity);
 
 @override
 String toString() {
-  return 'EstimatedIntensityPoint(regionCode: $regionCode, cityCode: $cityCode, station: $station, intensity: $intensity)';
+  return 'EstimatedIntensityPoint(regionCode: $regionCode, intensity: $intensity)';
 }
 
 
@@ -256,11 +243,11 @@ abstract mixin class _$EstimatedIntensityPointCopyWith<$Res> implements $Estimat
   factory _$EstimatedIntensityPointCopyWith(_EstimatedIntensityPoint value, $Res Function(_EstimatedIntensityPoint) _then) = __$EstimatedIntensityPointCopyWithImpl;
 @override @useResult
 $Res call({
- String regionCode, String cityCode, EarthquakeParameterStationItem station, double intensity
+ String regionCode, double intensity
 });
 
 
-@override $EarthquakeParameterStationItemCopyWith<$Res> get station;
+
 
 }
 /// @nodoc
@@ -273,26 +260,15 @@ class __$EstimatedIntensityPointCopyWithImpl<$Res>
 
 /// Create a copy of EstimatedIntensityPoint
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? regionCode = null,Object? cityCode = null,Object? station = null,Object? intensity = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? regionCode = null,Object? intensity = null,}) {
   return _then(_EstimatedIntensityPoint(
 regionCode: null == regionCode ? _self.regionCode : regionCode // ignore: cast_nullable_to_non_nullable
-as String,cityCode: null == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
-as String,station: null == station ? _self.station : station // ignore: cast_nullable_to_non_nullable
-as EarthquakeParameterStationItem,intensity: null == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
+as String,intensity: null == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
 as double,
   ));
 }
 
-/// Create a copy of EstimatedIntensityPoint
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$EarthquakeParameterStationItemCopyWith<$Res> get station {
-  
-  return $EarthquakeParameterStationItemCopyWith<$Res>(_self.station, (value) {
-    return _then(_self.copyWith(station: value));
-  });
-}
+
 }
 
 // dart format on

--- a/app/lib/core/provider/estimated_intensity/provider/estimated_intensity_provider.g.dart
+++ b/app/lib/core/provider/estimated_intensity/provider/estimated_intensity_provider.g.dart
@@ -40,7 +40,7 @@ final class EstimatedIntensityProvider
 }
 
 String _$estimatedIntensityHash() =>
-    r'7d4a7ab6464fb10687621b297aa471d0ef199596';
+    r'e18c2e7e0507a17a619036bef243fe4d045ebd14';
 
 abstract class _$EstimatedIntensity
     extends $AsyncNotifier<List<EstimatedIntensityPoint>> {
@@ -68,48 +68,6 @@ abstract class _$EstimatedIntensity
     element.handleCreate(ref, build);
   }
 }
-
-@ProviderFor(estimatedIntensityCity)
-final estimatedIntensityCityProvider = EstimatedIntensityCityProvider._();
-
-final class EstimatedIntensityCityProvider
-    extends
-        $FunctionalProvider<
-          AsyncValue<Map<String, double>>,
-          Map<String, double>,
-          Stream<Map<String, double>>
-        >
-    with
-        $FutureModifier<Map<String, double>>,
-        $StreamProvider<Map<String, double>> {
-  EstimatedIntensityCityProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'estimatedIntensityCityProvider',
-        isAutoDispose: false,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
-
-  @override
-  String debugGetCreateSourceHash() => _$estimatedIntensityCityHash();
-
-  @$internal
-  @override
-  $StreamProviderElement<Map<String, double>> $createElement(
-    $ProviderPointer pointer,
-  ) => $StreamProviderElement(pointer);
-
-  @override
-  Stream<Map<String, double>> create(Ref ref) {
-    return estimatedIntensityCity(ref);
-  }
-}
-
-String _$estimatedIntensityCityHash() =>
-    r'd260dc423fc1c3c73e9ce87ab6e57ac836789ae0';
 
 @ProviderFor(estimatedIntensityRegion)
 final estimatedIntensityRegionProvider = EstimatedIntensityRegionProvider._();

--- a/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart
+++ b/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/extension/double_to_jma_forecast_intensity.dart';
 import 'package:eqmonitor/core/provider/estimated_intensity/data/estimated_intensity_data_source.dart';
 import 'package:eqmonitor/core/provider/jma_parameter/jma_parameter.dart';
+import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshin_observation_points_provider.dart';
 import 'package:eqmonitor/core/provider/travel_time/model/travel_time_table.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_estimated_region.dart';
@@ -53,30 +54,34 @@ Future<List<EewEstimatedRegion>> eewEstimatedRegionIntensity(
     return [];
   }
 
-  final parameter = await ref.read(jmaParameterProvider.future);
+  final kyoshinParam =
+      await ref.read(kyoshinObservationPointsProvider.future);
+  final earthquakeParam = await ref.read(jmaParameterProvider.future);
   final travelTimeTables = ref.read(travelTimeProvider);
 
-  // station一覧を構築
-  final stations = <_RegionStation>[];
-  for (final prefecture in parameter.earthquake.prefectures) {
-    for (final region in prefecture.regions) {
-      for (final city in region.cities) {
-        for (final station in city.stations) {
-          if (station.arv400 == null) {
-            continue;
-          }
-          stations.add((
-            regionCode: region.code,
-            regionName: region.name.ja,
-            point: (
-              lat: station.location.lat,
-              lon: station.location.lon,
-              arv400: station.arv400!,
-            ),
-          ));
-        }
-      }
+  final regionNameLookup = <String, String>{};
+  for (final pref in earthquakeParam.earthquake.prefectures) {
+    for (final region in pref.regions) {
+      regionNameLookup[region.code] = region.name.ja;
     }
+  }
+
+  final stations = <_RegionStation>[];
+  for (final point in kyoshinParam.points) {
+    if (point.regionCode == null ||
+        point.arv400 == null ||
+        point.isSuspended) {
+      continue;
+    }
+    stations.add((
+      regionCode: point.regionCode!,
+      regionName: regionNameLookup[point.regionCode!] ?? point.name,
+      point: (
+        lat: point.location.lat,
+        lon: point.location.lon,
+        arv400: point.arv400!,
+      ),
+    ));
   }
 
   if (stations.isEmpty) {

--- a/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.g.dart
+++ b/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.g.dart
@@ -71,7 +71,7 @@ final class EewEstimatedRegionIntensityProvider
 }
 
 String _$eewEstimatedRegionIntensityHash() =>
-    r'7573f16b01b7e1684007055fc18d376141fc0f74';
+    r'4248b31b9f8ffa5c868705c72469f9ea8ad3a804';
 
 final class EewEstimatedRegionIntensityFamily extends $Family
     with

--- a/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_forecast_region_layer.dart
@@ -15,8 +15,8 @@ import 'package:maplibre/maplibre.dart';
 
 /// EEW震度予報区域レイヤー
 ///
-/// `displayMode` に応じて、府県地震予報区（areaForecastLocalEew）を
-/// 予想震度別 or 警報発表区域として塗りつぶす。
+/// `displayMode` に応じて、府県予報区（areaForecastLocalE）を
+/// 推計震度別 or 警報発表区域として塗りつぶす。
 class EewForecastRegionLayer extends HookConsumerWidget {
   const EewForecastRegionLayer({
     required this.eew,


### PR DESCRIPTION
## Summary
- EEW詳細画面/リプレイで推計震度（距離減衰式による推定震度）がマップ上に表示されないバグを修正
- ホーム画面のリアルタイムEEW推計震度表示も同様に修正

## 原因
`earthquake_stations` パラメータのstation情報に `arv_400`（地盤増幅率）フィールドが含まれていないため、推計震度の計算対象が0件となり何も表示されなかった。

`arv_400` は `kyoshin_observation_points` パラメータにのみ存在する（1743/1749点が有効）。

## 修正内容
- `eewEstimatedRegionIntensityProvider`: Kyoshin観測点パラメータから `arv_400` と `region_code` を取得するように変更
- `EstimatedIntensityProvider`: 同上
- `EstimatedIntensityPoint`: 未使用の `cityCode`, `station` フィールドを削除
- `estimatedIntensityCity` provider: 参照なしのため削除
- `EewForecastRegionLayer`: コメントを実際のソースレイヤー名に合わせて修正

## Test plan
- [ ] EEW履歴 → 任意のEEWをタップ → 推計震度表示をON → 地図上に推計震度の色塗りが表示されること
- [ ] EEWリプレイ → 推計震度の色塗りがシミュレーション中に更新されること
- [ ] ホーム画面 → ライブEEW時に推計震度が表示されること
- [ ] `dart analyze` pass

https://claude.ai/code/session_01SjxRm7QjvtKnsBKQAycZDa