### PR TITLE
feat(settings/debug): HTTPキャッシュ管理とSharedPreferencesデバッグ機能を追加

### DIFF
--- a/app/lib/core/api/http_cache_disabled_provider.dart
+++ b/app/lib/core/api/http_cache_disabled_provider.dart
@@ -1,0 +1,23 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/core/provider/shared_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'http_cache_disabled_provider.g.dart';
+
+/// HTTPキャッシュ(ETag/304透過キャッシュ)の読み書きを完全に無効化するフラグ。
+/// デバッグ用途。変更は dio プロバイダが watch しているため即座に反映される。
+@Riverpod(keepAlive: true)
+class HttpCacheDisabled extends _$HttpCacheDisabled {
+  static const SharedPreferencesKey _key =
+      SharedPreferencesKey.httpCacheDisabled;
+
+  @override
+  bool build() {
+    return ref.read(sharedPreferencesProvider).getBool(_key.key) ?? false;
+  }
+
+  Future<void> save({required bool isDisabled}) async {
+    await ref.read(sharedPreferencesProvider).setBool(_key.key, isDisabled);
+    state = isDisabled;
+  }
+}

--- a/app/lib/core/api/http_cache_disabled_provider.g.dart
+++ b/app/lib/core/api/http_cache_disabled_provider.g.dart
@@ -1,0 +1,73 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'http_cache_disabled_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// HTTPキャッシュ(ETag/304透過キャッシュ)の読み書きを完全に無効化するフラグ。
+/// デバッグ用途。変更は [dio] が watch しているため即座に反映される。
+
+@ProviderFor(HttpCacheDisabled)
+final httpCacheDisabledProvider = HttpCacheDisabledProvider._();
+
+/// HTTPキャッシュ(ETag/304透過キャッシュ)の読み書きを完全に無効化するフラグ。
+/// デバッグ用途。変更は [dio] が watch しているため即座に反映される。
+final class HttpCacheDisabledProvider
+    extends $NotifierProvider<HttpCacheDisabled, bool> {
+  /// HTTPキャッシュ(ETag/304透過キャッシュ)の読み書きを完全に無効化するフラグ。
+  /// デバッグ用途。変更は [dio] が watch しているため即座に反映される。
+  HttpCacheDisabledProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'httpCacheDisabledProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$httpCacheDisabledHash();
+
+  @$internal
+  @override
+  HttpCacheDisabled create() => HttpCacheDisabled();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$httpCacheDisabledHash() => r'080ae9e009188f1951fc33eab7d37153d807f09c';
+
+/// HTTPキャッシュ(ETag/304透過キャッシュ)の読み書きを完全に無効化するフラグ。
+/// デバッグ用途。変更は [dio] が watch しているため即座に反映される。
+
+abstract class _$HttpCacheDisabled extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/core/api/http_cache_size_provider.dart
+++ b/app/lib/core/api/http_cache_size_provider.dart
@@ -1,0 +1,14 @@
+import 'package:cache/cache.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'http_cache_size_provider.g.dart';
+
+/// HTTPキャッシュDBファイルの実サイズ(バイト)。ファイル未作成時は 0。
+@riverpod
+Future<int> httpCacheSize(Ref ref) async {
+  final file = await httpCacheDatabaseFile();
+  if (!file.existsSync()) {
+    return 0;
+  }
+  return file.length();
+}

--- a/app/lib/core/api/http_cache_size_provider.g.dart
+++ b/app/lib/core/api/http_cache_size_provider.g.dart
@@ -1,0 +1,49 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'http_cache_size_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// HTTPキャッシュDBファイルの実サイズ(バイト)。ファイル未作成時は 0。
+
+@ProviderFor(httpCacheSize)
+final httpCacheSizeProvider = HttpCacheSizeProvider._();
+
+/// HTTPキャッシュDBファイルの実サイズ(バイト)。ファイル未作成時は 0。
+
+final class HttpCacheSizeProvider
+    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
+    with $FutureModifier<int>, $FutureProvider<int> {
+  /// HTTPキャッシュDBファイルの実サイズ(バイト)。ファイル未作成時は 0。
+  HttpCacheSizeProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'httpCacheSizeProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$httpCacheSizeHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<int> create(Ref ref) {
+    return httpCacheSize(ref);
+  }
+}
+
+String _$httpCacheSizeHash() => r'50b8147f1bd28da18c2302f6caa0f64d4affd5bf';

--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -34,6 +34,7 @@ enum SharedPreferencesKey {
     'is_estimated_intensity_on_eew_replay_allowed',
   ),
   widgetRegionSelection('widget_region_selection'),
+  httpCacheDisabled('http_cache_disabled'),
   ;
 
   const SharedPreferencesKey(this.key);

--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:cache/cache.dart';
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/api/http_cache_disabled_provider.dart';
 import 'package:eqmonitor/core/api/http_cache_store_provider.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/core/provider/dio_base_options.dart';
