### PR TITLE
fix: 通知スロットの空ボディ PUT による本番 500 エラーを修正

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
@@ -36,20 +36,22 @@ class NotificationSlotRepository {
     JmaIntensity? earthquakeMinIntensity,
     List<NotificationOverride>? earthquakeOverrides,
   }) async {
+    final resolvedEewEnabled = eewEnabled ?? false;
+    final resolvedEarthquakeEnabled = earthquakeEnabled ?? false;
     final response = await _api.device
         .putV2DeviceMeSettingsSlotsCurrentLocation(
           body: api.UpsertSingletonSlotRequest(
-            eewEnabled: eewEnabled,
+            eewEnabled: resolvedEewEnabled,
             eewMinIntensity: resolveNotificationSlotMinIntensity(
-              enabled: eewEnabled,
+              enabled: resolvedEewEnabled,
               minIntensity: eewMinIntensity,
             )?.toApiJmaIntensity,
             eewOverrides: eewOverrides
                 ?.map((o) => o.toApiSlotOverride())
                 .toList(),
-            earthquakeEnabled: earthquakeEnabled,
+            earthquakeEnabled: resolvedEarthquakeEnabled,
             earthquakeMinIntensity: resolveNotificationSlotMinIntensity(
-              enabled: earthquakeEnabled,
+              enabled: resolvedEarthquakeEnabled,
               minIntensity: earthquakeMinIntensity,
             )?.toApiJmaIntensity,
             earthquakeOverrides: earthquakeOverrides
@@ -72,17 +74,19 @@ class NotificationSlotRepository {
     JmaIntensity? earthquakeMinIntensity,
     List<NotificationOverride>? earthquakeOverrides,
   }) async {
+    final resolvedEewEnabled = eewEnabled ?? false;
+    final resolvedEarthquakeEnabled = earthquakeEnabled ?? false;
     final response = await _api.device.putV2DeviceMeSettingsSlotsNationwide(
       body: api.UpsertSingletonSlotRequest(
-        eewEnabled: eewEnabled,
+        eewEnabled: resolvedEewEnabled,
         eewMinIntensity: resolveNotificationSlotMinIntensity(
-          enabled: eewEnabled,
+          enabled: resolvedEewEnabled,
           minIntensity: eewMinIntensity,
         )?.toApiJmaIntensity,
         eewOverrides: eewOverrides?.map((o) => o.toApiSlotOverride()).toList(),
-        earthquakeEnabled: earthquakeEnabled,
+        earthquakeEnabled: resolvedEarthquakeEnabled,
         earthquakeMinIntensity: resolveNotificationSlotMinIntensity(
-          enabled: earthquakeEnabled,
+          enabled: resolvedEarthquakeEnabled,
           minIntensity: earthquakeMinIntensity,
         )?.toApiJmaIntensity,
         earthquakeOverrides: earthquakeOverrides

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -18,6 +18,7 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/n
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/info_notification_tile.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_feature_widgets.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/earthquake_info_settings_page.dart';
@@ -934,7 +935,13 @@ class _SlotListSection extends ConsumerWidget {
                   (tsx) async {
                     await tsx
                         .get(notificationSlotsProvider.notifier)
-                        .putNationwide();
+                        .putNationwide(
+                          eewEnabled: true,
+                          eewMinIntensity: defaultNotificationSlotMinIntensity,
+                          earthquakeEnabled: true,
+                          earthquakeMinIntensity:
+                              defaultNotificationSlotMinIntensity,
+                        );
                   },
                 );
               },

--- a/app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_slot_repository_test.dart
@@ -47,6 +47,50 @@ void main() {
       expect(adapter.lastRequestBody, isNotNull);
       expect(adapter.lastRequestBody!['eew_enabled'], isTrue);
     });
+
+    test('sends eew_enabled/earthquake_enabled=false when called without '
+        'arguments', () async {
+      await repository.putCurrentLocation();
+
+      expect(adapter.lastRequestBody!['eew_enabled'], isFalse);
+      expect(adapter.lastRequestBody!['earthquake_enabled'], isFalse);
+      expect(
+        adapter.lastRequestBody!.containsKey('eew_min_intensity'),
+        isFalse,
+      );
+      expect(
+        adapter.lastRequestBody!.containsKey('earthquake_min_intensity'),
+        isFalse,
+      );
+    });
+  });
+
+  group('putNationwide', () {
+    test('sends request and returns slot', () async {
+      final slot = await repository.putNationwide(
+        eewEnabled: true,
+        eewMinIntensity: JmaIntensity.four,
+      );
+
+      expect(slot.slotType, NotificationSlotType.nationwide);
+      expect(adapter.lastRequestBody!['eew_enabled'], isTrue);
+    });
+
+    test('sends eew_enabled/earthquake_enabled=false when called without '
+        'arguments', () async {
+      await repository.putNationwide();
+
+      expect(adapter.lastRequestBody!['eew_enabled'], isFalse);
+      expect(adapter.lastRequestBody!['earthquake_enabled'], isFalse);
+      expect(
+        adapter.lastRequestBody!.containsKey('eew_min_intensity'),
+        isFalse,
+      );
+      expect(
+        adapter.lastRequestBody!.containsKey('earthquake_min_intensity'),
+        isFalse,
+      );
+    });
   });
 
   group('addRegion', () {


### PR DESCRIPTION
## Summary

- 通知設定画面の「全国を追加」ボタンが `putNationwide()` を引数なしで呼んでおり、`UpsertSingletonSlotRequest` の全フィールドが `includeIfNull: false` のためリクエストボディが空 JSON `{}` になっていた。backend はこれを `eew_enabled=true, eew_min_intensity=NULL` で INSERT しようとして CHECK 制約違反 → 500（本番で発生、backend 側の対処は YumNumm/eqmonitor-backend#812）
- `notification_settings_page.dart`: 「全国を追加」ボタンで `eewEnabled: true` + `defaultNotificationSlotMinIntensity`（震度3）等を明示送信（オンボーディングと同じ明示送信パターンに統一）
- `notification_slot_repository.dart`: `putCurrentLocation` / `putNationwide` で `eewEnabled ?? false` / `earthquakeEnabled ?? false` を解決してから送信するガードを追加し、空 JSON 化を構造的に防止。`enabled==true` で intensity 未指定時のデフォルト補完（`resolveNotificationSlotMinIntensity`）は既存挙動を維持

## Test plan

- [x] `dart analyze`（変更 3 ファイル）: No issues found
- [x] `notification_slot_repository_test.dart` に引数なし呼び出しのテストを追加（enabled が false で送信され min_intensity キーが含まれないこと）
- [ ] `flutter test` はローカルで実行不可（`app/pubspec.yaml` の `dependency_overrides: win32` と commit 済み `pubspec.lock` の不整合による既存問題。修正前のコードでも再現）。CI での green を確認する
- [ ] 実機で「全国を追加」→ スロットが作成され 500 にならないことを確認

https://claude.ai/code/session_01BqV7dLDESr77tGSLzLdXCx