### PR TITLE
fix: EEW Live Activityの表示不具合7件を修正

### DIFF
--- a/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
+++ b/app/ios/Widget/LiveActivity/EQMonitorLiveActivityWidget.swift
@@ -100,12 +100,13 @@ struct EewCompactTrailingView: View {
 
     var body: some View {
         let isWarning = state.isWarning ?? false
-        Text(isWarning ? "警報" : "予報")
+        let isCanceled = state.isCanceled == true
+        Text(isCanceled ? "取消" : isWarning ? "警報" : "予報")
             .font(.system(size: 10, weight: .heavy))
             .foregroundColor(.white)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
-            .background(isWarning ? Color.red : Color.orange)
+            .background(isCanceled ? Color.gray : isWarning ? Color.red : Color.orange)
             .clipShape(Capsule())
     }
 }
@@ -140,6 +141,7 @@ struct EewExpandedLeadingView: View {
                     .foregroundColor(.eqTextSecondary)
                 ExpandedIntensityBadge(intensity: intensity)
             }
+            .padding(.leading, 4)
         } else if let intensity = state.intensityValue {
             VStack(alignment: .leading, spacing: 2) {
                 Text("最大震度")
@@ -147,6 +149,7 @@ struct EewExpandedLeadingView: View {
                     .foregroundColor(.eqTextSecondary)
                 ExpandedIntensityBadge(intensity: intensity)
             }
+            .padding(.leading, 4)
         }
     }
 }
