### PR TITLE
fix(app): Android起動クラッシュ解消 — sqlite3 v3 native assets を有効化

### DIFF
--- a/app/lib/core/provider/chuck_provider.g.dart
+++ b/app/lib/core/provider/chuck_provider.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'chuck_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(chuck)
+final chuckProvider = ChuckProvider._();
+
+final class ChuckProvider extends $FunctionalProvider<Chuck, Chuck, Chuck>
+    with $Provider<Chuck> {
+  ChuckProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'chuckProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$chuckHash();
+
+  @$internal
+  @override
+  $ProviderElement<Chuck> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Chuck create(Ref ref) {
+    return chuck(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Chuck value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Chuck>(value),
+    );
+  }
+}
+
+String _$chuckHash() => r'bb341c34c5f24549abf2478f38e734ff67786697';

--- a/app/lib/feature/eew/data/eew.dart
+++ b/app/lib/feature/eew/data/eew.dart
@@ -11,7 +11,7 @@ import 'package:eqmonitor/core/realtime/realtime_event_provider.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'eew_telegram.g.dart';
+part 'eew.g.dart';
 
 @Riverpod(keepAlive: true)
 class Eew extends _$Eew {

--- a/app/lib/feature/eew/data/eew.g.dart
+++ b/app/lib/feature/eew/data/eew.g.dart
@@ -45,13 +45,13 @@ final class EewProvider
   }
 }
 
-String _$eewHash() => r'04601b512d60e0eb40d0188f79775715db19111f';
+String _$eewHash() => r'5df2ce02be3290cfd80f64b45a64b86eea25533c';
 
 abstract class _$Eew extends $Notifier<AsyncValue<List<EewTelegramItem>>> {
   AsyncValue<List<EewTelegramItem>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref
             as $Ref<
@@ -69,7 +69,7 @@ abstract class _$Eew extends $Notifier<AsyncValue<List<EewTelegramItem>>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -112,4 +112,4 @@ final class _EewRestProvider
   }
 }
 
-String _$_eewRestHash() => r'86c40a83aeca927f57d8a6897db30fefbcac3b52';
+String _$_eewRestHash() => r'8f688579fc41f21f4679b2c6044b7c922b4c953a';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,6 +18,8 @@ dependency_overrides:
   flutter_inappwebview: 6.2.0-beta.3
   # https://github.com/juliansteenbakker/flutter_secure_storage/issues/1119
   flutter_secure_storage_darwin: 0.2.0
+  # chuck_interceptor が引く permission_handler_apple を SwiftPM 対応版(9.4.8+)に固定する
+  permission_handler_apple: ^9.4.8
   maplibre:
     git:
       url: https://github.com/YumNumm/flutter-maplibre.git
@@ -57,6 +59,7 @@ dependencies:
   cache:
     path: ../packages/cache
   cached_network_image: ^3.4.1
+  chuck_interceptor: ^2.5.1
   clock: ^1.1.2
   collection: ^1.19.1
   connectivity_plus: ^7.1.1
@@ -68,7 +71,7 @@ dependencies:
     path: ../packages/dart_azarashi
   device_info_plus: ^13.1.0
   dio: ^5.8.0+1
-  drift: ^2.22.0
+  drift: ^2.33.0
   dynamic_color: ^1.7.0
   earthquake_replay:
     path: ../packages/earthquake_replay
@@ -159,7 +162,6 @@ dependencies:
       path: sheet
   skeletonizer: ^2.1.3
   soft_edge_blur: ^0.1.3
-  sqlite3_flutter_libs: ^0.6.0+eol
   synchronized: ^3.3.0
   talker_dio_logger: ^5.0.0
   talker_flutter: ^5.0.0
@@ -204,6 +206,9 @@ flutter_gen:
 flutter:
   config:
     enable-swift-package-manager: true
+    # package:sqlite3 v3 はビルドフック(native assets)で libsqlite3 を同梱する。
+    # 無効だと .so が同梱されず drift が起動時にクラッシュするため必須。
+    enable-native-assets: true
   uses-material-design: true
   assets:
     - assets/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -241,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  chuck_interceptor:
+    dependency: transitive
+    description:
+      name: chuck_interceptor
+      sha256: "176877d9a63273a2c6fb7132e630a1b149f7e6bdd17d8b9659c55cc5dc2daa00"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   cli_config:
     dependency: transitive
     description:
@@ -1645,6 +1653,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: transitive
+    description:
+      name: permission_handler
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.3"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: "direct overridden"
+    description:
+      name: permission_handler_apple
+      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.10"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -2123,14 +2179,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.4"
-  sqlite3_flutter_libs:
-    dependency: transitive
-    description:
-      name: sqlite3_flutter_libs
-      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:


### PR DESCRIPTION
## 概要

Android でスプラッシュから進まず `dlopen failed: library "libsqlite3.so" not found` になる問題を修正します。drift 経由の `cache` / `telemetry_store` が起動時に SQLite を開けず、`/v1/start` を含む全キャッシュ付き HTTP が失敗し、スプラッシュが進みませんでした。

## 根本原因

`sqlite3_flutter_libs: ^0.6.0+eol` は「何もしない廃止スタブ」で `libsqlite3.so` を一切同梱しません。`packages/cache`・`telemetry_store` は既に `package:sqlite3` v3(3.3.4)へ移行済みですが、**v3 は Dart build hooks(native assets)で `.so` を CodeAsset として同梱する方式**のため、native assets が無効だと `.so` が入らず drift が起動時にクラッシュしていました。

## 変更内容

- **`app/pubspec.yaml` の `flutter: config:` に `enable-native-assets: true` を追加(最重要)** — sqlite3 v3 のビルドフックが `libsqlite3.so` を同梱するために必須
- `sqlite3_flutter_libs`(eol スタブ)を削除、`drift` を `^2.33.0` に更新(sqlite3 ^3.x は drift 2.33+ のみ許容)
- `chuck_interceptor: ^2.5.1` を復活し、`dependency_overrides` に `permission_handler_apple: ^9.4.8` を追加 — 9.4.8 で SwiftPM 対応が入ったため、SPM 有効プロジェクトでも chuck を利用可能
- `eew.dart` の part ディレクティブを `eew_telegram.g.dart` → `eew.g.dart` に修正し stale 生成コード(旧 `runBuild` シグネチャで型不一致)を再生成 — 別件のビルドブロッカー

## 検証

- `dart analyze` エラーゼロ
- `flutter build apk --debug` 成功、APK に全 ABI 向け `libsqlite3.so`(約1.7MB)が同梱
- **グローバルフラグ off(CI 相当)でも pubspec 設定だけで `.so` が同梱される**ことを確認 → `deploy-app.yaml` の変更は不要

```
lib/arm64-v8a/libsqlite3.so    (1,725,112 bytes)
lib/armeabi-v7a/libsqlite3.so  (1,706,944 bytes)
lib/x86_64/libsqlite3.so       (1,703,640 bytes)
```

https://claude.ai/code/session_01DMdtzonRkPTM8Zqwfy2zmy