@@ -26,7 +27,7 @@ Future<Dio> dio(Ref ref) async {
   final deviceAuthTokenInterceptor = await ref.watch(
     deviceAuthTokenInterceptorProvider.future,
   );
-  final httpCache = await ref.watch(httpCacheStoreProvider.future);
+  final httpCacheDisabled = ref.watch(httpCacheDisabledProvider);
 
   final dio = Dio(buildApiBaseOptions(baseUrl: telegramUrl.restApiUrl));
   dio.options.headers.addAll({
@@ -41,7 +42,11 @@ Future<Dio> dio(Ref ref) async {
   // ETag/304 透過キャッシュ。onResponse は登録順に実行されるため
   // TalkerDioLogger より前に置く。304 ヒット時は handler.resolve で
   // キャッシュ復元して短絡し、以降のロガーには到達しない。
-  dio.interceptors.add(HttpCacheInterceptor(httpCache));
+  // デバッグでキャッシュ無効化された場合はインターセプタ自体を登録しない。
+  if (!httpCacheDisabled) {
+    final httpCache = await ref.watch(httpCacheStoreProvider.future);
+    dio.interceptors.add(HttpCacheInterceptor(httpCache));
+  }
   dio.interceptors.add(
     TalkerDioLogger(
       settings: TalkerDioLoggerSettings(

--- a/app/lib/core/provider/dio_provider.g.dart
+++ b/app/lib/core/provider/dio_provider.g.dart
@@ -42,4 +42,4 @@ final class DioProvider
   }
 }
 
-String _$dioHash() => r'ecddcf6244e61c55a1a7b07e8c15cc1f52ccbd84';
+String _$dioHash() => r'0014243ad0b4154f9621441f7b4cb70d06d0be82';

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -50,6 +50,7 @@ import 'package:eqmonitor/feature/settings/children/config/debug/navigation/navi
 import 'package:eqmonitor/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/playground/playground_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/shake_detection/debug_shake_detection_card_page.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/telemetry/debug_telemetry_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/tsunami/debug_tsunami_details_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/tsunami/tsunami_telegram_timeline_debug_page.dart';
@@ -379,6 +380,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
         TypedGoRoute<DebugDeviceSettingsRoute>(path: 'device-settings'),
         TypedGoRoute<DebugNavigationRoute>(path: 'navigation'),
         TypedGoRoute<DebugAppGroupRoute>(path: 'app-group'),
+        TypedGoRoute<DebugSharedPreferencesRoute>(path: 'shared-preferences'),
         TypedGoRoute<DebugIntensityIconRoute>(path: 'intensity-icon'),
         TypedGoRoute<DebugTelemetryRoute>(path: 'telemetry'),
         TypedGoRoute<DebugTsunamiDetailsRoute>(
@@ -452,7 +454,8 @@ class NotificationSettingsRoute extends GoRouteData
       const NotificationSettingsPage();
 }
 
-class HomeWidgetSettingsRoute extends GoRouteData with $HomeWidgetSettingsRoute {
+class HomeWidgetSettingsRoute extends GoRouteData
+    with $HomeWidgetSettingsRoute {
   const HomeWidgetSettingsRoute();
 
   @override
@@ -709,6 +712,16 @@ class DebugAppGroupRoute extends GoRouteData with $DebugAppGroupRoute {
   }
 }
 
+class DebugSharedPreferencesRoute extends GoRouteData
+    with $DebugSharedPreferencesRoute {
+  const DebugSharedPreferencesRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const DebugSharedPreferencesPage();
+  }
+}
+
 class DebugIntensityIconRoute extends GoRouteData
     with $DebugIntensityIconRoute {
   const DebugIntensityIconRoute();
@@ -868,8 +881,7 @@ class FeedRoute extends GoRouteData with $FeedRoute {
   const FeedRoute();
 
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const FeedPage();
+  Widget build(BuildContext context, GoRouterState state) => const FeedPage();
 }
 
 @TypedGoRoute<TsunamiDetailsRoute>(path: '/tsunami/:tsunamiId')

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -586,6 +586,10 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           factory: $DebugAppGroupRoute._fromState,
         ),
         GoRouteData.$route(
+          path: 'shared-preferences',
+          factory: $DebugSharedPreferencesRoute._fromState,
+        ),
+        GoRouteData.$route(
           path: 'intensity-icon',
           factory: $DebugIntensityIconRoute._fromState,
         ),
@@ -1341,6 +1345,28 @@ mixin $DebugAppGroupRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/settings/debug/app-group');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DebugSharedPreferencesRoute on GoRouteData {
+  static DebugSharedPreferencesRoute _fromState(GoRouterState state) =>
+      const DebugSharedPreferencesRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/shared-preferences');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:eqmonitor/core/api/http_cache_disabled_provider.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/provider/environment/environment.dart';
@@ -129,6 +130,29 @@ class _DebugWidget extends ConsumerWidget {
                 leading: const Icon(Icons.widgets_outlined),
                 onTap: () => const DebugAppGroupRoute().push<void>(context),
               ),
+            ListTile(
+              title: const Text('SharedPreferences'),
+              subtitle: const Text('保存されている Key-Value の一覧・編集'),
+              leading: const Icon(Icons.data_object),
+              onTap: () async =>
+                  const DebugSharedPreferencesRoute().push<void>(context),
+            ),
+            Builder(
+              builder: (context) {
+                final isDisabled = ref.watch(httpCacheDisabledProvider);
+                return ListTile(
+                  title: const Text('HTTPキャッシュを無効化'),
+                  subtitle: const Text('キャッシュの読み書きをスキップします'),
+                  leading: const Icon(Icons.cached),
+                  trailing: AppSwitch(
+                    value: isDisabled,
+                    onChanged: (value) async => ref
+                        .read(httpCacheDisabledProvider.notifier)
+                        .save(isDisabled: value),
+                  ),
+                );
+              },
+            ),
             ListTile(
               title: const Text('Telemetry Events'),
               leading: const Icon(Icons.analytics_outlined),

--- a/app/lib/feature/settings/children/config/debug/shared_preferences/debug_app_group_preferences_entries_provider.dart
+++ b/app/lib/feature/settings/children/config/debug/shared_preferences/debug_app_group_preferences_entries_provider.dart
@@ -1,0 +1,16 @@
+import 'package:eqmonitor/core/provider/app_group_preferences.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_app_group_preferences_entries_provider.g.dart';
+
+@riverpod
+Future<List<({String key, Object? value})>> debugAppGroupPreferencesEntries(
+  Ref ref,
+) async {
+  final prefs = await ref.watch(appGroupPreferencesProvider.future);
+  final all = await prefs.getAll();
+  final keys = all.keys.toList()..sort();
+  return [
+    for (final key in keys) (key: key, value: all[key]),
+  ];
+}

--- a/app/lib/feature/settings/children/config/debug/shared_preferences/debug_app_group_preferences_entries_provider.g.dart
+++ b/app/lib/feature/settings/children/config/debug/shared_preferences/debug_app_group_preferences_entries_provider.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_app_group_preferences_entries_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugAppGroupPreferencesEntries)
+final debugAppGroupPreferencesEntriesProvider =
+    DebugAppGroupPreferencesEntriesProvider._();
+
+final class DebugAppGroupPreferencesEntriesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<({String key, Object? value})>>,
+          List<({String key, Object? value})>,
+          FutureOr<List<({String key, Object? value})>>
+        >
+    with
+        $FutureModifier<List<({String key, Object? value})>>,
+        $FutureProvider<List<({String key, Object? value})>> {
+  DebugAppGroupPreferencesEntriesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugAppGroupPreferencesEntriesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugAppGroupPreferencesEntriesHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<({String key, Object? value})>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<({String key, Object? value})>> create(Ref ref) {
+    return debugAppGroupPreferencesEntries(ref);
+  }
+}
+
+String _$debugAppGroupPreferencesEntriesHash() =>
+    r'832668c8f583f3b0ab2f0aebdcfdb86c09c30de3';

--- a/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_entries_provider.dart
+++ b/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_entries_provider.dart
@@ -1,0 +1,25 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_shared_preferences_entries_provider.g.dart';
+
+@riverpod
+Future<List<({String key, Object? value})>> debugSharedPreferencesEntries(
+  Ref ref,
+) async {
+  final prefs = await ref.watch(sharedPreferencesProvider.future);
+  final knownKeys = SharedPreferencesKey.values.map((e) => e.key).toSet();
+
+  final unknown = <String>[];
+  final known = <String>[];
+  for (final key in prefs.getKeys()) {
+    (knownKeys.contains(key) ? known : unknown).add(key);
+  }
+  unknown.sort();
+  known.sort();
+
+  return [
+    for (final key in [...unknown, ...known]) (key: key, value: prefs.get(key)),
+  ];
+}

--- a/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_entries_provider.g.dart
+++ b/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_entries_provider.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_shared_preferences_entries_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugSharedPreferencesEntries)
+final debugSharedPreferencesEntriesProvider =
+    DebugSharedPreferencesEntriesProvider._();
+
+final class DebugSharedPreferencesEntriesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<({String key, Object? value})>>,
+          List<({String key, Object? value})>,
+          FutureOr<List<({String key, Object? value})>>
+        >
+    with
+        $FutureModifier<List<({String key, Object? value})>>,
+        $FutureProvider<List<({String key, Object? value})>> {
+  DebugSharedPreferencesEntriesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugSharedPreferencesEntriesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugSharedPreferencesEntriesHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<({String key, Object? value})>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<({String key, Object? value})>> create(Ref ref) {
+    return debugSharedPreferencesEntries(ref);
+  }
+}
+
+String _$debugSharedPreferencesEntriesHash() =>
+    r'4dcff6e8396c657e0a54df00acb583e2ac11c476';

--- a/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_page.dart
+++ b/app/lib/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_page.dart
@@ -1,0 +1,617 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences.dart';
+import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:eqmonitor/core/provider/app_group_preferences.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/shared_preferences/debug_app_group_preferences_entries_provider.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_entries_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 編集対象のストア種別。sync/async 双方のAPI差異をこの層で吸収する。
+enum _StoreKind { shared, appGroup }
+
+typedef _Entry = ({String key, Object? value});
+
+class DebugSharedPreferencesPage extends HookConsumerWidget {
+  const DebugSharedPreferencesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isIOS = Platform.isIOS;
+    final tabs = <Tab>[
+      const Tab(text: 'SharedPreferences'),
+      if (isIOS) const Tab(text: 'App Group'),
+    ];
+
+    return DefaultTabController(
+      length: tabs.length,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('SharedPreferences'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: '再取得',
+              onPressed: () {
+                ref
+                  ..invalidate(debugSharedPreferencesEntriesProvider)
+                  ..invalidate(debugAppGroupPreferencesEntriesProvider);
+              },
+            ),
+          ],
+          bottom: tabs.length > 1 ? TabBar(tabs: tabs) : null,
+        ),
+        body: TabBarView(
+          children: [
+            const _SharedView(),
+            if (isIOS) const _AppGroupView(),
+          ],
+        ),
+        floatingActionButton: Builder(
+          builder: (context) {
+            return FloatingActionButton(
+              onPressed: () {
+                final index = DefaultTabController.of(context).index;
+                final kind = (isIOS && index == 1)
+                    ? _StoreKind.appGroup
+                    : _StoreKind.shared;
+                unawaited(_showAddDialog(context, ref, kind));
+              },
+              child: const Icon(Icons.add),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _SharedView extends ConsumerWidget {
+  const _SharedView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entries = ref.watch(debugSharedPreferencesEntriesProvider);
+    return _EntriesList(
+      entries: entries,
+      kind: _StoreKind.shared,
+      onRefresh: () => ref.invalidate(debugSharedPreferencesEntriesProvider),
+    );
+  }
+}
+
+class _AppGroupView extends ConsumerWidget {
+  const _AppGroupView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entries = ref.watch(debugAppGroupPreferencesEntriesProvider);
+    return _EntriesList(
+      entries: entries,
+      kind: _StoreKind.appGroup,
+      onRefresh: () => ref.invalidate(debugAppGroupPreferencesEntriesProvider),
+    );
+  }
+}
+
+class _EntriesList extends ConsumerWidget {
+  const _EntriesList({
+    required this.entries,
+    required this.kind,
+    required this.onRefresh,
+  });
+
+  final AsyncValue<List<_Entry>> entries;
+  final _StoreKind kind;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return entries.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text('エラー: $error')),
+      data: (list) {
+        if (list.isEmpty) {
+          return RefreshIndicator(
+            onRefresh: () async => onRefresh(),
+            child: ListView(
+              children: const [
+                SizedBox(height: 200),
+                Center(child: Text('エントリがありません')),
+              ],
+            ),
+          );
+        }
+        return RefreshIndicator(
+          onRefresh: () async => onRefresh(),
+          child: ListView.builder(
+            itemCount: list.length,
+            itemBuilder: (context, index) {
+              final entry = list[index];
+              return ListTile(
+                title: Text(entry.key),
+                subtitle: Text(
+                  _preview(entry.value),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontFamily: FontFamily.googleSansCode,
+                  ),
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  tooltip: '削除',
+                  onPressed: () async {
+                    await _remove(ref, kind, entry.key);
+                    onRefresh();
+                  },
+                ),
+                onTap: () => _showEditDialog(context, ref, kind, entry),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+String _typeName(Object? value) => switch (value) {
+  bool() => 'bool',
+  int() => 'int',
+  double() => 'double',
+  String() => 'String',
+  List<String>() => 'List<String>',
+  _ => value.runtimeType.toString(),
+};
+
+String _preview(Object? value) => '${_typeName(value)}: $value';
+
+Future<void> _remove(WidgetRef ref, _StoreKind kind, String key) async {
+  switch (kind) {
+    case _StoreKind.shared:
+      final prefs = await ref.read(sharedPreferencesProvider.future);
+      await prefs.remove(key);
+    case _StoreKind.appGroup:
+      final prefs = await ref.read(appGroupPreferencesProvider.future);
+      await prefs.remove(key);
+  }
+}
+
+void _invalidate(WidgetRef ref, _StoreKind kind) {
+  switch (kind) {
+    case _StoreKind.shared:
+      ref.invalidate(debugSharedPreferencesEntriesProvider);
+    case _StoreKind.appGroup:
+      ref.invalidate(debugAppGroupPreferencesEntriesProvider);
+  }
+}
+
+Future<void> _setBool(
+  WidgetRef ref,
+  _StoreKind kind,
+  String key, {
+  required bool value,
+}) async {
+  switch (kind) {
+    case _StoreKind.shared:
+      final prefs = await ref.read(sharedPreferencesProvider.future);
+      await prefs.setBool(key, value);
+    case _StoreKind.appGroup:
+      final prefs = await ref.read(appGroupPreferencesProvider.future);
+      await prefs.setBool(key, value);
+  }
+}
+
+Future<void> _setInt(
+  WidgetRef ref,
+  _StoreKind kind,
+  String key,
+  int value,
+) async {
+  switch (kind) {
+    case _StoreKind.shared:
+      final prefs = await ref.read(sharedPreferencesProvider.future);
+      await prefs.setInt(key, value);
+    case _StoreKind.appGroup:
+      final prefs = await ref.read(appGroupPreferencesProvider.future);
+      await prefs.setInt(key, value);
+  }
+}
+
+Future<void> _setDouble(
+  WidgetRef ref,
+  _StoreKind kind,
+  String key,
+  double value,
+) async {
+  switch (kind) {
+    case _StoreKind.shared:
+      final prefs = await ref.read(sharedPreferencesProvider.future);
+      await prefs.setDouble(key, value);
+    case _StoreKind.appGroup:
+      final prefs = await ref.read(appGroupPreferencesProvider.future);
+      await prefs.setDouble(key, value);
+  }
+}
+
+Future<void> _setString(
+  WidgetRef ref,
+  _StoreKind kind,
+  String key,
+  String value,
+) async {
+  switch (kind) {
+    case _StoreKind.shared:
+      final prefs = await ref.read(sharedPreferencesProvider.future);
+      await prefs.setString(key, value);
+    case _StoreKind.appGroup:
+      final prefs = await ref.read(appGroupPreferencesProvider.future);
+      await prefs.setString(key, value);
+  }
+}
+
+Future<void> _setStringList(
+  WidgetRef ref,
+  _StoreKind kind,
+  String key,
+  List<String> value,
+) async {
+  switch (kind) {
+    case _StoreKind.shared:
+      final prefs = await ref.read(sharedPreferencesProvider.future);
+      await prefs.setStringList(key, value);
+    case _StoreKind.appGroup:
+      final prefs = await ref.read(appGroupPreferencesProvider.future);
+      await prefs.setStringList(key, value);
+  }
+}
+
+Future<void> _showEditDialog(
+  BuildContext context,
+  WidgetRef ref,
+  _StoreKind kind,
+  _Entry entry,
+) async {
+  await showDialog<void>(
+    context: context,
+    builder: (context) => _EditDialog(kind: kind, entry: entry),
+  );
+}
+
+Future<void> _showAddDialog(
+  BuildContext context,
+  WidgetRef ref,
+  _StoreKind kind,
+) async {
+  await showDialog<void>(
+    context: context,
+    builder: (context) => _AddDialog(kind: kind),
+  );
+}
+
+class _EditDialog extends HookConsumerWidget {
+  const _EditDialog({required this.kind, required this.entry});
+
+  final _StoreKind kind;
+  final _Entry entry;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final value = entry.value;
+    return AlertDialog(
+      title: Text(entry.key),
+      content: SingleChildScrollView(
+        child: _ValueEditor(
+          kind: kind,
+          keyName: () => entry.key,
+          initialValue: value,
+          onSaved: () => Navigator.of(context).pop(),
+        ),
+      ),
+    );
+  }
+}
+
+/// 型に応じた入力UIと保存処理をまとめる。新規追加時は [initialValue] が
+/// 選択された型のデフォルト値で渡ってくる。[keyName] は保存時に評価するため
+/// 関数で受け取る（新規追加ダイアログでキー入力が後から確定するため）。
+class _ValueEditor extends HookConsumerWidget {
+  const _ValueEditor({
+    required this.kind,
+    required this.keyName,
+    required this.initialValue,
+    required this.onSaved,
+    this.guard,
+    super.key,
+  });
+
+  final _StoreKind kind;
+  final String Function() keyName;
+  final Object? initialValue;
+  final VoidCallback onSaved;
+
+  /// 保存前チェック。false を返したら保存しない。
+  final bool Function()? guard;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final value = initialValue;
+    final key = keyName;
+
+    // UI コールバックから呼ぶため void 戻り。内部で fire-and-forget する。
+    void save(Future<void> Function(String key) setter) {
+      if (guard != null && !guard!()) {
+        return;
+      }
+      unawaited(() async {
+        await setter(key());
+        _invalidate(ref, kind);
+        onSaved();
+      }());
+    }
+
+    void showError(String message) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+    }
+
+    switch (value) {
+      case final bool boolValue:
+        final state = useState(boolValue);
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SwitchListTile(
+              title: Text(state.value.toString()),
+              value: state.value,
+              onChanged: (v) => state.value = v,
+            ),
+            _SaveButton(
+              onPressed: () => save(
+                (key) => _setBool(ref, kind, key, value: state.value),
+              ),
+            ),
+          ],
+        );
+      case final int intValue:
+        final controller = useTextEditingController(text: intValue.toString());
+        return _SingleFieldEditor(
+          controller: controller,
+          keyboardType: TextInputType.number,
+          onSave: () {
+            final parsed = int.tryParse(controller.text.trim());
+            if (parsed == null) {
+              showError('int としてパースできません');
+              return;
+            }
+            save((key) => _setInt(ref, kind, key, parsed));
+          },
+        );
+      case final double doubleValue:
+        final controller = useTextEditingController(
+          text: doubleValue.toString(),
+        );
+        return _SingleFieldEditor(
+          controller: controller,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          onSave: () {
+            final parsed = double.tryParse(controller.text.trim());
+            if (parsed == null) {
+              showError('double としてパースできません');
+              return;
+            }
+            save((key) => _setDouble(ref, kind, key, parsed));
+          },
+        );
+      case final String stringValue:
+        final controller = useTextEditingController(text: stringValue);
+        return _SingleFieldEditor(
+          controller: controller,
+          maxLines: 8,
+          onSave: () => save(
+            (key) => _setString(ref, kind, key, controller.text),
+          ),
+        );
+      case final List<String> listValue:
+        return _StringListEditor(
+          initial: listValue,
+          onSave: (list) => save(
+            (key) => _setStringList(ref, kind, key, list),
+          ),
+        );
+      case null:
+        return const Text('null 値は編集できません');
+      default:
+        return Text('未対応の型: ${value.runtimeType}');
+    }
+  }
+}
+
+class _SingleFieldEditor extends StatelessWidget {
+  const _SingleFieldEditor({
+    required this.controller,
+    required this.onSave,
+    this.keyboardType,
+    this.maxLines = 1,
+  });
+
+  final TextEditingController controller;
+  final VoidCallback onSave;
+  final TextInputType? keyboardType;
+  final int maxLines;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextField(
+          controller: controller,
+          keyboardType: keyboardType,
+          maxLines: maxLines,
+          minLines: 1,
+        ),
+        const SizedBox(height: 16),
+        _SaveButton(onPressed: onSave),
+      ],
+    );
+  }
+}
+
+class _StringListEditor extends HookWidget {
+  const _StringListEditor({required this.initial, required this.onSave});
+
+  final List<String> initial;
+  final void Function(List<String>) onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = useState<List<String>>([...initial]);
+
+    List<Widget> buildFields() => [
+      for (var i = 0; i < items.value.length; i++)
+        Row(
+          key: ValueKey(i),
+          children: [
+            Expanded(
+              child: TextFormField(
+                initialValue: items.value[i],
+                onChanged: (v) {
+                  final next = [...items.value];
+                  next[i] = v;
+                  items.value = next;
+                },
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.remove_circle_outline),
+              onPressed: () {
+                final next = [...items.value]..removeAt(i);
+                items.value = next;
+              },
+            ),
+          ],
+        ),
+    ];
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ...buildFields(),
+        TextButton.icon(
+          icon: const Icon(Icons.add),
+          label: const Text('要素を追加'),
+          onPressed: () => items.value = [...items.value, ''],
+        ),
+        const SizedBox(height: 8),
+        _SaveButton(onPressed: () => onSave(items.value)),
+      ],
+    );
+  }
+}
+
+class _SaveButton extends StatelessWidget {
+  const _SaveButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton(
+      onPressed: onPressed,
+      child: const Text('保存'),
+    );
+  }
+}
+
+enum _NewValueType { boolType, intType, doubleType, stringType, stringListType }
+
+class _AddDialog extends HookConsumerWidget {
+  const _AddDialog({required this.kind});
+
+  final _StoreKind kind;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final keyController = useTextEditingController();
+    final type = useState(_NewValueType.stringType);
+
+    Object? defaultValueFor(_NewValueType t) => switch (t) {
+      _NewValueType.boolType => false,
+      _NewValueType.intType => 0,
+      _NewValueType.doubleType => 0.0,
+      _NewValueType.stringType => '',
+      _NewValueType.stringListType => <String>[],
+    };
+
+    return AlertDialog(
+      title: const Text('新規追加'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: keyController,
+              decoration: const InputDecoration(labelText: 'キー名'),
+            ),
+            const SizedBox(height: 8),
+            DropdownButton<_NewValueType>(
+              value: type.value,
+              isExpanded: true,
+              items: const [
+                DropdownMenuItem(
+                  value: _NewValueType.boolType,
+                  child: Text('bool'),
+                ),
+                DropdownMenuItem(
+                  value: _NewValueType.intType,
+                  child: Text('int'),
+                ),
+                DropdownMenuItem(
+                  value: _NewValueType.doubleType,
+                  child: Text('double'),
+                ),
+                DropdownMenuItem(
+                  value: _NewValueType.stringType,
+                  child: Text('String'),
+                ),
+                DropdownMenuItem(
+                  value: _NewValueType.stringListType,
+                  child: Text('List<String>'),
+                ),
+              ],
+              onChanged: (v) {
+                if (v != null) {
+                  type.value = v;
+                }
+              },
+            ),
+            const SizedBox(height: 8),
+            _ValueEditor(
+              // 型を切り替えたら Editor 内部の hooks を作り直す。
+              key: ValueKey(type.value),
+              kind: kind,
+              keyName: () => keyController.text.trim(),
+              initialValue: defaultValueFor(type.value),
+              guard: () {
+                if (keyController.text.trim().isEmpty) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('キー名を入力してください')),
+                  );
+                  return false;
+                }
+                return true;
+              },
+              onSaved: () => Navigator.of(context).pop(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -1,3 +1,5 @@
+import 'package:eqmonitor/core/api/http_cache_size_provider.dart';
+import 'package:eqmonitor/core/api/http_cache_store_provider.dart';
 import 'package:eqmonitor/core/component/widget/app_switch.dart';
 import 'package:eqmonitor/core/gen/assets.gen.dart';
 import 'package:eqmonitor/core/provider/environment/environment.dart';
@@ -18,6 +20,7 @@ class SettingsPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isDebugEnabled = ref.watch(debugProvider).value;
+    final cacheSize = ref.watch(httpCacheSizeProvider);
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 
@@ -112,6 +115,34 @@ class SettingsPage extends ConsumerWidget {
                     (tsx) async => tsx.get(adsOptOutProvider.notifier).toggle(),
                   ),
                 ),
