### PR TITLE
fix: EarthquakeStationStatus を API の大文字 enum 値に追従

### DIFF
--- a/app/lib/feature/parameter/data/model/earthquake/earthquake_parameter.dart
+++ b/app/lib/feature/parameter/data/model/earthquake/earthquake_parameter.dart
@@ -78,12 +78,16 @@ abstract class EarthquakeParameterStationItem
       _$EarthquakeParameterStationItemFromJson(json);
 }
 
-@JsonEnum(fieldRename: FieldRename.snake)
+@JsonEnum()
 enum EarthquakeStationStatus {
+  @JsonValue('OPERATING')
   operating,
+  @JsonValue('CHANGED')
   changed,
-  @JsonValue('new')
+  @JsonValue('NEW')
   valueNew,
+  @JsonValue('ABOLISHED')
   abolished,
+  @JsonValue('UNKNOWN')
   unknown,
 }

--- a/app/lib/feature/parameter/data/model/earthquake/earthquake_parameter.g.dart
+++ b/app/lib/feature/parameter/data/model/earthquake/earthquake_parameter.g.dart
@@ -184,9 +184,9 @@ Map<String, dynamic> _$EarthquakeParameterStationItemToJson(
 };
 
 const _$EarthquakeStationStatusEnumMap = {
-  EarthquakeStationStatus.operating: 'operating',
-  EarthquakeStationStatus.changed: 'changed',
-  EarthquakeStationStatus.valueNew: 'new',
-  EarthquakeStationStatus.abolished: 'abolished',
-  EarthquakeStationStatus.unknown: 'unknown',
+  EarthquakeStationStatus.operating: 'OPERATING',
+  EarthquakeStationStatus.changed: 'CHANGED',
+  EarthquakeStationStatus.valueNew: 'NEW',
+  EarthquakeStationStatus.abolished: 'ABOLISHED',
+  EarthquakeStationStatus.unknown: 'UNKNOWN',
 };

--- a/app/test/feature/parameter/earthquake_parameter_test.dart
+++ b/app/test/feature/parameter/earthquake_parameter_test.dart
@@ -1,0 +1,53 @@
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('EarthquakeParameterStationItem.fromJson', () {
+    Map<String, Object?> stationJson({required String status}) => {
+      'code': '0110100',
+      'no_code': '011012625',
+      'name': {'ja': '札幌中央区北２条', 'en': ''},
+      'kana': 'さっぽろしちゅうおうくきたにじょう',
+      'status': status,
+      'source_status': '現',
+      'owner': '気象庁',
+      'location': {'lat': 43.0672, 'lon': 141.3519},
+      'arv_400': 1.517,
+    };
+
+    test('"OPERATING" → EarthquakeStationStatus.operating', () {
+      final item = EarthquakeParameterStationItem.fromJson(
+        stationJson(status: 'OPERATING'),
+      );
+      expect(item.status, EarthquakeStationStatus.operating);
+    });
+
+    test('"NEW" → EarthquakeStationStatus.valueNew', () {
+      final item = EarthquakeParameterStationItem.fromJson(
+        stationJson(status: 'NEW'),
+      );
+      expect(item.status, EarthquakeStationStatus.valueNew);
+    });
+
+    test('"UNKNOWN" → EarthquakeStationStatus.unknown', () {
+      final item = EarthquakeParameterStationItem.fromJson(
+        stationJson(status: 'UNKNOWN'),
+      );
+      expect(item.status, EarthquakeStationStatus.unknown);
+    });
+
+    test('"CHANGED" → EarthquakeStationStatus.changed', () {
+      final item = EarthquakeParameterStationItem.fromJson(
+        stationJson(status: 'CHANGED'),
+      );
+      expect(item.status, EarthquakeStationStatus.changed);
+    });
+
+    test('"ABOLISHED" → EarthquakeStationStatus.abolished', () {
+      final item = EarthquakeParameterStationItem.fromJson(
+        stationJson(status: 'ABOLISHED'),
+      );
+      expect(item.status, EarthquakeStationStatus.abolished);
+    });
+  });
+}

