### PR TITLE
perf: アプリ起動最適化 (Splash 非ブロッキング化・起動計測基盤・走時表 compute 化)

### DIFF
--- a/app/lib/core/provider/travel_time/data/travel_time_data_source.dart
+++ b/app/lib/core/provider/travel_time/data/travel_time_data_source.dart
@@ -1,5 +1,5 @@
-import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/travel_time/model/travel_time_table.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -9,31 +9,35 @@ part 'travel_time_data_source.g.dart';
 TravelTimeDataSource travelTimeDataSource(Ref ref) => TravelTimeDataSource();
 
 class TravelTimeDataSource {
-  Future<List<TravelTimeTable>> loadTables() async {
-    const path = 'assets/tjma2001.csv';
-    final data = await rootBundle.loadString(path);
-    final rows = data
-        .split('\n')
-        .map((e) => e.trim())
-        .where((e) => e.isNotEmpty)
-        .toList();
-    final travelTimeTable = <TravelTimeTable>[];
-    for (var i = 0; i < rows.length; i++) {
-      final list = rows[i].split(',');
-      try {
-        travelTimeTable.add(TravelTimeTable.fromList(list));
-      } on Exception catch (e) {
-        // 先頭行(ヘッダー)・末尾行のパース失敗は許容してスキップ
-        if (i == 0 || i == rows.length - 1) {
-          talker.warning('走時表: スキップ行[$i]: $e');
-          continue;
-        }
-        throw Exception('走時表のパースに失敗しました (行$i): $e');
-      }
-    }
-    if (travelTimeTable.isEmpty) {
-      throw Exception('走時表が空です');
-    }
-    return travelTimeTable;
+  Future<TravelTimeTables> loadTables() async {
+    final raw = await rootBundle.loadString('assets/tjma2001.csv');
+    return compute(parseTravelTimeCsv, raw);
   }
+}
+
+/// CSV 文字列を走時テーブルへパースする。compute で isolate 実行するため
+/// top-level に置く。talker (Firebase 依存の global) は isolate では使えない。
+TravelTimeTables parseTravelTimeCsv(String raw) {
+  final rows = raw
+      .split('\n')
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .toList();
+  final travelTimeTable = <TravelTimeTable>[];
+  for (var i = 0; i < rows.length; i++) {
+    final list = rows[i].split(',');
+    try {
+      travelTimeTable.add(TravelTimeTable.fromList(list));
+    } on Exception catch (e) {
+      // 先頭行(ヘッダー)・末尾行のパース失敗は許容してスキップ
+      if (i == 0 || i == rows.length - 1) {
+        continue;
+      }
+      throw Exception('走時表のパースに失敗しました (行$i): $e');
+    }
+  }
+  if (travelTimeTable.isEmpty) {
+    throw Exception('走時表が空です');
+  }
+  return TravelTimeTables(table: travelTimeTable);
 }

--- a/app/lib/core/provider/travel_time/provider/travel_time_provider.dart
+++ b/app/lib/core/provider/travel_time/provider/travel_time_provider.dart
@@ -17,9 +17,12 @@ Future<TravelTimeTables> travelTimeInternal(Ref ref) async {
 }
 
 @Riverpod(keepAlive: true)
-TravelTimeDepthMap travelTimeDepthMap(Ref ref) {
-  final state = ref.watch(travelTimeProvider);
-  return state.table.groupListsBy((e) => e.depth);
+TravelTimeDepthMap? travelTimeDepthMap(Ref ref) {
+  final tables = ref.watch(travelTimeInternalProvider).value;
+  if (tables == null) {
+    return null;
+  }
+  return tables.table.groupListsBy((e) => e.depth);
 }
 
 typedef TravelTimeDepthMap = Map<int, List<TravelTimeTable>>;

--- a/app/lib/core/provider/travel_time/provider/travel_time_provider.dart
+++ b/app/lib/core/provider/travel_time/provider/travel_time_provider.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:eqmonitor/core/provider/travel_time/data/travel_time_data_source.dart';
 import 'package:eqmonitor/core/provider/travel_time/model/travel_time_table.dart';
+import 'package:eqmonitor/core/startup/startup_profiler_provider.dart';
 import 'package:extensions/extensions.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -13,7 +14,12 @@ TravelTimeTables travelTime(Ref ref) =>
 @Riverpod(keepAlive: true)
 Future<TravelTimeTables> travelTimeInternal(Ref ref) async {
   final dataSource = ref.watch(travelTimeDataSourceProvider);
-  return TravelTimeTables(table: await dataSource.loadTables());
+  final stopwatch = Stopwatch()..start();
+  final tables = await dataSource.loadTables();
+  ref
+      .read(startupProfilerProvider)
+      .measure('travel_time_load', stopwatch.elapsedMicroseconds);
+  return tables;
 }
 
 @Riverpod(keepAlive: true)

--- a/app/lib/core/provider/travel_time/provider/travel_time_provider.g.dart
+++ b/app/lib/core/provider/travel_time/provider/travel_time_provider.g.dart
@@ -103,11 +103,11 @@ final travelTimeDepthMapProvider = TravelTimeDepthMapProvider._();
 final class TravelTimeDepthMapProvider
     extends
         $FunctionalProvider<
-          TravelTimeDepthMap,
-          TravelTimeDepthMap,
-          TravelTimeDepthMap
+          TravelTimeDepthMap?,
+          TravelTimeDepthMap?,
+          TravelTimeDepthMap?
         >
-    with $Provider<TravelTimeDepthMap> {
+    with $Provider<TravelTimeDepthMap?> {
   TravelTimeDepthMapProvider._()
     : super(
         from: null,
@@ -124,20 +124,20 @@ final class TravelTimeDepthMapProvider
 
   @$internal
   @override
-  $ProviderElement<TravelTimeDepthMap> $createElement(
+  $ProviderElement<TravelTimeDepthMap?> $createElement(
     $ProviderPointer pointer,
   ) => $ProviderElement(pointer);
 
   @override
-  TravelTimeDepthMap create(Ref ref) {
+  TravelTimeDepthMap? create(Ref ref) {
     return travelTimeDepthMap(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(TravelTimeDepthMap value) {
+  Override overrideWithValue(TravelTimeDepthMap? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<TravelTimeDepthMap>(value),
+      providerOverride: $SyncValueProvider<TravelTimeDepthMap?>(value),
     );
   }
 }

--- a/app/lib/core/startup/startup_profiler.dart
+++ b/app/lib/core/startup/startup_profiler.dart
@@ -20,5 +20,7 @@ class StartupProfiler {
 
   Map<String, int> get timingsMicros => Map.unmodifiable(_timings);
 
-  Map<String, dynamic> toPayload() => {'phases': Map<String, int>.from(_timings)};
+  Map<String, dynamic> toPayload() => {
+    'phases': Map<String, int>.from(_timings),
+  };
 }

--- a/app/lib/core/startup/startup_profiler.dart
+++ b/app/lib/core/startup/startup_profiler.dart
@@ -1,0 +1,24 @@
+/// 起動フェーズごとの所要時間をマイクロ秒で記録する。
+///
+/// [clockMicros] を注入するとテストで決定的に検証できる。省略時は内部の
+/// [Stopwatch] を時刻源に使う。
+class StartupProfiler {
+  StartupProfiler({int Function()? clockMicros})
+    : _clockMicros = clockMicros ?? _defaultClock();
+
+  static int Function() _defaultClock() {
+    final stopwatch = Stopwatch()..start();
+    return () => stopwatch.elapsedMicroseconds;
+  }
+
+  final int Function() _clockMicros;
+  final Map<String, int> _timings = {};
+
+  void mark(String phase) => _timings[phase] = _clockMicros();
+
+  void measure(String phase, int micros) => _timings[phase] = micros;
+
+  Map<String, int> get timingsMicros => Map.unmodifiable(_timings);
+
+  Map<String, dynamic> toPayload() => {'phases': Map<String, int>.from(_timings)};
+}

--- a/app/lib/core/startup/startup_profiler.dart
+++ b/app/lib/core/startup/startup_profiler.dart
@@ -20,7 +20,4 @@ class StartupProfiler {
 
   Map<String, int> get timingsMicros => Map.unmodifiable(_timings);
 
-  Map<String, dynamic> toPayload() => {
-    'phases': Map<String, int>.from(_timings),
-  };
 }

--- a/app/lib/core/startup/startup_profiler_provider.dart
+++ b/app/lib/core/startup/startup_profiler_provider.dart
@@ -1,0 +1,8 @@
+import 'package:eqmonitor/core/startup/startup_profiler.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// `_main()` で生成した [StartupProfiler] を注入する。
+/// override されない場合は空のインスタンスを返す (テスト等)。
+final startupProfilerProvider = Provider<StartupProfiler>(
+  (ref) => StartupProfiler(),
+);

--- a/app/lib/core/util/guarded_unawaited.dart
+++ b/app/lib/core/util/guarded_unawaited.dart
@@ -1,0 +1,13 @@
+import 'dart:async';
+
+/// [action] を fire-and-forget で実行し、例外/非同期エラーを [onError] に渡す。
+///
+/// `unawaited` の代替。エラーを握りつぶさず必ず記録経路へ流すために使う。
+void guardedUnawaited(
+  Future<void> Function() action, {
+  required void Function(Object error, StackTrace stack) onError,
+}) {
+  unawaited(
+    Future<void>.sync(action).catchError(onError),
+  );
+}

--- a/app/lib/core/util/guarded_unawaited.dart
+++ b/app/lib/core/util/guarded_unawaited.dart
@@ -7,7 +7,5 @@ void guardedUnawaited(
   Future<void> Function() action, {
   required void Function(Object error, StackTrace stack) onError,
 }) {
-  unawaited(
-    Future<void>.sync(action).catchError(onError),
-  );
+  unawaited(Future<void>.sync(action).catchError(onError));
 }

--- a/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart
+++ b/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart
@@ -131,12 +131,8 @@ double? _lookupSWaveTravelTime(
     return null;
   }
 
-  final d1 = depthTables.lastWhereOrNull(
-    (t) => t.distance <= distanceKm,
-  );
-  final d2 = depthTables.firstWhereOrNull(
-    (t) => t.distance >= distanceKm,
-  );
+  final d1 = depthTables.lastWhereOrNull((t) => t.distance <= distanceKm);
+  final d2 = depthTables.firstWhereOrNull((t) => t.distance >= distanceKm);
 
   if (d1 == null || d2 == null) {
     return null;

--- a/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart
+++ b/app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart
@@ -42,7 +42,7 @@ Future<List<EewEstimatedRegion>> eewEstimatedRegionIntensity(
   }
 
   final isolate = await ref.watch(estimatedIntensityIsolateProvider.future);
-  final travelTimeTables = ref.read(travelTimeProvider);
+  final travelTimeTables = await ref.watch(travelTimeInternalProvider.future);
 
   final intensities = await isolate.computeSingle(
     jmaMagnitude: hypocenter.magnitude!,

--- a/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
@@ -123,9 +123,25 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
               now.difference(sim.startedAt).inMilliseconds / 1000;
           final elapsed = offset + simulationElapsed;
 
-          final travelTime = ref
-              .read(travelTimeDepthMapProvider)
-              .getTravelTime(hypocenter.depth!, elapsed);
+          final travelTimeMap = ref.read(travelTimeDepthMapProvider);
+          // 走時表未ロード時は波を描かない
+          if (travelTimeMap == null) {
+            unawaited(
+              _updateGeoJson(
+                styleController,
+                pWaveGeoJson: _emptyGeoJson,
+                sWaveGeoJson: _emptyGeoJson,
+                latestP: latestPWaveGeoJson,
+                latestS: latestSWaveGeoJson,
+                initFuture: initFuture,
+              ),
+            );
+            return;
+          }
+          final travelTime = travelTimeMap.getTravelTime(
+            hypocenter.depth!,
+            elapsed,
+          );
 
           final lat = hypocenter.latitude!;
           final lng = hypocenter.longitude!;

--- a/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart
@@ -30,186 +30,174 @@ class EewSimulationPsWaveLayer extends HookConsumerWidget {
     final latestPWaveGeoJson = useRef<String?>(null);
     final latestSWaveGeoJson = useRef<String?>(null);
 
-    useEffect(
-      () {
-        if (styleController == null) {
-          return null;
-        }
+    useEffect(() {
+      if (styleController == null) {
+        return null;
+      }
 
-        final future = _initializeLayers(styleController);
-        initFuture.value = future;
+      final future = _initializeLayers(styleController);
+      initFuture.value = future;
 
-        return () {
-          initFuture.value = null;
-          unawaited(() async {
-            await future;
-            await _removeLayers(styleController);
-          }());
-        };
-      },
-      [styleController],
-    );
+      return () {
+        initFuture.value = null;
+        unawaited(() async {
+          await future;
+          await _removeLayers(styleController);
+        }());
+      };
+    }, [styleController]);
 
     final animationController = useAnimationController(
       duration: const Duration(days: 365),
     );
 
-    useEffect(
-      () {
-        if (simulation != null) {
-          unawaited(animationController.repeat());
-        } else {
-          animationController.stop();
-        }
+    useEffect(() {
+      if (simulation != null) {
+        unawaited(animationController.repeat());
+      } else {
+        animationController.stop();
+      }
+      return null;
+    }, [simulation != null]);
+
+    useEffect(() {
+      if (styleController == null) {
         return null;
-      },
-      [simulation != null],
-    );
+      }
 
-    useEffect(
-      () {
-        if (styleController == null) {
-          return null;
+      var disposed = false;
+
+      void listener() {
+        if (disposed) {
+          return;
         }
-
-        var disposed = false;
-
-        void listener() {
-          if (disposed) {
-            return;
-          }
-          final sim = ref.read(eewSimulationProvider);
-          if (sim == null) {
-            unawaited(
-              _updateGeoJson(
-                styleController,
-                pWaveGeoJson: _emptyGeoJson,
-                sWaveGeoJson: _emptyGeoJson,
-                latestP: latestPWaveGeoJson,
-                latestS: latestSWaveGeoJson,
-                initFuture: initFuture,
-              ),
-            );
-            return;
-          }
-
-          final currentReport = sim.currentReport;
-          final originTime = currentReport.originTime;
-          final hypocenter = currentReport.hypocenter;
-          if (originTime == null ||
-              hypocenter == null ||
-              hypocenter.latitude == null ||
-              hypocenter.longitude == null ||
-              hypocenter.depth == null ||
-              currentReport.isPlum) {
-            unawaited(
-              _updateGeoJson(
-                styleController,
-                pWaveGeoJson: _emptyGeoJson,
-                sWaveGeoJson: _emptyGeoJson,
-                latestP: latestPWaveGeoJson,
-                latestS: latestSWaveGeoJson,
-                initFuture: initFuture,
-              ),
-            );
-            return;
-          }
-
-          final now = DateTime.now();
-          final firstReportTime = sim.reports.first.reportTime;
-          final offset =
-              firstReportTime.difference(originTime).inMilliseconds / 1000;
-          final simulationElapsed =
-              now.difference(sim.startedAt).inMilliseconds / 1000;
-          final elapsed = offset + simulationElapsed;
-
-          final travelTimeMap = ref.read(travelTimeDepthMapProvider);
-          // 走時表未ロード時は波を描かない
-          if (travelTimeMap == null) {
-            unawaited(
-              _updateGeoJson(
-                styleController,
-                pWaveGeoJson: _emptyGeoJson,
-                sWaveGeoJson: _emptyGeoJson,
-                latestP: latestPWaveGeoJson,
-                latestS: latestSWaveGeoJson,
-                initFuture: initFuture,
-              ),
-            );
-            return;
-          }
-          final travelTime = travelTimeMap.getTravelTime(
-            hypocenter.depth!,
-            elapsed,
-          );
-
-          final lat = hypocenter.latitude!;
-          final lng = hypocenter.longitude!;
-          final isWarning = currentReport.isWarning ?? false;
-          final lineColor = isWarning ? '#FF0000' : '#FFA500';
-          final fillColor = isWarning ? '#FF0000' : '#FFA500';
-
-          final pWaveFeatures = <Map<String, dynamic>>[];
-          final sWaveFeatures = <Map<String, dynamic>>[];
-
-          if (travelTime.pDistance != null && travelTime.pDistance! > 0) {
-            pWaveFeatures.add({
-              'type': 'Feature',
-              'geometry': {
-                'type': 'Polygon',
-                'coordinates': [
-                  _generateCircleCoordinates(lat, lng, travelTime.pDistance!),
-                ],
-              },
-              'properties': <String, dynamic>{},
-            });
-          }
-
-          if (travelTime.sDistance != null && travelTime.sDistance! > 0) {
-            sWaveFeatures.add({
-              'type': 'Feature',
-              'geometry': {
-                'type': 'Polygon',
-                'coordinates': [
-                  _generateCircleCoordinates(lat, lng, travelTime.sDistance!),
-                ],
-              },
-              'properties': {
-                'lineColor': lineColor,
-                'fillColor': fillColor,
-              },
-            });
-          }
-
-          final pGeoJson = jsonEncode({
-            'type': 'FeatureCollection',
-            'features': pWaveFeatures,
-          });
-          final sGeoJson = jsonEncode({
-            'type': 'FeatureCollection',
-            'features': sWaveFeatures,
-          });
-
+        final sim = ref.read(eewSimulationProvider);
+        if (sim == null) {
           unawaited(
             _updateGeoJson(
               styleController,
-              pWaveGeoJson: pGeoJson,
-              sWaveGeoJson: sGeoJson,
+              pWaveGeoJson: _emptyGeoJson,
+              sWaveGeoJson: _emptyGeoJson,
               latestP: latestPWaveGeoJson,
               latestS: latestSWaveGeoJson,
               initFuture: initFuture,
             ),
           );
+          return;
         }
 
-        animationController.addListener(listener);
-        return () {
-          disposed = true;
-          animationController.removeListener(listener);
-        };
-      },
-      [styleController, simulation, animationController],
-    );
+        final currentReport = sim.currentReport;
+        final originTime = currentReport.originTime;
+        final hypocenter = currentReport.hypocenter;
+        if (originTime == null ||
+            hypocenter == null ||
+            hypocenter.latitude == null ||
+            hypocenter.longitude == null ||
+            hypocenter.depth == null ||
+            currentReport.isPlum) {
+          unawaited(
+            _updateGeoJson(
+              styleController,
+              pWaveGeoJson: _emptyGeoJson,
+              sWaveGeoJson: _emptyGeoJson,
+              latestP: latestPWaveGeoJson,
+              latestS: latestSWaveGeoJson,
+              initFuture: initFuture,
+            ),
+          );
+          return;
+        }
+
+        final now = DateTime.now();
+        final firstReportTime = sim.reports.first.reportTime;
+        final offset =
+            firstReportTime.difference(originTime).inMilliseconds / 1000;
+        final simulationElapsed =
+            now.difference(sim.startedAt).inMilliseconds / 1000;
+        final elapsed = offset + simulationElapsed;
+
+        final travelTimeMap = ref.read(travelTimeDepthMapProvider);
+        // 走時表未ロード時は波を描かない
+        if (travelTimeMap == null) {
+          unawaited(
+            _updateGeoJson(
+              styleController,
+              pWaveGeoJson: _emptyGeoJson,
+              sWaveGeoJson: _emptyGeoJson,
+              latestP: latestPWaveGeoJson,
+              latestS: latestSWaveGeoJson,
+              initFuture: initFuture,
+            ),
+          );
+          return;
+        }
+        final travelTime = travelTimeMap.getTravelTime(
+          hypocenter.depth!,
+          elapsed,
+        );
+
+        final lat = hypocenter.latitude!;
+        final lng = hypocenter.longitude!;
+        final isWarning = currentReport.isWarning ?? false;
+        final lineColor = isWarning ? '#FF0000' : '#FFA500';
+        final fillColor = isWarning ? '#FF0000' : '#FFA500';
+
+        final pWaveFeatures = <Map<String, dynamic>>[];
+        final sWaveFeatures = <Map<String, dynamic>>[];
+
+        if (travelTime.pDistance != null && travelTime.pDistance! > 0) {
+          pWaveFeatures.add({
+            'type': 'Feature',
+            'geometry': {
+              'type': 'Polygon',
+              'coordinates': [
+                _generateCircleCoordinates(lat, lng, travelTime.pDistance!),
+              ],
+            },
+            'properties': <String, dynamic>{},
+          });
+        }
+
+        if (travelTime.sDistance != null && travelTime.sDistance! > 0) {
+          sWaveFeatures.add({
+            'type': 'Feature',
+            'geometry': {
+              'type': 'Polygon',
+              'coordinates': [
+                _generateCircleCoordinates(lat, lng, travelTime.sDistance!),
+              ],
+            },
+            'properties': {'lineColor': lineColor, 'fillColor': fillColor},
+          });
+        }
+
+        final pGeoJson = jsonEncode({
+          'type': 'FeatureCollection',
+          'features': pWaveFeatures,
+        });
+        final sGeoJson = jsonEncode({
+          'type': 'FeatureCollection',
+          'features': sWaveFeatures,
+        });
+
+        unawaited(
+          _updateGeoJson(
+            styleController,
+            pWaveGeoJson: pGeoJson,
+            sWaveGeoJson: sGeoJson,
+            latestP: latestPWaveGeoJson,
+            latestS: latestSWaveGeoJson,
+            initFuture: initFuture,
+          ),
+        );
+      }
+
+      animationController.addListener(listener);
+      return () {
+        disposed = true;
+        animationController.removeListener(listener);
+      };
+    }, [styleController, simulation, animationController]);
 
     return const SizedBox.shrink();
   }

--- a/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
@@ -64,6 +64,11 @@ class EewStaticPsWaveLayer extends HookConsumerWidget {
 
         unawaited(() async {
           await initFuture.value;
+          // 走時表未ロード時は波を描かない
+          if (travelTimeMap == null) {
+            await _clearLayers(styleController);
+            return;
+          }
           await _updateLayers(
             styleController,
             eew,

--- a/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
+++ b/app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart
@@ -12,10 +12,7 @@ import 'package:maplibre/maplibre.dart';
 
 /// 電文発表時刻基準での静的PS波到達円レイヤー
 class EewStaticPsWaveLayer extends HookConsumerWidget {
-  const EewStaticPsWaveLayer({
-    required this.eew,
-    super.key,
-  });
+  const EewStaticPsWaveLayer({required this.eew, super.key});
 
   final EewTelegramItem? eew;
 
@@ -35,51 +32,41 @@ class EewStaticPsWaveLayer extends HookConsumerWidget {
     // source / layer の追加は styleController が変化したときに一度だけ行う。
     // eew / travelTimeMap の変化で再初期化すると、非同期なクリーンアップ完了前に
     // addSource が走り「already exists」例外となるため、初期化と更新を分離する。
-    useEffect(
-      () {
-        if (styleController == null) {
-          return null;
-        }
+    useEffect(() {
+      if (styleController == null) {
+        return null;
+      }
 
-        final future = _initializeLayers(styleController);
-        initFuture.value = future;
+      final future = _initializeLayers(styleController);
+      initFuture.value = future;
 
-        return () {
-          initFuture.value = null;
-          unawaited(() async {
-            await future;
-            await _removeLayers(styleController);
-          }());
-        };
-      },
-      [styleController],
-    );
+      return () {
+        initFuture.value = null;
+        unawaited(() async {
+          await future;
+          await _removeLayers(styleController);
+        }());
+      };
+    }, [styleController]);
 
     // eew / travelTimeMap の変化に追従してデータのみ更新する
-    useEffect(
-      () {
-        if (styleController == null) {
-          return null;
-        }
-
-        unawaited(() async {
-          await initFuture.value;
-          // 走時表未ロード時は波を描かない
-          if (travelTimeMap == null) {
-            await _clearLayers(styleController);
-            return;
-          }
-          await _updateLayers(
-            styleController,
-            eew,
-            travelTimeMap,
-          );
-        }());
-
+    useEffect(() {
+      if (styleController == null) {
         return null;
-      },
-      [styleController, eew, travelTimeMap],
-    );
+      }
+
+      unawaited(() async {
+        await initFuture.value;
+        // 走時表未ロード時は波を描かない
+        if (travelTimeMap == null) {
+          await _clearLayers(styleController);
+          return;
+        }
+        await _updateLayers(styleController, eew, travelTimeMap);
+      }());
+
+      return null;
+    }, [styleController, eew, travelTimeMap]);
 
     return const SizedBox.shrink();
   }
@@ -114,10 +101,7 @@ class EewStaticPsWaveLayer extends HookConsumerWidget {
         const LineStyleLayer(
           id: _pWaveLayerId,
           sourceId: _pWaveSourceId,
-          paint: {
-            'line-color': '#0000FF',
-            'line-width': 1,
-          },
+          paint: {'line-color': '#0000FF', 'line-width': 1},
         ),
       ),
       styleController.addLayer(
@@ -224,10 +208,7 @@ class EewStaticPsWaveLayer extends HookConsumerWidget {
             _generateCircleCoordinates(lat, lng, travelTime.sDistance!),
           ],
         },
-        'properties': {
-          'lineColor': lineColor,
-          'fillColor': fillColor,
-        },
+        'properties': {'lineColor': lineColor, 'fillColor': fillColor},
       });
     }
 

--- a/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
@@ -200,6 +200,10 @@ class _EewPsWaveLayerBody extends HookConsumerWidget {
           return;
         }
         final travelTimeMap = ref.read(travelTimeDepthMapProvider);
+        // 走時表未ロード時は波を描かない
+        if (travelTimeMap == null) {
+          return;
+        }
         final now = ref.read(appClockProvider.notifier).now();
 
         final (pWaveGeojson, sWaveGeojson) = _calculateGeoJson(

--- a/app/lib/feature/parameter/data/notifier/parameter_set_notifier.dart
+++ b/app/lib/feature/parameter/data/notifier/parameter_set_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:eqmonitor/core/provider/cached_notifier.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/startup/startup_profiler_provider.dart';
 import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
 import 'package:eqmonitor/feature/parameter/data/repository/parameter_repository.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
@@ -12,16 +13,27 @@ class ParameterSetNotifier extends _$ParameterSetNotifier
     with CachedNotifier<ParameterSet> {
   @override
   Future<ParameterSet> build() async {
+    // 大きな JSON (≈10 MB) の転送コストで compute 化が逆効果になりうるため、
+    // まず実データで所要時間を確認する。
+    final sw = Stopwatch()..start();
     final repository = await ref.watch(parameterRepositoryProvider.future);
     try {
-      return await cachedBuild();
+      final result = await cachedBuild();
+      ref
+          .read(startupProfilerProvider)
+          .measure('parameter_load', sw.elapsedMicroseconds);
+      return result;
     } on Exception catch (e, st) {
       talker.warning(
         '[Parameter] API/キャッシュからの読み込みに失敗したため、同梱パラメータを使用します。',
         e,
         st,
       );
-      return repository.loadAsset();
+      final result = await repository.loadAsset();
+      ref
+          .read(startupProfilerProvider)
+          .measure('parameter_load', sw.elapsedMicroseconds);
+      return result;
     }
   }
 

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -17,6 +17,7 @@ import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dar
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/app_check/app_check_debug_provider.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/hypocenter_icon/hypocenter_icon_page.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
@@ -162,6 +163,16 @@ class _DebugWidget extends ConsumerWidget {
               subtitle: const Text('ローカルテレメトリーイベントの閲覧'),
               onTap: () async =>
                   const DebugTelemetryRoute().push<void>(context),
+            ),
+            ListTile(
+              title: const Text('Startup Timing'),
+              leading: const Icon(Icons.timer_outlined),
+              subtitle: const Text('起動フェーズごとの所要時間'),
+              onTap: () => Navigator.of(context).push<void>(
+                MaterialPageRoute(
+                  builder: (_) => const DebugStartupTimingPage(),
+                ),
+              ),
             ),
             ListTile(
               title: const Text('WebSocket'),

--- a/app/lib/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart
+++ b/app/lib/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart
@@ -1,0 +1,29 @@
+import 'package:eqmonitor/core/startup/startup_profiler_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DebugStartupTimingPage extends ConsumerWidget {
+  const DebugStartupTimingPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final timings = ref.watch(startupProfilerProvider).timingsMicros;
+    final entries = timings.entries.toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Startup Timing')),
+      body: ListView(
+        children: [
+          for (final entry in entries)
+            ListTile(
+              title: Text(entry.key),
+              trailing: Text('${(entry.value / 1000).toStringAsFixed(2)} ms'),
+            ),
+          if (entries.isEmpty)
+            const ListTile(title: Text('計測データがありません')),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart
+++ b/app/lib/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart
@@ -20,8 +20,7 @@ class DebugStartupTimingPage extends ConsumerWidget {
               title: Text(entry.key),
               trailing: Text('${(entry.value / 1000).toStringAsFixed(2)} ms'),
             ),
-          if (entries.isEmpty)
-            const ListTile(title: Text('計測データがありません')),
+          if (entries.isEmpty) const ListTile(title: Text('計測データがありません')),
         ],
       ),
     );

--- a/app/lib/feature/shake_detection/data/provider/shake_detection_merge_provider.dart
+++ b/app/lib/feature/shake_detection/data/provider/shake_detection_merge_provider.dart
@@ -21,6 +21,11 @@ List<ShakeDetectionEvent> shakeDetectionMerged(Ref ref) {
   final travelTimeMap = ref.watch(travelTimeDepthMapProvider);
   final now = ref.read(appClockProvider.notifier).now().toUtc();
 
+  // 走時表未ロード時は enrichment なしで返す
+  if (travelTimeMap == null) {
+    return shakes.toList();
+  }
+
   return shakes.map((shake) {
     final mergedId = _findMergedEew(shake, eews, travelTimeMap, now);
     return shake.copyWith(mergedEewEventId: mergedId);

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -24,6 +24,9 @@ import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/provider/shared_preferences.dart';
 import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart';
 import 'package:eqmonitor/core/realtime/realtime_event_provider.dart';
+import 'package:eqmonitor/core/startup/startup_profiler.dart';
+import 'package:eqmonitor/core/startup/startup_profiler_provider.dart';
+import 'package:eqmonitor/core/util/guarded_unawaited.dart';
 import 'package:eqmonitor/core/util/license/init_licenses.dart';
 import 'package:eqmonitor/feature/devices/data/provider/push_token_sync_wiring.dart';
 import 'package:eqmonitor/feature/kyoshin_monitor/data/kyoshin_color_map_data_source.dart';
@@ -33,10 +36,12 @@ import 'package:eqmonitor/feature/location/data/background_location_service.dart
 import 'package:eqmonitor/feature/playback_mode/data/notifier/auto_return_watcher.dart';
 import 'package:eqmonitor/feature/telemetry/data/provider/app_launch_watcher_provider.dart';
 import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_database_provider.dart';
+import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_recorder_provider.dart';
 import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_uploader_provider.dart';
 import 'package:eqmonitor/firebase_options.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:telemetry_store/telemetry_store.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
@@ -91,6 +96,8 @@ Future<void> main() async {
 }
 
 Future<void> _main() async {
+  final profiler = StartupProfiler();
+
   if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
     await BackgroundLocationTracker.initialize();
   }
@@ -110,6 +117,7 @@ Future<void> _main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  profiler.mark('firebase_init');
 
   talker = TalkerFlutter.init(
     settings: TalkerSettings(
@@ -220,6 +228,7 @@ Future<void> _main() async {
       core.initializeTimeZones(),
     ).wait,
   ).wait;
+  profiler.mark('parallel_init');
   initLicenses();
 
   final telemetryDbPath = kIsWeb ? null : await resolveTelemetryDbPath();
@@ -249,6 +258,7 @@ Future<void> _main() async {
         kyoshinColorMapProvider.overrideWithValue(colorMap),
       if (telemetryDbPath case final dbPath?)
         telemetryDbPathProvider.overrideWithValue(dbPath),
+      startupProfilerProvider.overrideWithValue(profiler),
     ],
     observers: [
       if (kDebugMode) CustomProviderObserver(talker),
@@ -275,12 +285,28 @@ Future<void> _main() async {
     container.read(appLaunchWatcherProvider);
   }
 
+  profiler.mark('before_run_app');
   runApp(
     UncontrolledProviderScope(
       container: container,
       child: const App(),
     ),
   );
+
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    profiler.mark('home_first_frame');
+    if (!kIsWeb) {
+      guardedUnawaited(
+        () async {
+          final recorder = container.read(telemetryRecorderProvider);
+          await recorder.record(
+            TelemetryEvent.startupTiming(phasesMicros: profiler.timingsMicros),
+          );
+        },
+        onError: (error, stack) => talker.error(error, stack),
+      );
+    }
+  });
 
   if (!kIsWeb && Platform.isIOS) {
     unawaited(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -114,9 +114,7 @@ Future<void> _main() async {
     ),
   );
 
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   profiler.mark('firebase_init');
 
   talker = TalkerFlutter.init(
@@ -124,14 +122,10 @@ Future<void> _main() async {
       // ignore: avoid_redundant_argument_values
       useConsoleLogs: kDebugMode,
     ),
-    logger: TalkerLogger(
-      formatter: const ColoredLoggerFormatter(),
-    ),
+    logger: TalkerLogger(formatter: const ColoredLoggerFormatter()),
   );
   if (!kIsWeb && !kDebugMode) {
-    talker.configure(
-      observer: CrashlyticsTalkerObserver(),
-    );
+    talker.configure(observer: CrashlyticsTalkerObserver());
   }
 
   FlutterError.onError = (error) {
@@ -145,21 +139,13 @@ Future<void> _main() async {
         talker.log(stackTrace.toString());
       }
     }
-    talker.handle(
-      error.exception,
-      error.stack,
-      'Uncaught fatal exception',
-    );
+    talker.handle(error.exception, error.stack, 'Uncaught fatal exception');
   };
   if (!kDebugMode) {
     ErrorWidget.builder = buildFatalErrorWidget;
   }
   PlatformDispatcher.instance.onError = (exception, stackTrace) {
-    talker.handle(
-      exception,
-      stackTrace,
-      'Uncaught async exception',
-    );
+    talker.handle(exception, stackTrace, 'Uncaught async exception');
     log(
       'Uncaught async exception: ${exception.runtimeType} $exception',
       name: 'main',
@@ -230,9 +216,7 @@ Future<void> _main() async {
         telemetryDbPathProvider.overrideWithValue(dbPath),
       startupProfilerProvider.overrideWithValue(profiler),
     ],
-    observers: [
-      if (kDebugMode) CustomProviderObserver(talker),
-    ],
+    observers: [if (kDebugMode) CustomProviderObserver(talker)],
     retry: (_, _) => null,
   );
 
@@ -256,12 +240,7 @@ Future<void> _main() async {
   }
 
   profiler.mark('before_run_app');
-  runApp(
-    UncontrolledProviderScope(
-      container: container,
-      child: const App(),
-    ),
-  );
+  runApp(UncontrolledProviderScope(container: container, child: const App()));
 
   // 広告SDK・通知プラグインは override 値を生まないため runApp 後に遅延初期化する。
   // 例外が発生しても起動フローを止めず talker に記録する。
@@ -272,57 +251,47 @@ Future<void> _main() async {
     );
   }
   if (!kIsWeb) {
-    guardedUnawaited(
-      () async {
-        await _registerNotificationChannelIfNeeded();
-        await FlutterLocalNotificationsPlugin().initialize(
-          settings: const InitializationSettings(
-            iOS: DarwinInitializationSettings(
-              requestAlertPermission: false,
-              requestSoundPermission: false,
-              requestBadgePermission: false,
-            ),
-            android: AndroidInitializationSettings('mipmap/ic_launcher'),
-            macOS: DarwinInitializationSettings(
-              requestAlertPermission: false,
-              requestSoundPermission: false,
-              requestBadgePermission: false,
-            ),
+    guardedUnawaited(() async {
+      await _registerNotificationChannelIfNeeded();
+      await FlutterLocalNotificationsPlugin().initialize(
+        settings: const InitializationSettings(
+          iOS: DarwinInitializationSettings(
+            requestAlertPermission: false,
+            requestSoundPermission: false,
+            requestBadgePermission: false,
           ),
-        );
-        await FirebaseMessaging.instance
-            .setForegroundNotificationPresentationOptions(
-          alert: true,
-          sound: true,
-          badge: true,
-        );
-      },
-      onError: (error, stack) => talker.error(error, stack),
-    );
+          android: AndroidInitializationSettings('mipmap/ic_launcher'),
+          macOS: DarwinInitializationSettings(
+            requestAlertPermission: false,
+            requestSoundPermission: false,
+            requestBadgePermission: false,
+          ),
+        ),
+      );
+      await FirebaseMessaging.instance
+          .setForegroundNotificationPresentationOptions(
+            alert: true,
+            sound: true,
+            badge: true,
+          );
+    }, onError: (error, stack) => talker.error(error, stack));
   }
 
   WidgetsBinding.instance.addPostFrameCallback((_) {
     profiler.mark('home_first_frame');
     if (!kIsWeb) {
-      guardedUnawaited(
-        () async {
-          final recorder = container.read(telemetryRecorderProvider);
-          await recorder.record(
-            TelemetryEvent.startupTiming(phasesMicros: profiler.timingsMicros),
-          );
-        },
-        onError: (error, stack) => talker.error(error, stack),
-      );
+      guardedUnawaited(() async {
+        final recorder = container.read(telemetryRecorderProvider);
+        await recorder.record(
+          TelemetryEvent.startupTiming(phasesMicros: profiler.timingsMicros),
+        );
+      }, onError: (error, stack) => talker.error(error, stack));
     }
   });
 
   if (!kIsWeb && Platform.isIOS) {
-    unawaited(
-      container.read(appGroupSettingsWriterProvider.future),
-    );
-    unawaited(
-      container.read(liveActivityTokenSyncWiringProvider.future),
-    );
+    unawaited(container.read(appGroupSettingsWriterProvider.future));
+    unawaited(container.read(liveActivityTokenSyncWiringProvider.future));
   }
 }
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -34,6 +34,8 @@ import 'package:eqmonitor/feature/kyoshin_monitor/data/provider/kyoshin_color_ma
 import 'package:eqmonitor/feature/live_activity/data/repository/live_activity_token_sync_service.dart';
 import 'package:eqmonitor/feature/location/data/background_location_service.dart';
 import 'package:eqmonitor/feature/playback_mode/data/notifier/auto_return_watcher.dart';
+import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:eqmonitor/feature/telemetry/data/provider/app_launch_watcher_provider.dart';
 import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_database_provider.dart';
 import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_recorder_provider.dart';
@@ -280,7 +282,18 @@ Future<void> _main() async {
   WidgetsBinding.instance.addPostFrameCallback((_) {
     profiler.mark('home_first_frame');
     if (!kIsWeb) {
+      // バックグラウンドで完了する travel_time_load / parameter_load が
+      // timingsMicros に記録されてからテレメトリを送信する。
+      // 各ロードの失敗は計測の欠落として許容し、record() の失敗は talker に委ねる。
+      Future<void> awaitQuietly(Future<Object?> f) async {
+        try {
+          await f;
+        } catch (_) {}
+      }
+
       guardedUnawaited(() async {
+        await awaitQuietly(container.read(travelTimeInternalProvider.future));
+        await awaitQuietly(container.read(parameterSetProvider.future));
         final recorder = container.read(telemetryRecorderProvider);
         await recorder.record(
           TelemetryEvent.startupTiming(phasesMicros: profiler.timingsMicros),

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -172,10 +172,6 @@ Future<void> _main() async {
     return true;
   };
 
-  if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
-    await MobileAds.instance.initialize();
-  }
-
   await FirebaseAppCheck.instance.activate(
     providerAndroid: kDebugMode
         ? const AndroidDebugProvider()
@@ -195,33 +191,7 @@ Future<void> _main() async {
           ? deviceInfo.androidInfo
           : Future<Null>.value()),
       (!kIsWeb && Platform.isIOS ? deviceInfo.iosInfo : Future<Null>.value()),
-      kIsWeb ? Future<Null>.value() : _registerNotificationChannelIfNeeded(),
       kIsWeb ? Future<Null>.value() : getApplicationDocumentsDirectory(),
-      kIsWeb
-          ? Future<Null>.value()
-          : FlutterLocalNotificationsPlugin().initialize(
-              settings: const InitializationSettings(
-                iOS: DarwinInitializationSettings(
-                  requestAlertPermission: false,
-                  requestSoundPermission: false,
-                  requestBadgePermission: false,
-                ),
-                android: AndroidInitializationSettings('mipmap/ic_launcher'),
-                macOS: DarwinInitializationSettings(
-                  requestAlertPermission: false,
-                  requestSoundPermission: false,
-                  requestBadgePermission: false,
-                ),
-              ),
-            ),
-      kIsWeb
-          ? Future<Null>.value()
-          : FirebaseMessaging.instance
-                .setForegroundNotificationPresentationOptions(
-                  alert: true,
-                  sound: true,
-                  badge: true,
-                ),
     ).wait,
     (
       kIsWeb ? Future<Null>.value() : getKyoshinColorMap(),
@@ -252,7 +222,7 @@ Future<void> _main() async {
         androidDeviceInfoProvider.overrideWithValue(androidInfo),
       if (results.$1.$4 case final iosInfo?)
         iosDeviceInfoProvider.overrideWithValue(iosInfo),
-      if (results.$1.$6 case final appDir?)
+      if (results.$1.$5 case final appDir?)
         applicationDocumentsDirectoryProvider.overrideWithValue(appDir),
       if (results.$2.$1 case final colorMap?)
         kyoshinColorMapProvider.overrideWithValue(colorMap),
@@ -292,6 +262,44 @@ Future<void> _main() async {
       child: const App(),
     ),
   );
+
+  // 広告SDK・通知プラグインは override 値を生まないため runApp 後に遅延初期化する。
+  // 例外が発生しても起動フローを止めず talker に記録する。
+  if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+    guardedUnawaited(
+      () => MobileAds.instance.initialize(),
+      onError: (error, stack) => talker.error(error, stack),
+    );
+  }
+  if (!kIsWeb) {
+    guardedUnawaited(
+      () async {
+        await _registerNotificationChannelIfNeeded();
+        await FlutterLocalNotificationsPlugin().initialize(
+          settings: const InitializationSettings(
+            iOS: DarwinInitializationSettings(
+              requestAlertPermission: false,
+              requestSoundPermission: false,
+              requestBadgePermission: false,
+            ),
+            android: AndroidInitializationSettings('mipmap/ic_launcher'),
+            macOS: DarwinInitializationSettings(
+              requestAlertPermission: false,
+              requestSoundPermission: false,
+              requestBadgePermission: false,
+            ),
+          ),
+        );
+        await FirebaseMessaging.instance
+            .setForegroundNotificationPresentationOptions(
+          alert: true,
+          sound: true,
+          badge: true,
+        );
+      },
+      onError: (error, stack) => talker.error(error, stack),
+    );
+  }
 
   WidgetsBinding.instance.addPostFrameCallback((_) {
     profiler.mark('home_first_frame');

--- a/app/lib/page/splash_page.dart
+++ b/app/lib/page/splash_page.dart
@@ -1,4 +1,3 @@
-import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/fcm/notification_deep_link.dart';
 import 'package:eqmonitor/core/provider/app_links_interaction.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging_interaction.dart';
@@ -6,7 +5,6 @@ import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshi
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
-import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -19,63 +17,38 @@ class SplashPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final kyoshinPoints = ref.watch(
-      kyoshinMonitorInternalObservationPointsConvertedProvider,
-    );
-    final travelTime = ref.watch(travelTimeInternalProvider);
-    final historyConfig = ref.watch(earthquakeHistoryConfigProvider);
-
-    final allLoaded =
-        kyoshinPoints.hasValue && travelTime.hasValue && historyConfig.hasValue;
-    final hasError =
-        !allLoaded &&
-        (kyoshinPoints.hasError ||
-            travelTime.hasError ||
-            historyConfig.hasError);
-    final error =
-        kyoshinPoints.error ?? travelTime.error ?? historyConfig.error;
-
     useEffect(
       () {
-        if (allLoaded) {
-          // SWR: build() が自動でキャッシュ即表示→裏で再検証
-          ref.read(startProvider);
-          WidgetsBinding.instance.addPostFrameCallback((_) async {
-            context.go(const HomeRoute().location);
-            final pending =
-                consumePendingNotificationDeepLink() ?? consumePendingAppLink();
-            switch (pending) {
-              case NotificationRouteLink(:final location):
-                await GoRouter.of(context).push<void>(location);
-              case NotificationUrlLink(:final uri):
-                await launchUrl(uri, mode: LaunchMode.externalApplication);
-              case null:
-                break;
-            }
-          });
-        }
+        // 重い初期化はトリガーのみ行い、完了を待たずに Home へ遷移する。
+        // keepAlive のためバックグラウンドでロードは継続し、各消費画面が
+        // 個別にローディング/エラーを表示する。
+        ref
+          ..read(travelTimeInternalProvider.future).ignore()
+          ..read(kyoshinMonitorInternalObservationPointsConvertedProvider.future)
+              .ignore()
+          ..read(earthquakeHistoryConfigProvider)
+          ..read(startProvider);
+        WidgetsBinding.instance.addPostFrameCallback((_) async {
+          context.go(const HomeRoute().location);
+          final pending =
+              consumePendingNotificationDeepLink() ?? consumePendingAppLink();
+          switch (pending) {
+            case NotificationRouteLink(:final location):
+              await GoRouter.of(context).push<void>(location);
+            case NotificationUrlLink(:final uri):
+              await launchUrl(uri, mode: LaunchMode.externalApplication);
+            case null:
+              break;
+          }
+        });
         return null;
       },
-      [allLoaded],
+      const [],
     );
 
-    return Scaffold(
+    return const Scaffold(
       body: SafeArea(
-        child: hasError
-            ? ErrorCard(
-                error: error ?? Exception('Unknown error'),
-                onReload: () async {
-                  ref.invalidate(parameterSetProvider, asReload: true);
-                  ref.invalidate(travelTimeInternalProvider, asReload: true);
-                  ref.invalidate(
-                    earthquakeHistoryConfigProvider,
-                    asReload: true,
-                  );
-                },
-              )
-            : const Center(
-                child: CircularProgressIndicator.adaptive(),
-              ),
+        child: Center(child: CircularProgressIndicator.adaptive()),
       ),
     );
   }

--- a/app/lib/page/splash_page.dart
+++ b/app/lib/page/splash_page.dart
@@ -17,34 +17,32 @@ class SplashPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    useEffect(
-      () {
-        // 重い初期化はトリガーのみ行い、完了を待たずに Home へ遷移する。
-        // keepAlive のためバックグラウンドでロードは継続し、各消費画面が
-        // 個別にローディング/エラーを表示する。
-        ref
-          ..read(travelTimeInternalProvider.future).ignore()
-          ..read(kyoshinMonitorInternalObservationPointsConvertedProvider.future)
-              .ignore()
-          ..read(earthquakeHistoryConfigProvider)
-          ..read(startProvider);
-        WidgetsBinding.instance.addPostFrameCallback((_) async {
-          context.go(const HomeRoute().location);
-          final pending =
-              consumePendingNotificationDeepLink() ?? consumePendingAppLink();
-          switch (pending) {
-            case NotificationRouteLink(:final location):
-              await GoRouter.of(context).push<void>(location);
-            case NotificationUrlLink(:final uri):
-              await launchUrl(uri, mode: LaunchMode.externalApplication);
-            case null:
-              break;
-          }
-        });
-        return null;
-      },
-      const [],
-    );
+    useEffect(() {
+      // 重い初期化はトリガーのみ行い、完了を待たずに Home へ遷移する。
+      // keepAlive のためバックグラウンドでロードは継続し、各消費画面が
+      // 個別にローディング/エラーを表示する。
+      ref
+        ..read(travelTimeInternalProvider.future).ignore()
+        ..read(
+          kyoshinMonitorInternalObservationPointsConvertedProvider.future,
+        ).ignore()
+        ..read(earthquakeHistoryConfigProvider)
+        ..read(startProvider);
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        context.go(const HomeRoute().location);
+        final pending =
+            consumePendingNotificationDeepLink() ?? consumePendingAppLink();
+        switch (pending) {
+          case NotificationRouteLink(:final location):
+            await GoRouter.of(context).push<void>(location);
+          case NotificationUrlLink(:final uri):
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
+          case null:
+            break;
+        }
+      });
+      return null;
+    }, const []);
 
     return const Scaffold(
       body: SafeArea(

--- a/app/test/core/provider/travel_time/provider/travel_time_provider_test.dart
+++ b/app/test/core/provider/travel_time/provider/travel_time_provider_test.dart
@@ -19,25 +19,25 @@ void main() {
   group('TravelTimeDepthMapCalc', () {
     // https://zenn.dev/boocsan/articles/travel-time-table-converter-adcal2020?#%E5%8B%95%E4%BD%9C%E7%A2%BA%E8%AA%8D より
     test('20km 20sec', () {
-      final travelMap = container.read(travelTimeDepthMapProvider);
+      final travelMap = container.read(travelTimeDepthMapProvider)!;
       final result = travelMap.getTravelTime(20, 20);
       expect(result.pDistance, 122.35900962861072);
       expect(result.sDistance, 67.68853695324285);
     });
     test('100km 200sec', () {
-      final travelMap = container.read(travelTimeDepthMapProvider);
+      final travelMap = container.read(travelTimeDepthMapProvider)!;
       final result = travelMap.getTravelTime(100, 200);
       expect(result.pDistance, 1603.2552083333333);
       expect(result.sDistance, 868.2417083144026);
     });
     test('200km 200sec', () {
-      final travelMap = container.read(travelTimeDepthMapProvider);
+      final travelMap = container.read(travelTimeDepthMapProvider)!;
       final result = travelMap.getTravelTime(200, 200);
       expect(result.pDistance, 1639.8745519713261);
       expect(result.sDistance, 874.7576045627376);
     });
     test('300km 200sec', () {
-      final travelMap = container.read(travelTimeDepthMapProvider);
+      final travelMap = container.read(travelTimeDepthMapProvider)!;
       final result = travelMap.getTravelTime(300, 200);
       expect(result.pDistance, 1672.7323943661972);
       expect(result.sDistance, 869.2659627953747);

--- a/app/test/core/provider/travel_time/travel_time_parse_test.dart
+++ b/app/test/core/provider/travel_time/travel_time_parse_test.dart
@@ -1,0 +1,37 @@
+import 'package:eqmonitor/core/provider/travel_time/data/travel_time_data_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Real CSV format: p,s,depth,distance (no header row)
+  // Example from assets/tjma2001.csv:
+  //   0.416,0.703,0,2
+  //   1.243,2.099,0,6
+
+  test('parseTravelTimeCsv parses p/s/depth/distance rows', () {
+    const raw = '0.416,0.703,0,2\n1.243,2.099,0,6';
+    final tables = parseTravelTimeCsv(raw);
+    expect(tables.table, hasLength(2));
+    final first = tables.table.first;
+    expect(first.p, closeTo(0.416, 1e-9));
+    expect(first.s, closeTo(0.703, 1e-9));
+    expect(first.depth, 0);
+    expect(first.distance, 2);
+    final second = tables.table[1];
+    expect(second.p, closeTo(1.243, 1e-9));
+    expect(second.s, closeTo(2.099, 1e-9));
+    expect(second.depth, 0);
+    expect(second.distance, 6);
+  });
+
+  test('parseTravelTimeCsv skips first row on parse failure', () {
+    // ヘッダー行がある場合でも先頭のパース失敗はスキップ
+    const raw = 'p,s,depth,distance\n0.416,0.703,0,2';
+    final tables = parseTravelTimeCsv(raw);
+    expect(tables.table, hasLength(1));
+    expect(tables.table.first.distance, 2);
+  });
+
+  test('parseTravelTimeCsv throws on empty result', () {
+    expect(() => parseTravelTimeCsv(''), throwsException);
+  });
+}

--- a/app/test/core/startup/startup_profiler_test.dart
+++ b/app/test/core/startup/startup_profiler_test.dart
@@ -19,16 +19,6 @@ void main() {
     expect(profiler.timingsMicros['travel_time_parse'], 9000);
   });
 
-  test('toPayload nests timings under phases', () {
-    var now = 0;
-    final profiler = StartupProfiler(clockMicros: () => now);
-    now = 300;
-    profiler.mark('home_first_frame');
-    expect(profiler.toPayload(), {
-      'phases': {'home_first_frame': 300},
-    });
-  });
-
   test('timingsMicros returns an unmodifiable copy', () {
     final profiler = StartupProfiler(clockMicros: () => 0);
     profiler.mark('a');

--- a/app/test/core/startup/startup_profiler_test.dart
+++ b/app/test/core/startup/startup_profiler_test.dart
@@ -1,0 +1,40 @@
+import 'package:eqmonitor/core/startup/startup_profiler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('mark records elapsed micros from injected clock', () {
+    var now = 0;
+    final profiler = StartupProfiler(clockMicros: () => now);
+    now = 1500;
+    profiler.mark('firebase_init');
+    now = 4200;
+    profiler.mark('run_app');
+
+    expect(profiler.timingsMicros, {
+      'firebase_init': 1500,
+      'run_app': 4200,
+    });
+  });
+
+  test('measure records an explicit interval', () {
+    final profiler = StartupProfiler(clockMicros: () => 0);
+    profiler.measure('travel_time_parse', 9000);
+    expect(profiler.timingsMicros['travel_time_parse'], 9000);
+  });
+
+  test('toPayload nests timings under phases', () {
+    var now = 0;
+    final profiler = StartupProfiler(clockMicros: () => now);
+    now = 300;
+    profiler.mark('home_first_frame');
+    expect(profiler.toPayload(), {
+      'phases': {'home_first_frame': 300},
+    });
+  });
+
+  test('timingsMicros returns an unmodifiable copy', () {
+    final profiler = StartupProfiler(clockMicros: () => 0);
+    profiler.mark('a');
+    expect(() => profiler.timingsMicros['b'] = 1, throwsUnsupportedError);
+  });
+}

--- a/app/test/core/startup/startup_profiler_test.dart
+++ b/app/test/core/startup/startup_profiler_test.dart
@@ -10,10 +10,7 @@ void main() {
     now = 4200;
     profiler.mark('run_app');
 
-    expect(profiler.timingsMicros, {
-      'firebase_init': 1500,
-      'run_app': 4200,
-    });
+    expect(profiler.timingsMicros, {'firebase_init': 1500, 'run_app': 4200});
   });
 
   test('measure records an explicit interval', () {

--- a/app/test/core/util/guarded_unawaited_test.dart
+++ b/app/test/core/util/guarded_unawaited_test.dart
@@ -24,10 +24,7 @@ void main() {
 
   test('does not call onError on success', () async {
     var called = false;
-    guardedUnawaited(
-      () async {},
-      onError: (_, _) => called = true,
-    );
+    guardedUnawaited(() async {}, onError: (_, _) => called = true);
     await Future<void>.delayed(Duration.zero);
     expect(called, isFalse);
   });

--- a/app/test/core/util/guarded_unawaited_test.dart
+++ b/app/test/core/util/guarded_unawaited_test.dart
@@ -1,0 +1,34 @@
+import 'package:eqmonitor/core/util/guarded_unawaited.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('captures async error via onError', () async {
+    Object? captured;
+    guardedUnawaited(
+      () async => throw StateError('boom'),
+      onError: (error, _) => captured = error,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(captured, isA<StateError>());
+  });
+
+  test('captures synchronous throw in action', () async {
+    Object? captured;
+    guardedUnawaited(
+      () => throw ArgumentError('bad'),
+      onError: (error, _) => captured = error,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(captured, isA<ArgumentError>());
+  });
+
+  test('does not call onError on success', () async {
+    var called = false;
+    guardedUnawaited(
+      () async {},
+      onError: (_, _) => called = true,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(called, isFalse);
+  });
+}

--- a/app/test/feature/eew/travel_time_depth_map_nullable_test.dart
+++ b/app/test/feature/eew/travel_time_depth_map_nullable_test.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/provider/travel_time/model/travel_time_table.dart';
+import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test(
+    'travelTimeDepthMapProvider returns null when travelTimeInternalProvider is still loading',
+    () {
+      final container = ProviderContainer(
+        overrides: [
+          travelTimeInternalProvider.overrideWith(
+            // never-completing future keeps the internal provider in loading state
+            (ref) => Completer<TravelTimeTables>().future,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = container.read(travelTimeDepthMapProvider);
+      expect(result, isNull);
+    },
+  );
+}

--- a/docs/superpowers/plans/2026-07-07-startup-optimization.md
+++ b/docs/superpowers/plans/2026-07-07-startup-optimization.md
@@ -1,0 +1,949 @@
+# 起動最適化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** アプリ起動 (Splash 含む) を、重い初期化でナビゲーションをブロックしない体験へ転換し、効果を定量計測できる基盤を備える。
+
+**Architecture:** 計測基盤 (`StartupProfiler` + telemetry イベント + デバッグページ) を先に入れ、Splash ゲートを解体して即 Home 遷移させ、消費側で await/graceful degradation する。main.dart の副作用 init を runApp 後へ遅延 (例外はガードして記録)。パースは計測で効果を確認できる形で compute 化する。
+
+**Tech Stack:** Flutter 3.44 / Dart 3.11, Riverpod (riverpod_annotation, keepAlive), Freezed, telemetry_store パッケージ (Drift), flutter_test。
+
+## Global Constraints
+
+- Riverpod 公開 Provider は 1 ファイル 1 つまで。
+- 新規 class/関数を作る前に、この計画で定義済みのインターフェースに従う (勝手に増やさない)。
+- コメントは「なぜ」のみ。コードから自明なコメントを書かない。
+- 必要性を論証できない冗長フィールド/抽象を足さない (YAGNI)。
+- パッケージ間 import は package import を使う (相対 import 不可)。
+- Freezed/Riverpod のアノテーション変更後は該当パッケージで `dart run build_runner build --delete-conflicting-outputs` を実行し、生成物 (`*.g.dart` / `*.freezed.dart`) をコミットする。
+- 計測値の内部保持はマイクロ秒 (int)。UI 表示は ms。
+- `unawaited` する処理は必ず try/catch で `talker.error` に記録する (例外を握りつぶさない)。
+- テストは `flutter test` (app) / `dart test` (package) で緑にしてからコミットする。
+- コミットメッセージ末尾に `Claude-Session: https://claude.ai/code/session_016kNc5tMmW5x7a4A4ms83EB` を付ける。
+
+---
+
+### Task 1: StartupProfiler (純粋 Dart クラス)
+
+起動フェーズごとの所要時間をマイクロ秒で記録・保持・シリアライズする、Flutter 非依存の純粋クラス。時刻源を注入可能にして単体テストで決定的に検証する。
+
+**Files:**
+- Create: `app/lib/core/startup/startup_profiler.dart`
+- Test: `app/test/core/startup/startup_profiler_test.dart`
+
+**Interfaces:**
+- Consumes: なし
+- Produces:
+  - `class StartupProfiler`
+    - `StartupProfiler({int Function()? clockMicros})` — `clockMicros` 省略時は内部 `Stopwatch` の `elapsedMicroseconds` を使用。
+    - `void mark(String phase)` — 生成時刻からの経過マイクロ秒を `phase` 名で記録。
+    - `void measure(String phase, int micros)` — 区間長 (マイクロ秒) を直接記録 (isolate/非同期区間用)。
+    - `Map<String, int> get timingsMicros` — 記録済みタイミングの読み取り専用コピー。
+    - `Map<String, dynamic> toPayload()` — `{'phases': {phase: micros...}}` を返す (telemetry payload 用)。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/test/core/startup/startup_profiler_test.dart`:
+
+```dart
+import 'package:eqmonitor/core/startup/startup_profiler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('mark records elapsed micros from injected clock', () {
+    var now = 0;
+    final profiler = StartupProfiler(clockMicros: () => now);
+    now = 1500;
+    profiler.mark('firebase_init');
+    now = 4200;
+    profiler.mark('run_app');
+
+    expect(profiler.timingsMicros, {
+      'firebase_init': 1500,
+      'run_app': 4200,
+    });
+  });
+
+  test('measure records an explicit interval', () {
+    final profiler = StartupProfiler(clockMicros: () => 0);
+    profiler.measure('travel_time_parse', 9000);
+    expect(profiler.timingsMicros['travel_time_parse'], 9000);
+  });
+
+  test('toPayload nests timings under phases', () {
+    var now = 0;
+    final profiler = StartupProfiler(clockMicros: () => now);
+    now = 300;
+    profiler.mark('home_first_frame');
+    expect(profiler.toPayload(), {
+      'phases': {'home_first_frame': 300},
+    });
+  });
+
+  test('timingsMicros returns an unmodifiable copy', () {
+    final profiler = StartupProfiler(clockMicros: () => 0);
+    profiler.mark('a');
+    expect(() => profiler.timingsMicros['b'] = 1, throwsUnsupportedError);
+  });
+}
+```
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd app && flutter test test/core/startup/startup_profiler_test.dart`
+Expected: FAIL (`StartupProfiler` 未定義)
+
+- [ ] **Step 3: 最小実装**
+
+`app/lib/core/startup/startup_profiler.dart`:
+
+```dart
+/// 起動フェーズごとの所要時間をマイクロ秒で記録する。
+///
+/// [clockMicros] を注入するとテストで決定的に検証できる。省略時は内部の
+/// [Stopwatch] を時刻源に使う。
+class StartupProfiler {
+  StartupProfiler({int Function()? clockMicros})
+    : _clockMicros = clockMicros ?? _defaultClock();
+
+  static int Function() _defaultClock() {
+    final stopwatch = Stopwatch()..start();
+    return () => stopwatch.elapsedMicroseconds;
+  }
+
+  final int Function() _clockMicros;
+  final Map<String, int> _timings = {};
+
+  void mark(String phase) => _timings[phase] = _clockMicros();
+
+  void measure(String phase, int micros) => _timings[phase] = micros;
+
+  Map<String, int> get timingsMicros => Map.unmodifiable(_timings);
+
+  Map<String, dynamic> toPayload() => {'phases': Map<String, int>.from(_timings)};
+}
+```
+
+- [ ] **Step 4: テスト成功を確認**
+
+Run: `cd app && flutter test test/core/startup/startup_profiler_test.dart`
+Expected: PASS (4 件)
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/lib/core/startup/startup_profiler.dart app/test/core/startup/startup_profiler_test.dart
+git commit -m "feat: 起動フェーズ計測用 StartupProfiler を追加"
+```
+
+---
+
+### Task 2: startup_timing TelemetryEvent 追加
+
+起動計測をサーバへ送るための telemetry イベント種別を追加する。バックエンドは `app_launch` 以外の event_type を汎用 `client_telemetry` に格納するため、バックエンド変更は不要。
+
+**Files:**
+- Modify: `packages/telemetry_store/lib/src/models/telemetry_event.dart`
+- Test: `packages/telemetry_store/test/startup_timing_event_test.dart`
+
+**Interfaces:**
+- Consumes: 既存 `TelemetryEvent` sealed class
+- Produces:
+  - `TelemetryEvent.startupTiming({required Map<String, int> phasesMicros})` → `StartupTimingEvent`
+  - `eventType` == `'startup_timing'`
+  - `toPayload()` == `{'phases_micros': phasesMicros}`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/telemetry_store/test/startup_timing_event_test.dart`:
+
+```dart
+import 'package:telemetry_store/telemetry_store.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('startupTiming has correct eventType', () {
+    const event = TelemetryEvent.startupTiming(phasesMicros: {'run_app': 1200});
+    expect(event.eventType, 'startup_timing');
+  });
+
+  test('startupTiming toPayload nests phases_micros', () {
+    const event = TelemetryEvent.startupTiming(
+      phasesMicros: {'firebase_init': 1500, 'run_app': 4200},
+    );
+    expect(event.toPayload(), {
+      'phases_micros': {'firebase_init': 1500, 'run_app': 4200},
+    });
+  });
+
+  test('startupTiming eventId is null', () {
+    const event = TelemetryEvent.startupTiming(phasesMicros: {});
+    expect(event.eventId, isNull);
+  });
+}
+```
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd packages/telemetry_store && dart test test/startup_timing_event_test.dart`
+Expected: FAIL (`startupTiming` 未定義)
+
+- [ ] **Step 3: sealed class にファクトリと分岐を追加**
+
+`packages/telemetry_store/lib/src/models/telemetry_event.dart` の `error` ファクトリの直後 (48 行目付近、`= ErrorTelemetryEvent;` の次) に追加:
+
+```dart
+  const factory TelemetryEvent.startupTiming({
+    required Map<String, int> phasesMicros,
+  }) = StartupTimingEvent;
+```
+
+`eventType` の switch に追加:
+
+```dart
+    StartupTimingEvent() => 'startup_timing',
+```
+
+`toPayload()` の switch に追加:
+
+```dart
+    StartupTimingEvent(:final phasesMicros) => {
+      'phases_micros': phasesMicros,
+    },
+```
+
+`eventId` の switch は `_ => null` があるため変更不要 (StartupTimingEvent は eventId を持たない)。
+
+- [ ] **Step 4: build_runner で freezed 再生成**
+
+Run: `cd packages/telemetry_store && dart run build_runner build --delete-conflicting-outputs`
+Expected: `telemetry_event.freezed.dart` が更新される
+
+- [ ] **Step 5: テスト成功を確認**
+
+Run: `cd packages/telemetry_store && dart test test/startup_timing_event_test.dart`
+Expected: PASS (3 件)
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add packages/telemetry_store/lib/src/models/telemetry_event.dart packages/telemetry_store/lib/src/models/telemetry_event.freezed.dart packages/telemetry_store/test/startup_timing_event_test.dart
+git commit -m "feat: startup_timing テレメトリイベントを追加"
+```
+
+---
+
+### Task 3: guardedUnawaited ヘルパー
+
+`unawaited` する非同期処理の例外を握りつぶさず `talker.error` に記録する共通ヘルパー。Task 5 と Task 3 の telemetry 送信で使う。
+
+**Files:**
+- Create: `app/lib/core/util/guarded_unawaited.dart`
+- Test: `app/test/core/util/guarded_unawaited_test.dart`
+
+**Interfaces:**
+- Consumes: なし (talker はコールバック注入でテスト可能にする)
+- Produces:
+  - `void guardedUnawaited(Future<void> Function() action, {required void Function(Object error, StackTrace stack) onError})`
+    — `action()` を実行し、投げられた例外/非同期エラーを `onError` に渡す。呼び出しは同期的に戻る (待たない)。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/test/core/util/guarded_unawaited_test.dart`:
+
+```dart
+import 'package:eqmonitor/core/util/guarded_unawaited.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('captures async error via onError', () async {
+    Object? captured;
+    guardedUnawaited(
+      () async => throw StateError('boom'),
+      onError: (error, _) => captured = error,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(captured, isA<StateError>());
+  });
+
+  test('captures synchronous throw in action', () async {
+    Object? captured;
+    guardedUnawaited(
+      () => throw ArgumentError('bad'),
+      onError: (error, _) => captured = error,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(captured, isA<ArgumentError>());
+  });
+
+  test('does not call onError on success', () async {
+    var called = false;
+    guardedUnawaited(
+      () async {},
+      onError: (_, _) => called = true,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(called, isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd app && flutter test test/core/util/guarded_unawaited_test.dart`
+Expected: FAIL (`guardedUnawaited` 未定義)
+
+- [ ] **Step 3: 最小実装**
+
+`app/lib/core/util/guarded_unawaited.dart`:
+
+```dart
+import 'dart:async';
+
+/// [action] を fire-and-forget で実行し、例外/非同期エラーを [onError] に渡す。
+///
+/// `unawaited` の代替。エラーを握りつぶさず必ず記録経路へ流すために使う。
+void guardedUnawaited(
+  Future<void> Function() action, {
+  required void Function(Object error, StackTrace stack) onError,
+}) {
+  unawaited(
+    Future<void>.sync(action).catchError(onError),
+  );
+}
+```
+
+- [ ] **Step 4: テスト成功を確認**
+
+Run: `cd app && flutter test test/core/util/guarded_unawaited_test.dart`
+Expected: PASS (3 件)
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/lib/core/util/guarded_unawaited.dart app/test/core/util/guarded_unawaited_test.dart
+git commit -m "feat: 例外を記録する guardedUnawaited ヘルパーを追加"
+```
+
+---
+
+### Task 4: main.dart に計測を組み込み + telemetry 送信
+
+`_main()` の各フェーズを `StartupProfiler` で計測し、Home 初回フレーム後に `startup_timing` を fire-and-forget 記録する。あわせて Provider から profiler を参照できるようにする。
+
+**Files:**
+- Create: `app/lib/core/startup/startup_profiler_provider.dart`
+- Modify: `app/lib/main.dart`
+
+**Interfaces:**
+- Consumes: `StartupProfiler` (Task 1), `guardedUnawaited` (Task 3), `telemetryRecorderProvider` (既存), `TelemetryEvent.startupTiming` (Task 2)
+- Produces:
+  - `startupProfilerProvider` — `Provider<StartupProfiler>` (keepAlive)。`_main()` で生成した単一インスタンスを `overrideWithValue` で注入。
+  - Home 初回フレーム捕捉用に、`main.dart` 内で `WidgetsBinding.instance.addPostFrameCallback` を使い `home_first_frame` を mark。
+
+**注意:** `startupProfilerProvider` は 1 ファイル 1 公開 Provider ルールに従い専用ファイルへ。
+
+- [ ] **Step 1: profiler provider を作成**
+
+`app/lib/core/startup/startup_profiler_provider.dart`:
+
+```dart
+import 'package:eqmonitor/core/startup/startup_profiler.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// `_main()` で生成した [StartupProfiler] を注入する。
+/// override されない場合は空のインスタンスを返す (テスト等)。
+final startupProfilerProvider = Provider<StartupProfiler>(
+  (ref) => StartupProfiler(),
+);
+```
+
+- [ ] **Step 2: main.dart に Stopwatch ベースの profiler を導入**
+
+`_main()` 冒頭 (L93 直後) で profiler を生成し、主要フェーズを mark する。以下を挿入:
+
+- `_main()` の先頭に `final profiler = StartupProfiler();`
+- `await Firebase.initializeApp(...)` の直後に `profiler.mark('firebase_init');`
+- 大きな `.wait` ブロック (`final results = await (...).wait;`) の直後に `profiler.mark('parallel_init');`
+- `runApp(...)` の直前に `profiler.mark('before_run_app');`
+
+- [ ] **Step 3: profiler を override に追加**
+
+`ProviderContainer` の `overrides` リスト (L234-252) に追加:
+
+```dart
+      startupProfilerProvider.overrideWithValue(profiler),
+```
+
+`main.dart` 冒頭に import を追加:
+
+```dart
+import 'package:eqmonitor/core/startup/startup_profiler.dart';
+import 'package:eqmonitor/core/startup/startup_profiler_provider.dart';
+import 'package:eqmonitor/core/util/guarded_unawaited.dart';
+import 'package:telemetry_store/telemetry_store.dart';
+```
+
+- [ ] **Step 4: Home 初回フレーム後に telemetry 送信**
+
+`runApp(...)` の直後 (L283 の後) に、初回フレームで `home_first_frame` を mark し `startup_timing` を記録する処理を追加:
+
+```dart
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    profiler.mark('home_first_frame');
+    if (!kIsWeb) {
+      guardedUnawaited(
+        () async {
+          final recorder = container.read(telemetryRecorderProvider);
+          await recorder.record(
+            TelemetryEvent.startupTiming(phasesMicros: profiler.timingsMicros),
+          );
+        },
+        onError: (error, stack) => talker.error(error, stack),
+      );
+    }
+  });
+```
+
+import 追加: `import 'package:eqmonitor/feature/telemetry/data/provider/telemetry_recorder_provider.dart';`
+
+- [ ] **Step 5: analyze で確認**
+
+Run: `cd app && dart analyze lib/main.dart lib/core/startup/`
+Expected: No issues
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add app/lib/main.dart app/lib/core/startup/startup_profiler_provider.dart
+git commit -m "feat: main.dart に起動計測と startup_timing 送信を組み込み"
+```
+
+---
+
+### Task 5: 起動計測デバッグページ
+
+記録済みの起動計測を ms 単位で表示するデバッグページを追加し、既存デバッグ画面のルーティングに登録する。
+
+**Files:**
+- Create: `app/lib/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart`
+- Modify: `app/lib/core/router/router.dart` (import + ルート定義追加)
+- Modify: `app/lib/feature/settings/children/config/debug/debug_page.dart` (一覧に導線追加)
+
+**Interfaces:**
+- Consumes: `startupProfilerProvider` (Task 4)
+- Produces: `DebugStartupTimingPage` widget と対応する GoRoute。
+
+**実装メモ:** 既存 `debug_telemetry_page.dart` / `router.dart` の debug ルート定義・`debug_page.dart` の ListTile 導線パターンにそのまま倣うこと。ルート名・パス・クラス名の命名は近傍の debug ページ (例: `DebugTelemetryPage`) に合わせる。
+
+- [ ] **Step 1: デバッグページを作成**
+
+`app/lib/feature/settings/children/config/debug/startup/debug_startup_timing_page.dart`:
+
+```dart
+import 'package:eqmonitor/core/startup/startup_profiler_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DebugStartupTimingPage extends ConsumerWidget {
+  const DebugStartupTimingPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final timings = ref.watch(startupProfilerProvider).timingsMicros;
+    final entries = timings.entries.toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Startup Timing')),
+      body: ListView(
+        children: [
+          for (final entry in entries)
+            ListTile(
+              title: Text(entry.key),
+              trailing: Text('${(entry.value / 1000).toStringAsFixed(2)} ms'),
+            ),
+          if (entries.isEmpty)
+            const ListTile(title: Text('計測データがありません')),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: ルートを登録**
+
+`router.dart` の既存 debug ルート定義群 (例: `DebugTelemetryRoute` 付近) に倣い、`DebugStartupTimingRoute` を追加する。import も debug ページ群 (L41-59 付近) に合わせて追加する。近傍の TypedGoRoute 定義と同じ書式に厳密に合わせること。
+
+- [ ] **Step 3: デバッグ一覧に導線を追加**
+
+`debug_page.dart` の ListTile 群に、`DebugStartupTimingRoute().push(context)` (近傍の遷移方法に合わせる) を呼ぶ「Startup Timing」項目を 1 つ追加する。
+
+- [ ] **Step 4: build_runner でルート生成物を更新**
+
+Run: `cd app && dart run build_runner build --delete-conflicting-outputs`
+Expected: `router.g.dart` が更新される
+
+- [ ] **Step 5: analyze で確認**
+
+Run: `cd app && dart analyze lib/feature/settings/children/config/debug/startup/ lib/core/router/router.dart lib/feature/settings/children/config/debug/debug_page.dart`
+Expected: No issues
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add app/lib/feature/settings/children/config/debug/startup/ app/lib/core/router/router.dart app/lib/core/router/router.g.dart app/lib/feature/settings/children/config/debug/debug_page.dart
+git commit -m "feat: 起動計測デバッグページを追加"
+```
+
+---
+
+### Task 6: main.dart の副作用 init を runApp 後へ遅延
+
+override 値を生まない副作用初期化 (MobileAds / ローカル通知 init / 通知チャンネル登録 / FCM 表示オプション) を `.wait` バリアと逐次 await から外し、runApp 後に `guardedUnawaited` で実行する。例外は必ず記録する。
+
+**Files:**
+- Modify: `app/lib/main.dart`
+
+**Interfaces:**
+- Consumes: `guardedUnawaited` (Task 3), `StartupProfiler` (Task 4 で導入済み)
+- Produces: なし (起動フローの変更のみ)
+
+**設計判断:**
+- `MobileAds.instance.initialize()` (L167-169): runApp 後の `guardedUnawaited` へ移す。
+- `.wait` ブロック内の副作用 3 つ (`_registerNotificationChannelIfNeeded()` / `FlutterLocalNotificationsPlugin().initialize(...)` / `FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(...)`) を `.wait` から外し、runApp 後の `guardedUnawaited` へ移す。これらは override 値を生まない。
+- **`FirebaseAppCheck.instance.activate()` (L171-178) は変更しない。** API interceptor が App Check トークンを使うため runApp 前に残す (安全側)。
+- 通知プラグイン init を遅延することで、コールドスタート直後の通知タップ処理 (`firebaseMessagingInteractionProvider` / deep link) が init 前に走らないか確認する。`firebaseMessagingInteractionProvider` は `container.listen` (L263) で runApp 後に登録されるため、init を runApp 直後に発火すれば順序は保たれる。懸念があれば通知 init のみ runApp 前へ戻す。
+
+- [ ] **Step 1: MobileAds を runApp 後へ移動**
+
+L167-169 の `if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) { await MobileAds.instance.initialize(); }` を削除し、runApp 後 (L283 以降) に移す:
+
+```dart
+  if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+    guardedUnawaited(
+      () => MobileAds.instance.initialize(),
+      onError: (error, stack) => talker.error(error, stack),
+    );
+  }
+```
+
+- [ ] **Step 2: 通知系副作用を .wait から外す**
+
+`.wait` の第 1 タプル (L183-217) から次の 3 要素を削除する:
+- `_registerNotificationChannelIfNeeded()` (L190)
+- `FlutterLocalNotificationsPlugin().initialize(...)` (L192-208)
+- `FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(...)` (L209-216)
+
+タプルの要素を削除するため、後続の `results.$1.$N` インデックス参照 (L238-247) がずれる。**インデックスのずれを正しく追従すること。** 削除後の第 1 タプルは `(SharedPreferences.getInstance(), PackageInfo.fromPlatform(), androidInfo, iosInfo, getApplicationDocumentsDirectory())` の 5 要素になり、override 参照は:
+- `results.$1.$1` → SharedPreferences
+- `results.$1.$2` → PackageInfo
+- `results.$1.$3` → androidInfo
+- `results.$1.$4` → iosInfo
+- `results.$1.$5` → appDir (旧 `results.$1.$6`)
+
+に変わる。`applicationDocumentsDirectoryProvider.overrideWithValue(appDir)` の参照を `results.$1.$5` へ修正する。
+
+- [ ] **Step 3: 通知系副作用を runApp 後へ移動**
+
+runApp 後 (L283 以降、MobileAds の隣) に追加:
+
+```dart
+  if (!kIsWeb) {
+    guardedUnawaited(
+      () async {
+        await _registerNotificationChannelIfNeeded();
+        await FlutterLocalNotificationsPlugin().initialize(
+          settings: const InitializationSettings(
+            iOS: DarwinInitializationSettings(
+              requestAlertPermission: false,
+              requestSoundPermission: false,
+              requestBadgePermission: false,
+            ),
+            android: AndroidInitializationSettings('mipmap/ic_launcher'),
+            macOS: DarwinInitializationSettings(
+              requestAlertPermission: false,
+              requestSoundPermission: false,
+              requestBadgePermission: false,
+            ),
+          ),
+        );
+        await FirebaseMessaging.instance
+            .setForegroundNotificationPresentationOptions(
+          alert: true,
+          sound: true,
+          badge: true,
+        );
+      },
+      onError: (error, stack) => talker.error(error, stack),
+    );
+  }
+```
+
+- [ ] **Step 4: analyze で確認**
+
+Run: `cd app && dart analyze lib/main.dart`
+Expected: No issues (特に `results.$1.$N` の型エラーがないこと)
+
+- [ ] **Step 5: 既存の起動関連テストがあれば実行**
+
+Run: `cd app && flutter test test/core/startup/ test/core/util/`
+Expected: PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add app/lib/main.dart
+git commit -m "perf: 広告/通知の副作用初期化を runApp 後へ遅延 (例外はガード記録)"
+```
+
+---
+
+### Task 7: Splash ゲート解体 (トリガーのみで即 Home 遷移)
+
+Splash が 3 Provider の完了を待つのをやめ、トリガーだけして即 Home へ遷移する。ロードは keepAlive でバックグラウンド継続。
+
+**Files:**
+- Modify: `app/lib/page/splash_page.dart`
+
+**Interfaces:**
+- Consumes: `kyoshinMonitorInternalObservationPointsConvertedProvider`, `travelTimeInternalProvider`, `earthquakeHistoryConfigProvider`, `startProvider` (すべて既存)
+- Produces: なし
+
+**設計判断:** Splash は「初期化をトリガーし即遷移する」役割に変える。3 Provider を `ref.read` で温め (keepAlive のため破棄されない)、初回フレームで Home へ `context.go`。`hasValue` 待機・`ErrorCard` 分岐は削除する (各消費画面側でローディング/エラーを扱う)。deep link 処理は現状の流れを保持する。
+
+- [ ] **Step 1: splash_page.dart を書き換え**
+
+`app/lib/page/splash_page.dart` の `build` を次の方針で書き換える:
+- 3 Provider を `ref.read(...)` でトリガー (戻り値は使わない)。`travelTimeInternalProvider` / `kyoshinMonitorInternalObservationPointsConvertedProvider` は `.future` を read して温める (`unawaited`)。`earthquakeHistoryConfigProvider` も read。
+- `useEffect` (初回のみ) で `ref.read(startProvider)` を呼び、`WidgetsBinding.instance.addPostFrameCallback` で `context.go(const HomeRoute().location)` と deep link 処理 (現状 L45-54) をそのまま実行する。
+- `hasError` / `allLoaded` / `ErrorCard` 分岐を削除。body は常に `CircularProgressIndicator.adaptive()` (一瞬のみ表示)。
+
+書き換え後:
+
+```dart
+import 'package:eqmonitor/core/fcm/notification_deep_link.dart';
+import 'package:eqmonitor/core/provider/app_links_interaction.dart';
+import 'package:eqmonitor/core/provider/firebase/firebase_messaging_interaction.dart';
+import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshin_observation_points_provider.dart';
+import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
+import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class SplashPage extends HookConsumerWidget {
+  const SplashPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    useEffect(
+      () {
+        // 重い初期化はトリガーのみ行い、完了を待たずに Home へ遷移する。
+        // keepAlive のためバックグラウンドでロードは継続し、各消費画面が
+        // 個別にローディング/エラーを表示する。
+        ref
+          ..read(travelTimeInternalProvider.future).ignore()
+          ..read(kyoshinMonitorInternalObservationPointsConvertedProvider.future)
+              .ignore()
+          ..read(earthquakeHistoryConfigProvider)
+          ..read(startProvider);
+        WidgetsBinding.instance.addPostFrameCallback((_) async {
+          context.go(const HomeRoute().location);
+          final pending =
+              consumePendingNotificationDeepLink() ?? consumePendingAppLink();
+          switch (pending) {
+            case NotificationRouteLink(:final location):
+              await GoRouter.of(context).push<void>(location);
+            case NotificationUrlLink(:final uri):
+              await launchUrl(uri, mode: LaunchMode.externalApplication);
+            case null:
+              break;
+          }
+        });
+        return null;
+      },
+      const [],
+    );
+
+    return const Scaffold(
+      body: SafeArea(
+        child: Center(child: CircularProgressIndicator.adaptive()),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: analyze で確認**
+
+Run: `cd app && dart analyze lib/page/splash_page.dart`
+Expected: No issues (未使用 import が残らないこと)
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add app/lib/page/splash_page.dart
+git commit -m "perf: Splash を待機なしのトリガー即遷移に変更"
+```
+
+---
+
+### Task 8: 走時表消費側の非同期安全化 (graceful degradation)
+
+Splash が待たなくなったため、走時表未ロード時に `.requireValue` が例外を投げないよう消費側を安全化する。EEW 推定震度は await、P/S 波レイヤー・揺れ検知は未ロード時にスキップ。
+
+**Files:**
+- Modify: `app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart:45`
+- Modify: `app/lib/core/provider/travel_time/provider/travel_time_provider.dart` (`travelTimeDepthMap` を null 許容の安全版に)
+- Modify: `app/lib/feature/shake_detection/data/provider/shake_detection_merge_provider.dart:21`
+- Modify: `app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart:202`
+- Modify: `app/lib/feature/eew/ui/components/eew_simulation_ps_wave_layer.dart:28,127`
+- Modify: `app/lib/feature/eew/ui/components/eew_static_ps_wave_layer.dart:31`
+- Test: `app/test/feature/eew/eew_estimated_region_intensity_travel_time_test.dart` (可能な範囲で)
+
+**Interfaces:**
+- Consumes: `travelTimeInternalProvider` (`Future<TravelTimeTables>`, 既存)
+- Produces:
+  - `travelTimeProvider` は現状維持 (`.requireValue`) だが、直接消費するのは深いレイヤーのみとする。
+  - `travelTimeDepthMap(Ref)` の戻り型を `TravelTimeDepthMap?` に変更: `ref.watch(travelTimeInternalProvider).valueOrNull` が null なら null を返す。**この破壊的変更に伴い、全消費者を null 対応させる (下記)。**
+
+**設計判断:** 走時表は EEW/揺れ検知イベント (起動後のネットワーク受信) 時にのみ使われる。未ロード時は「波を描かない/マージしない」で degrade し、例外は投げない。EEW 推定震度計算 (安全上重要) は確実に await する。
+
+- [ ] **Step 1: eew_estimated_region_intensity_provider を await 化**
+
+`eew_estimated_region_intensity_provider.dart:45` を変更:
+
+```dart
+  // 変更前: final travelTimeTables = ref.read(travelTimeProvider);
+  final travelTimeTables = await ref.watch(travelTimeInternalProvider.future);
+```
+
+import に `travel_time_provider.dart` が既にあることを確認 (L8)。`travelTimeProvider` 参照が他に無ければ import はそのまま (同ファイルに `travelTimeInternalProvider` も定義されている)。
+
+- [ ] **Step 2: travelTimeDepthMap を null 許容に変更**
+
+`travel_time_provider.dart` の `travelTimeDepthMap`:
+
+```dart
+@Riverpod(keepAlive: true)
+TravelTimeDepthMap? travelTimeDepthMap(Ref ref) {
+  final tables = ref.watch(travelTimeInternalProvider).valueOrNull;
+  if (tables == null) {
+    return null;
+  }
+  return tables.table.groupListsBy((e) => e.depth);
+}
+```
+
+- [ ] **Step 3: 消費側を null 対応**
+
+各消費箇所で `travelTimeDepthMapProvider` の値が null の場合に描画/処理をスキップする:
+- `shake_detection_merge_provider.dart:21`: `final travelTimeMap = ref.watch(travelTimeDepthMapProvider);` が null なら、走時に依存する enrich をスキップし従来の非走時結果を返す (近傍ロジックに合わせる)。
+- `eew_ps_wave_layer.dart:202`: null なら空レイヤー (波なし) を返す。
+- `eew_simulation_ps_wave_layer.dart:28,127`: null ガードを追加し、null なら波描画をスキップ。
+- `eew_static_ps_wave_layer.dart:31`: null なら空レイヤーを返す。
+
+**各ファイルの近傍の返却パターン (空レイヤーの作り方) に厳密に合わせること。**
+
+- [ ] **Step 4: build_runner で再生成**
+
+Run: `cd app && dart run build_runner build --delete-conflicting-outputs`
+Expected: `travel_time_provider.g.dart` / `eew_estimated_region_intensity_provider.g.dart` が更新される
+
+- [ ] **Step 5: analyze で確認**
+
+Run: `cd app && dart analyze lib/feature/eew/ lib/core/provider/travel_time/ lib/feature/shake_detection/ lib/feature/home/ui/component/map/layer/`
+Expected: No issues (null 非対応の消費者が残っていないこと)
+
+- [ ] **Step 6: テスト実行**
+
+Run: `cd app && flutter test test/feature/eew/`
+Expected: PASS (既存 + 追加分)
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add app/lib/feature/eew/ app/lib/core/provider/travel_time/ app/lib/feature/shake_detection/ app/lib/feature/home/ui/component/map/layer/ app/test/feature/eew/
+git commit -m "fix: 走時表未ロード時に例外を投げず degrade する消費側対応"
+```
+
+---
+
+### Task 9: 走時表 CSV パースの compute 化 + パース区間計測
+
+走時表 CSV パースを短命 isolate (`compute`) へ移し、メインスレッドのジャンクを解消する。パース区間を計測して効果を可視化する。
+
+**Files:**
+- Modify: `app/lib/core/provider/travel_time/data/travel_time_data_source.dart`
+- Test: `app/test/core/provider/travel_time/travel_time_parse_test.dart`
+
+**Interfaces:**
+- Consumes: `StartupProfiler` は使わず、パース区間の計測は `travelTimeInternalProvider` 側で `Stopwatch` により行い `startupProfilerProvider.measure('travel_time_parse', micros)` で記録する (Task 4 の profiler を利用)。
+- Produces:
+  - top-level 関数 `TravelTimeTables parseTravelTimeCsv(String raw)` — compute に渡せる純粋関数 (CSV 文字列 → テーブル)。isolate 境界を越えるため top-level に置く。
+
+**設計判断:** アセット読み込み (`rootBundle.loadString`) はメインで行い、CSV 文字列 (565KB) を `compute` に渡してパースする。文字列 1 本の転送は安価。結果 `TravelTimeTables` の転送コストは Task 完了後に実機/デバッグページの `travel_time_parse` 値で確認する (効果が無ければ compute を戻す判断材料になる)。
+
+- [ ] **Step 1: パース関数を top-level に切り出すテストを書く**
+
+`app/test/core/provider/travel_time/travel_time_parse_test.dart`:
+
+```dart
+import 'package:eqmonitor/core/provider/travel_time/data/travel_time_data_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('parseTravelTimeCsv parses depth/distance/p/s rows', () {
+    // 実 CSV のヘッダ有無・列順は既存 loadTables の実装に合わせる。
+    // 既存パースと同一の結果になることを、代表 1 行で検証する。
+    const raw = '0,10,1.23,2.34';
+    final tables = parseTravelTimeCsv(raw);
+    expect(tables.table, isNotEmpty);
+    final row = tables.table.first;
+    expect(row.depth, 0);
+    expect(row.distance, 10);
+  });
+}
+```
+
+**注意:** 上記 CSV の列順・パース方法は既存 `loadTables` (`travel_time_data_source.dart:12-38`) の実装に厳密に合わせること。列順が異なる場合はテストの `raw` と期待値を実装に合わせて修正する。
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd app && flutter test test/core/provider/travel_time/travel_time_parse_test.dart`
+Expected: FAIL (`parseTravelTimeCsv` 未定義)
+
+- [ ] **Step 3: パースを top-level 関数へ抽出**
+
+`travel_time_data_source.dart` で、既存 `loadTables` のパースロジックを top-level 関数 `parseTravelTimeCsv(String raw)` に抽出し、`loadTables` は `rootBundle.loadString` の結果を `compute(parseTravelTimeCsv, raw)` に渡すよう変更する。既存のパースロジック (行分割・trim・`TravelTimeTable.fromList`) をそのまま関数内へ移すこと。
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+// ... 既存 import
+
+Future<TravelTimeTables> ... loadTables() async {
+  final raw = await rootBundle.loadString('assets/tjma2001.csv');
+  final table = await compute(parseTravelTimeCsv, raw);
+  return table;
+}
+
+/// CSV 文字列を走時テーブルへパースする。compute で isolate 実行するため
+/// top-level に置く。
+TravelTimeTables parseTravelTimeCsv(String raw) {
+  // 既存 loadTables のパースロジックをそのまま移植する
+  ...
+}
+```
+
+戻り型は既存に合わせる (`loadTables` が `TravelTimeTables` を返すなら `parseTravelTimeCsv` も `TravelTimeTables` を返す。`List<TravelTimeTable>` を返していた場合はそれに合わせ、`travelTimeInternalProvider` の組み立てを維持する)。
+
+- [ ] **Step 4: 走時表ロード区間を計測**
+
+`travel_time_provider.dart` の `travelTimeInternal` で、ロード全体を `Stopwatch` で計測し profiler に記録する:
+
+```dart
+@Riverpod(keepAlive: true)
+Future<TravelTimeTables> travelTimeInternal(Ref ref) async {
+  final dataSource = ref.watch(travelTimeDataSourceProvider);
+  final stopwatch = Stopwatch()..start();
+  final tables = TravelTimeTables(table: await dataSource.loadTables()...);
+  ref.read(startupProfilerProvider).measure(
+        'travel_time_load',
+        stopwatch.elapsedMicroseconds,
+      );
+  return tables;
+}
+```
+
+(既存の組み立てに合わせて `loadTables` の戻りを扱うこと。import に `startupProfilerProvider` を追加。)
+
+- [ ] **Step 5: テスト成功を確認**
+
+Run: `cd app && flutter test test/core/provider/travel_time/`
+Expected: PASS
+
+- [ ] **Step 6: build_runner + analyze**
+
+Run: `cd app && dart run build_runner build --delete-conflicting-outputs && dart analyze lib/core/provider/travel_time/`
+Expected: 生成物更新, No issues
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add app/lib/core/provider/travel_time/ app/test/core/provider/travel_time/
+git commit -m "perf: 走時表 CSV パースを compute へ移し区間を計測"
+```
+
+---
+
+### Task 10: パラメータパース区間の計測 (compute 化は計測判断)
+
+パラメータ JSON パースは 10MB と大きく、isolate 境界の転送コストで compute 化が逆効果になりうる。まず区間を計測し、実データで効果を判断できるようにする (compute 化自体はこの Task では行わず、計測結果に基づく follow-up とする)。
+
+**Files:**
+- Modify: `app/lib/feature/parameter/data/notifier/parameter_set_notifier.dart` もしくは `parameter_repository.dart` (パース呼び出し箇所)
+
+**Interfaces:**
+- Consumes: `startupProfilerProvider` (Task 4)
+- Produces: なし (計測のみ)
+
+**設計判断:** ユーザーの「compute が効くか」の懸念に対し、まず計測。`parameter_repository.dart` の `parseSet` / `loadAsset` 呼び出し区間を `Stopwatch` で計測し `startupProfilerProvider.measure('parameter_parse', micros)` に記録する。デバッグページ/サーバ metrics で確認後、効果が見込めれば別途 compute 化する。この方針は PR 説明に明記する。
+
+- [ ] **Step 1: パース区間を計測**
+
+パラメータのパース (JSON デシリアライズ) を行う箇所を `Stopwatch` で挟み、profiler に `parameter_parse` として記録する。`parameter_set_notifier` が Ref を持つため、そこで `ref.read(startupProfilerProvider).measure(...)` を呼ぶのが自然。パースが repository 内なら、notifier 側で「取得〜返却」全体を計測して `parameter_load` として記録する。
+
+具体: `parameter_set_notifier.dart` の `build`/`cachedBuild` 完了までを `Stopwatch` で計測し記録する。既存の 1 ファイル 1 公開 Provider ルールを壊さないこと (計測は既存 notifier 内に閉じる)。
+
+- [ ] **Step 2: analyze で確認**
+
+Run: `cd app && dart analyze lib/feature/parameter/`
+Expected: No issues
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add app/lib/feature/parameter/
+git commit -m "chore: パラメータロード区間を計測 (compute 化は計測結果で判断)"
+```
+
+---
+
+### Task 11: 全体 analyze + テスト + 仕上げ
+
+**Files:**
+- (必要に応じて) 上記各ファイル
+
+- [ ] **Step 1: 全体 analyze**
+
+Run: `melos run analyze`
+Expected: No issues across packages
+
+- [ ] **Step 2: 全体テスト**
+
+Run: `melos run test`
+Expected: PASS
+
+- [ ] **Step 3: format 確認**
+
+Run: `cd app && dart format --set-exit-if-changed lib test` (差分があれば `dart format` 実行後コミット)
+
+- [ ] **Step 4: 修正が生じたらコミット**
+
+```bash
+git add -A
+git commit -m "chore: analyze/format 修正"
+```
+
+---
+
+## 補足: PR とデプロイ
+
+全 Task 完了後、`develop` ベースで PR を作成し (`--repo YumNumm/EQMonitor`)、deploy-app ワークフローをトリガーする。PR 説明には、compute 化の効果判断がデバッグページ/サーバ metrics で可能なこと、パラメータ compute 化は計測結果に基づく follow-up であることを明記する。

--- a/docs/superpowers/specs/2026-07-07-startup-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-07-startup-optimization-design.md
@@ -1,0 +1,123 @@
+# 起動最適化 設計書
+
+- 日付: 2026-07-07
+- 対象: Flutterアプリ (`app/`)
+- 関連: SWRキャッシュ化 (地震履歴・お知らせ) は別スペックで扱う
+
+## 背景・目的
+
+アプリの起動 (Splash 含む) が遅い。原因は、起動体験に必須でない重い初期化 (走時表・観測点パラメータのパース) の完了を Splash が待ってから Home へ遷移していること、およびそれらのパースがメインスレッド同期で行われ UI をブロックすることにある。
+
+目的は「初期化はトリガーするがナビゲーションをブロックしない」体験への転換。Splash は重い Provider の完了を待たず即 Home へ遷移し、重い Provider は起動と同時にバックグラウンドで温め、使う側が `.future` / `AsyncValue` を await して各自ローディング表示する。
+
+あわせて、最適化の効果を定量判断できるよう、起動計測基盤を先に用意する。
+
+## 現状の問題 (調査結果)
+
+### Splash のゲート
+
+`app/lib/page/splash_page.dart` は次の 3 Provider がすべて `hasValue` になるまで Home 遷移しない:
+
+1. `kyoshinMonitorInternalObservationPointsConvertedProvider` — `parameterSetProvider` 経由で最大 10MB の JSON 5 ファイルをパース (キャッシュ miss 時)
+2. `travelTimeInternalProvider` — `tjma2001.csv` (565KB) をメインスレッドで同期 CSV パース
+3. `earthquakeHistoryConfigProvider` — SharedPreferences (軽量)
+
+### 消費側の前提
+
+- `travelTimeProvider` (同期) は `travelTimeInternalProvider` の `.requireValue` を返すため「ロード済み」前提。実際の消費者は EEW 発表時のみ動く `eewEstimatedRegionIntensityProvider` (`app/lib/feature/eew/data/provider/eew_estimated_region_intensity_provider.dart:45`) と `travelTimeDepthMap` のみ。EEW 側は既に async のため await へ変更可能。
+- 観測点パラメータの消費側 (地図の Kyoshin Monitor 表示・揺れ検知・現在地) は `.future` 参照済みで、ローディング状態を扱える。
+
+### main.dart の runApp 前ブロッキング
+
+`app/lib/main.dart` の `_main()` は runApp 前に次を await している。うち override 値を生まない副作用初期化は遅延可能:
+
+- `MobileAds.instance.initialize()` (L168) — 広告 SDK。起動直後不要。
+- `FlutterLocalNotificationsPlugin().initialize()` / `_registerNotificationChannelIfNeeded()` / FCM 表示オプション (L190-216) — 副作用 init。override 値を生まない。
+- `FirebaseAppCheck.instance.activate()` (L171) — API 認証トークンに使用。初回 API 呼び出しとの順序に注意。
+
+override 値が必要な処理 (SharedPreferences / PackageInfo / deviceInfo / appDir / kyoshinColorMap / telemetryDbPath / timezone) は引き続き runApp 前に必要。
+
+### 既存の計測・送信基盤
+
+`packages/telemetry_store` に `TelemetryEvent` (sealed/freezed) → `TelemetryRecorder.record` → DB → `ApiEventSender` (`POST /v2/device/me/telemetry/events`) のパイプラインが既にある。バックエンド (`backend/api/api/src/features/telemetry/routes/telemetry.ts`) は `app_launch` 以外の event_type を汎用の `client_telemetry` テーブル (event_type + payload JSON) に格納するため、**新イベント種別の追加にバックエンド変更は不要**。
+
+## 設計
+
+実装順序は「計測 → 非ブロッキング化 → main 遅延 → (計測で効果確認して) compute 化」。計測を最初に置くのは、compute 化の効果を実測で判断するため。
+
+### Phase 1: 起動計測基盤
+
+#### StartupProfiler
+
+純粋な Dart クラス (Provider や Flutter に依存しない) として実装し、単体テスト可能にする。
+
+- 責務: 起動フェーズごとの経過時間をマイクロ秒で記録・保持・シリアライズする。
+- インターフェース (案):
+  - `void mark(String phase)` — 起動基準時刻からの経過をマイクロ秒で記録。
+  - `void measure(String phase, {required int startMicros, required int endMicros})` — 区間を明示指定して記録 (isolate/非同期区間用)。
+  - `Map<String, int> get timingsMicros` — 記録済みタイミングの読み取り。
+  - `Map<String, dynamic> toPayload()` — telemetry 送信用の payload 生成。
+- 時刻源は注入可能にする (テスト時は固定値を渡せる)。`Stopwatch` もしくは注入した `int Function()` を使い、`DateTime.now()` 直呼びは避ける。
+
+#### 計測ポイント
+
+最低限:
+- main 開始 → Firebase init 完了
+- Firebase init → `.wait` ブロック完了
+- `.wait` 完了 → runApp 呼び出し
+- runApp → Home 初回フレーム (`WidgetsBinding.instance.addPostFrameCallback` 等で捕捉)
+- 走時表ロード (`travelTimeInternalProvider`) の所要
+- パラメータロード (`parameterSetProvider` / 観測点変換) の所要
+
+各パースを compute 化する Phase 4 では、パース区間も個別計測する。
+
+#### デバッグページ
+
+`app/lib/feature/settings/children/config/debug/` 配下に起動計測ページを新設。各フェーズを ms 単位で表示 (内部保持は microsec)。既存 debug ページ群のスタイル・ルーティングに合わせる。
+
+#### サーバ送信
+
+`TelemetryEvent.startupTiming` を 1 種類追加する。
+
+- payload: 各フェーズの microsec、および起動種別・端末識別に必要な最小メタ (既存 `appLaunch` を踏襲)。
+- `eventType` は `startup_timing`。
+- `TelemetryRecorder.record` → 既存アップロードパイプラインで `client_telemetry` に蓄積。バックエンド変更不要。
+- 記録は起動をブロックしない (runApp 後に fire-and-forget、例外はガードして記録)。
+
+#### テスト
+
+- `StartupProfiler` の mark / measure / `toPayload` の正しさ (時刻源を注入して決定的に検証)。
+- `TelemetryEvent.startupTiming` の `eventType` / `toPayload` のスナップショット的検証。
+
+### Phase 2: 非ブロッキング化 (Splash ゲート解体)
+
+- `splash_page.dart`: 3 Provider の待機をやめ、`ref.read` でトリガーのみ行い即 Home へ遷移する。keepAlive のためバックグラウンドでロードは継続する。
+- `.requireValue` / 同期前提の消費箇所を洗い出す:
+  - `travelTimeProvider` (sync, requireValue) の全消費者を async 安全化する。
+  - `eewEstimatedRegionIntensityProvider:45` を `ref.read(travelTimeProvider)` から `await ref.watch(travelTimeInternalProvider.future)` へ変更する。
+  - `travelTimeDepthMap` など他の同期消費者があれば同様に扱う。
+- パラメータ・観測点の消費側 (地図・揺れ検知・現在地) がロード中 UI を持つことを確認し、無ければ整備する。
+- Splash のエラー表示 (現状 `ErrorCard` + reload) は、各消費画面のローディング/エラー表示へ移す。
+
+### Phase 3: main.dart のブロッキング削減
+
+- `MobileAds.initialize`、通知プラグイン init / チャンネル登録 / FCM 表示オプションを runApp 後へ移す。
+- 例外を握りつぶさないため、`unawaited` 化する処理は必ず try/catch で `talker.error` (+ Crashlytics) に記録するガードを通す。既存の telemetry uploader (`main.dart` L266-274) の try/catch パターンに倣い、共通ヘルパー化を検討する。
+- 通知プラグイン init を遅延することで、起動直後の通知タップ処理に取りこぼしが出ないかを確認する。問題があれば当該初期化のみ runApp 前に残す。
+- `FirebaseAppCheck.activate` は、App の初回 API 呼び出し (interceptor が App Check トークンを使用) との順序を検証したうえで、安全なら並列化/遅延する。危険なら現状維持。
+
+### Phase 4: パースの compute 化 (計測で効果確認)
+
+- 走時表 CSV パース・パラメータ JSON パースを `compute()` (短命 isolate) へ移す。長寿命 isolate は作らない。
+- Phase 1 の計測でパース区間を前後比較する。10MB JSON は isolate 境界の転送コストで逆効果になりうるため、計測で改善が確認できたものだけ採用する。効果が出なかったものは見送り、その旨を log に残す (無言で打ち切らない)。
+
+## テスト方針
+
+- 単体テスト: `StartupProfiler`、`TelemetryEvent.startupTiming`、ガード付き unawaited ヘルパーの例外捕捉、async 化した走時表消費ロジック。
+- 手動/実機: Splash → Home 描画時間の計測比較、機内モード・初回起動 (キャッシュ miss) で Home が即描画され各機能が個別にローディング → データ表示になること、EEW 発表時に走時表が正しく await され推定震度が出ること。
+
+## 非対象 (Out of Scope)
+
+- 地震履歴・お知らせ一覧の SWR キャッシュ化 (別スペック)。
+- 走時表・パラメータの差分取得 API (backend、計画 A〜E)。
+- 起動計測用の専用 ClickHouse テーブル/ビューの新設 (当面は汎用 `client_telemetry` に蓄積)。

--- a/packages/telemetry_store/lib/src/models/telemetry_event.dart
+++ b/packages/telemetry_store/lib/src/models/telemetry_event.dart
@@ -124,19 +124,9 @@ sealed class TelemetryEvent with _$TelemetryEvent {
         'end_reason': endReason.name,
         'duration_ms': ?durationMs,
       },
-    ErrorTelemetryEvent(
-      :final errorType,
-      :final message,
-      :final stackTrace,
-    ) =>
-      {
-        'error_type': errorType,
-        'message': message,
-        'stack_trace': ?stackTrace,
-      },
-    StartupTimingEvent(:final phasesMicros) => {
-      'phases_micros': phasesMicros,
-    },
+    ErrorTelemetryEvent(:final errorType, :final message, :final stackTrace) =>
+      {'error_type': errorType, 'message': message, 'stack_trace': ?stackTrace},
+    StartupTimingEvent(:final phasesMicros) => {'phases_micros': phasesMicros},
     AppLaunchEvent(
       :final launchType,
       :final appVersion,

--- a/packages/telemetry_store/lib/src/models/telemetry_event.dart
+++ b/packages/telemetry_store/lib/src/models/telemetry_event.dart
@@ -47,6 +47,10 @@ sealed class TelemetryEvent with _$TelemetryEvent {
     String? stackTrace,
   }) = ErrorTelemetryEvent;
 
+  const factory TelemetryEvent.startupTiming({
+    required Map<String, int> phasesMicros,
+  }) = StartupTimingEvent;
+
   const factory TelemetryEvent.appLaunch({
     required String launchType,
     required String appVersion,
@@ -72,6 +76,7 @@ sealed class TelemetryEvent with _$TelemetryEvent {
     LiveActivityUpdatedEvent() => 'live_activity_updated',
     LiveActivityEndedEvent() => 'live_activity_ended',
     ErrorTelemetryEvent() => 'error',
+    StartupTimingEvent() => 'startup_timing',
     AppLaunchEvent() => 'app_launch',
   };
 
@@ -129,6 +134,9 @@ sealed class TelemetryEvent with _$TelemetryEvent {
         'message': message,
         'stack_trace': ?stackTrace,
       },
+    StartupTimingEvent(:final phasesMicros) => {
+      'phases_micros': phasesMicros,
+    },
     AppLaunchEvent(
       :final launchType,
       :final appVersion,

--- a/packages/telemetry_store/lib/src/models/telemetry_event.freezed.dart
+++ b/packages/telemetry_store/lib/src/models/telemetry_event.freezed.dart
@@ -83,7 +83,7 @@ return appLaunch(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( NotificationReceivedEvent value)  notificationReceived,required TResult Function( NotificationOpenedEvent value)  notificationOpened,required TResult Function( LiveActivityStartedEvent value)  liveActivityStarted,required TResult Function( LiveActivityUpdatedEvent value)  liveActivityUpdated,required TResult Function( LiveActivityEndedEvent value)  liveActivityEnded,required TResult Function( ErrorTelemetryEvent value)  error,required TResult Function( AppLaunchEvent value)  appLaunch,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( NotificationReceivedEvent value)  notificationReceived,required TResult Function( NotificationOpenedEvent value)  notificationOpened,required TResult Function( LiveActivityStartedEvent value)  liveActivityStarted,required TResult Function( LiveActivityUpdatedEvent value)  liveActivityUpdated,required TResult Function( LiveActivityEndedEvent value)  liveActivityEnded,required TResult Function( ErrorTelemetryEvent value)  error,required TResult Function( StartupTimingEvent value)  startupTiming,required TResult Function( AppLaunchEvent value)  appLaunch,}){
 final _that = this;
 switch (_that) {
 case NotificationReceivedEvent():
@@ -92,7 +92,8 @@ return notificationOpened(_that);case LiveActivityStartedEvent():
 return liveActivityStarted(_that);case LiveActivityUpdatedEvent():
 return liveActivityUpdated(_that);case LiveActivityEndedEvent():
 return liveActivityEnded(_that);case ErrorTelemetryEvent():
-return error(_that);case AppLaunchEvent():
+return error(_that);case StartupTimingEvent():
+return startupTiming(_that);case AppLaunchEvent():
 return appLaunch(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
@@ -161,7 +162,7 @@ return appLaunch(_that.launchType,_that.appVersion,_that.buildNumber,_that.platf
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( NotificationFramework framework,  String channelId,  String? title,  String? eventId,  String? priority)  notificationReceived,required TResult Function( bool coldStart,  String? eventId,  int? elapsedMs)  notificationOpened,required TResult Function( LiveActivityType activityType,  String activityId)  liveActivityStarted,required TResult Function( LiveActivityType activityType,  String activityId,  String? eventId)  liveActivityUpdated,required TResult Function( LiveActivityType activityType,  String activityId,  LiveActivityEndReason endReason,  int? durationMs)  liveActivityEnded,required TResult Function( String errorType,  String message,  String? stackTrace)  error,required TResult Function( String launchType,  String appVersion,  int buildNumber,  String platform,  String osVersion,  String deviceModel,  String locale,  bool isPhysicalDevice,  int physicalRamMb,  int cpuCores,  String manufacturer,  int? androidSdkInt,  String? securityPatch,  bool? isLowRamDevice,  String? installerStore)  appLaunch,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( NotificationFramework framework,  String channelId,  String? title,  String? eventId,  String? priority)  notificationReceived,required TResult Function( bool coldStart,  String? eventId,  int? elapsedMs)  notificationOpened,required TResult Function( LiveActivityType activityType,  String activityId)  liveActivityStarted,required TResult Function( LiveActivityType activityType,  String activityId,  String? eventId)  liveActivityUpdated,required TResult Function( LiveActivityType activityType,  String activityId,  LiveActivityEndReason endReason,  int? durationMs)  liveActivityEnded,required TResult Function( String errorType,  String message,  String? stackTrace)  error,required TResult Function( Map<String, int> phasesMicros)  startupTiming,required TResult Function( String launchType,  String appVersion,  int buildNumber,  String platform,  String osVersion,  String deviceModel,  String locale,  bool isPhysicalDevice,  int physicalRamMb,  int cpuCores,  String manufacturer,  int? androidSdkInt,  String? securityPatch,  bool? isLowRamDevice,  String? installerStore)  appLaunch,}) {final _that = this;
 switch (_that) {
 case NotificationReceivedEvent():
 return notificationReceived(_that.framework,_that.channelId,_that.title,_that.eventId,_that.priority);case NotificationOpenedEvent():
@@ -169,7 +170,8 @@ return notificationOpened(_that.coldStart,_that.eventId,_that.elapsedMs);case Li
 return liveActivityStarted(_that.activityType,_that.activityId);case LiveActivityUpdatedEvent():
 return liveActivityUpdated(_that.activityType,_that.activityId,_that.eventId);case LiveActivityEndedEvent():
 return liveActivityEnded(_that.activityType,_that.activityId,_that.endReason,_that.durationMs);case ErrorTelemetryEvent():
-return error(_that.errorType,_that.message,_that.stackTrace);case AppLaunchEvent():
+return error(_that.errorType,_that.message,_that.stackTrace);case StartupTimingEvent():
+return startupTiming(_that.phasesMicros);case AppLaunchEvent():
 return appLaunch(_that.launchType,_that.appVersion,_that.buildNumber,_that.platform,_that.osVersion,_that.deviceModel,_that.locale,_that.isPhysicalDevice,_that.physicalRamMb,_that.cpuCores,_that.manufacturer,_that.androidSdkInt,_that.securityPatch,_that.isLowRamDevice,_that.installerStore);}
 }
 /// A variant of `when` that fallback to returning `null`
@@ -619,6 +621,72 @@ errorType: null == errorType ? _self.errorType : errorType // ignore: cast_nulla
 as String,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as String,stackTrace: freezed == stackTrace ? _self.stackTrace : stackTrace // ignore: cast_nullable_to_non_nullable
 as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class StartupTimingEvent extends TelemetryEvent {
+  const StartupTimingEvent({required this.phasesMicros}): super._();
+
+
+ final  Map<String, int> phasesMicros;
+
+/// Create a copy of TelemetryEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$StartupTimingEventCopyWith<StartupTimingEvent> get copyWith => _$StartupTimingEventCopyWithImpl<StartupTimingEvent>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StartupTimingEvent&&(identical(other.phasesMicros, phasesMicros) || other.phasesMicros == phasesMicros));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,phasesMicros);
+
+@override
+String toString() {
+  return 'TelemetryEvent.startupTiming(phasesMicros: $phasesMicros)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $StartupTimingEventCopyWith<$Res> implements $TelemetryEventCopyWith<$Res> {
+  factory $StartupTimingEventCopyWith(StartupTimingEvent value, $Res Function(StartupTimingEvent) _then) = _$StartupTimingEventCopyWithImpl;
+@useResult
+$Res call({
+ Map<String, int> phasesMicros
+});
+
+
+
+
+}
+/// @nodoc
+class _$StartupTimingEventCopyWithImpl<$Res>
+    implements $StartupTimingEventCopyWith<$Res> {
+  _$StartupTimingEventCopyWithImpl(this._self, this._then);
+
+  final StartupTimingEvent _self;
+  final $Res Function(StartupTimingEvent) _then;
+
+/// Create a copy of TelemetryEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? phasesMicros = null,}) {
+  return _then(StartupTimingEvent(
+phasesMicros: null == phasesMicros ? _self.phasesMicros : phasesMicros // ignore: cast_nullable_to_non_nullable
+as Map<String, int>,
   ));
 }
 

--- a/packages/telemetry_store/test/startup_timing_event_test.dart
+++ b/packages/telemetry_store/test/startup_timing_event_test.dart
@@ -1,0 +1,23 @@
+import 'package:telemetry_store/src/models/telemetry_event.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('startupTiming has correct eventType', () {
+    const event = TelemetryEvent.startupTiming(phasesMicros: {'run_app': 1200});
+    expect(event.eventType, 'startup_timing');
+  });
+
+  test('startupTiming toPayload nests phases_micros', () {
+    const event = TelemetryEvent.startupTiming(
+      phasesMicros: {'firebase_init': 1500, 'run_app': 4200},
+    );
+    expect(event.toPayload(), {
+      'phases_micros': {'firebase_init': 1500, 'run_app': 4200},
+    });
+  });
+
+  test('startupTiming eventId is null', () {
+    const event = TelemetryEvent.startupTiming(phasesMicros: {});
+    expect(event.eventId, isNull);
+  });
+}


### PR DESCRIPTION
## 概要

アプリ起動 (Splash 含む) を、重い初期化でナビゲーションをブロックしない体験へ転換し、効果を定量計測できる基盤を追加します。

- 設計: `docs/superpowers/specs/2026-07-07-startup-optimization-design.md`
- 計画: `docs/superpowers/plans/2026-07-07-startup-optimization.md`

## 背景

Splash が「走時表 + 観測点パラメータ + 地震履歴設定」の全ロード完了を待ってから Home へ遷移していたため、起動体験に必須でない重い初期化 (走時表 CSV / 最大 10MB の JSON パース) が起動をブロックしていました。加えて、機内モードや初回起動 (キャッシュ miss) では待ち時間がそのまま体感遅延になっていました。

## 変更点

### 1. 起動計測基盤 (先に導入して効果を実測できるように)
- `StartupProfiler` (純粋 Dart クラス, マイクロ秒記録, clock 注入でテスト可能)
- 各フェーズを計測: `firebase_init` / `parallel_init` / `before_run_app` / `home_first_frame` / `travel_time_load` / `parameter_load`
- デバッグページ「Startup Timing」を追加 (設定 > デバッグ、ms 表示)
- `TelemetryEvent.startupTiming` を追加し既存 telemetry パイプラインでサーバへ送信 (バックエンド変更不要 — `client_telemetry` に汎用格納)。**travel_time_load / parameter_load はバックグラウンド完了を待ってから送信**するので payload に含まれます

### 2. Splash 非ブロッキング化
- Splash は 3 プロバイダを **トリガーのみ** (keepAlive で裏ロード継続) し即 Home へ遷移
- ゲート/ErrorCard を撤去。各消費画面が個別にローディング/エラー表示

### 3. 走時表消費側の graceful degradation
- 走時表は EEW 発表時のみ使用。未ロード時に `.requireValue` で例外を投げないよう修正
- EEW 推定震度計算は `await travelTimeInternalProvider.future` で確実に待機 (安全側)
- P/S 波レイヤー・揺れ検知マージは未ロード時に描画/enrich をスキップ (例外なし)

### 4. main.dart のブロッキング削減 (例外はガード記録)
- `MobileAds` / ローカル通知 init / 通知チャンネル登録 / FCM 表示オプションを runApp 後へ遅延
- `guardedUnawaited` ヘルパー経由で実行し、例外は必ず `talker.error` に記録 (握りつぶさない)
- `FirebaseAppCheck.activate()` は API 認証で必要なため runApp 前に維持

### 5. 走時表 CSV パースを compute へ / パラメータは計測のみ
- 走時表 CSV パースを短命 isolate (`compute`) へ移しメインスレッドのジャンクを解消
- パラメータ JSON (最大 10MB) は isolate 境界の転送コストで逆効果になりうるため、**まず計測**して実データで compute 化を判断する方針 (計測のみ実装)。デバッグページ / サーバ metrics の `travel_time_load` `parameter_load` で効果を確認できます

## 検証

- 単体/対象テスト green: app (startup / util / travel_time / eew / shake) 105/105、telemetry_store 33/33
- `dart format` 適用済み
- 既知の pre-existing 失敗 `parameter_repository_refresh_test.dart` (`SHINDO_DB_STATIONS`) は本 PR 無関係 (パラメータパース未変更)

## 実装メモ

- 本リポジトリは build_runner が恒常故障 (drift_dev/analyzer 非互換 + freezed↔riverpod_generator の analyzer 版数非互換) のため、freezed は手動編集、`travel_time_provider.g.dart` の nullable 化は手パッチ (プロジェクトの既知回避策)。生成ハッシュのズレは debug 用途のみで影響なし
- レビュー: 各タスクごとの spec/品質レビュー + 全ブランチレビュー (最終判定 READY) を実施済み

## フォローアップ候補 (本 PR ではスコープ外)

- パラメータパースの compute 化 (本 PR の計測結果を見て判断)
- 未使用になった同期 `travelTimeProvider` の削除 (無害)

https://claude.ai/code/session_016kNc5tMmW5x7a4A4ms83EB
