### PR TITLE
fix(ui): 地震履歴一覧などでRefreshIndicatorの位置がずれる問題を修正 (#1348)

### DIFF
--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_parameter_persistent_delegate.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_parameter_persistent_delegate.dart
@@ -22,6 +22,8 @@ class EarthquakeHistoryParameterPersistentDelegate
     required this.onChanged,
   });
 
+  static const double height = 48;
+
   final EarthquakeHistoryParameter parameter;
   final void Function(EarthquakeHistoryParameter) onChanged;
 
@@ -41,10 +43,10 @@ class EarthquakeHistoryParameterPersistentDelegate
   }
 
   @override
-  double get maxExtent => 48;
+  double get maxExtent => height;
 
   @override
-  double get minExtent => 48;
+  double get minExtent => height;
 
   @override
   bool shouldRebuild(

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
@@ -86,7 +86,11 @@ class _PagingBody extends StatelessWidget {
 
     return RefreshIndicator(
       onRefresh: onRefresh,
-
+      edgeOffset:
+          MediaQuery.paddingOf(context).top +
+          kToolbarHeight +
+          AdSize.banner.height.toDouble() +
+          EarthquakeHistoryParameterPersistentDelegate.height,
       child: CustomScrollView(
         slivers: [
           SliverAppBar(

--- a/app/lib/feature/eew_history/ui/components/eew_list_parameter_persistent_delegate.dart
+++ b/app/lib/feature/eew_history/ui/components/eew_list_parameter_persistent_delegate.dart
@@ -15,11 +15,17 @@ class EewListParameterPersistentDelegate
     required this.onChanged,
   });
 
+  static const double height = 48;
+
   final EewListParameter parameter;
   final void Function(EewListParameter) onChanged;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
     return ColoredBox(
       color: Theme.of(context).colorScheme.surface,
       child: _FilterChipBar(parameter: parameter, onChanged: onChanged),
@@ -27,10 +33,10 @@ class EewListParameterPersistentDelegate
   }
 
   @override
-  double get maxExtent => 48;
+  double get maxExtent => height;
 
   @override
-  double get minExtent => 48;
+  double get minExtent => height;
 
   @override
   bool shouldRebuild(covariant EewListParameterPersistentDelegate old) =>

--- a/app/lib/feature/eew_history/ui/eew_history_page.dart
+++ b/app/lib/feature/eew_history/ui/eew_history_page.dart
@@ -62,6 +62,10 @@ class _PagingBody extends StatelessWidget {
     final theme = Theme.of(context);
     return RefreshIndicator(
       onRefresh: onRefresh,
+      edgeOffset:
+          MediaQuery.paddingOf(context).top +
+          kToolbarHeight +
+          EewListParameterPersistentDelegate.height,
       child: CustomScrollView(
         slivers: [
           const SliverAppBar(

--- a/app/lib/feature/feed/ui/page/feed_page.dart
+++ b/app/lib/feature/feed/ui/page/feed_page.dart
@@ -37,6 +37,7 @@ class _PagingBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return RefreshIndicator(
       onRefresh: dataSource.refresh,
+      edgeOffset: MediaQuery.paddingOf(context).top + kToolbarHeight,
       child: CustomScrollView(
         slivers: [
           const SliverAppBar(
@@ -66,15 +67,14 @@ class _PagingBody extends StatelessWidget {
           SliverToBoxAdapter(
             child: AppendLoadStateBuilder(
               dataSource: dataSource,
-              builder: (context, hasMore, isLoading) =>
-                  !hasMore && !isLoading
-                      ? const Padding(
-                          padding: EdgeInsets.all(16),
-                          child: Center(
-                            child: Text('すべてのお知らせを表示しました'),
-                          ),
-                        )
-                      : const SizedBox.shrink(),
+              builder: (context, hasMore, isLoading) => !hasMore && !isLoading
+                  ? const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Center(
+                        child: Text('すべてのお知らせを表示しました'),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
             ),
           ),
         ],


### PR DESCRIPTION
## 概要

Issue #1348 の対応。pull-to-refresh のインジケーター(スピナー)が画面最上部のピン留めヘッダー(`SliverAppBar` / AdBanner / フィルタバー)に重なって表示される問題を修正します。

## 根本原因

該当画面は `RefreshIndicator` が `CustomScrollView` 全体をラップしている。`RefreshIndicator` はスピナーを内部の `Stack` で **自身の描画ボックス上端から `edgeOffset`(既定 0) + `displacement`(既定 40)** の位置に、スクロールビューの上に重ねて描画する。ピン留めされた `SliverAppBar` 等はスクロールビューの一部として描かれるため、既定ではスピナーがそれらの**上に重なって**画面最上部(タイトル付近)に出てしまっていた。

## 修正内容

各画面の `RefreshIndicator` に、その画面に**実在するピン留めスライバーの合計高さ**を `edgeOffset` として渡し、スピナーがピン留め領域の下に収まるようにした。

- `earthquake_history_page.dart`: `paddingTop + kToolbarHeight + AdSize.banner.height + フィルタ48`
- `eew_history_page.dart`: `paddingTop + kToolbarHeight + フィルタ48`(`PinnedActiveEewSection` は `SliverToBoxAdapter` でスクロールするため除外)
- `feed_page.dart`: `paddingTop + kToolbarHeight`(フィルタなし)

フィルタバー高さ `48` は各 `SliverPersistentHeaderDelegate` に `static const double height = 48;` を追加し、`minExtent`/`maxExtent` と `edgeOffset` 計算の両方で参照する形にして単一情報源化した(マジックナンバーのドリフト防止)。

`displacement` は既定のまま変更していない。

## 対象画面

Issue は地震履歴一覧画面のみだが、同一構造(`RefreshIndicator > CustomScrollView > pinned SliverAppBar`)を持つ EEW 履歴画面・お知らせ画面でも同じ不具合が発生していたため、まとめて修正した。

## 検証

- `dart analyze`(変更 5 ファイル): `No issues found!`
- `dart format --set-exit-if-changed`(変更 5 ファイル): 差分なし
- レイアウト定数の修正のため widget テストは追加していない(対象ページが Riverpod/広告SDK の重いモックを要し、値の再エンコードにしかならないため)。表示位置の確認は目視によるものとする。

Closes #1348