### PR TITLE
feat: 通知タップで地震履歴詳細・Feed詳細・任意URLへ遷移できるように

### DIFF
--- a/app/lib/core/fcm/notification_deep_link.dart
+++ b/app/lib/core/fcm/notification_deep_link.dart
@@ -1,0 +1,49 @@
+sealed class NotificationDeepLink {
+  const NotificationDeepLink();
+
+  static const _internalScheme = 'eqmonitor';
+  static const _allowedPathPrefixes = [
+    '/earthquake-history-details/',
+    '/feed/source/',
+  ];
+
+  static NotificationDeepLink? fromData(Map<String, Object?> data) {
+    final link = data['link'];
+    if (link is String) {
+      final uri = Uri.tryParse(link);
+      if (uri != null) {
+        if (uri.scheme == _internalScheme &&
+            _allowedPathPrefixes.any(uri.path.startsWith)) {
+          return NotificationRouteLink(
+            location: Uri(
+              path: uri.path,
+              query: uri.hasQuery ? uri.query : null,
+            ).toString(),
+          );
+        }
+        if (uri.scheme == 'https' || uri.scheme == 'http') {
+          return NotificationUrlLink(uri: uri);
+        }
+      }
+    }
+    final eventId = data['eventId'];
+    if (eventId is String && eventId.isNotEmpty) {
+      return NotificationRouteLink(
+        location: '/earthquake-history-details/$eventId',
+      );
+    }
+    return null;
+  }
+}
+
+class NotificationRouteLink extends NotificationDeepLink {
+  const NotificationRouteLink({required this.location});
+
+  final String location;
+}
+
+class NotificationUrlLink extends NotificationDeepLink {
+  const NotificationUrlLink({required this.uri});
+
+  final Uri uri;
+}

--- a/app/lib/core/provider/firebase/firebase_messaging_interaction.dart
+++ b/app/lib/core/provider/firebase/firebase_messaging_interaction.dart
@@ -1,3 +1,4 @@
+import 'package:eqmonitor/core/fcm/notification_deep_link.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_recorder_provider.dart';
@@ -5,15 +6,16 @@ import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_uploader_pro
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:telemetry_store/telemetry_store.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 part 'firebase_messaging_interaction.g.dart';
 
-String? _pendingNotificationEventId;
+NotificationDeepLink? _pendingNotificationDeepLink;
 
-String? consumePendingNotificationEventId() {
-  final eventId = _pendingNotificationEventId;
-  _pendingNotificationEventId = null;
-  return eventId;
+NotificationDeepLink? consumePendingNotificationDeepLink() {
+  final link = _pendingNotificationDeepLink;
+  _pendingNotificationDeepLink = null;
+  return link;
 }
 
 @Riverpod(keepAlive: true)
@@ -30,10 +32,9 @@ Stream<RemoteMessage> firebaseMessagingInteraction(Ref ref) async* {
       initialMessage,
       coldStart: true,
     );
-    final eventId = initialMessage.data['eventId'] as String?;
-    if (eventId != null) {
-      _pendingNotificationEventId = eventId;
-    }
+    _pendingNotificationDeepLink = NotificationDeepLink.fromData(
+      initialMessage.data,
+    );
     yield initialMessage;
   }
 
@@ -44,11 +45,14 @@ Stream<RemoteMessage> firebaseMessagingInteraction(Ref ref) async* {
       message,
       coldStart: false,
     );
-    final eventId = message.data['eventId'] as String?;
-    if (eventId != null) {
-      await ref
-          .read(goRouterProvider)
-          .push(EarthquakeHistoryDetailsRoute(eventId: eventId).location);
+    final link = NotificationDeepLink.fromData(message.data);
+    switch (link) {
+      case NotificationRouteLink(:final location):
+        await ref.read(goRouterProvider).push(location);
+      case NotificationUrlLink(:final uri):
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      case null:
+        break;
     }
     yield message;
   }

--- a/app/lib/core/provider/firebase/firebase_messaging_interaction.g.dart
+++ b/app/lib/core/provider/firebase/firebase_messaging_interaction.g.dart
@@ -50,4 +50,4 @@ final class FirebaseMessagingInteractionProvider
 }
 
 String _$firebaseMessagingInteractionHash() =>
-    r'350dc7e9df382c018d991bebce92c5131d7b09c9';
+    r'9fc81a3c3006ef9b0c8550f0892a87f5b86d42df';

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -14,6 +14,7 @@ import 'package:eqmonitor/feature/earthquake_search/data/model/earthquake_search
 import 'package:eqmonitor/feature/earthquake_search/ui/earthquake_search_result_page.dart';
 import 'package:eqmonitor/feature/eew/ui/page/eew_details_by_event_id_page.dart';
 import 'package:eqmonitor/feature/eew_history/ui/eew_history_page.dart';
+import 'package:eqmonitor/feature/feed/ui/page/feed_details_page.dart';
 import 'package:eqmonitor/feature/feed/ui/page/feed_page.dart';
 import 'package:eqmonitor/feature/home/ui/page/home_map_layer_page.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/intensity_history_page.dart';
