### PR TITLE
fix(app): S波到達予想円の塗り潰しレイヤー順の修正と震央点滅の不透明度変更

### DIFF
--- a/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
@@ -236,7 +236,7 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
             'fill-opacity': 0.1,
           },
         ),
-        belowLayerId: BaseLayer.areaForecastLocalELine.name,
+        belowLayerId: BaseLayer.areaForecastLocalEewLine.name,
       ),
     ).wait;
   }

--- a/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
@@ -134,7 +134,7 @@ class EewStaticPsWaveLayer extends HookConsumerWidget {
             'fill-opacity': 0.2,
           },
         ),
-        belowLayerId: BaseLayer.areaForecastLocalELine.name,
+        belowLayerId: BaseLayer.areaForecastLocalEewLine.name,
       ),
     ).wait;
   }

--- a/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
@@ -28,7 +28,7 @@ class EewHypocenterLayer extends HookConsumerWidget {
     lowPrecise: 'eew-hypocenter-low-precise',
   );
 
-  static Map<String, dynamic> _convertEew(EewTelegramItem eew) {
+  static Map<String, dynamic> _convertEew(EewTelegramItem eew, double opacity) {
     final hypo = eew.hypocenter!;
     return {
       'type': 'Feature',
@@ -39,6 +39,7 @@ class EewHypocenterLayer extends HookConsumerWidget {
       'properties': {
         'magnitude': hypo.magnitude,
         'depth': hypo.depth,
+        'opacity': opacity,
       },
     };
   }
@@ -88,12 +89,7 @@ class EewHypocenterLayer extends HookConsumerWidget {
       [enableBlink],
     );
 
-    final displayNormalEews = isVisible.value
-        ? normalEews
-        : <EewTelegramItem>[];
-    final displayLowPreciseEews = isVisible.value
-        ? lowPreciseEews
-        : <EewTelegramItem>[];
+    final iconOpacity = isVisible.value ? 1.0 : 0.75;
 
     useEffect(
       () {
@@ -153,6 +149,9 @@ class EewHypocenterLayer extends HookConsumerWidget {
                     0.4,
                   ],
                 },
+                paint: const {
+                  'icon-opacity': ['get', 'opacity'],
+                },
               ),
             ),
             styleController.addLayer(
@@ -173,6 +172,9 @@ class EewHypocenterLayer extends HookConsumerWidget {
                     0.4,
                   ],
                 },
+                paint: const {
+                  'icon-opacity': ['get', 'opacity'],
+                },
               ),
             ),
           ).wait;
@@ -182,14 +184,18 @@ class EewHypocenterLayer extends HookConsumerWidget {
               id: sourceId.normal,
               data: jsonEncode({
                 'type': 'FeatureCollection',
-                'features': displayNormalEews.map(_convertEew).toList(),
+                'features': normalEews
+                    .map((eew) => _convertEew(eew, iconOpacity))
+                    .toList(),
               }),
             ),
             styleController.updateGeoJsonSource(
               id: sourceId.lowPrecise,
               data: jsonEncode({
                 'type': 'FeatureCollection',
-                'features': displayLowPreciseEews.map(_convertEew).toList(),
+                'features': lowPreciseEews
+                    .map((eew) => _convertEew(eew, iconOpacity))
+                    .toList(),
               }),
             ),
           ).wait;
@@ -220,14 +226,18 @@ class EewHypocenterLayer extends HookConsumerWidget {
                   id: sourceId.normal,
                   data: jsonEncode({
                     'type': 'FeatureCollection',
-                    'features': displayNormalEews.map(_convertEew).toList(),
+                    'features': normalEews
+                        .map((eew) => _convertEew(eew, iconOpacity))
+                        .toList(),
                   }),
                 ),
                 styleController.updateGeoJsonSource(
                   id: sourceId.lowPrecise,
                   data: jsonEncode({
                     'type': 'FeatureCollection',
-                    'features': displayLowPreciseEews.map(_convertEew).toList(),
+                    'features': lowPreciseEews
+                        .map((eew) => _convertEew(eew, iconOpacity))
+                        .toList(),
                   }),
                 ),
               ).wait;
@@ -239,7 +249,7 @@ class EewHypocenterLayer extends HookConsumerWidget {
 
         return null;
       },
-      [styleController, displayNormalEews, displayLowPreciseEews],
+      [styleController, normalEews, lowPreciseEews, iconOpacity],
     );
 
     return const SizedBox.shrink();

--- a/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
@@ -7,6 +7,7 @@ import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provide
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
+import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -137,6 +138,7 @@ class _EewPsWaveLayerBody extends HookConsumerWidget {
                     'fill-opacity': 0.2,
                   },
                 ),
+                belowLayerId: BaseLayer.areaForecastLocalEewLine.name,
               ),
             ).wait;
 


### PR DESCRIPTION
## 概要

Closes #1430

- **S波到達予想円の塗り潰しを、観測点・予想震度塗り潰しの下に描画**
  S波fillレイヤーを `belowLayerId: BaseLayer.areaForecastLocalEewLine.name` で挿入するように変更。予想震度fill(`areaForecastLocalELine` 直下)より1段下の静的レイヤーを挿入先にすることで、レイヤー追加のタイミングに依存せず順序が保証されます。P波線・S波線は従来どおり最前面のままです(「円の線は上でOK」)。
  - ホーム: `eew_ps_wave_layer.dart`(belowLayerId 追加)
  - EEW詳細(静的/シミュレーション): `eew_static_ps_wave_layer.dart` / `eew_simulation_ps_wave_layer.dart`(`areaForecastLocalELine` → `areaForecastLocalEewLine`。詳細ページも予想震度fillと同じ挿入先を取り合ってタイミング次第でfillが上に出るため同修正)

- **震央アイコンの点滅を不透明度 0/100% → 75/100% に変更**
  点滅時に GeoJSON features を空にする方式をやめ、data-driven な `icon-opacity`(`['get', 'opacity']` + feature property)で 1.0⇔0.75 を切り替えます。flutter-maplibre の `StyleController` には paint を後から更新する API がないため、既存の `updateGeoJsonSource` フローに乗せています。`enableBlink: false`(ホーム)では常に不透明度 1.0 で従来と同じ見た目です。

## レイヤー順(修正後)

```
(下) 陸地fill < S波fill < EEW区域線 < 予想震度fill < 予報区域線 < 観測点 / P・S波線 / 震央 (上)
```

## 検証

- `flutter test app/test`: 全テストパス(exit 0、rebase後・最終コミットで確認)
- 変更ファイルに80桁超えなし・最小diff(4ファイル、26+/14-)

## 補足(スコープ外の既知事項)

- `EewWarningRegionsLayer`(fillMode=warning)の警報区域fillは `belowLayerId` なしのままで、観測点より上に出る可能性があります(既存挙動、本PRでは未変更)

https://claude.ai/code/session_01EuaaRRHREhZf2WtBTCFVk2