+                const SettingsSectionHeader(text: 'キャッシュ'),
+                ListTile(
+                  title: const Text('HTTPキャッシュ'),
+                  leading: const Icon(Icons.storage_outlined),
+                  subtitle: Text(
+                    cacheSize.when(
+                      data: formatBytes,
+                      loading: () => '計算中…',
+                      error: (_, _) => '取得に失敗しました',
+                    ),
+                  ),
+                ),
+                ListTile(
+                  title: const Text('HTTPキャッシュを削除'),
+                  leading: const Icon(Icons.delete_outline),
+                  onTap: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    final store = await ref.read(
+                      httpCacheStoreProvider.future,
+                    );
+                    await store.clearAll();
+                    await store.vacuum();
+                    ref.invalidate(httpCacheSizeProvider);
+                    messenger.showSnackBar(
+                      const SnackBar(content: Text('HTTPキャッシュを削除しました')),
+                    );
+                  },
+                ),
                 Center(
                   child: Text(
                     'Powered by Flutter',
@@ -146,6 +177,16 @@ class SettingsPage extends ConsumerWidget {
       ),
     );
   }
+}
+
+String formatBytes(int bytes) {
+  if (bytes < 1024) {
+    return '$bytes B';
+  }
+  if (bytes < 1024 * 1024) {
+    return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  }
+  return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
 }
 
 class _AppVersionInformation extends HookConsumerWidget {

--- a/docs/superpowers/specs/2026-07-03-http-cache-and-shared-preferences-debug-design.md
+++ b/docs/superpowers/specs/2026-07-03-http-cache-and-shared-preferences-debug-design.md
@@ -1,0 +1,101 @@
+# HTTPキャッシュ管理 & SharedPreferences デバッグ機能 設計
+
+作成日: 2026-07-03
+
+## 概要
+
+3つの独立した機能を追加する。
+
+1. **設定画面**: HTTPキャッシュの容量表示と削除ボタン
+2. **デバッグページ**: HTTPキャッシュ無効化トグル
+3. **デバッグページ**: SharedPreferences の Key-Value 一覧・編集ページ
+
+対象は `app/`（Flutter）と `packages/cache`。HTTPキャッシュは Drift(SQLite) の DB `eqmonitor_http_cache.db` に保存されている。
+
+---
+
+## 機能① 設定画面: HTTPキャッシュ容量表示 + 削除
+
+### 仕様
+- 「容量」= **DBファイルの実サイズ**（`File.stat().size`）。人間可読形式（例 `1.2 MB`）で表示。
+- 削除ボタン押下で `HttpCacheStore.clearAll()` → **`VACUUM`** を実行し、ファイルを物理的に縮小する。その後、容量表示を再取得。
+- 配置は `settings_page.dart` の下部、"Powered by Flutter" テキストの手前に「キャッシュ」セクションを新設。
+
+### 実装
+- `packages/cache`:
+  - `open_http_cache_database.dart`: DBファイルパスを `Future<File> httpCacheDatabaseFile()` に単一化し、オープン処理と容量計測で共用。
+  - `CacheDatabase.vacuum()` = `customStatement('VACUUM')`。
+  - `HttpCacheStore.vacuum()` = `db.vacuum()`。
+- `app/lib/core/api/http_cache_size_provider.dart`（新規, 公開Provider 1つ）:
+  - autoDispose FutureProvider。`httpCacheDatabaseFile()` を stat し、バイト数を返す。ファイル未存在時は 0。
+- `settings_page.dart`:
+  - 「キャッシュ」`SettingsSectionHeader`。
+  - 容量表示 `ListTile`（サイズをバイト→可読形式に整形して subtitle 等に表示）。
+  - 「HTTPキャッシュを削除」`ListTile`（削除アイコン）。押下で store 取得 → `clearAll()` → `vacuum()` → size provider を invalidate → 完了 SnackBar。
+
+---
+
+## 機能② デバッグページ: HTTPキャッシュ無効化トグル
+
+### 仕様
+- 「無効化」= **キャッシュの読み書きを完全にバイパス**（`HttpCacheInterceptor` を dio に追加しない。304条件付きリクエストも200保存も行わない）。
+- 状態は SharedPreferences に保存。
+- **即時反映**: `dio` は `keepAlive` だが、無効化フラグの Provider を `watch` することでフラグ変更時に dio が再構築される。
+
+### 実装
+- `SharedPreferencesKey.httpCacheDisabled('http_cache_disabled')`（bool）を enum に追加。
+- `app/lib/core/api/http_cache_disabled_provider.dart`（新規, 公開Provider 1つ）:
+  - `@Riverpod(keepAlive: true) class HttpCacheDisabled` notifier。`build()` で bool 読み込み（既定 false）、`save({required bool isDisabled})` で保存。
+- `dio_provider.dart`:
+  - `final httpCacheDisabled = ref.watch(httpCacheDisabledProvider);`
+  - `if (!httpCacheDisabled) { final httpCache = await ref.watch(httpCacheStoreProvider.future); dio.interceptors.add(HttpCacheInterceptor(httpCache)); }`
+- `debug_page.dart`:
+  - `AppSwitch` 付き `ListTile`（title「HTTPキャッシュを無効化」、subtitle「キャッシュの読み書きをスキップします」）。onChanged で notifier.save。
+
+---
+
+## 機能③ デバッグページ: SharedPreferences 一覧・編集ページ
+
+### 仕様
+- 新規サブページ `DebugSharedPreferencesPage`。`debug_page.dart` に導線、`router.dart` に `DebugSharedPreferencesRoute`（path `shared-preferences`）を追加。
+- **TabBar 2タブ**: 「SharedPreferences」/「App Group」。App Group タブは **iOS のみ**表示（App Group ストアは iOS 専用）。
+- **並び順**（通常ストア）: `SharedPreferencesKey` の既知キーに **含まれない** キーを先頭（key 昇順）→ 既知キー（key 昇順）。App Group はキー昇順。
+- **表示**: 各行にキー名・型・値プレビュー。
+- **編集（型対応）**: `bool`→スイッチ、`int`/`double`→数値入力、`String`→複数行テキスト（JSON も文字列編集）、`List<String>`→要素ごとテキスト。
+- **新規追加**: キー名・型・値を指定して作成。
+- **削除**: 各行から削除。
+- **確認ダイアログなし・即時反映**。
+
+### データアクセス（既存API利用、新ラッパーは作らない）
+- 通常ストア: `sharedPreferences`(`Future<SharedPreferences>`) の `getKeys()`/`get()`/`set*`/`remove()`。
+- App Group: `appGroupPreferences`(`SharedPreferencesAsync`) の `getAll()`/`set*`/`remove()`。iOS 専用。
+
+### 実装（新規ファイル、`.../debug/shared_preferences/`）
+- `debug_shared_preferences_entries_provider.dart`（通常ストアのエントリ一覧, 公開Provider 1つ）。
+- `debug_app_group_preferences_entries_provider.dart`（App Group のエントリ一覧, 公開Provider 1つ）。
+- `debug_shared_preferences_page.dart`（`DebugSharedPreferencesPage`）。
+
+### 既知の制約
+- raw な SharedPreferences へ直接書き込むため、編集してもアプリ側の Riverpod 状態は自動更新されない（反映に再起動が必要な場合がある）。デバッグ専用機能として許容する。
+
+---
+
+## 影響範囲まとめ
+
+| 種別 | ファイル |
+|------|----------|
+| 変更 | `packages/cache/lib/src/database/open_http_cache_database.dart`, `.../http_cache_database.dart`, `.../http/http_cache_store.dart` |
+| 変更 | `app/lib/core/provider/dio_provider.dart` |
+| 変更 | `app/lib/core/data/preferences/shared/shared_preferences_key.dart` |
+| 変更 | `app/lib/feature/settings/settings_page.dart` |
+| 変更 | `app/lib/feature/settings/children/config/debug/debug_page.dart` |
+| 変更 | `app/lib/core/router/router.dart` |
+| 新規 | `app/lib/core/api/http_cache_size_provider.dart` |
+| 新規 | `app/lib/core/api/http_cache_disabled_provider.dart` |
+| 新規 | `app/lib/feature/settings/children/config/debug/shared_preferences/*.dart`（3ファイル） |
+
+コード生成（`melos run generate`）と `dart analyze` / `dart format` を最後に一括実行する。
+
+## テスト方針
+- `packages/cache` の既存テスト（`http_cache_store_test.dart` 等）が壊れないことを確認。`vacuum()` の単純な呼び出しテストを追加してもよい。
+- UI（設定/デバッグ）は手動確認。デバッグ専用機能のためユニットテストは必須としない。

--- a/packages/cache/lib/src/database/http_cache_database.dart
+++ b/packages/cache/lib/src/database/http_cache_database.dart
@@ -21,4 +21,6 @@ class CacheDatabase extends _$CacheDatabase {
       (delete(httpCacheEntries)..where((t) => t.key.equals(key))).go();
 
   Future<void> clear() => delete(httpCacheEntries).go();
+
+  Future<void> vacuum() => customStatement('VACUUM');
 }

--- a/packages/cache/lib/src/database/open_http_cache_database.dart
+++ b/packages/cache/lib/src/database/open_http_cache_database.dart
@@ -4,11 +4,13 @@ import 'package:cache/src/database/http_cache_database.dart';
 import 'package:drift/native.dart';
 import 'package:path_provider/path_provider.dart';
 
-Future<CacheDatabase> openHttpCacheDatabase() async {
+/// HTTPキャッシュDBの実体ファイル。オープン処理と容量計測で共用する。
+Future<File> httpCacheDatabaseFile() async {
   final dir = await getApplicationSupportDirectory();
-  return CacheDatabase(
-    NativeDatabase.createInBackground(
-      File('${dir.path}/eqmonitor_http_cache.db'),
-    ),
-  );
+  return File('${dir.path}/eqmonitor_http_cache.db');
+}
+
+Future<CacheDatabase> openHttpCacheDatabase() async {
+  final file = await httpCacheDatabaseFile();
+  return CacheDatabase(NativeDatabase.createInBackground(file));
 }

--- a/packages/cache/lib/src/http/http_cache_store.dart
+++ b/packages/cache/lib/src/http/http_cache_store.dart
@@ -52,6 +52,8 @@ class HttpCacheStore {
 
   Future<void> clearAll() => db.clear();
 
+  Future<void> vacuum() => db.vacuum();
+
   String primaryKeyForUrl(RequestOptions options) => buildHttpCacheKey(
     schemaVersion: schemaVersion,
     appBuild: appBuild,


### PR DESCRIPTION
## 概要

3つの独立した機能を追加します。設計は `docs/superpowers/specs/2026-07-03-http-cache-and-shared-preferences-debug-design.md` を参照。

### ① 設定画面: HTTPキャッシュ容量表示 + 削除
- 設定画面下部に「キャッシュ」セクションを追加
- 容量 = HTTPキャッシュDB (`eqmonitor_http_cache.db`) の**実ファイルサイズ**を可読形式で表示
- 「HTTPキャッシュを削除」で `clearAll()` → **`VACUUM`** を実行し、ファイルを物理的に縮小 → 容量再取得

### ② デバッグページ: HTTPキャッシュ無効化トグル
- SharedPreferences (`http_cache_disabled`) に保存する無効化フラグを追加
- 無効化 = `HttpCacheInterceptor` を dio に登録しない（読み書きを完全バイパス）
- `dio` プロバイダがフラグを `watch` するため**即時反映**

### ③ デバッグページ: SharedPreferences 一覧・編集ページ
- TabBar で「SharedPreferences」/「App Group」を切り替え（App Group タブは **iOS のみ**）
- 並び順: `SharedPreferencesKey` enum 未定義キーを先頭（key昇順）→ 既知キー（key昇順）
- 型対応の編集（bool/int/double/String/List&lt;String&gt;）・新規追加・削除。確認ダイアログなしの即時反映

## 実装メモ
- `packages/cache`: `httpCacheDatabaseFile()` を単一情報源化、`CacheDatabase.vacuum()` / `HttpCacheStore.vacuum()` を追加
- 公開Providerは1ファイル1つの規約に従い分割

## 既知の制約
- 一覧ページは raw な SharedPreferences へ直接書き込むため、編集してもアプリ側の Riverpod 状態は自動更新されない（反映に再起動が必要な場合あり）。デバッグ専用機能として許容。

## 確認
- [x] `dart analyze`（変更ファイル）: No issues
- [x] `dart format`: 適用済み
- [x] `packages/cache` テスト 49件 pass
- [x] `build_runner` 生成済み

https://claude.ai/code/session_0194CgRs1jNv9Z4Nw5CAW84a