@@ -875,6 +876,17 @@ class FeedRoute extends GoRouteData with $FeedRoute {
 
   @override
   Widget build(BuildContext context, GoRouterState state) => const FeedPage();
+}
+
+@TypedGoRoute<FeedDetailsRoute>(path: '/feed/source/:telegramHash')
+class FeedDetailsRoute extends GoRouteData with $FeedDetailsRoute {
+  const FeedDetailsRoute({required this.telegramHash});
+
+  final String telegramHash;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      FeedDetailsPage(telegramHash: telegramHash);
 }
 
 @TypedGoRoute<TsunamiDetailsRoute>(path: '/tsunami/:tsunamiId')

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -24,6 +24,7 @@ List<RouteBase> get $appRoutes => [
   $talkerRoute,
   $settingsRoute,
   $feedRoute,
+  $feedDetailsRoute,
   $tsunamiDetailsRoute,
   $paywallRoute,
   $subscriptionSettingsRoute,
@@ -1725,6 +1726,36 @@ mixin $FeedRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/feed');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $feedDetailsRoute => GoRouteData.$route(
+  path: '/feed/source/:telegramHash',
+  factory: $FeedDetailsRoute._fromState,
+);
+
+mixin $FeedDetailsRoute on GoRouteData {
+  static FeedDetailsRoute _fromState(GoRouterState state) =>
+      FeedDetailsRoute(telegramHash: state.pathParameters['telegramHash']!);
+
+  FeedDetailsRoute get _self => this as FeedDetailsRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/feed/source/${Uri.encodeComponent(_self.telegramHash)}',
+  );
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/feed/data/provider/feed_by_source_provider.dart
+++ b/app/lib/feature/feed/data/provider/feed_by_source_provider.dart
@@ -1,0 +1,14 @@
+import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feed_by_source_provider.g.dart';
+
+@riverpod
+Future<api.FeedDetailResponse> feedBySource(
+  Ref ref,
+  String telegramHash,
+) async {
+  final repository = await ref.watch(feedRepositoryProvider.future);
+  return repository.fetchByTelegramHash(telegramHash);
+}

