### PR TITLE
chore(ci): Deploy iOS ジョブ名を Deploy iOS (App Store Connect) に変更

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -242,7 +242,7 @@ jobs:
           if-no-files-found: error
 
   deploy-ios:
-    name: Deploy iOS
+    name: Deploy iOS (App Store Connect)
     needs:
       - build-ios
       - define-matrix


### PR DESCRIPTION
## 概要

`deploy-app.yaml` の `deploy-ios` ジョブの表示名を `Deploy iOS` → `Deploy iOS (App Store Connect)` に変更します。

先行して追加した `Deploy iOS (Firebase App Distribution)`（PR #1413）と配布先を区別しやすくするための表示名のみの変更です。ジョブ ID・依存関係・処理内容は変更ありません。

## 検証

- `actionlint` パス
- pre-commit hooks パス

https://claude.ai/code/session_012rfkecaccKhvp7S1BUKbZw