--- a/app/test/feature/parameter/parameter_asset_parse_test.dart
+++ b/app/test/feature/parameter/parameter_asset_parse_test.dart
@@ -1,0 +1,39 @@
+// 同梱アセットとモデルの契約ズレを CI で検出するための回帰テスト。
+// flutter test の cwd は app/ なので assets/parameters/... の相対パスで読める。
+import 'dart:io';
+
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:eqmonitor/feature/parameter/data/repository/parameter_json_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const parser = ParameterJsonParser();
+
+  test('同梱パラメータアセット全体が例外なくパースできる', () {
+    final manifestJson =
+        File('assets/parameters/manifest.json').readAsStringSync();
+    final parameterJsonByType = {
+      for (final type in ParameterType.values)
+        type: File('assets/parameters/${type.pathSegment}.json')
+            .readAsStringSync(),
+    };
+
+    final result = parser.parseSet(
+      manifestJson: manifestJson,
+      parameterJsonByType: parameterJsonByType,
+    );
+
+    // 地震観測点データが空でないこと
+    expect(result.earthquake.prefectures, isNotEmpty);
+
+    // 全 station の status が enum 値として解決されていること(パース成功が主目的)
+    final allStations = result.earthquake.prefectures
+        .expand((pref) => pref.regions)
+        .expand((region) => region.cities)
+        .expand((city) => city.stations);
+    for (final station in allStations) {
+      expect(EarthquakeStationStatus.values, contains(station.status));
+    }
+  });
+}

--- a/app/test/feature/parameter/parameter_repository_refresh_test.dart
+++ b/app/test/feature/parameter/parameter_repository_refresh_test.dart
@@ -43,6 +43,7 @@ void main() {
         'KYOSHIN_OBSERVATION_POINTS',
         'EARTHQUAKE_STATIONS',
         'TSUNAMI_STATIONS',
+        'SHINDO_DB_STATIONS',
       ]);
     },
   );
@@ -104,6 +105,7 @@ Map<String, Object?> _parameterJson(String type) => switch (type) {
     'code_tables': {
       'area_forecast_local_eew': <Object?>[],
       'area_information_prefecture_earthquake': <Object?>[],
+      'area_information_city': <Object?>[],
       'area_epicenter': <Object?>[],
       'area_epicenter_abbreviation': <Object?>[],
       'area_epicenter_detail': <Object?>[],
@@ -120,6 +122,10 @@ Map<String, Object?> _parameterJson(String type) => switch (type) {
   'TSUNAMI_STATIONS' => {
     'metadata': _metadataJson(type),
     'prefectures': <Object?>[],
+  },
+  'SHINDO_DB_STATIONS' => {
+    'metadata': _metadataJson(type),
+    'stations': <Object?>[],
   },
   _ => throw StateError('Unexpected parameter type: $type'),
 };


### PR DESCRIPTION
## 概要

起動時に `ParameterRepository.loadAsset` が `CheckedFromJsonException`(`OPERATING` is not one of the supported values)で失敗する問題の修正。

## 原因

- backend `ed28d682`「refactor(api)!: enforce field naming conventions」(2026-06-23)で API の enum 値が大文字化(`operating` → `OPERATING` 等)
- 生成クライアント `packages/eqmonitor_api` は openapi 再生成で追従済みだったが、feature 層の手書きモデル `EarthquakeStationStatus`(`app/lib/feature/parameter/data/model/earthquake/earthquake_parameter.dart`)だけ `FieldRename.snake`(小文字)のまま取り残された
- 同梱アセットが旧形式(5/4 取得)だったため潜伏し、`290878163`「chore: 同梱パラメータを最新APIから更新」(7/2)でアセットが大文字化した瞬間に顕在化

## 変更内容

1. **fix**: `EarthquakeStationStatus` を `@JsonValue('OPERATING')` 等の大文字値に修正(Dart メンバー名は維持、`.g.dart` 再生成)
2. **test**: 同梱アセット `app/assets/parameters/*.json` 全体を `ParameterJsonParser.parseSet` に通す回帰テストを追加(今後のアセット更新時に契約ズレを CI で検出)
3. **test**: 分岐元 develop 時点から失敗していた `parameter_repository_refresh_test.dart` を修理(モックに `SHINDO_DB_STATIONS` ケース追加・`JMA_CODE_TABLE` モックに必須フィールド `area_information_city` 追加)

## 互換性

- 端末に旧形式(小文字)の HTTP キャッシュが残っている場合: `CachedNotifier.cachedBuild` がパース例外を握って force-fresh 再取得で自己修復。オフライン時はアセットフォールバックで正常動作(レビューで検証済み)
- `EarthquakeStationStatus` の使用箇所は enum メンバー名のみに依存しており、JSON 値変更の影響なし(`.name` / 文字列比較の使用なし)

## テスト

`flutter test test/feature/parameter/` 7/7 PASS(既存 refresh テスト含む)

https://claude.ai/code/session_01GagqjF9WD7QJzn1dx1Eizr