--- a/app/lib/feature/feed/data/provider/feed_by_source_provider.g.dart
+++ b/app/lib/feature/feed/data/provider/feed_by_source_provider.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'feed_by_source_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(feedBySource)
+final feedBySourceProvider = FeedBySourceFamily._();
+
+final class FeedBySourceProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<api.FeedDetailResponse>,
+          api.FeedDetailResponse,
+          FutureOr<api.FeedDetailResponse>
+        >
+    with
+        $FutureModifier<api.FeedDetailResponse>,
+        $FutureProvider<api.FeedDetailResponse> {
+  FeedBySourceProvider._({
+    required FeedBySourceFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'feedBySourceProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$feedBySourceHash();
+
+  @override
+  String toString() {
+    return r'feedBySourceProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<api.FeedDetailResponse> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<api.FeedDetailResponse> create(Ref ref) {
+    final argument = this.argument as String;
+    return feedBySource(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is FeedBySourceProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$feedBySourceHash() => r'37807bb92070c3ffd76da7e7f6098d4e050b9a71';
+
+final class FeedBySourceFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<api.FeedDetailResponse>, String> {
+  FeedBySourceFamily._()
+    : super(
+        retry: null,
+        name: r'feedBySourceProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  FeedBySourceProvider call(String telegramHash) =>
+      FeedBySourceProvider._(argument: telegramHash, from: this);
+
+  @override
+  String toString() => r'feedBySourceProvider';
+}

--- a/app/lib/feature/feed/data/repository/feed_repository.dart
+++ b/app/lib/feature/feed/data/repository/feed_repository.dart
@@ -19,4 +19,13 @@ class FeedRepository {
     final response = await _api.feed.getV2Feeds(after: after);
     return response.data;
   }
+
+  Future<api.FeedDetailResponse> fetchByTelegramHash(
+    String telegramHash,
+  ) async {
+    final response = await _api.feed.getV2FeedsSourceTelegramHash(
+      telegramHash: telegramHash,
+    );
+    return response.data;
+  }
 }

--- a/app/lib/feature/feed/ui/page/feed_details_page.dart
+++ b/app/lib/feature/feed/ui/page/feed_details_page.dart
@@ -1,0 +1,113 @@
+// ignore_for_file: avoid_eqmonitor_api_in_ui
+import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/feature/feed/data/provider/feed_by_source_provider.dart';
+import 'package:eqmonitor/feature/feed/ui/component/feed_item_card.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class FeedDetailsPage extends ConsumerWidget {
+  const FeedDetailsPage({required this.telegramHash, super.key});
+
+  final String telegramHash;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final feed = ref.watch(feedBySourceProvider(telegramHash));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('お知らせ')),
+      body: feed.when(
+        loading: () =>
+            const Center(child: CircularProgressIndicator.adaptive()),
+        error: (error, _) => ErrorCard(
+          error: error,
+          onReload: () async =>
+              ref.invalidate(feedBySourceProvider(telegramHash)),
+        ),
+        data: (item) => _FeedDetailsBody(item: item),
+      ),
+    );
+  }
+}
+
+class _FeedDetailsBody extends StatelessWidget {
+  const _FeedDetailsBody({required this.item});
+
+  final api.FeedDetailResponse item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final publishedAt = DateTime.tryParse(item.publishedAt)?.toLocal();
+    final dateStr = publishedAt != null
+        ? DateFormat('yyyy年MM月dd日 HH:mm').format(publishedAt)
+        : item.publishedAt;
+    final url = _url(item.data);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (item.title case final title?)
+            Text(
+              title,
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              FeedPriorityBadge(priority: item.priority),
+              const SizedBox(width: 8),
+              FeedTypeBadge(data: item.data),
+              const Spacer(),
+              Text(dateStr, style: theme.textTheme.labelSmall),
+            ],
+          ),
+          const SizedBox(height: 16),
+          const Divider(),
+          const SizedBox(height: 16),
+          SelectableText(_bodyText(item), style: theme.textTheme.bodyMedium),
+          if (url != null) ...[
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: () async =>
+                  launchUrl(url, mode: LaunchMode.externalApplication),
+              icon: const Icon(Icons.open_in_new),
+              label: const Text('詳細を開く'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  static String _bodyText(api.FeedDetailResponse item) {
+    if (item.body case final body? when body.isNotEmpty) {
+      return body;
+    }
+    return switch (item.data) {
+      api.FeedItemDataUnionFeedEarthquakeNankaiData(
+        :final text,
+        :final earthquakeInfo,
+      ) =>
+        text ?? earthquakeInfo?.text ?? item.summary ?? '',
+      final data => FeedItemCard.dataText(data),
+    };
+  }
+
+  static Uri? _url(api.FeedItemDataUnion data) {
+    final url = switch (data) {
+      api.FeedItemDataUnionFeedAppUpdateData(:final url) => url,
+      api.FeedItemDataUnionFeedIncidentData(:final url) => url,
+      api.FeedItemDataUnionFeedDeveloperMessageData(:final url) => url,
+      _ => null,
+    };
+    return url != null ? Uri.tryParse(url) : null;
+  }
+}

--- a/app/lib/page/splash_page.dart
+++ b/app/lib/page/splash_page.dart
@@ -1,4 +1,5 @@
 import 'package:eqmonitor/core/component/error/error_card.dart';
+import 'package:eqmonitor/core/fcm/notification_deep_link.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging_interaction.dart';
 import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshin_observation_points_provider.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
@@ -10,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class SplashPage extends HookConsumerWidget {
   const SplashPage({super.key});
@@ -39,11 +41,14 @@ class SplashPage extends HookConsumerWidget {
           ref.read(startProvider);
           WidgetsBinding.instance.addPostFrameCallback((_) async {
             context.go(const HomeRoute().location);
-            final pendingEventId = consumePendingNotificationEventId();
-            if (pendingEventId != null) {
-              await EarthquakeHistoryDetailsRoute(
-                eventId: pendingEventId,
-              ).push<void>(context);
+            final pending = consumePendingNotificationDeepLink();
+            switch (pending) {
+              case NotificationRouteLink(:final location):
+                await GoRouter.of(context).push<void>(location);
+              case NotificationUrlLink(:final uri):
+                await launchUrl(uri, mode: LaunchMode.externalApplication);
+              case null:
+                break;
             }
           });
         }

--- a/app/test/core/fcm/notification_deep_link_test.dart
+++ b/app/test/core/fcm/notification_deep_link_test.dart
@@ -1,0 +1,95 @@
+import 'package:eqmonitor/core/fcm/notification_deep_link.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NotificationDeepLink.fromData', () {
+    test('eqmonitor スキームの link は内部遷移になる', () {
+      final link = NotificationDeepLink.fromData({
+        'link': 'eqmonitor:///earthquake-history-details/20260703123456',
+        'eventId': '20260703123456',
+      });
+      expect(
+        link,
+        isA<NotificationRouteLink>().having(
+          (l) => l.location,
+          'location',
+          '/earthquake-history-details/20260703123456',
+        ),
+      );
+    });
+
+    test('feed/source への link も内部遷移になる', () {
+      final link = NotificationDeepLink.fromData({
+        'link': 'eqmonitor:///feed/source/hash-abc',
+      });
+      expect(
+        link,
+        isA<NotificationRouteLink>().having(
+          (l) => l.location,
+          'location',
+          '/feed/source/hash-abc',
+        ),
+      );
+    });
+
+    test('https の link は外部 URL になる', () {
+      final link = NotificationDeepLink.fromData({
+        'link': 'https://status.eqmonitor.app/',
+      });
+      expect(
+        link,
+        isA<NotificationUrlLink>().having(
+          (l) => l.uri.toString(),
+          'uri',
+          'https://status.eqmonitor.app/',
+        ),
+      );
+    });
+
+    test('allowlist 外の内部パスは無視して eventId フォールバックする', () {
+      final link = NotificationDeepLink.fromData({
+        'link': 'eqmonitor:///settings/debug',
+        'eventId': '20260703123456',
+      });
+      expect(
+        link,
+        isA<NotificationRouteLink>().having(
+          (l) => l.location,
+          'location',
+          '/earthquake-history-details/20260703123456',
+        ),
+      );
+    });
+
+    test('link 無しは eventId フォールバック', () {
+      final link = NotificationDeepLink.fromData({'eventId': 'ev1'});
+      expect(
+        link,
+        isA<NotificationRouteLink>().having(
+          (l) => l.location,
+          'location',
+          '/earthquake-history-details/ev1',
+        ),
+      );
+    });
+
+    test('link も eventId も無ければ null', () {
+      expect(NotificationDeepLink.fromData({'type': 'EEW'}), isNull);
+    });
+
+    test('不正な URI は eventId フォールバック', () {
+      final link = NotificationDeepLink.fromData({
+        'link': '::not a uri::',
+        'eventId': 'ev1',
+      });
+      expect(
+        link,
+        isA<NotificationRouteLink>().having(
+          (l) => l.location,
+          'location',
+          '/earthquake-history-details/ev1',
+        ),
+      );
+    });
+  });
+}

--- a/app/test/feature/feed/feed_by_source_provider_test.dart
+++ b/app/test/feature/feed/feed_by_source_provider_test.dart
@@ -1,0 +1,83 @@
+import 'package:eqmonitor/feature/feed/data/provider/feed_by_source_provider.dart';
+import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class _FakeFeedRepository implements FeedRepository {
+  _FakeFeedRepository({this.response, this.error});
+
+  final api.FeedDetailResponse? response;
+  final Object? error;
+
+  String? lastTelegramHash;
+
+  @override
+  Future<api.FeedListResponse> fetch({String? after}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<api.FeedDetailResponse> fetchByTelegramHash(
+    String telegramHash,
+  ) async {
+    lastTelegramHash = telegramHash;
+    if (error case final error?) {
+      throw error;
+    }
+    return response!;
+  }
+}
+
+void main() {
+  final feed = api.FeedDetailResponse(
+    id: 'feed-1',
+    feedType: api.FeedType.incident,
+    priority: api.FeedPriority.high,
+    isImportant: true,
+    publishedAt: '2026-07-03T10:00:00+09:00',
+    expiresAt: null,
+    title: 'メンテナンスのお知らせ',
+    summary: null,
+    body: '本文',
+    data: const api.FeedItemDataUnion.feedIncidentData(
+      type: 'INCIDENT',
+      url: 'https://status.eqmonitor.app/',
+    ),
+  );
+
+  test('telegramHash を repository に渡して FeedDetailResponse を返す', () async {
+    final repository = _FakeFeedRepository(response: feed);
+    final container = ProviderContainer(
+      retry: (retryCount, error) => null,
+      overrides: [
+        feedRepositoryProvider.overrideWith((ref) async => repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.listen(feedBySourceProvider('hash-abc'), (_, _) {});
+    final result = await container.read(
+      feedBySourceProvider('hash-abc').future,
+    );
+
+    expect(result.id, 'feed-1');
+    expect(repository.lastTelegramHash, 'hash-abc');
+  });
+
+  test('repository のエラーは AsyncError として伝播する', () async {
+    final repository = _FakeFeedRepository(error: Exception('not found'));
+    final container = ProviderContainer(
+      retry: (retryCount, error) => null,
+      overrides: [
+        feedRepositoryProvider.overrideWith((ref) async => repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.listen(feedBySourceProvider('unknown'), (_, _) {});
+    await expectLater(
+      container.read(feedBySourceProvider('unknown').future),
+      throwsA(isA<Exception>()),
+    );
+  });
+}

--- a/packages/eqmonitor_api/bin/generate.dart
+++ b/packages/eqmonitor_api/bin/generate.dart
@@ -151,6 +151,10 @@ void main(List<String> args) async {
     _patchTelegramBodyReference(libDir);
   });
 
+  await _step('FeedItemData 参照を FeedItemDataUnion に修正', () async {
+    _patchFeedItemDataReference(libDir);
+  });
+
   await _step('DeviceLocale デフォルト値パッチ', () async {
     _patchDeviceLocaleDefault(libDir);
   });
@@ -817,6 +821,46 @@ void _patchTelegramBodyReference(Directory libDir) {
     if (content != original) {
       entity.writeAsStringSync(content);
       stdout.writeln('  Patched TelegramBody ref: ${entity.path}');
+    }
+  }
+}
+
+/// swagger_parser は `FeedItemData` (anyOf ref) を `FeedItemDataUnion`
+/// というクラス名で `feed_item_data_union.dart` に生成するが、
+/// `FeedDetailResponse` 等の参照先は `FeedItemData` / `feed_item_data.dart` のまま。
+/// import パスとクラス名を統一する。
+void _patchFeedItemDataReference(Directory libDir) {
+  final modelsDir = Directory('${libDir.path}/models');
+  if (!modelsDir.existsSync()) {
+    return;
+  }
+
+  for (final entity in modelsDir.listSync()) {
+    if (entity is! File || !entity.path.endsWith('.dart')) {
+      continue;
+    }
+    if (entity.path.endsWith('.g.dart') ||
+        entity.path.endsWith('.freezed.dart')) {
+      continue;
+    }
+
+    var content = entity.readAsStringSync();
+    final original = content;
+
+    content = content.replaceAll(
+      "import 'feed_item_data.dart';",
+      "import 'feed_item_data_union.dart';",
+    );
+    // 単独の `FeedItemData` 参照のみ置換する。`FeedItemDataUnion` や
+    // `FeedItemDataUnionFeedAppUpdateData` 等は単語境界で除外される。
+    content = content.replaceAll(
+      RegExp(r'\bFeedItemData\b'),
+      'FeedItemDataUnion',
+    );
+
+    if (content != original) {
+      entity.writeAsStringSync(content);
+      stdout.writeln('  Patched FeedItemData ref: ${entity.path}');
     }
   }
 }

--- a/packages/eqmonitor_api/lib/src/clients/feed_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/feed_api_client.dart
@@ -6,6 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
 import '../models/feed_create_response.dart';
+import '../models/feed_detail_response.dart';
 import '../models/feed_list_response.dart';
 import '../models/v2_feeds_admin_request_body.dart';
 
@@ -27,6 +28,13 @@ abstract class FeedApiClient {
     @Query('statuses') List<TelegramStatus> statuses = const [.normal],
   });
 
+  /// 電文ハッシュから Feed を1件取得（通知ディープリンク用）
+  @GET(FeedApiClientUrls.getV2FeedsSourceTelegramHash)
+  Future<HttpResponse<FeedDetailResponse>> getV2FeedsSourceTelegramHash({
+    @Path('telegramHash') required String telegramHash,
+    @Query('locale') String? locale = 'ja',
+  });
+
   /// Feed作成（管理者のみ）
   @POST(FeedApiClientUrls.postV2FeedsAdmin)
   Future<HttpResponse<FeedCreateResponse>> postV2FeedsAdmin({
@@ -38,6 +46,8 @@ abstract class FeedApiClient {
 abstract class FeedApiClientUrls {
 	/// /v2/feeds
 	static const getV2Feeds = "/v2/feeds";
+	/// /v2/feeds/source/{telegramHash}
+	static const getV2FeedsSourceTelegramHash = "/v2/feeds/source/{telegramHash}";
 	/// /v2/feeds/admin
 	static const postV2FeedsAdmin = "/v2/feeds/admin";
 }

--- a/packages/eqmonitor_api/lib/src/clients/feed_api_client.g.dart
+++ b/packages/eqmonitor_api/lib/src/clients/feed_api_client.g.dart
@@ -63,6 +63,38 @@ class _FeedApiClient implements FeedApiClient {
   }
 
   @override
+  Future<HttpResponse<FeedDetailResponse>> getV2FeedsSourceTelegramHash({
+    required String telegramHash,
+    String? locale = 'ja',
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'locale': locale};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<FeedDetailResponse>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v2/feeds/source/${telegramHash}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, Object?>>(_options);
+    late FeedDetailResponse _value;
+    try {
+      _value = FeedDetailResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
   Future<HttpResponse<FeedCreateResponse>> postV2FeedsAdmin({
     required V2FeedsAdminRequestBody body,
   }) async {

--- a/packages/eqmonitor_api/lib/src/export.dart
+++ b/packages/eqmonitor_api/lib/src/export.dart
@@ -184,6 +184,7 @@ export 'models/feed_developer_message_data.dart';
 export 'models/feed_item_data_union.dart';
 export 'models/feed_item.dart';
 export 'models/feed_list_response.dart';
+export 'models/feed_detail_response.dart';
 export 'models/feed_create_type.dart';
 export 'models/feed_create_response.dart';
 export 'models/parameter_type.dart';

--- a/packages/eqmonitor_api/lib/src/models/feed_detail_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_detail_response.dart
@@ -1,0 +1,37 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'feed_item_data_union.dart';
+import 'feed_priority.dart';
+import 'feed_type.dart';
+
+part 'feed_detail_response.freezed.dart';
+part 'feed_detail_response.g.dart';
+
+@Freezed()
+abstract class FeedDetailResponse with _$FeedDetailResponse {
+  const factory FeedDetailResponse({
+    required String id,
+    @JsonKey(name: 'feed_type')
+    required FeedType feedType,
+    required FeedPriority priority,
+    @JsonKey(name: 'is_important')
+    required bool isImportant,
+    @JsonKey(name: 'published_at')
+    required String publishedAt,
+    @JsonKey(includeIfNull: true,name: 'expires_at')
+    required String? expiresAt,
+    @JsonKey(includeIfNull: true)
+    required String? title,
+    @JsonKey(includeIfNull: true)
+    required String? summary,
+    @JsonKey(includeIfNull: true)
+    required String? body,
+    required FeedItemDataUnion data,
+  }) = _FeedDetailResponse;
+  
+  factory FeedDetailResponse.fromJson(Map<String, Object?> json) => _$FeedDetailResponseFromJson(json);
+}

--- a/packages/eqmonitor_api/lib/src/models/feed_detail_response.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_detail_response.freezed.dart
@@ -1,0 +1,322 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'feed_detail_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$FeedDetailResponse {
+
+ String get id;@JsonKey(name: 'feed_type') FeedType get feedType; FeedPriority get priority;@JsonKey(name: 'is_important') bool get isImportant;@JsonKey(name: 'published_at') String get publishedAt;@JsonKey(includeIfNull: true, name: 'expires_at') String? get expiresAt;@JsonKey(includeIfNull: true) String? get title;@JsonKey(includeIfNull: true) String? get summary;@JsonKey(includeIfNull: true) String? get body; FeedItemDataUnion get data;
+/// Create a copy of FeedDetailResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FeedDetailResponseCopyWith<FeedDetailResponse> get copyWith => _$FeedDetailResponseCopyWithImpl<FeedDetailResponse>(this as FeedDetailResponse, _$identity);
+
+  /// Serializes this FeedDetailResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FeedDetailResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.feedType, feedType) || other.feedType == feedType)&&(identical(other.priority, priority) || other.priority == priority)&&(identical(other.isImportant, isImportant) || other.isImportant == isImportant)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.title, title) || other.title == title)&&(identical(other.summary, summary) || other.summary == summary)&&(identical(other.body, body) || other.body == body)&&(identical(other.data, data) || other.data == data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,feedType,priority,isImportant,publishedAt,expiresAt,title,summary,body,data);
+
+@override
+String toString() {
+  return 'FeedDetailResponse(id: $id, feedType: $feedType, priority: $priority, isImportant: $isImportant, publishedAt: $publishedAt, expiresAt: $expiresAt, title: $title, summary: $summary, body: $body, data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FeedDetailResponseCopyWith<$Res>  {
+  factory $FeedDetailResponseCopyWith(FeedDetailResponse value, $Res Function(FeedDetailResponse) _then) = _$FeedDetailResponseCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'feed_type') FeedType feedType, FeedPriority priority,@JsonKey(name: 'is_important') bool isImportant,@JsonKey(name: 'published_at') String publishedAt,@JsonKey(includeIfNull: true, name: 'expires_at') String? expiresAt,@JsonKey(includeIfNull: true) String? title,@JsonKey(includeIfNull: true) String? summary,@JsonKey(includeIfNull: true) String? body, FeedItemDataUnion data
+});
+
+
+$FeedItemDataUnionCopyWith<$Res> get data;
+
+}
+/// @nodoc
+class _$FeedDetailResponseCopyWithImpl<$Res>
+    implements $FeedDetailResponseCopyWith<$Res> {
+  _$FeedDetailResponseCopyWithImpl(this._self, this._then);
+
+  final FeedDetailResponse _self;
+  final $Res Function(FeedDetailResponse) _then;
+
+/// Create a copy of FeedDetailResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? feedType = null,Object? priority = null,Object? isImportant = null,Object? publishedAt = null,Object? expiresAt = freezed,Object? title = freezed,Object? summary = freezed,Object? body = freezed,Object? data = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,feedType: null == feedType ? _self.feedType : feedType // ignore: cast_nullable_to_non_nullable
+as FeedType,priority: null == priority ? _self.priority : priority // ignore: cast_nullable_to_non_nullable
+as FeedPriority,isImportant: null == isImportant ? _self.isImportant : isImportant // ignore: cast_nullable_to_non_nullable
+as bool,publishedAt: null == publishedAt ? _self.publishedAt : publishedAt // ignore: cast_nullable_to_non_nullable
+as String,expiresAt: freezed == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,summary: freezed == summary ? _self.summary : summary // ignore: cast_nullable_to_non_nullable
+as String?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String?,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as FeedItemDataUnion,
+  ));
+}
+/// Create a copy of FeedDetailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$FeedItemDataUnionCopyWith<$Res> get data {
+  
+  return $FeedItemDataUnionCopyWith<$Res>(_self.data, (value) {
+    return _then(_self.copyWith(data: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [FeedDetailResponse].
+extension FeedDetailResponsePatterns on FeedDetailResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _FeedDetailResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _FeedDetailResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _FeedDetailResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _FeedDetailResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _FeedDetailResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _FeedDetailResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'feed_type')  FeedType feedType,  FeedPriority priority, @JsonKey(name: 'is_important')  bool isImportant, @JsonKey(name: 'published_at')  String publishedAt, @JsonKey(includeIfNull: true, name: 'expires_at')  String? expiresAt, @JsonKey(includeIfNull: true)  String? title, @JsonKey(includeIfNull: true)  String? summary, @JsonKey(includeIfNull: true)  String? body,  FeedItemDataUnion data)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _FeedDetailResponse() when $default != null:
+return $default(_that.id,_that.feedType,_that.priority,_that.isImportant,_that.publishedAt,_that.expiresAt,_that.title,_that.summary,_that.body,_that.data);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'feed_type')  FeedType feedType,  FeedPriority priority, @JsonKey(name: 'is_important')  bool isImportant, @JsonKey(name: 'published_at')  String publishedAt, @JsonKey(includeIfNull: true, name: 'expires_at')  String? expiresAt, @JsonKey(includeIfNull: true)  String? title, @JsonKey(includeIfNull: true)  String? summary, @JsonKey(includeIfNull: true)  String? body,  FeedItemDataUnion data)  $default,) {final _that = this;
+switch (_that) {
+case _FeedDetailResponse():
+return $default(_that.id,_that.feedType,_that.priority,_that.isImportant,_that.publishedAt,_that.expiresAt,_that.title,_that.summary,_that.body,_that.data);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'feed_type')  FeedType feedType,  FeedPriority priority, @JsonKey(name: 'is_important')  bool isImportant, @JsonKey(name: 'published_at')  String publishedAt, @JsonKey(includeIfNull: true, name: 'expires_at')  String? expiresAt, @JsonKey(includeIfNull: true)  String? title, @JsonKey(includeIfNull: true)  String? summary, @JsonKey(includeIfNull: true)  String? body,  FeedItemDataUnion data)?  $default,) {final _that = this;
+switch (_that) {
+case _FeedDetailResponse() when $default != null:
+return $default(_that.id,_that.feedType,_that.priority,_that.isImportant,_that.publishedAt,_that.expiresAt,_that.title,_that.summary,_that.body,_that.data);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _FeedDetailResponse implements FeedDetailResponse {
+  const _FeedDetailResponse({required this.id, @JsonKey(name: 'feed_type') required this.feedType, required this.priority, @JsonKey(name: 'is_important') required this.isImportant, @JsonKey(name: 'published_at') required this.publishedAt, @JsonKey(includeIfNull: true, name: 'expires_at') required this.expiresAt, @JsonKey(includeIfNull: true) required this.title, @JsonKey(includeIfNull: true) required this.summary, @JsonKey(includeIfNull: true) required this.body, required this.data});
+  factory _FeedDetailResponse.fromJson(Map<String, dynamic> json) => _$FeedDetailResponseFromJson(json);
+
+@override final  String id;
+@override@JsonKey(name: 'feed_type') final  FeedType feedType;
+@override final  FeedPriority priority;
+@override@JsonKey(name: 'is_important') final  bool isImportant;
+@override@JsonKey(name: 'published_at') final  String publishedAt;
+@override@JsonKey(includeIfNull: true, name: 'expires_at') final  String? expiresAt;
+@override@JsonKey(includeIfNull: true) final  String? title;
+@override@JsonKey(includeIfNull: true) final  String? summary;
+@override@JsonKey(includeIfNull: true) final  String? body;
+@override final  FeedItemDataUnion data;
+
+/// Create a copy of FeedDetailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FeedDetailResponseCopyWith<_FeedDetailResponse> get copyWith => __$FeedDetailResponseCopyWithImpl<_FeedDetailResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$FeedDetailResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FeedDetailResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.feedType, feedType) || other.feedType == feedType)&&(identical(other.priority, priority) || other.priority == priority)&&(identical(other.isImportant, isImportant) || other.isImportant == isImportant)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.title, title) || other.title == title)&&(identical(other.summary, summary) || other.summary == summary)&&(identical(other.body, body) || other.body == body)&&(identical(other.data, data) || other.data == data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,feedType,priority,isImportant,publishedAt,expiresAt,title,summary,body,data);
+
+@override
+String toString() {
+  return 'FeedDetailResponse(id: $id, feedType: $feedType, priority: $priority, isImportant: $isImportant, publishedAt: $publishedAt, expiresAt: $expiresAt, title: $title, summary: $summary, body: $body, data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$FeedDetailResponseCopyWith<$Res> implements $FeedDetailResponseCopyWith<$Res> {
+  factory _$FeedDetailResponseCopyWith(_FeedDetailResponse value, $Res Function(_FeedDetailResponse) _then) = __$FeedDetailResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'feed_type') FeedType feedType, FeedPriority priority,@JsonKey(name: 'is_important') bool isImportant,@JsonKey(name: 'published_at') String publishedAt,@JsonKey(includeIfNull: true, name: 'expires_at') String? expiresAt,@JsonKey(includeIfNull: true) String? title,@JsonKey(includeIfNull: true) String? summary,@JsonKey(includeIfNull: true) String? body, FeedItemDataUnion data
+});
+
+
+@override $FeedItemDataUnionCopyWith<$Res> get data;
+
+}
+/// @nodoc
+class __$FeedDetailResponseCopyWithImpl<$Res>
+    implements _$FeedDetailResponseCopyWith<$Res> {
+  __$FeedDetailResponseCopyWithImpl(this._self, this._then);
+
+  final _FeedDetailResponse _self;
+  final $Res Function(_FeedDetailResponse) _then;
+
+/// Create a copy of FeedDetailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? feedType = null,Object? priority = null,Object? isImportant = null,Object? publishedAt = null,Object? expiresAt = freezed,Object? title = freezed,Object? summary = freezed,Object? body = freezed,Object? data = null,}) {
+  return _then(_FeedDetailResponse(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,feedType: null == feedType ? _self.feedType : feedType // ignore: cast_nullable_to_non_nullable
+as FeedType,priority: null == priority ? _self.priority : priority // ignore: cast_nullable_to_non_nullable
+as FeedPriority,isImportant: null == isImportant ? _self.isImportant : isImportant // ignore: cast_nullable_to_non_nullable
+as bool,publishedAt: null == publishedAt ? _self.publishedAt : publishedAt // ignore: cast_nullable_to_non_nullable
+as String,expiresAt: freezed == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,summary: freezed == summary ? _self.summary : summary // ignore: cast_nullable_to_non_nullable
+as String?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as String?,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as FeedItemDataUnion,
+  ));
+}
+
+/// Create a copy of FeedDetailResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$FeedItemDataUnionCopyWith<$Res> get data {
+  
+  return $FeedItemDataUnionCopyWith<$Res>(_self.data, (value) {
+    return _then(_self.copyWith(data: value));
+  });
+}
+}
+
+// dart format on

--- a/packages/eqmonitor_api/lib/src/models/feed_detail_response.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_detail_response.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'feed_detail_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_FeedDetailResponse _$FeedDetailResponseFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      '_FeedDetailResponse',
+      json,
+      ($checkedConvert) {
+        final val = _FeedDetailResponse(
+          id: $checkedConvert('id', (v) => v as String),
+          feedType: $checkedConvert(
+            'feed_type',
+            (v) => $enumDecode(_$FeedTypeEnumMap, v),
+          ),
+          priority: $checkedConvert(
+            'priority',
+            (v) => $enumDecode(_$FeedPriorityEnumMap, v),
+          ),
+          isImportant: $checkedConvert('is_important', (v) => v as bool),
+          publishedAt: $checkedConvert('published_at', (v) => v as String),
+          expiresAt: $checkedConvert('expires_at', (v) => v as String?),
+          title: $checkedConvert('title', (v) => v as String?),
+          summary: $checkedConvert('summary', (v) => v as String?),
+          body: $checkedConvert('body', (v) => v as String?),
+          data: $checkedConvert(
+            'data',
+            (v) => FeedItemDataUnion.fromJson(v as Map<String, dynamic>),
+          ),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'feedType': 'feed_type',
+        'isImportant': 'is_important',
+        'publishedAt': 'published_at',
+        'expiresAt': 'expires_at',
+      },
+    );
+
+Map<String, dynamic> _$FeedDetailResponseToJson(_FeedDetailResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'feed_type': instance.feedType,
+      'priority': instance.priority,
+      'is_important': instance.isImportant,
+      'published_at': instance.publishedAt,
+      'expires_at': instance.expiresAt,
+      'title': instance.title,
+      'summary': instance.summary,
+      'body': instance.body,
+      'data': instance.data,
+    };
+
+const _$FeedTypeEnumMap = {
+  FeedType.earthquakeNotice: 'EARTHQUAKE_NOTICE',
+  FeedType.earthquakeExplanation: 'EARTHQUAKE_EXPLANATION',
+  FeedType.earthquakeCounts: 'EARTHQUAKE_COUNTS',
+  FeedType.earthquakeNankai: 'EARTHQUAKE_NANKAI',
+  FeedType.appUpdate: 'APP_UPDATE',
+  FeedType.incident: 'INCIDENT',
+  FeedType.developerMessage: 'DEVELOPER_MESSAGE',
+};
+
+const _$FeedPriorityEnumMap = {
+  FeedPriority.critical: 'CRITICAL',
+  FeedPriority.high: 'HIGH',
+  FeedPriority.normal: 'NORMAL',
+  FeedPriority.low: 'LOW',
+};

--- a/packages/eqmonitor_api/lib/src/models/feed_earthquake_nankai_data.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_earthquake_nankai_data.freezed.dart
@@ -16,7 +16,8 @@ T _$identity<T>(T value) => value;
 mixin _$FeedEarthquakeNankaiData {
 
 /// const: "EARTHQUAKE_NANKAI"
- String get type; InfoType get infoType; String get telegramType;@JsonKey(includeIfNull: false) FeedNankaiEarthquakeInfo? get earthquakeInfo;@JsonKey(includeIfNull: false) String? get nextAdvisory;@JsonKey(includeIfNull: false) String? get text;
+ String get type; InfoType get infoType;/// const: "NANKAI"
+ String get telegramType;@JsonKey(includeIfNull: false) FeedNankaiEarthquakeInfo? get earthquakeInfo;@JsonKey(includeIfNull: false) String? get nextAdvisory;@JsonKey(includeIfNull: false) String? get text;
 /// Create a copy of FeedEarthquakeNankaiData
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -233,6 +234,7 @@ class _FeedEarthquakeNankaiData implements FeedEarthquakeNankaiData {
 /// const: "EARTHQUAKE_NANKAI"
 @override final  String type;
 @override final  InfoType infoType;
+/// const: "NANKAI"
 @override final  String telegramType;
 @override@JsonKey(includeIfNull: false) final  FeedNankaiEarthquakeInfo? earthquakeInfo;
 @override@JsonKey(includeIfNull: false) final  String? nextAdvisory;

--- a/packages/eqmonitor_api/lib/src/models/feed_item_data_union.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/feed_item_data_union.freezed.dart
@@ -575,6 +575,7 @@ class FeedItemDataUnionFeedEarthquakeNankaiData implements FeedItemDataUnion {
 /// const: "EARTHQUAKE_NANKAI"
 @override final  String type;
  final  InfoType infoType;
+/// const: "NANKAI"
  final  String telegramType;
 @JsonKey(includeIfNull: false) final  FeedNankaiEarthquakeInfo? earthquakeInfo;
 @JsonKey(includeIfNull: false) final  String? nextAdvisory;


### PR DESCRIPTION
## 概要

通知タップでアプリを起動したとき、通知種別に応じた画面へ遷移できるようにする(Part B / アプリ側)。

Closes #1417

## 変更内容

### 1. `NotificationDeepLink` — 通知 `data.link` の解決ロジック (`app/lib/core/fcm/notification_deep_link.dart`)

- `eqmonitor://` スキーム + allowlist(`/earthquake-history-details/`・`/feed/source/`)→ go_router へ push
- `http(s)://` → 外部ブラウザ(`launchUrl`)
- `link` 無し/不正 → 従来どおり `eventId` から地震履歴詳細へフォールバック(旧 payload 互換)

### 2. 通知タップハンドリングの置き換え

- warm(`onMessageOpenedApp`)/ cold start(`getInitialMessage`→splash pending)の両経路を `NotificationDeepLink` 経由に一本化
- pending 機構は eventId 保持から `NotificationDeepLink?` 保持へ一般化

### 3. Feed 詳細画面(南海トラフ関連情報等の遷移先)

- `FeedDetailsRoute`: `/feed/source/:telegramHash`
- `FeedRepository.fetchByTelegramHash` + `feedBySourceProvider` で新 API `GET /v2/feeds/source/{telegramHash}` から取得
- タイトル・種別/優先度バッジ・日時・本文を表示。URL 系 Feed(APP_UPDATE/INCIDENT/DEVELOPER_MESSAGE)はリンクボタン

### 4. API クライアント再生成 (`packages/eqmonitor_api`)

- backend submodule を PR YumNumm/eqmonitor-backend#803 の先端に更新して再生成
- `FeedDetailResponse` の `data` 参照が `FeedItemData` のまま生成される swagger_parser の問題に対し、`TelegramBody` と同型の参照パッチを `bin/generate.dart` に追加

## 依存関係(Draft の理由)

- **backend PR https://github.com/YumNumm/eqmonitor-backend/pull/803 のマージが先**。マージ後に submodule pin を main のマージコミットへ更新してから ready にする
- リリース順序: backend デプロイ → アプリリリース(旧アプリは `link` を無視して従来動作のため backend 先行は安全)

## テスト

- `NotificationDeepLink`: 7ケース(スキーム分岐・allowlist・フォールバック・不正URI)
- `feedBySourceProvider`: 取得・エラー伝播(Riverpod 3 の自動 retry はテスト側で無効化)
- 全体 `flutter test`: 567 passed / 24 failed — 24件は develop 由来の既存失敗(`eqmonitor_realtime_event_mapper_test` / `device_repository_auth_token_test` 等)で、本ブランチによる新規失敗なし
- ローカル `dart analyze` は既知の analyzer プラグイン競合により実行不可(CI で確認)

https://claude.ai/code/session_014okdZSJuWdxsb8DpXpXbvg