@@ -157,7 +160,15 @@ struct EewExpandedTrailingView: View {
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 4) {
-            if let isWarning = state.isWarning {
+            if state.isCanceled == true {
+                Text("取消")
+                    .font(.system(size: 11, weight: .heavy))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background(Color.gray)
+                    .clipShape(Capsule())
+            } else if let isWarning = state.isWarning {
                 Text(isWarning ? "警報" : "予報")
                     .font(.system(size: 11, weight: .heavy))
                     .foregroundColor(.white)
@@ -166,7 +177,7 @@ struct EewExpandedTrailingView: View {
                     .background(isWarning ? Color.red : Color.orange)
                     .clipShape(Capsule())
             }
-            if let serialNo = state.serialNo {
+            if let serialNo = state.serialNo, serialNo > 0 {
                 HStack(alignment: .firstTextBaseline, spacing: 0) {
                     Text("第")
                         .font(.system(size: 9, weight: .medium))
@@ -187,14 +198,22 @@ struct EewExpandedCenterView: View {
     let state: EewContentState
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(state.isPlum == true || state.isLevel == true ? "検知観測点" : "震源地")
-                .font(.system(size: 9, weight: .medium))
-                .foregroundColor(.eqTextSecondary)
-            if let hypocenterName = state.hypocenterName {
-                Text(hypocenterName)
-                    .font(.system(size: 16, weight: .bold))
-                    .lineLimit(1)
+        if state.isCanceled == true {
+            Text("緊急地震速報は取り消されました")
+                .font(.system(size: 13, weight: .bold))
+                .lineLimit(2)
+                .minimumScaleFactor(0.75)
+        } else {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(state.isPlum == true || state.isLevel == true ? "検知観測点" : "震源地")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(.eqTextSecondary)
+                if let hypocenterName = state.hypocenterName {
+                    Text(hypocenterName)
+                        .font(.system(size: 16, weight: .bold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
             }
         }
     }
@@ -222,7 +241,7 @@ struct EewExpandedBottomView: View {
                         Text("深さ")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(.eqTextSecondary)
-                        Text("\(depth)")
+                        Text("\(Int(depth))")
                             .font(.system(size: 16, weight: .bold, design: .monospaced))
                         Text("km")
                             .font(.system(size: 11, weight: .medium))
@@ -235,6 +254,7 @@ struct EewExpandedBottomView: View {
                 ArrivalInfoView(location: location)
             }
         }
+        .padding(.leading, 4)
     }
 }
 
@@ -414,6 +434,9 @@ struct MinimalIntensityBadge: View {
             }
         }
         .foregroundColor(intensity.textColor)
+        .frame(minWidth: 22, minHeight: 22)
+        .background(intensity.backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 }
 

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityAttributes.swift
@@ -19,7 +19,7 @@ struct EewContentState: Codable, Hashable {
     let type: String
     let hypocenterName: String?
     let magnitude: Double?
-    let depth: Int?
+    let depth: Double?
     let time: String?
     let isOriginTime: Bool?
     let maxIntensity: String?

--- a/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
+++ b/app/ios/Widget/LiveActivity/Eew/EewLiveActivityView.swift
@@ -29,6 +29,7 @@ extension View {
 @available(iOS 16.1, *)
 struct HeaderContainer: View {
     let isWarning: Bool
+    let isCanceled: Bool
     let headline: String?
     let serialNo: Int?
     let isFinal: Bool
@@ -38,7 +39,7 @@ struct HeaderContainer: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            StripePattern(isWarning: isWarning)
+            stripePattern
                 .frame(height: stripeHeight)
 
             HStack(alignment: .center, spacing: 8) {
@@ -55,7 +56,7 @@ struct HeaderContainer: View {
                         .foregroundColor(eewHeaderSecondaryTextColor)
 
                     // headline: "XXXで地震" または警報時 "XX YYで強い揺れ"
-                    if let headline = headline, !headline.isEmpty {
+                    if let headline = headline, !headline.isEmpty, !isCanceled {
                         Text(headline)
                             .font(.system(size: 15, weight: .heavy))
                             .foregroundColor(.primary)
@@ -102,9 +103,24 @@ struct HeaderContainer: View {
         .clipShape(ContainerRelativeShape())
     }
 
+    private var stripePattern: StripePattern {
+        if isCanceled {
+            return StripePattern(colors: [
+                Color(red: 0.5, green: 0.5, blue: 0.5),
+                Color(red: 0.25, green: 0.25, blue: 0.25),
+            ])
+        }
+        return StripePattern(isWarning: isWarning)
+    }
+
     private var eewTypeLabelWithSerial: String {
-        let typeLabel = isWarning ? "緊急地震速報(警報)" : "緊急地震速報(予報)"
-        if let serialNo = serialNo {
+        let typeLabel: String
+        if isCanceled {
+            typeLabel = "緊急地震速報(取消)"
+        } else {
+            typeLabel = isWarning ? "緊急地震速報(警報)" : "緊急地震速報(予報)"
+        }
+        if let serialNo = serialNo, serialNo > 0 {
             if isFinal {
                 return "\(typeLabel) 第\(serialNo)報(最終)"
             } else {
@@ -115,7 +131,9 @@ struct HeaderContainer: View {
     }
 
     private var backgroundColor: Color {
-        if isWarning {
+        if isCanceled {
+            return Color(red: 0.4, green: 0.4, blue: 0.4)
+        } else if isWarning {
             return Color(red: 0.7, green: 0.1, blue: 0.1)
         } else {
             return Color(red: 0.8, green: 0.4, blue: 0.05)
@@ -135,6 +153,7 @@ struct EewLockScreenView: View {
         VStack(spacing: 0) {
             HeaderContainer(
                 isWarning: state.isWarning ?? false,
+                isCanceled: state.isCanceled == true,
                 headline: state.headline,
                 serialNo: state.serialNo,
                 isFinal: state.isFinal ?? false,
@@ -191,6 +210,12 @@ struct EewLockScreenView: View {
 
     private var detailsView: some View {
         VStack(alignment: .leading, spacing: 4) {
+            if state.isCanceled == true {
+                Text("緊急地震速報は取り消されました")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(.primary)
+            }
+
             if let hypocenterName = state.hypocenterName {
                 HStack(alignment: .firstTextBaseline, spacing: 4) {
                     Text(
@@ -201,6 +226,7 @@ struct EewLockScreenView: View {
                         .font(.system(size: 16, weight: .heavy))
                         .foregroundColor(.primary)
                         .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                 }
             }
 
@@ -230,7 +256,7 @@ struct EewLockScreenView: View {
                         }
                     }
                     if let depth = state.depth {
-                        depthView(depth: depth)
+                        depthView(depth: Int(depth))
                     }
                 }
             }

--- a/app/ios/Widget/Models/IntensityValue.swift
+++ b/app/ios/Widget/Models/IntensityValue.swift
@@ -122,9 +122,9 @@ enum IntensityValue: String, Codable, CaseIterable, Comparable {
     /// テキスト色（コントラスト改善版）
     var textColor: Color {
         switch self {
-        case .one, .four:
+        case .zero, .one, .four:
             return .black
-        case .zero, .two, .three:
+        case .two, .three:
             return .white
         default:
             return .white


### PR DESCRIPTION
## 概要

EEW Live Activity の表示を網羅監査し、実機で確認された症状2件を含む表示不具合7件を修正しました。

## 実機で確認されていた症状と原因

| 症状 | 原因 |
|---|---|
| Dynamic Island 拡張表示で「最大震度」の「最」と「M4.1」の「M」が左に見切れる | `EewExpandedLeadingView` / `EewExpandedBottomView` に padding がなくリージョン端でクリップ |
| 他の Live Activity と共存時のミニマル表示で震度が素の白文字だけになる | `MinimalIntensityBadge` に背景色・フレームの定義がなかった |

## 変更内容

- Dynamic Island expanded leading/bottom に `.padding(.leading, 4)` を追加しクリップを解消
- `MinimalIntensityBadge` に震度色の背景バッジ（角丸）を追加（Compact 表示と同スタイル）
- 震度0のテキスト色を白→黒に変更（グレー背景で視認不可だった。Flutter 側の震度配色に準拠）
- backend が serialNo 欠損時に `0` を送るため「第0報」と表示され得た問題を `serialNo > 0` ガードで修正
- 震源地名の `Text` に `.minimumScaleFactor(0.75)` を追加し長い地名の truncation を緩和
- `EewContentState.depth` を `Int?` → `Double?` に変更（backend は number 型のため、小数が来た場合に decode 失敗で更新が丸ごと落ちるのを防止。表示は整数のまま）
- キャンセル報（`isCanceled`）の表示に対応：グレーの「取消」バッジ・ヘッダのグレー化・「緊急地震速報は取り消されました」の表示・誤解を招く headline（backend からは「地震発生」が届く）の抑止。従来は `isCanceled` がどの View からも参照されておらず、取消後も「地震発生」+ 予報バッジが残っていた

## 検証

- `xcrun swiftc -parse`: 変更4ファイルで exit 0
- クロスファイル整合を個別確認済み（`StripePattern(colors:)` の実在、`HeaderContainer` 呼び出し元の追随、`depthView(Int)` の型整合、Widget ターゲット外から `EewContentState` への参照なし）
- WidgetExtension のフルビルドは作業環境（worktree に Flutter.framework 未生成 + Xcode 27 beta の SPM 解決不良）では完走できていないため、CI のビルドで最終確認をお願いします

## 補足（このPRのスコープ外）

調査で backend 側にも文言課題を確認しています（警報時 headline「〜で地震 で強い揺れ」の不自然な連結、キャンセル報の headline が「地震発生」のまま、update push の stale-date 未設定）。backend リポジトリ側で別途対応が必要です。

https://claude.ai/code/session_0177uj5LM838jKX6eRBQtuV3