### PR TITLE
fix(ci): Firebase App Distribution ジョブを x64 ランナーに戻す

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -402,7 +402,9 @@ jobs:
   deploy-android-firebase-app-distribution:
     name: Deploy Android (Firebase App Distribution)
     needs: build-android
-    runs-on: ubuntu-24.04-arm
+    # firebase-tools は linux-arm64 バイナリを配布しておらず、aqua registry の
+    # supported_envs も amd64 のみ。arm ランナーでは mise --locked が失敗するため x64 を使う
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
## 概要

`Deploy App` ワークフローの **Deploy Android (Firebase App Distribution)** ジョブが `Install Mise dependencies` ステップで失敗していた問題を修正します。

[失敗した実行例](https://github.com/YumNumm/EQMonitor/actions/runs/28587860519/job/84765951798)

## 原因

当該ジョブのランナーが `ubuntu-24.04-arm` に変更されたことで、`mise install --locked firebase` が以下のエラーで失敗していました。

```
mise ERROR Failed to install aqua:firebase/firebase-tools@latest: No lockfile URL found for firebase@15.19.0 on platform linux-arm64 (--locked mode)
```

- firebase-tools のリリースには `firebase-tools-linux` (x64) しか存在せず、**linux-arm64 バイナリが配布されていない**
- aqua registry の `firebase/firebase-tools` も `supported_envs: darwin / windows / amd64` のみで **linux-arm64 を非サポート**

そのため `mise.lock` に linux-arm64 の URL を生成することができず、arm ランナー上では `--locked` モードで必ず失敗します。

## 修正内容

`deploy-android-firebase-app-distribution` ジョブのランナーを `ubuntu-24.04-arm` → `ubuntu-24.04` (x64) に戻しました。

- `deploy-android-google-play` ジョブは `google-play-cli` が arm64 対応済みのため `ubuntu-24.04-arm` のまま維持しています。

## 確認

- `actionlint` パス
- pre-commit hooks (gitleaks / zizmor / pinact 等) パス

https://claude.ai/code/session_012rfkecaccKhvp7S1BUKbZw