### PR TITLE
fix(earthquake_history): フィルターチップ押下時UIの不具合修正と一貫性向上

### DIFF
--- a/app/lib/core/component/chip/datasource_filter_chip.dart
+++ b/app/lib/core/component/chip/datasource_filter_chip.dart
@@ -14,13 +14,14 @@ class DatasourceFilterChip extends StatelessWidget {
 
     return RawChip(
       onSelected: (_) async {
-        final result = await showModalBottomSheet<EarthquakeDataSource?>(
-          clipBehavior: Clip.antiAlias,
-          context: context,
-          builder: (context) => _DatasourceFilterModal(current: datasource),
-        );
-        if (result != null || context.mounted) {
-          onChanged?.call(result);
+        final result =
+            await showModalBottomSheet<({EarthquakeDataSource? value})?>(
+              clipBehavior: Clip.antiAlias,
+              context: context,
+              builder: (context) => _DatasourceFilterModal(current: datasource),
+            );
+        if (result != null && context.mounted) {
+          onChanged?.call(result.value);
         }
       },
       label: isActive
@@ -60,40 +61,44 @@ class _DatasourceFilterModal extends StatelessWidget {
     );
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              'データソース',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                'データソース',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 8),
-          for (final ds in EarthquakeDataSource.values)
+            const SizedBox(height: 8),
+            for (final ds in EarthquakeDataSource.values)
+              ListTile(
+                title: Text(ds.label),
+                subtitle: Text(ds.description),
+                trailing: current == ds
+                    ? Icon(Icons.check, color: designSystem.colorTheme.primary)
+                    : null,
+                onTap: () => Navigator.of(context).pop((value: ds)),
+              ),
             ListTile(
-              title: Text(ds.label),
-              subtitle: Text(ds.description),
-              trailing: current == ds
+              title: const Text('すべて'),
+              subtitle: const Text('データソースで絞り込まない'),
+              trailing: current == null
                   ? Icon(Icons.check, color: designSystem.colorTheme.primary)
                   : null,
-              onTap: () => Navigator.of(context).pop(ds),
+              onTap: () => Navigator.of(
+                context,
+              ).pop((value: null as EarthquakeDataSource?)),
             ),
-          ListTile(
-            title: const Text('すべて'),
-            subtitle: const Text('データソースで絞り込まない'),
-            trailing: current == null
-                ? Icon(Icons.check, color: designSystem.colorTheme.primary)
-                : null,
-            onTap: () => Navigator.of(context).pop(),
-          ),
-          const SizedBox(height: 8),
-        ],
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/core/component/chip/date_range_filter_chip.dart
+++ b/app/lib/core/component/chip/date_range_filter_chip.dart
@@ -18,6 +18,15 @@ class DateRangeFilterChip extends StatelessWidget {
 
   static final format = DateFormat('yyyy/MM/dd');
 
+  @visibleForTesting
+  static DateTimeRange? clampInitialDateRange(DateTime? min, DateTime? max) {
+    if (min == null || max == null) return null;
+    final start = min.isBefore(initialMin) ? initialMin : min;
+    final end = max.isAfter(initialMax) ? initialMax : max;
+    if (start.isAfter(end)) return null;
+    return DateTimeRange(start: start, end: end);
+  }
+
   @override
   Widget build(BuildContext context) {
     final range = (min, max);
@@ -31,6 +40,7 @@ class DateRangeFilterChip extends StatelessWidget {
           currentDate: DateTime.now(),
           locale: const Locale('ja'),
           initialEntryMode: DatePickerEntryMode.input,
+          initialDateRange: clampInitialDateRange(min, max),
         );
         if (result != null) {
           onChanged?.call(result.start, result.end);

--- a/app/lib/core/component/chip/depth_filter_chip.dart
+++ b/app/lib/core/component/chip/depth_filter_chip.dart
@@ -81,59 +81,62 @@ class _DepthFilterModal extends HookWidget {
     );
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              '震源の深さ',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                '震源の深さ',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 24),
-          RangeSlider(
-            values: RangeValues(min.value.toDouble(), max.value.toDouble()),
-            min: initialMin.toDouble(),
-            max: initialMax.toDouble(),
-            onChanged: (state) {
-              min.value =
-                  (state.start.toInt() / 10).roundToDouble().toInt() * 10;
-              max.value = (state.end.toInt() / 10).roundToDouble().toInt() * 10;
-            },
-            labels: RangeLabels('${min.value}km', '${max.value}km'),
-            divisions: (initialMax - initialMin) ~/ 10,
-          ),
-          const SizedBox(height: 16),
-          Center(
-            child: Text(
-              (min.value, max.value).toRangeString,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                fontWeight: FontWeight.bold,
+            const SizedBox(height: 24),
+            RangeSlider(
+              values: RangeValues(min.value.toDouble(), max.value.toDouble()),
+              min: initialMin.toDouble(),
+              max: initialMax.toDouble(),
+              onChanged: (state) {
+                min.value =
+                    (state.start.toInt() / 10).roundToDouble().toInt() * 10;
+                max.value =
+                    (state.end.toInt() / 10).roundToDouble().toInt() * 10;
+              },
+              labels: RangeLabels('${min.value}km', '${max.value}km'),
+              divisions: (initialMax - initialMin) ~/ 10,
+            ),
+            const SizedBox(height: 16),
+            Center(
+              child: Text(
+                (min.value, max.value).toRangeString,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('キャンセル'),
-              ),
-              TextButton(
-                onPressed: () =>
-                    Navigator.of(context).pop((min.value, max.value)),
-                child: const Text('完了'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-        ],
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () =>
+                      Navigator.of(context).pop((min.value, max.value)),
+                  child: const Text('完了'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }
@@ -143,8 +146,8 @@ extension _MinMaxint on (int?, int?) {
   int? get min => this.$1;
   int? get max => this.$2;
 
-  bool get isMinSelected => min == 0 || min == null;
-  bool get isMaxSelected => max == 700 || max == null;
+  bool get isMinSelected => min == DepthFilterChip.initialMin || min == null;
+  bool get isMaxSelected => max == DepthFilterChip.initialMax || max == null;
 
   bool get isAllSelected => isMinSelected && isMaxSelected;
 

--- a/app/lib/core/component/chip/earthquake_type_filter_chip.dart
+++ b/app/lib/core/component/chip/earthquake_type_filter_chip.dart
@@ -81,15 +81,6 @@ class _EarthquakeTypeFilterModal extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 8),
-            ListTile(
-              title: const Text('すべて'),
-              subtitle: const Text('種別で絞り込まない'),
-              trailing: currentType == null
-                  ? Icon(Icons.check, color: designSystem.colorTheme.primary)
-                  : null,
-              onTap: () =>
-                  Navigator.of(context).pop((value: null as EarthquakeType?)),
-            ),
             ...EarthquakeType.values.map(
               (type) => ListTile(
                 title: Text(type.displayLabel),
@@ -98,6 +89,15 @@ class _EarthquakeTypeFilterModal extends StatelessWidget {
                     : null,
                 onTap: () => Navigator.of(context).pop((value: type)),
               ),
+            ),
+            ListTile(
+              title: const Text('すべて'),
+              subtitle: const Text('種別で絞り込まない'),
+              trailing: currentType == null
+                  ? Icon(Icons.check, color: designSystem.colorTheme.primary)
+                  : null,
+              onTap: () =>
+                  Navigator.of(context).pop((value: null as EarthquakeType?)),
             ),
             const SizedBox(height: 8),
           ],

--- a/app/lib/core/component/chip/earthquake_type_filter_chip.dart
+++ b/app/lib/core/component/chip/earthquake_type_filter_chip.dart
@@ -18,15 +18,14 @@ class EarthquakeTypeFilterChip extends StatelessWidget {
 
     return RawChip(
       onSelected: (_) async {
-        final result = await showModalBottomSheet<EarthquakeType?>(
+        final result = await showModalBottomSheet<({EarthquakeType? value})?>(
           clipBehavior: Clip.antiAlias,
           context: context,
-          builder: (context) => _EarthquakeTypeFilterModal(
-            currentType: earthquakeType,
-          ),
+          builder: (context) =>
+              _EarthquakeTypeFilterModal(currentType: earthquakeType),
         );
-        if (result != null || !context.mounted) {
-          onChanged?.call(result);
+        if (result != null && context.mounted) {
+          onChanged?.call(result.value);
         }
       },
       label: isDefault
@@ -66,32 +65,43 @@ class _EarthquakeTypeFilterModal extends StatelessWidget {
     );
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              '地震種別',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                '地震種別',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 8),
-          ...EarthquakeType.values.map(
-            (type) => ListTile(
-              title: Text(type.displayLabel),
-              trailing: currentType == type
+            const SizedBox(height: 8),
+            ListTile(
+              title: const Text('すべて'),
+              subtitle: const Text('種別で絞り込まない'),
+              trailing: currentType == null
                   ? Icon(Icons.check, color: designSystem.colorTheme.primary)
                   : null,
-              onTap: () => Navigator.of(context).pop(type),
+              onTap: () =>
+                  Navigator.of(context).pop((value: null as EarthquakeType?)),
             ),
-          ),
-          const SizedBox(height: 8),
-        ],
+            ...EarthquakeType.values.map(
+              (type) => ListTile(
+                title: Text(type.displayLabel),
+                trailing: currentType == type
+                    ? Icon(Icons.check, color: designSystem.colorTheme.primary)
+                    : null,
+                onTap: () => Navigator.of(context).pop((value: type)),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/core/component/chip/intensity_filter_chip.dart
+++ b/app/lib/core/component/chip/intensity_filter_chip.dart
@@ -97,60 +97,65 @@ class _IntensityFilterModal extends HookWidget {
         _sliderValues[i.clamp(0, _sliderValues.length - 1)];
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              '最大観測震度',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                '最大観測震度',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 24),
-          RangeSlider(
-            values: RangeValues(
-              valueToIndex(min.value).toDouble(),
-              valueToIndex(max.value).toDouble(),
+            const SizedBox(height: 24),
+            RangeSlider(
+              values: RangeValues(
+                valueToIndex(min.value).toDouble(),
+                valueToIndex(max.value).toDouble(),
+              ),
+              max: (_sliderValues.length - 1).toDouble(),
+              onChanged: (state) {
+                min.value = indexToValue(state.start.toInt());
+                max.value = indexToValue(state.end.toInt());
+              },
+              labels: RangeLabels(
+                '震度${min.value.label}',
+                '震度${max.value.label}',
+              ),
+              divisions: _sliderValues.length - 1,
             ),
-            max: (_sliderValues.length - 1).toDouble(),
-            onChanged: (state) {
-              min.value = indexToValue(state.start.toInt());
-              max.value = indexToValue(state.end.toInt());
-            },
-            labels: RangeLabels('震度${min.value.label}', '震度${max.value.label}'),
-            divisions: _sliderValues.length - 1,
-          ),
-          const SizedBox(height: 16),
-          Center(
-            child: Text(
-              (min.value, max.value).toRangeString,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                fontWeight: FontWeight.bold,
+            const SizedBox(height: 16),
+            Center(
+              child: Text(
+                (min.value, max.value).toRangeString,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('キャンセル'),
-              ),
-              TextButton(
-                onPressed: () =>
-                    Navigator.of(context).pop((min.value, max.value)),
-                child: const Text('完了'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-        ],
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () =>
+                      Navigator.of(context).pop((min.value, max.value)),
+                  child: const Text('完了'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/core/component/chip/lat_lng_filter_chip.dart
+++ b/app/lib/core/component/chip/lat_lng_filter_chip.dart
@@ -156,13 +156,21 @@ class _LatLngFilterModal extends HookWidget {
     var lngLteErr = (nlv != null && (nlv < -180 || nlv > 180))
         ? '-180〜180の範囲'
         : null;
-    if (lgv != null && llv != null && lgv > llv) {
-      latGteErr ??= '南≦北の順で入力';
-      latLteErr ??= '南≦北の順で入力';
+    if (lgv != null &&
+        llv != null &&
+        latGteErr == null &&
+        latLteErr == null &&
+        lgv > llv) {
+      latGteErr = '南≦北の順で入力';
+      latLteErr = '南≦北の順で入力';
     }
-    if (ngv != null && nlv != null && ngv > nlv) {
-      lngGteErr ??= '西≦東の順で入力';
-      lngLteErr ??= '西≦東の順で入力';
+    if (ngv != null &&
+        nlv != null &&
+        lngGteErr == null &&
+        lngLteErr == null &&
+        ngv > nlv) {
+      lngGteErr = '西≦東の順で入力';
+      lngLteErr = '西≦東の順で入力';
     }
     final isValid =
         latGteErr == null &&
@@ -341,6 +349,14 @@ class _CoordField extends HookWidget {
     final controller = useTextEditingController(
       text: value == null ? '' : value.toString(),
     );
+
+    useEffect(() {
+      final current = double.tryParse(controller.text);
+      if (value != current) {
+        controller.text = value == null ? '' : value.toString();
+      }
+      return null;
+    }, [value]);
 
     return TextField(
       controller: controller,

--- a/app/lib/core/component/chip/lat_lng_filter_chip.dart
+++ b/app/lib/core/component/chip/lat_lng_filter_chip.dart
@@ -139,6 +139,37 @@ class _LatLngFilterModal extends HookWidget {
     final lngGte = useState<double?>(longitudeGte);
     final lngLte = useState<double?>(longitudeLte);
 
+    final lgv = latGte.value;
+    final llv = latLte.value;
+    final ngv = lngGte.value;
+    final nlv = lngLte.value;
+
+    var latGteErr = (lgv != null && (lgv < -90 || lgv > 90))
+        ? '-90〜90の範囲'
+        : null;
+    var latLteErr = (llv != null && (llv < -90 || llv > 90))
+        ? '-90〜90の範囲'
+        : null;
+    var lngGteErr = (ngv != null && (ngv < -180 || ngv > 180))
+        ? '-180〜180の範囲'
+        : null;
+    var lngLteErr = (nlv != null && (nlv < -180 || nlv > 180))
+        ? '-180〜180の範囲'
+        : null;
+    if (lgv != null && llv != null && lgv > llv) {
+      latGteErr ??= '南≦北の順で入力';
+      latLteErr ??= '南≦北の順で入力';
+    }
+    if (ngv != null && nlv != null && ngv > nlv) {
+      lngGteErr ??= '西≦東の順で入力';
+      lngLteErr ??= '西≦東の順で入力';
+    }
+    final isValid =
+        latGteErr == null &&
+        latLteErr == null &&
+        lngGteErr == null &&
+        lngLteErr == null;
+
     final theme = Theme.of(context);
     final designSystem = context.designSystem;
     final sheetBar = Container(
@@ -167,116 +198,125 @@ class _LatLngFilterModal extends HookWidget {
         padding: EdgeInsets.only(
           bottom: MediaQuery.of(context).viewInsets.bottom,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Center(child: sheetBar),
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-              child: Text(
-                '緯度経度範囲',
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(child: sheetBar),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: 8,
+                  horizontal: 16,
+                ),
+                child: Text(
+                  '緯度経度範囲',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Wrap(
-                spacing: 8,
-                children: [
-                  for (final preset in LatLngFilterChip._presets)
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Wrap(
+                  spacing: 8,
+                  children: [
+                    for (final preset in LatLngFilterChip._presets)
+                      ActionChip(
+                        label: Text(preset.label),
+                        onPressed: () => applyPreset(preset.range),
+                      ),
                     ActionChip(
-                      label: Text(preset.label),
-                      onPressed: () => applyPreset(preset.range),
+                      label: const Text('クリア'),
+                      onPressed: () {
+                        latGte.value = null;
+                        latLte.value = null;
+                        lngGte.value = null;
+                        lngLte.value = null;
+                      },
                     ),
-                  ActionChip(
-                    label: const Text('クリア'),
-                    onPressed: () {
-                      latGte.value = null;
-                      latLte.value = null;
-                      lngGte.value = null;
-                      lngLte.value = null;
-                    },
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 16),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: _CoordField(
-                      label: '緯度(南)',
-                      value: latGte.value,
-                      onChanged: (v) => latGte.value = v,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  const Text('~'),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: _CoordField(
-                      label: '緯度(北)',
-                      value: latLte.value,
-                      onChanged: (v) => latLte.value = v,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: _CoordField(
-                      label: '経度(西)',
-                      value: lngGte.value,
-                      onChanged: (v) => lngGte.value = v,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  const Text('~'),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: _CoordField(
-                      label: '経度(東)',
-                      value: lngLte.value,
-                      onChanged: (v) => lngLte.value = v,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('キャンセル'),
+                  ],
                 ),
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(
-                    (
-                      latitudeGte: latGte.value,
-                      latitudeLte: latLte.value,
-                      longitudeGte: lngGte.value,
-                      longitudeLte: lngLte.value,
+              ),
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: _CoordField(
+                        label: '緯度(南)',
+                        value: latGte.value,
+                        errorText: latGteErr,
+                        onChanged: (v) => latGte.value = v,
+                      ),
                     ),
-                  ),
-                  child: const Text('完了'),
+                    const SizedBox(width: 8),
+                    const Text('~'),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: _CoordField(
+                        label: '緯度(北)',
+                        value: latLte.value,
+                        errorText: latLteErr,
+                        onChanged: (v) => latLte.value = v,
+                      ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
-            const SizedBox(height: 8),
-          ],
+              ),
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: _CoordField(
+                        label: '経度(西)',
+                        value: lngGte.value,
+                        errorText: lngGteErr,
+                        onChanged: (v) => lngGte.value = v,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    const Text('~'),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: _CoordField(
+                        label: '経度(東)',
+                        value: lngLte.value,
+                        errorText: lngLteErr,
+                        onChanged: (v) => lngLte.value = v,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('キャンセル'),
+                  ),
+                  TextButton(
+                    onPressed: isValid
+                        ? () => Navigator.of(context).pop((
+                            latitudeGte: latGte.value,
+                            latitudeLte: latLte.value,
+                            longitudeGte: lngGte.value,
+                            longitudeLte: lngLte.value,
+                          ))
+                        : null,
+                    child: const Text('完了'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
         ),
       ),
     );
@@ -288,16 +328,18 @@ class _CoordField extends HookWidget {
     required this.label,
     required this.value,
     required this.onChanged,
+    this.errorText,
   });
 
   final String label;
   final double? value;
   final ValueChanged<double?> onChanged;
+  final String? errorText;
 
   @override
   Widget build(BuildContext context) {
     final controller = useTextEditingController(
-      text: value?.toStringAsFixed(1) ?? '',
+      text: value == null ? '' : value.toString(),
     );
 
     return TextField(
@@ -311,6 +353,7 @@ class _CoordField extends HookWidget {
         border: const OutlineInputBorder(),
         isDense: true,
         suffixText: '°',
+        errorText: errorText,
       ),
       onChanged: (text) {
         final parsed = double.tryParse(text);

--- a/app/lib/core/component/chip/lpgm_intensity_filter_chip.dart
+++ b/app/lib/core/component/chip/lpgm_intensity_filter_chip.dart
@@ -25,10 +25,8 @@ class LpgmIntensityFilterChip extends StatelessWidget {
             await showModalBottomSheet<(JmaLpgmIntensity?, JmaLpgmIntensity?)?>(
               clipBehavior: Clip.antiAlias,
               context: context,
-              builder: (context) => _LpgmIntensityFilterModal(
-                currentMin: min,
-                currentMax: max,
-              ),
+              builder: (context) =>
+                  _LpgmIntensityFilterModal(currentMin: min, currentMax: max),
             );
         if (result != null) {
           onChanged?.call(result.$1, result.$2);
@@ -104,68 +102,70 @@ class _LpgmIntensityFilterModal extends HookWidget {
         _values[i.clamp(0, _values.length - 1)];
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              '長周期地震動階級',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                '長周期地震動階級',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 24),
-          RangeSlider(
-            values: RangeValues(
-              valueToIndex(min.value).toDouble(),
-              valueToIndex(max.value).toDouble(),
+            const SizedBox(height: 24),
+            RangeSlider(
+              values: RangeValues(
+                valueToIndex(min.value).toDouble(),
+                valueToIndex(max.value).toDouble(),
+              ),
+              max: (_values.length - 1).toDouble(),
+              onChanged: (state) {
+                min.value = indexToValue(state.start.toInt());
+                max.value = indexToValue(state.end.toInt());
+              },
+              labels: RangeLabels(
+                '階級${min.value.label}',
+                '階級${max.value.label}',
+              ),
+              divisions: _values.length - 1,
             ),
-            max: (_values.length - 1).toDouble(),
-            onChanged: (state) {
-              min.value = indexToValue(state.start.toInt());
-              max.value = indexToValue(state.end.toInt());
-            },
-            labels: RangeLabels(
-              '階級${min.value.label}',
-              '階級${max.value.label}',
-            ),
-            divisions: _values.length - 1,
-          ),
-          const SizedBox(height: 16),
-          Center(
-            child: Text(
-              LpgmIntensityFilterChip._rangeString(min.value, max.value),
-              style: theme.textTheme.bodyLarge?.copyWith(
-                fontWeight: FontWeight.bold,
+            const SizedBox(height: 16),
+            Center(
+              child: Text(
+                LpgmIntensityFilterChip._rangeString(min.value, max.value),
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('キャンセル'),
-              ),
-              TextButton(
-                onPressed: () {
-                  final isDefault =
-                      min.value == _values.first && max.value == _values.last;
-                  Navigator.of(context).pop(
-                    isDefault ? (null, null) : (min.value, max.value),
-                  );
-                },
-                child: const Text('完了'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-        ],
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    final isDefault =
+                        min.value == _values.first && max.value == _values.last;
+                    Navigator.of(
+                      context,
+                    ).pop(isDefault ? (null, null) : (min.value, max.value));
+                  },
+                  child: const Text('完了'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/core/component/chip/magnitude_filter_chip.dart
+++ b/app/lib/core/component/chip/magnitude_filter_chip.dart
@@ -78,62 +78,64 @@ class _MagnitudeFilterModal extends HookWidget {
     );
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              'マグニチュード',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                'マグニチュード',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 24),
-          RangeSlider(
-            values: RangeValues(min.value, max.value),
-            max: 9,
-            onChanged: (state) {
-              // 小数第1位以下切り捨て
-              min.value = (state.start * 10).floorToDouble() / 10;
-              max.value = (state.end * 10).floorToDouble() / 10;
-            },
-            labels: RangeLabels('M${min.value}', 'M${max.value}'),
-            divisions:
-                (MagnitudeFilterChip.initialMax -
-                        MagnitudeFilterChip.initialMin)
-                    .toInt() *
-                10,
-          ),
-          const SizedBox(height: 16),
-          Center(
-            child: Text(
-              (min.value, max.value).toRangeString,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                fontWeight: FontWeight.bold,
+            const SizedBox(height: 24),
+            RangeSlider(
+              values: RangeValues(min.value, max.value),
+              max: 9,
+              onChanged: (state) {
+                // 小数第1位以下切り捨て
+                min.value = (state.start * 10).floorToDouble() / 10;
+                max.value = (state.end * 10).floorToDouble() / 10;
+              },
+              labels: RangeLabels('M${min.value}', 'M${max.value}'),
+              divisions:
+                  (MagnitudeFilterChip.initialMax -
+                          MagnitudeFilterChip.initialMin)
+                      .toInt() *
+                  10,
+            ),
+            const SizedBox(height: 16),
+            Center(
+              child: Text(
+                (min.value, max.value).toRangeString,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('キャンセル'),
-              ),
-              TextButton(
-                onPressed: () =>
-                    Navigator.of(context).pop((min.value, max.value)),
-                child: const Text('完了'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-        ],
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () =>
+                      Navigator.of(context).pop((min.value, max.value)),
+                  child: const Text('完了'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/core/component/chip/status_filter_chip.dart
+++ b/app/lib/core/component/chip/status_filter_chip.dart
@@ -74,57 +74,65 @@ class _StatusFilterModal extends HookWidget {
     );
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              'ステータス',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                'ステータス',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 8),
-          ...TelegramStatus.values.map(
-            (status) => CheckboxListTile(
-              title: Text(status.label),
-              subtitle: Text(status.description),
-              value: selectedStatuses.value.contains(status),
-              onChanged: (checked) {
-                final newSet = Set<TelegramStatus>.from(selectedStatuses.value);
-                if (checked ?? false) {
-                  newSet.add(status);
-                } else {
-                  // 最低1つは選択されている必要がある
-                  if (newSet.length > 1) {
-                    newSet.remove(status);
+            const SizedBox(height: 8),
+            ...TelegramStatus.values.map(
+              (status) => CheckboxListTile(
+                title: Text(status.label),
+                subtitle: Text(status.description),
+                value: selectedStatuses.value.contains(status),
+                enabled:
+                    !(selectedStatuses.value.contains(status) &&
+                        selectedStatuses.value.length == 1),
+                onChanged: (checked) {
+                  final newSet = Set<TelegramStatus>.from(
+                    selectedStatuses.value,
+                  );
+                  if (checked ?? false) {
+                    newSet.add(status);
+                  } else {
+                    // 最低1つは選択されている必要がある
+                    if (newSet.length > 1) {
+                      newSet.remove(status);
+                    }
                   }
-                }
-                selectedStatuses.value = newSet;
-              },
+                  selectedStatuses.value = newSet;
+                },
+              ),
             ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('キャンセル'),
-              ),
-              TextButton(
-                onPressed: () =>
-                    Navigator.of(context).pop(selectedStatuses.value.toList()),
-                child: const Text('完了'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-        ],
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(
+                    context,
+                  ).pop(selectedStatuses.value.toList()),
+                  child: const Text('完了'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/core/component/chip/telegram_type_filter_chip.dart
+++ b/app/lib/core/component/chip/telegram_type_filter_chip.dart
@@ -82,58 +82,65 @@ class _TelegramTypeFilterModal extends HookWidget {
     );
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(child: sheetBar),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-            child: Text(
-              '電文種別',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
-          const SizedBox(height: 8),
-          ...EarthquakeTelegramType.values.map(
-            (type) => CheckboxListTile(
-              title: Text(type.label),
-              subtitle: Text(type.description),
-              value: selected.value.contains(type),
-              onChanged: (checked) {
-                final newSet = Set<EarthquakeTelegramType>.from(selected.value);
-                if (checked ?? false) {
-                  newSet.add(type);
-                } else {
-                  if (newSet.length > 1) {
-                    newSet.remove(type);
-                  }
-                }
-                selected.value = newSet;
-              },
-            ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('キャンセル'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(
-                  selected.value.toList()
-                    ..sort((a, b) => a.index.compareTo(b.index)),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(child: sheetBar),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Text(
+                '電文種別',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
                 ),
-                child: const Text('完了'),
               ),
-            ],
-          ),
-          const SizedBox(height: 8),
-        ],
+            ),
+            const SizedBox(height: 8),
+            ...EarthquakeTelegramType.values.map(
+              (type) => CheckboxListTile(
+                title: Text(type.label),
+                subtitle: Text(type.description),
+                value: selected.value.contains(type),
+                enabled:
+                    !(selected.value.contains(type) &&
+                        selected.value.length == 1),
+                onChanged: (checked) {
+                  final newSet = Set<EarthquakeTelegramType>.from(
+                    selected.value,
+                  );
+                  if (checked ?? false) {
+                    newSet.add(type);
+                  } else {
+                    if (newSet.length > 1) {
+                      newSet.remove(type);
+                    }
+                  }
+                  selected.value = newSet;
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(
+                    selected.value.toList()
+                      ..sort((a, b) => a.index.compareTo(b.index)),
+                  ),
+                  child: const Text('完了'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/app/test/core/component/chip/datasource_filter_chip_test.dart
+++ b/app/test/core/component/chip/datasource_filter_chip_test.dart
@@ -1,0 +1,82 @@
+import 'package:eqmonitor/core/component/chip/datasource_filter_chip.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap({
+    EarthquakeDataSource? datasource,
+    ValueChanged<EarthquakeDataSource?>? onChanged,
+  }) => ProviderScope(
+    child: MaterialApp(
+      theme: ThemeData.light().copyWith(
+        extensions: <ThemeExtension<dynamic>>[
+          DesignSystemThemeExtension.light(),
+        ],
+      ),
+      home: Scaffold(
+        body: DatasourceFilterChip(
+          datasource: datasource,
+          onChanged: onChanged,
+        ),
+      ),
+    ),
+  );
+
+  testWidgets('(a) dismiss でonChangedが呼ばれない', (tester) async {
+    var callCount = 0;
+    await tester.pumpWidget(wrap(onChanged: (_) => callCount++));
+    await tester.pump();
+
+    // Open the sheet
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    // Tap the barrier (top-left corner, outside the bottom sheet)
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    expect(callCount, 0, reason: 'dismiss should not call onChanged');
+  });
+
+  testWidgets('(b) 「すべて」タップでonChanged(null)が呼ばれる', (tester) async {
+    EarthquakeDataSource? received = EarthquakeDataSource.jmaIntensityDatabase;
+    await tester.pumpWidget(
+      wrap(
+        datasource: EarthquakeDataSource.jmaIntensityDatabase,
+        onChanged: (v) => received = v,
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('すべて'));
+    await tester.pumpAndSettle();
+
+    expect(received, isNull, reason: '「すべて」should call onChanged(null)');
+  });
+
+  testWidgets('(c) データソース項目タップで該当値が渡る', (tester) async {
+    EarthquakeDataSource? received;
+    await tester.pumpWidget(wrap(onChanged: (v) => received = v));
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('震度データベース'));
+    await tester.pumpAndSettle();
+
+    expect(
+      received,
+      EarthquakeDataSource.jmaIntensityDatabase,
+      reason: 'Tapping a datasource item should pass the correct value',
+    );
+  });
+}

--- a/app/test/core/component/chip/datasource_filter_chip_test.dart
+++ b/app/test/core/component/chip/datasource_filter_chip_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   Widget wrap({
     EarthquakeDataSource? datasource,
     ValueChanged<EarthquakeDataSource?>? onChanged,
@@ -32,11 +30,9 @@ void main() {
     await tester.pumpWidget(wrap(onChanged: (_) => callCount++));
     await tester.pump();
 
-    // Open the sheet
     await tester.tap(find.byType(RawChip));
     await tester.pumpAndSettle();
 
-    // Tap the barrier (top-left corner, outside the bottom sheet)
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
 

--- a/app/test/core/component/chip/date_range_filter_chip_test.dart
+++ b/app/test/core/component/chip/date_range_filter_chip_test.dart
@@ -1,0 +1,76 @@
+import 'package:eqmonitor/core/component/chip/date_range_filter_chip.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DateRangeFilterChip.clampInitialDateRange', () {
+    final min = DateRangeFilterChip.initialMin;
+    final max = DateRangeFilterChip.initialMax;
+    final midDate = DateTime(2020);
+    final laterDate = DateTime(2022);
+
+    test('min null → null', () {
+      expect(DateRangeFilterChip.clampInitialDateRange(null, midDate), isNull);
+    });
+
+    test('max null → null', () {
+      expect(DateRangeFilterChip.clampInitialDateRange(midDate, null), isNull);
+    });
+
+    test('both null → null', () {
+      expect(DateRangeFilterChip.clampInitialDateRange(null, null), isNull);
+    });
+
+    test('normal range within bounds → returned as-is', () {
+      final result = DateRangeFilterChip.clampInitialDateRange(
+        midDate,
+        laterDate,
+      );
+      expect(result, isNotNull);
+      expect(result!.start, midDate);
+      expect(result.end, laterDate);
+    });
+
+    test('min before firstDate → clamped to firstDate', () {
+      final beforeMin = DateTime(1900);
+      final result = DateRangeFilterChip.clampInitialDateRange(
+        beforeMin,
+        midDate,
+      );
+      expect(result, isNotNull);
+      expect(result!.start, min);
+      expect(result.end, midDate);
+    });
+
+    test('max after lastDate → clamped to lastDate', () {
+      final afterMax = DateTime(2099);
+      final result = DateRangeFilterChip.clampInitialDateRange(
+        midDate,
+        afterMax,
+      );
+      expect(result, isNotNull);
+      expect(result!.start, midDate);
+      expect(result.end, max);
+    });
+
+    test('inverted range after clamp → null (start > end prevention)', () {
+      // min is valid but max is before firstDate → end clamps to firstDate,
+      // start remains after end
+      final result = DateRangeFilterChip.clampInitialDateRange(
+        laterDate,
+        DateTime(1800),
+      );
+      expect(result, isNull);
+    });
+
+    test('same date for start and end → allowed', () {
+      final result = DateRangeFilterChip.clampInitialDateRange(
+        midDate,
+        midDate,
+      );
+      expect(result, isNotNull);
+      expect(result!.start, midDate);
+      expect(result.end, midDate);
+    });
+  });
+}

--- a/app/test/core/component/chip/date_range_filter_chip_test.dart
+++ b/app/test/core/component/chip/date_range_filter_chip_test.dart
@@ -1,5 +1,4 @@
 import 'package:eqmonitor/core/component/chip/date_range_filter_chip.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -54,8 +53,8 @@ void main() {
     });
 
     test('inverted range after clamp → null (start > end prevention)', () {
-      // min is valid but max is before firstDate → end clamps to firstDate,
-      // start remains after end
+      // end(=DateTime(1800)) is not clamped to firstDate — only values after
+      // lastDate are clamped; start(=laterDate=2022) > end(1800) → null
       final result = DateRangeFilterChip.clampInitialDateRange(
         laterDate,
         DateTime(1800),

--- a/app/test/core/component/chip/earthquake_type_filter_chip_test.dart
+++ b/app/test/core/component/chip/earthquake_type_filter_chip_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   Widget wrap({
     EarthquakeType? earthquakeType,
     void Function(EarthquakeType?)? onChanged,
@@ -32,11 +30,9 @@ void main() {
     await tester.pumpWidget(wrap(onChanged: (_) => callCount++));
     await tester.pump();
 
-    // Open the sheet
     await tester.tap(find.byType(RawChip));
     await tester.pumpAndSettle();
 
-    // Tap the barrier (top-left corner, outside the bottom sheet)
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
 

--- a/app/test/core/component/chip/earthquake_type_filter_chip_test.dart
+++ b/app/test/core/component/chip/earthquake_type_filter_chip_test.dart
@@ -1,0 +1,82 @@
+import 'package:eqmonitor/core/component/chip/earthquake_type_filter_chip.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap({
+    EarthquakeType? earthquakeType,
+    void Function(EarthquakeType?)? onChanged,
+  }) => ProviderScope(
+    child: MaterialApp(
+      theme: ThemeData.light().copyWith(
+        extensions: <ThemeExtension<dynamic>>[
+          DesignSystemThemeExtension.light(),
+        ],
+      ),
+      home: Scaffold(
+        body: EarthquakeTypeFilterChip(
+          earthquakeType: earthquakeType,
+          onChanged: onChanged,
+        ),
+      ),
+    ),
+  );
+
+  testWidgets('(a) dismiss でonChangedが呼ばれない', (tester) async {
+    var callCount = 0;
+    await tester.pumpWidget(wrap(onChanged: (_) => callCount++));
+    await tester.pump();
+
+    // Open the sheet
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    // Tap the barrier (top-left corner, outside the bottom sheet)
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    expect(callCount, 0, reason: 'dismiss should not call onChanged');
+  });
+
+  testWidgets('(b) 「すべて」タップでonChanged(null)が呼ばれる', (tester) async {
+    EarthquakeType? received = EarthquakeType.normal;
+    await tester.pumpWidget(
+      wrap(
+        earthquakeType: EarthquakeType.normal,
+        onChanged: (v) => received = v,
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('すべて'));
+    await tester.pumpAndSettle();
+
+    expect(received, isNull, reason: '「すべて」should call onChanged(null)');
+  });
+
+  testWidgets('(c) 種別タップで該当値が渡る', (tester) async {
+    EarthquakeType? received;
+    await tester.pumpWidget(wrap(onChanged: (v) => received = v));
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('遠地地震'));
+    await tester.pumpAndSettle();
+
+    expect(
+      received,
+      EarthquakeType.distant,
+      reason: 'Tapping a type item should pass the correct value',
+    );
+  });
+}

--- a/app/test/core/component/chip/lat_lng_filter_chip_test.dart
+++ b/app/test/core/component/chip/lat_lng_filter_chip_test.dart
@@ -5,8 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   Widget wrap({LatLngRange? value, void Function(LatLngRange?)? onChanged}) =>
       ProviderScope(
         child: MaterialApp(
@@ -100,5 +98,62 @@ void main() {
     expect(received?.latitudeLte, 40.0);
     expect(received?.longitudeGte, 135.0);
     expect(received?.longitudeLte, 140.0);
+  });
+
+  testWidgets('(d) プリセットチップ押下でTextFieldにプリセット値が反映される', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await openModal(tester);
+
+    await tester.tap(find.text('日本周辺'));
+    await tester.pump();
+
+    expect(
+      tester.widget<TextField>(fieldByLabel('緯度(南)')).controller?.text,
+      '20.0',
+    );
+    expect(
+      tester.widget<TextField>(fieldByLabel('緯度(北)')).controller?.text,
+      '50.0',
+    );
+    expect(
+      tester.widget<TextField>(fieldByLabel('経度(西)')).controller?.text,
+      '122.0',
+    );
+    expect(
+      tester.widget<TextField>(fieldByLabel('経度(東)')).controller?.text,
+      '154.0',
+    );
+  });
+
+  testWidgets('(e) クリア押下でTextFieldが空になる', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await openModal(tester);
+
+    await tester.tap(find.text('日本周辺'));
+    await tester.pump();
+
+    await tester.tap(find.text('クリア'));
+    await tester.pump();
+
+    expect(
+      tester.widget<TextField>(fieldByLabel('緯度(南)')).controller?.text,
+      isEmpty,
+    );
+    expect(
+      tester.widget<TextField>(fieldByLabel('緯度(北)')).controller?.text,
+      isEmpty,
+    );
+    expect(
+      tester.widget<TextField>(fieldByLabel('経度(西)')).controller?.text,
+      isEmpty,
+    );
+    expect(
+      tester.widget<TextField>(fieldByLabel('経度(東)')).controller?.text,
+      isEmpty,
+    );
   });
 }

--- a/app/test/core/component/chip/lat_lng_filter_chip_test.dart
+++ b/app/test/core/component/chip/lat_lng_filter_chip_test.dart
@@ -1,0 +1,104 @@
+import 'package:eqmonitor/core/component/chip/lat_lng_filter_chip.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap({LatLngRange? value, void Function(LatLngRange?)? onChanged}) =>
+      ProviderScope(
+        child: MaterialApp(
+          theme: ThemeData.light().copyWith(
+            extensions: <ThemeExtension<dynamic>>[
+              DesignSystemThemeExtension.light(),
+            ],
+          ),
+          home: Scaffold(
+            body: LatLngFilterChip(
+              latitudeGte: value?.latitudeGte,
+              latitudeLte: value?.latitudeLte,
+              longitudeGte: value?.longitudeGte,
+              longitudeLte: value?.longitudeLte,
+              onChanged: onChanged,
+            ),
+          ),
+        ),
+      );
+
+  Future<void> openModal(WidgetTester tester) async {
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+  }
+
+  Finder fieldByLabel(String label) => find
+      .ancestor(of: find.text(label), matching: find.byType(TextField))
+      .first;
+
+  bool isDoneEnabled(WidgetTester tester) {
+    final button = tester.widget<TextButton>(
+      find
+          .ancestor(of: find.text('完了'), matching: find.byType(TextButton))
+          .first,
+    );
+    return button.onPressed != null;
+  }
+
+  testWidgets('(a) 緯度100（値域外）で「完了」が無効', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await openModal(tester);
+
+    await tester.enterText(fieldByLabel('緯度(南)'), '100');
+    await tester.pump();
+
+    expect(isDoneEnabled(tester), isFalse, reason: '緯度100は-90〜90の範囲外なので完了は無効');
+  });
+
+  testWidgets('(b) latGte=40、latLte=30（逆転）で「完了」が無効', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await openModal(tester);
+
+    await tester.enterText(fieldByLabel('緯度(南)'), '40');
+    await tester.pump();
+    await tester.enterText(fieldByLabel('緯度(北)'), '30');
+    await tester.pump();
+
+    expect(isDoneEnabled(tester), isFalse, reason: '緯度(南)>緯度(北)は逆転なので完了は無効');
+  });
+
+  testWidgets('(c) 正常入力で「完了」が有効になり、tapで期待LatLngRangeが渡る', (tester) async {
+    LatLngRange? received;
+    await tester.pumpWidget(wrap(onChanged: (v) => received = v));
+    await tester.pump();
+
+    await openModal(tester);
+
+    await tester.enterText(fieldByLabel('緯度(南)'), '35.0');
+    await tester.pump();
+    await tester.enterText(fieldByLabel('緯度(北)'), '40.0');
+    await tester.pump();
+    await tester.enterText(fieldByLabel('経度(西)'), '135.0');
+    await tester.pump();
+    await tester.enterText(fieldByLabel('経度(東)'), '140.0');
+    await tester.pump();
+
+    expect(isDoneEnabled(tester), isTrue, reason: '全フィールド正常値なので完了は有効');
+
+    await tester.tap(
+      find
+          .ancestor(of: find.text('完了'), matching: find.byType(TextButton))
+          .first,
+    );
+    await tester.pumpAndSettle();
+
+    expect(received?.latitudeGte, 35.0);
+    expect(received?.latitudeLte, 40.0);
+    expect(received?.longitudeGte, 135.0);
+    expect(received?.longitudeLte, 140.0);
+  });
+}

--- a/app/test/core/component/chip/status_filter_chip_test.dart
+++ b/app/test/core/component/chip/status_filter_chip_test.dart
@@ -1,0 +1,79 @@
+import 'package:eqmonitor/core/component/chip/status_filter_chip.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap({
+    List<TelegramStatus>? statuses,
+    void Function(List<TelegramStatus>?)? onChanged,
+  }) => ProviderScope(
+    child: MaterialApp(
+      theme: ThemeData.light().copyWith(
+        extensions: <ThemeExtension<dynamic>>[
+          DesignSystemThemeExtension.light(),
+        ],
+      ),
+      home: Scaffold(
+        body: StatusFilterChip(statuses: statuses, onChanged: onChanged),
+      ),
+    ),
+  );
+
+  testWidgets('(a) 1つだけ選択時、その項目のCheckboxListTileがenabled == false', (
+    tester,
+  ) async {
+    await tester.pumpWidget(wrap(statuses: [TelegramStatus.normal]));
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    final normalTile = tester.widget<CheckboxListTile>(
+      find.ancestor(
+        of: find.text('通常'),
+        matching: find.byType(CheckboxListTile),
+      ),
+    );
+    expect(normalTile.enabled, isFalse);
+
+    final trainingTile = tester.widget<CheckboxListTile>(
+      find.ancestor(
+        of: find.text('訓練'),
+        matching: find.byType(CheckboxListTile),
+      ),
+    );
+    expect(trainingTile.enabled, isTrue);
+
+    final testTile = tester.widget<CheckboxListTile>(
+      find.ancestor(
+        of: find.text('試験'),
+        matching: find.byType(CheckboxListTile),
+      ),
+    );
+    expect(testTile.enabled, isTrue);
+  });
+
+  testWidgets('(b) 2つ以上選択時、全てのCheckboxListTileがenabled == true', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(statuses: [TelegramStatus.normal, TelegramStatus.training]),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    final tiles = tester
+        .widgetList<CheckboxListTile>(find.byType(CheckboxListTile))
+        .toList();
+    for (final tile in tiles) {
+      expect(tile.enabled, isTrue);
+    }
+  });
+}

--- a/app/test/core/component/chip/telegram_type_filter_chip_test.dart
+++ b/app/test/core/component/chip/telegram_type_filter_chip_test.dart
@@ -1,0 +1,81 @@
+import 'package:eqmonitor/core/component/chip/telegram_type_filter_chip.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget wrap({
+    List<EarthquakeTelegramType>? telegramTypes,
+    ValueChanged<List<EarthquakeTelegramType>?>? onChanged,
+  }) => ProviderScope(
+    child: MaterialApp(
+      theme: ThemeData.light().copyWith(
+        extensions: <ThemeExtension<dynamic>>[
+          DesignSystemThemeExtension.light(),
+        ],
+      ),
+      home: Scaffold(
+        body: TelegramTypeFilterChip(
+          telegramTypes: telegramTypes,
+          onChanged: onChanged,
+        ),
+      ),
+    ),
+  );
+
+  testWidgets('(a) 1つだけ選択時、その項目のCheckboxListTileがenabled == false', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(telegramTypes: [EarthquakeTelegramType.vxse51]),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    final vxse51Tile = tester.widget<CheckboxListTile>(
+      find.ancestor(
+        of: find.text('震度速報'),
+        matching: find.byType(CheckboxListTile),
+      ),
+    );
+    expect(vxse51Tile.enabled, isFalse);
+
+    final vxse52Tile = tester.widget<CheckboxListTile>(
+      find.ancestor(
+        of: find.text('震源に関する情報'),
+        matching: find.byType(CheckboxListTile),
+      ),
+    );
+    expect(vxse52Tile.enabled, isTrue);
+  });
+
+  testWidgets('(b) 2つ以上選択時、全てのCheckboxListTileがenabled == true', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(
+        telegramTypes: [
+          EarthquakeTelegramType.vxse51,
+          EarthquakeTelegramType.vxse52,
+        ],
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byType(RawChip));
+    await tester.pumpAndSettle();
+
+    final tiles = tester
+        .widgetList<CheckboxListTile>(find.byType(CheckboxListTile))
+        .toList();
+    for (final tile in tiles) {
+      expect(tile.enabled, isTrue);
+    }
+  });
+}


### PR DESCRIPTION
## 概要

地震履歴画面のフィルターチップ（Filter chip）実装を全チップ横断で調査し、各チップ押下時に開くUI（BottomSheet / Dialog / FullscreenDialog）の問題を洗い出して修正しました。

## 背景

地震履歴のフィルターは12種のチップで構成されており、それぞれ押下時にモーダルを開きます。実装をチップ横断で確認したところ、実害のあるバグ・UIの一貫性欠如・入力検証の不足が見つかりました。

## 修正内容

### バグ修正
- **データソース: dismissでフィルタが消える** — BottomSheetを枠外タップで閉じただけで `onChanged(null)` が発火し、アクティブなデータソースフィルタが意図せず解除されていた（`pop()`のnullとdismissのnullを区別できていなかった）。内部で wrapper record `({value})?` を導入し、**dismissではフィルタを保持**、明示的な「すべて（絞り込み解除）」でのみ解除するように統一。
- **地震種別: 逆転した mounted ガード** — `if (result != null || !context.mounted)` の `!` が逆で、unmount後に `onChanged(null)` を呼びうる状態だった。`result != null && context.mounted` に修正。あわせて「すべて」項目を追加し、データソースと挙動を統一。

### UI一貫性・オーバーフロー対策
- BottomSheetを開く**9モーダル**（intensity / magnitude / depth / lpgm / status / telegram_type / earthquake_type / datasource / lat_lng）を `SingleChildScrollView` でラップし、`sort` と構造を統一。小画面・大文字サイズ設定・キーボード表示時の見切れを防止。
- depth チップの拡張がリテラル `0` / `700` をハードコードしていたのを `DepthFilterChip.initialMin/Max` の定数参照へ。

### UX改善
- **地震発生日**: `showDateRangePicker` に `initialDateRange` を渡し、再オープン時に前回選択範囲を反映（範囲外は firstDate/lastDate にクランプ、逆転は回避）。
- **緯度経度**: 値域検証（緯度 -90〜90 / 経度 -180〜180）・順序検証（南≦北 / 西≦東）を追加し、不正時は「完了」を無効化＋該当フィールドに `errorText` を表示。プリセット/クリア押下時に**テキスト欄が更新されない既存バグ**も修正。入力精度が `toStringAsFixed(1)` で丸められる問題も解消。
- **ステータス / 電文種別**: 「最低1つ選択必須」で最後の1つのチェックを外そうとした時に無反応（サイレント）だったのを、該当項目を無効化（グレーアウト）して制約を可視化。

## テスト

- チップ用の widget test を新規追加（`app/test/core/component/chip/`）: datasource / earthquake_type / status / telegram_type / lat_lng / date_range。
- dismiss保持・「すべて」解除・値域/順序検証・チェックボックス無効化・プリセット反映・クランプ境界などを実挙動で検証。
- `flutter test test/core/component/chip/` → **全23件 pass**、`dart analyze`（対象）警告ゼロ、`dart format` 準拠。

## 補足

- 各チップの public な `onChanged` シグネチャは不変で、呼び出し側の delegate（`earthquake_history_parameter_persistent_delegate.dart`）は未変更です。
- `sort` / `region_intensity` は既存実装で問題が無かったため変更していません。

https://claude.ai/code/session_0178tirYRfWhgHoAYduDP82v
