### PR TITLE
fix: 一覧のSWRキャッシュ化 (地震履歴・お知らせ一覧のオフライン対応)

### DIFF
--- a/app/lib/core/component/cached_data_banner.dart
+++ b/app/lib/core/component/cached_data_banner.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -54,6 +55,45 @@ class CachedDataBanner extends StatelessWidget {
       duration: const Duration(milliseconds: 200),
       alignment: Alignment.topCenter,
       child: content,
+    );
+  }
+}
+
+/// DataSource の `isRevalidating` (`ValueListenable<bool>`) を購読し、
+/// true の間だけ `CachedDataBanner` の更新中表示と同等のバナーを出す。
+/// 一覧ページのリスト上部に `SliverToBoxAdapter` で挿入する用途を想定。
+class RevalidatingBanner extends StatelessWidget {
+  const RevalidatingBanner({required this.isRevalidating, super.key});
+
+  final ValueListenable<bool> isRevalidating;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: isRevalidating,
+      builder: (context, revalidating, _) {
+        final colorScheme = Theme.of(context).colorScheme;
+        return AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          alignment: Alignment.topCenter,
+          child: revalidating
+              ? _BannerContent(
+                  key: const ValueKey('revalidating-banner'),
+                  leading: SizedBox(
+                    width: 12,
+                    height: 12,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 1.5,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  message: 'キャッシュ表示中・更新を確認しています…',
+                  backgroundColor: colorScheme.surfaceContainerHighest,
+                  foregroundColor: colorScheme.onSurfaceVariant,
+                )
+              : const SizedBox.shrink(),
+        );
+      },
     );
   }
 }

--- a/app/lib/core/paging/cache_first_refresh.dart
+++ b/app/lib/core/paging/cache_first_refresh.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:paging_view/paging_view.dart';
+
+/// paging_view DataSource の初回ページ (Refresh) を cache-first にする。
+///
+/// cache-only 取得がヒットしたら即 [Success] を返し、背景で通常取得して
+/// [upsert] で in-place 更新する。cache-only が失敗 (miss/corrupt) したら
+/// 通常取得にフォールバックし、それも失敗すれば [Failure]。
+///
+/// 背景更新は [isActive] が false (DataSource 破棄後・再 Refresh 後) ならスキップし、
+/// 失敗は [onRevalidateError] に渡して握りつぶさない。
+Future<LoadResult<String?, V>> cacheFirstRefresh<V>({
+  required Future<PageData<String?, V>> Function({required bool cacheOnly})
+  fetchPage,
+  required void Function(List<V> fresh) upsert,
+  required bool Function() isActive,
+  ValueNotifier<bool>? isRevalidating,
+  void Function(Object error, StackTrace stackTrace)? onRevalidateError,
+}) async {
+  try {
+    final cached = await fetchPage(cacheOnly: true);
+    isRevalidating?.value = true;
+    unawaited(
+      Future.microtask(() async {
+        try {
+          final fresh = await fetchPage(cacheOnly: false);
+          if (isActive()) {
+            upsert(fresh.data);
+          }
+        } on Object catch (error, stackTrace) {
+          onRevalidateError?.call(error, stackTrace);
+        } finally {
+          if (isActive()) {
+            isRevalidating?.value = false;
+          }
+        }
+      }),
+    );
+    return Success(page: cached);
+  } on Object catch (_) {
+    try {
+      final fresh = await fetchPage(cacheOnly: false);
+      return Success(page: fresh);
+    } on Exception catch (error, stackTrace) {
+      return Failure(error: error, stackTrace: stackTrace);
+    }
+  }
+}

--- a/app/lib/core/paging/cache_first_refresh.dart
+++ b/app/lib/core/paging/cache_first_refresh.dart
@@ -9,8 +9,10 @@ import 'package:paging_view/paging_view.dart';
 /// [upsert] で in-place 更新する。cache-only が失敗 (miss/corrupt) したら
 /// 通常取得にフォールバックし、それも失敗すれば [Failure]。
 ///
-/// 背景更新は [isActive] が false (DataSource 破棄後・再 Refresh 後) ならスキップし、
+/// 背景更新は [isActive] が false (DataSource 破棄後) ならスキップし、
 /// 失敗は [onRevalidateError] に渡して握りつぶさない。
+/// 世代ガードは持たないため、直前の Refresh の背景更新が新しい Refresh 後に
+/// 走り得るが、[upsert] は id 一致の冪等マージのため実害はない。
 Future<LoadResult<String?, V>> cacheFirstRefresh<V>({
   required Future<PageData<String?, V>> Function({required bool cacheOnly})
   fetchPage,
@@ -21,7 +23,10 @@ Future<LoadResult<String?, V>> cacheFirstRefresh<V>({
 }) async {
   try {
     final cached = await fetchPage(cacheOnly: true);
-    isRevalidating?.value = true;
+    // cache 読込中に破棄された場合、破棄済み ValueNotifier への書き込みを避ける。
+    if (isActive()) {
+      isRevalidating?.value = true;
+    }
     unawaited(
       Future.microtask(() async {
         try {

--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:eqmonitor/core/api/cache_only_api_client_provider.dart';
+import 'package:eqmonitor/core/paging/cache_first_refresh.dart';
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
@@ -7,14 +9,27 @@ import 'package:eqmonitor/core/realtime/realtime_event_provider.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_search_response.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:paging_view/paging_view.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'earthquake_history_data_source.g.dart';
+
+/// デフォルトの「全て」パラメータかどうかを判定する。
+/// フィルタや並び替えが変更されていない初期状態と一致する場合のみ true。
+bool isDefaultAllParameter(EarthquakeHistoryParameter p) =>
+    p ==
+    const EarthquakeHistoryParameter.all(
+      sortBy: EarthquakeSortBy.eventId,
+      sortOrder: SortOrder.desc,
+    );
 
 @riverpod
 Future<EarthquakeHistoryDataSource> earthquakeHistoryDataSource(
@@ -24,10 +39,12 @@ Future<EarthquakeHistoryDataSource> earthquakeHistoryDataSource(
   final repository = await ref.watch(
     earthquakeHistoryRepositoryProvider.future,
   );
+  final cacheOnly = await ref.watch(cacheOnlyApiClientProvider.future);
 
   final dataSource = EarthquakeHistoryDataSource(
     repository: repository,
     parameter: parameter,
+    cacheOnlyClient: cacheOnly,
     onRefreshStarted: () =>
         ref.invalidate(earthquakeHistoryDetailsProvider, asReload: true),
   );
@@ -68,9 +85,11 @@ class EarthquakeHistoryDataSource
   EarthquakeHistoryDataSource({
     required EarthquakeHistoryRepository repository,
     required EarthquakeHistoryParameter parameter,
+    required api.ApiClient cacheOnlyClient,
     VoidCallback? onRefreshStarted,
   }) : _repository = repository,
-       _parameter = parameter {
+       _parameter = parameter,
+       _cacheOnlyClient = cacheOnlyClient {
     onLoadStarted = (action) {
       if (action is Refresh) {
         onRefreshStarted?.call();
@@ -80,6 +99,17 @@ class EarthquakeHistoryDataSource
 
   final EarthquakeHistoryRepository _repository;
   final EarthquakeHistoryParameter _parameter;
+  final api.ApiClient _cacheOnlyClient;
+
+  final ValueNotifier<bool> isRevalidating = ValueNotifier(false);
+  bool _disposed = false;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    isRevalidating.dispose();
+    super.dispose();
+  }
 
   static final _dateFormatter = DateFormat('yyyy/MM/dd');
 
@@ -94,6 +124,21 @@ class EarthquakeHistoryDataSource
   Future<LoadResult<String?, EarthquakePartial>> load(
     LoadAction<String?> action,
   ) async => switch (action) {
+    Refresh() when isDefaultAllParameter(_parameter) =>
+      await cacheFirstRefresh<EarthquakePartial>(
+        fetchPage: ({required cacheOnly}) async {
+          final page = await _fetch(
+            limit: 10,
+            cursor: null,
+            client: cacheOnly ? _cacheOnlyClient : null,
+          );
+          return PageData(data: page.items, appendKey: page.nextToken);
+        },
+        upsert: upsertItems,
+        isActive: () => !_disposed,
+        isRevalidating: isRevalidating,
+        onRevalidateError: (e, st) => talker.error(e, st),
+      ),
     Refresh() => await _load(
       limit: _parameter is EarthquakeHistoryParameterAll ? 10 : 50,
       cursor: null,
@@ -127,6 +172,7 @@ class EarthquakeHistoryDataSource
   Future<PaginatedResponse<EarthquakePartial>> _fetch({
     required int limit,
     required String? cursor,
+    api.ApiClient? client,
   }) async {
     final parameter = _parameter;
 
@@ -155,6 +201,7 @@ class EarthquakeHistoryDataSource
         longitudeLte: parameter.longitudeLte,
         sortBy: parameter.sortBy,
         sortOrder: parameter.sortOrder,
+        client: client,
       ),
       EarthquakeHistoryParameterRegion(:final String regionCode) =>
         _repository.searchByRegion(

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
@@ -1,3 +1,4 @@
+import 'package:eqmonitor/core/component/cached_data_banner.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
@@ -69,7 +70,7 @@ class _PagingBody extends StatelessWidget {
     required this.onRefresh,
   });
 
-  final GroupedDataSource<String?, String, EarthquakePartial> dataSource;
+  final EarthquakeHistoryDataSource dataSource;
   final ValueNotifier<EarthquakeHistoryParameter> parameter;
   final ValueChanged<EarthquakeHistoryParameter> onParameterChanged;
   final Future<void> Function() onRefresh;
@@ -99,6 +100,11 @@ class _PagingBody extends StatelessWidget {
             delegate: EarthquakeHistoryParameterPersistentDelegate(
               parameter: parameter.value,
               onChanged: onParameterChanged,
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: RevalidatingBanner(
+              isRevalidating: dataSource.isRevalidating,
             ),
           ),
           SliverGroupedPagingList<String?, String, EarthquakePartial>(

--- a/app/lib/feature/feed/data/notifier/feed_data_source.dart
+++ b/app/lib/feature/feed/data/notifier/feed_data_source.dart
@@ -74,8 +74,10 @@ class FeedDataSource extends DataSource<String?, FeedItem> {
     }
   }
 
-  /// id 一致で in-place 更新、未登録は末尾に追加する。
-  /// Append が古い順に追加するページング構造なので、新規は末尾で視覚的に矛盾しない。
+  /// id 一致で in-place 更新する (背景 revalidate の主目的)。
+  /// 未登録の新規は暫定的に末尾へ追加する。お知らせは新しい順のため本来は先頭寄り
+  /// が正しいが、revalidate 窓 (数秒) に新規公開された場合のみで、次の定期/手動
+  /// リフレッシュで正順に是正される。厳密な先頭挿入は follow-up (Issue #1452)。
   void upsertItems(List<FeedItem> fresh) {
     for (final item in fresh) {
       final currentItems = [...notifier.values];

--- a/app/lib/feature/feed/data/notifier/feed_data_source.dart
+++ b/app/lib/feature/feed/data/notifier/feed_data_source.dart
@@ -1,5 +1,10 @@
+import 'package:eqmonitor/core/api/cache_only_api_client_provider.dart';
+import 'package:eqmonitor/core/paging/cache_first_refresh.dart';
+import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/feed/data/model/feed_items.dart';
 import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/foundation.dart';
 import 'package:paging_view/paging_view.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -8,22 +13,52 @@ part 'feed_data_source.g.dart';
 @riverpod
 Future<FeedDataSource> feedDataSource(Ref ref) async {
   final repository = await ref.watch(feedRepositoryProvider.future);
-  final dataSource = FeedDataSource(repository: repository);
+  final cacheOnly = await ref.watch(cacheOnlyApiClientProvider.future);
+  final dataSource = FeedDataSource(
+    repository: repository,
+    cacheOnlyClient: cacheOnly,
+  );
   ref.onDispose(dataSource.dispose);
   return dataSource;
 }
 
 class FeedDataSource extends DataSource<String?, FeedItem> {
-  FeedDataSource({required FeedRepository repository})
-    : _repository = repository;
+  FeedDataSource({
+    required FeedRepository repository,
+    required api.ApiClient cacheOnlyClient,
+  }) : _repository = repository,
+       _cacheOnlyClient = cacheOnlyClient;
 
   final FeedRepository _repository;
+  final api.ApiClient _cacheOnlyClient;
+
+  final ValueNotifier<bool> isRevalidating = ValueNotifier(false);
+  bool _disposed = false;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    isRevalidating.dispose();
+    super.dispose();
+  }
 
   @override
   Future<LoadResult<String?, FeedItem>> load(
     LoadAction<String?> action,
   ) async => switch (action) {
-    Refresh() => await _fetch(null),
+    Refresh() => await cacheFirstRefresh<FeedItem>(
+      fetchPage: ({required cacheOnly}) async {
+        final response = await _repository.fetch(
+          after: null,
+          client: cacheOnly ? _cacheOnlyClient : null,
+        );
+        return PageData(data: response.feeds, appendKey: response.nextCursor);
+      },
+      upsert: upsertItems,
+      isActive: () => !_disposed,
+      isRevalidating: isRevalidating,
+      onRevalidateError: (e, st) => talker.error(e, st),
+    ),
     Append(:final key) => await _fetch(key),
     Prepend() => const None(),
   };
@@ -36,6 +71,20 @@ class FeedDataSource extends DataSource<String?, FeedItem> {
       );
     } on Exception catch (e, st) {
       return Failure(error: e, stackTrace: st);
+    }
+  }
+
+  /// id 一致で in-place 更新、未登録は末尾に追加する。
+  /// Append が古い順に追加するページング構造なので、新規は末尾で視覚的に矛盾しない。
+  void upsertItems(List<FeedItem> fresh) {
+    for (final item in fresh) {
+      final currentItems = [...notifier.values];
+      final index = currentItems.indexWhere((e) => e.id == item.id);
+      if (index != -1) {
+        updateItem(index, (_) => item);
+        continue;
+      }
+      insertItem(currentItems.length, item);
     }
   }
 }

--- a/app/lib/feature/feed/data/notifier/feed_notifier.dart
+++ b/app/lib/feature/feed/data/notifier/feed_notifier.dart
@@ -1,6 +1,8 @@
 import 'package:eqmonitor/core/extension/async_value.dart';
+import 'package:eqmonitor/core/provider/cached_notifier.dart';
 import 'package:eqmonitor/feature/feed/data/model/feed_items.dart';
 import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'feed_notifier.g.dart';
@@ -8,13 +10,16 @@ part 'feed_notifier.g.dart';
 typedef FeedNotifierState = ({List<FeedItem> items, String? nextCursor});
 
 @riverpod
-class FeedNotifier extends _$FeedNotifier {
+class FeedNotifier extends _$FeedNotifier with CachedNotifier<FeedNotifierState> {
   @override
-  Future<FeedNotifierState> build() async {
+  Future<FeedNotifierState> fetch(api.ApiClient client) async {
     final repository = await ref.read(feedRepositoryProvider.future);
-    final response = await repository.fetch();
+    final response = await repository.fetch(client: client);
     return (items: response.feeds, nextCursor: response.nextCursor);
   }
+
+  @override
+  Future<FeedNotifierState> build() => cachedBuild();
 
   Future<void> fetchNextData() async {
     if (state.isRefreshing || state.isReloading) {

--- a/app/lib/feature/feed/data/notifier/feed_notifier.dart
+++ b/app/lib/feature/feed/data/notifier/feed_notifier.dart
@@ -10,7 +10,8 @@ part 'feed_notifier.g.dart';
 typedef FeedNotifierState = ({List<FeedItem> items, String? nextCursor});
 
 @riverpod
-class FeedNotifier extends _$FeedNotifier with CachedNotifier<FeedNotifierState> {
+class FeedNotifier extends _$FeedNotifier
+    with CachedNotifier<FeedNotifierState> {
   @override
   Future<FeedNotifierState> fetch(api.ApiClient client) async {
     final repository = await ref.read(feedRepositoryProvider.future);

--- a/app/lib/feature/feed/data/repository/feed_repository.dart
+++ b/app/lib/feature/feed/data/repository/feed_repository.dart
@@ -16,8 +16,8 @@ class FeedRepository {
 
   final api.ApiClient _api;
 
-  Future<FeedListResponse> fetch({String? after}) async {
-    final response = await _api.feed.getV2Feeds(after: after);
+  Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
+    final response = await (client ?? _api).feed.getV2Feeds(after: after);
     return response.data.toFeedListResponse();
   }
 

--- a/app/lib/feature/feed/ui/page/feed_page.dart
+++ b/app/lib/feature/feed/ui/page/feed_page.dart
@@ -1,3 +1,4 @@
+import 'package:eqmonitor/core/component/cached_data_banner.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/feature/feed/data/model/feed_items.dart';
 import 'package:eqmonitor/feature/feed/data/notifier/feed_data_source.dart';
@@ -43,6 +44,11 @@ class _PagingBody extends StatelessWidget {
             pinned: true,
             centerTitle: false,
             title: Text('お知らせ'),
+          ),
+          SliverToBoxAdapter(
+            child: RevalidatingBanner(
+              isRevalidating: dataSource.isRevalidating,
+            ),
           ),
           SliverPagingList<String?, FeedItem>(
             dataSource: dataSource,

--- a/app/test/core/paging/cache_first_refresh_test.dart
+++ b/app/test/core/paging/cache_first_refresh_test.dart
@@ -1,0 +1,68 @@
+import 'package:eqmonitor/core/paging/cache_first_refresh.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paging_view/paging_view.dart';
+
+PageData<String?, int> _page(List<int> data) =>
+    PageData(data: data, appendKey: null);
+
+void main() {
+  test('cache hit: Success を即返し、背景で upsert が呼ばれる', () async {
+    final upserted = <int>[];
+    final result = await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async =>
+          _page(cacheOnly ? [1, 2] : [1, 2, 3]),
+      upsert: upserted.addAll,
+      isActive: () => true,
+    );
+    expect(result, isA<Success<String?, int>>());
+    expect((result as Success<String?, int>).page.data, [1, 2]);
+    await Future<void>.delayed(Duration.zero);
+    expect(upserted, [1, 2, 3]); // 背景 revalidate の fresh
+  });
+
+  test('cache miss: 通常取得の Success を返す', () async {
+    final result = await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async {
+        if (cacheOnly) throw Exception('cache miss');
+        return _page([9]);
+      },
+      upsert: (_) {},
+      isActive: () => true,
+    );
+    expect((result as Success<String?, int>).page.data, [9]);
+  });
+
+  test('cache miss かつ通常取得も失敗 → Failure', () async {
+    final result = await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async => throw Exception('offline'),
+      upsert: (_) {},
+      isActive: () => true,
+    );
+    expect(result, isA<Failure<String?, int>>());
+  });
+
+  test('isActive()==false なら背景 upsert をスキップ', () async {
+    final upserted = <int>[];
+    await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async => _page([1]),
+      upsert: upserted.addAll,
+      isActive: () => false,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(upserted, isEmpty);
+  });
+
+  test('cache hit で isRevalidating が true→false に遷移', () async {
+    final flag = ValueNotifier(false);
+    await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async => _page([1]),
+      upsert: (_) {},
+      isActive: () => true,
+      isRevalidating: flag,
+    );
+    expect(flag.value, isTrue); // 即返し直後は revalidate 中
+    await Future<void>.delayed(Duration.zero);
+    expect(flag.value, isFalse); // 背景完了で false
+  });
+}

--- a/app/test/feature/earthquake_history/earthquake_history_data_source_cache_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_data_source_cache_test.dart
@@ -1,0 +1,45 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('isDefaultAllParameter: 既定 All は true', () {
+    expect(
+      isDefaultAllParameter(
+        const EarthquakeHistoryParameter.all(
+          sortBy: EarthquakeSortBy.eventId,
+          sortOrder: SortOrder.desc,
+        ),
+      ),
+      isTrue,
+    );
+  });
+
+  test('isDefaultAllParameter: magnitudeGte 付き All は false', () {
+    expect(
+      isDefaultAllParameter(
+        const EarthquakeHistoryParameter.all(
+          sortBy: EarthquakeSortBy.eventId,
+          sortOrder: SortOrder.desc,
+          magnitudeGte: 5,
+        ),
+      ),
+      isFalse,
+    );
+  });
+
+  test('isDefaultAllParameter: prefecture 検索は false', () {
+    expect(
+      isDefaultAllParameter(
+        const EarthquakeHistoryParameter.prefecture(
+          sortBy: EarthquakeSortBy.eventId,
+          sortOrder: SortOrder.desc,
+          prefectureCode: '13',
+        ),
+      ),
+      isFalse,
+    );
+  });
+}

--- a/app/test/feature/earthquake_history/earthquake_history_data_source_fetch_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_data_source_fetch_test.dart
@@ -263,6 +263,7 @@ final class _SpyEarthquakeHistoryRepository
     double? longitudeLte,
     EarthquakeSortBy? sortBy,
     SortOrder? sortOrder,
+    api.ApiClient? client,
   }) async {
     fetchEarthquakeListCalls.add({
       'limit': limit,

--- a/app/test/feature/earthquake_history/earthquake_history_data_source_fetch_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_data_source_fetch_test.dart
@@ -36,6 +36,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -75,6 +76,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -109,6 +111,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -136,6 +139,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -163,6 +167,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 

--- a/app/test/feature/earthquake_history/earthquake_history_upsert_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_upsert_test.dart
@@ -38,6 +38,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -68,6 +69,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -97,6 +99,7 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
+        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -124,6 +127,7 @@ void main() {
     final dataSource = EarthquakeHistoryDataSource(
       repository: repository,
       parameter: parameter,
+      cacheOnlyClient: api.ApiClient(Dio()),
     );
     addTearDown(dataSource.dispose);
 
@@ -220,5 +224,6 @@ final class _FakeEarthquakeHistoryRepository
     double? longitudeLte,
     EarthquakeSortBy? sortBy,
     SortOrder? sortOrder,
+    api.ApiClient? client,
   }) async => PaginatedResponse(items: items, nextToken: null);
 }

--- a/app/test/feature/feed/feed_by_source_provider_test.dart
+++ b/app/test/feature/feed/feed_by_source_provider_test.dart
@@ -35,7 +35,8 @@ class _FakeFeedRepository implements FeedRepository {
   String? lastTelegramHash;
 
   @override
-  Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) => throw UnimplementedError();
+  Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) =>
+      throw UnimplementedError();
 
   @override
   Future<FeedDetail> fetchByTelegramHash(

--- a/app/test/feature/feed/feed_by_source_provider_test.dart
+++ b/app/test/feature/feed/feed_by_source_provider_test.dart
@@ -35,7 +35,7 @@ class _FakeFeedRepository implements FeedRepository {
   String? lastTelegramHash;
 
   @override
-  Future<FeedListResponse> fetch({String? after}) => throw UnimplementedError();
+  Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) => throw UnimplementedError();
 
   @override
   Future<FeedDetail> fetchByTelegramHash(

--- a/app/test/feature/feed/feed_data_source_test.dart
+++ b/app/test/feature/feed/feed_data_source_test.dart
@@ -10,9 +10,7 @@ void main() {
   // cacheFirstRefresh がキャッシュミスの場合はネットワーク fetch にフォールバックする。
 
   test('upsertItems: 同一 id のアイテムは in-place で更新される', () async {
-    final dataSource = _buildDataSource(
-      initial: [_item('id-1', 'original')],
-    );
+    final dataSource = _buildDataSource(initial: [_item('id-1', 'original')]);
     addTearDown(dataSource.dispose);
 
     await dataSource.refresh();
@@ -26,9 +24,7 @@ void main() {
   });
 
   test('upsertItems: 新規 id のアイテムは末尾に追加される', () async {
-    final dataSource = _buildDataSource(
-      initial: [_item('id-1', 'item 1')],
-    );
+    final dataSource = _buildDataSource(initial: [_item('id-1', 'item 1')]);
     addTearDown(dataSource.dispose);
 
     await dataSource.refresh();
@@ -97,10 +93,7 @@ final class _FakeFeedRepository extends FeedRepository {
   final List<FeedItem> initialItems;
 
   @override
-  Future<FeedListResponse> fetch({
-    String? after,
-    api.ApiClient? client,
-  }) async {
+  Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
     if (client != null) {
       throw Exception('cache miss');
     }

--- a/app/test/feature/feed/feed_data_source_test.dart
+++ b/app/test/feature/feed/feed_data_source_test.dart
@@ -1,0 +1,109 @@
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/feature/feed/data/model/feed_items.dart';
+import 'package:eqmonitor/feature/feed/data/notifier/feed_data_source.dart';
+import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // upsertItems は DataSource のロード後に呼ばれることを前提とする。
+  // cacheFirstRefresh がキャッシュミスの場合はネットワーク fetch にフォールバックする。
+
+  test('upsertItems: 同一 id のアイテムは in-place で更新される', () async {
+    final dataSource = _buildDataSource(
+      initial: [_item('id-1', 'original')],
+    );
+    addTearDown(dataSource.dispose);
+
+    await dataSource.refresh();
+
+    dataSource.upsertItems([_item('id-1', 'updated')]);
+
+    final values = dataSource.notifier.values;
+    expect(values.length, 1);
+    expect(values[0].id, 'id-1');
+    expect(values[0].title, 'updated');
+  });
+
+  test('upsertItems: 新規 id のアイテムは末尾に追加される', () async {
+    final dataSource = _buildDataSource(
+      initial: [_item('id-1', 'item 1')],
+    );
+    addTearDown(dataSource.dispose);
+
+    await dataSource.refresh();
+
+    dataSource.upsertItems([_item('id-2', 'item 2')]);
+
+    final values = dataSource.notifier.values;
+    expect(values.length, 2);
+    expect(values[0].id, 'id-1');
+    expect(values[1].id, 'id-2');
+  });
+
+  test('upsertItems: 更新と追加を同時に処理できる', () async {
+    final dataSource = _buildDataSource(
+      initial: [_item('id-1', 'item 1'), _item('id-2', 'item 2')],
+    );
+    addTearDown(dataSource.dispose);
+
+    await dataSource.refresh();
+
+    dataSource.upsertItems([
+      _item('id-1', 'item 1 updated'),
+      _item('id-3', 'item 3 new'),
+    ]);
+
+    final values = dataSource.notifier.values;
+    expect(values.length, 3);
+    expect(values[0].id, 'id-1');
+    expect(values[0].title, 'item 1 updated');
+    expect(values[1].id, 'id-2');
+    expect(values[2].id, 'id-3');
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+FeedDataSource _buildDataSource({required List<FeedItem> initial}) {
+  return FeedDataSource(
+    repository: _FakeFeedRepository(initialItems: initial),
+    // cacheOnlyClient は cache miss を模倣するため、実際の Dio は不要
+    cacheOnlyClient: api.ApiClient(Dio()),
+  );
+}
+
+FeedItem _item(String id, String title) => FeedItem(
+  id: id,
+  feedType: FeedType.developerMessage,
+  priority: FeedPriority.normal,
+  isImportant: false,
+  publishedAt: DateTime.parse('2026-07-07T00:00:00Z'),
+  expiresAt: null,
+  title: title,
+  summary: null,
+  data: const FeedItemData.developerMessage(url: null),
+);
+
+/// キャッシュミスを模倣する Fake リポジトリ。
+/// client が指定された場合 (cache-only) は例外を投げ、
+/// 指定がない場合 (network) は [initialItems] を返す。
+final class _FakeFeedRepository extends FeedRepository {
+  _FakeFeedRepository({required this.initialItems})
+    : super(api: api.ApiClient(Dio()));
+
+  final List<FeedItem> initialItems;
+
+  @override
+  Future<FeedListResponse> fetch({
+    String? after,
+    api.ApiClient? client,
+  }) async {
+    if (client != null) {
+      throw Exception('cache miss');
+    }
+    return FeedListResponse(feeds: initialItems, nextCursor: null);
+  }
+}

--- a/app/test/feature/feed/feed_notifier_test.dart
+++ b/app/test/feature/feed/feed_notifier_test.dart
@@ -41,10 +41,7 @@ class _FakeFeedRepository implements FeedRepository {
   _FakeFeedRepository();
 
   @override
-  Future<FeedListResponse> fetch({
-    String? after,
-    api.ApiClient? client,
-  }) async {
+  Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
     if (identical(client, _cacheOnlyClient)) {
       // キャッシュヒット: キャッシュ用クライアントのときはキャッシュデータを返す
       return FeedListResponse(feeds: [_cachedFeed], nextCursor: null);
@@ -62,10 +59,7 @@ class _FakeFeedRepository implements FeedRepository {
 
 class _CacheMissFeedRepository implements FeedRepository {
   @override
-  Future<FeedListResponse> fetch({
-    String? after,
-    api.ApiClient? client,
-  }) async {
+  Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
     if (identical(client, _cacheOnlyClient)) {
       throw DioException(
         requestOptions: RequestOptions(),
@@ -89,9 +83,7 @@ ProviderContainer _container(FeedRepository repository) {
     retry: (retryCount, error) => null,
     overrides: [
       feedRepositoryProvider.overrideWith((ref) async => repository),
-      cacheOnlyApiClientProvider.overrideWith(
-        (ref) async => _cacheOnlyClient,
-      ),
+      cacheOnlyApiClientProvider.overrideWith((ref) async => _cacheOnlyClient),
       apiClientProvider.overrideWith((ref) async => _networkClient),
       dioProvider.overrideWith((ref) async => Dio()),
     ],

--- a/app/test/feature/feed/feed_notifier_test.dart
+++ b/app/test/feature/feed/feed_notifier_test.dart
@@ -1,0 +1,153 @@
+import 'package:cache/cache.dart';
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/core/api/cache_only_api_client_provider.dart';
+import 'package:eqmonitor/core/provider/dio_provider.dart';
+import 'package:eqmonitor/feature/feed/data/model/feed_items.dart';
+import 'package:eqmonitor/feature/feed/data/notifier/feed_notifier.dart';
+import 'package:eqmonitor/feature/feed/data/repository/feed_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+late api.ApiClient _cacheOnlyClient;
+late api.ApiClient _networkClient;
+
+final _cachedFeed = FeedItem(
+  id: 'cached-1',
+  feedType: FeedType.incident,
+  priority: FeedPriority.normal,
+  isImportant: false,
+  publishedAt: DateTime.parse('2026-07-01T00:00:00+09:00'),
+  expiresAt: null,
+  title: 'キャッシュデータ',
+  summary: null,
+  data: const FeedItemData.incident(),
+);
+
+final _freshFeed = FeedItem(
+  id: 'fresh-1',
+  feedType: FeedType.incident,
+  priority: FeedPriority.normal,
+  isImportant: false,
+  publishedAt: DateTime.parse('2026-07-02T00:00:00+09:00'),
+  expiresAt: null,
+  title: 'フレッシュデータ',
+  summary: null,
+  data: const FeedItemData.incident(),
+);
+
+class _FakeFeedRepository implements FeedRepository {
+  _FakeFeedRepository();
+
+  @override
+  Future<FeedListResponse> fetch({
+    String? after,
+    api.ApiClient? client,
+  }) async {
+    if (identical(client, _cacheOnlyClient)) {
+      // キャッシュヒット: キャッシュ用クライアントのときはキャッシュデータを返す
+      return FeedListResponse(feeds: [_cachedFeed], nextCursor: null);
+    }
+    // 通常クライアント: フレッシュデータを返す
+    return FeedListResponse(feeds: [_freshFeed], nextCursor: null);
+  }
+
+  @override
+  Future<FeedDetail> fetchByTelegramHash(
+    String telegramHash, {
+    api.ApiClient? client,
+  }) => throw UnimplementedError();
+}
+
+class _CacheMissFeedRepository implements FeedRepository {
+  @override
+  Future<FeedListResponse> fetch({
+    String? after,
+    api.ApiClient? client,
+  }) async {
+    if (identical(client, _cacheOnlyClient)) {
+      throw DioException(
+        requestOptions: RequestOptions(),
+        error: const CacheMissException(),
+      );
+    }
+    return FeedListResponse(feeds: [_freshFeed], nextCursor: null);
+  }
+
+  @override
+  Future<FeedDetail> fetchByTelegramHash(
+    String telegramHash, {
+    api.ApiClient? client,
+  }) => throw UnimplementedError();
+}
+
+ProviderContainer _container(FeedRepository repository) {
+  _cacheOnlyClient = api.ApiClient(Dio());
+  _networkClient = api.ApiClient(Dio());
+  return ProviderContainer(
+    retry: (retryCount, error) => null,
+    overrides: [
+      feedRepositoryProvider.overrideWith((ref) async => repository),
+      cacheOnlyApiClientProvider.overrideWith(
+        (ref) async => _cacheOnlyClient,
+      ),
+      apiClientProvider.overrideWith((ref) async => _networkClient),
+      dioProvider.overrideWith((ref) async => Dio()),
+    ],
+  );
+}
+
+Future<void> _pumpMicrotasks() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+void main() {
+  group('FeedNotifier (CachedNotifier)', () {
+    test('cache hit: 初回値はキャッシュ由来', () async {
+      final container = _container(_FakeFeedRepository());
+      addTearDown(container.dispose);
+
+      final result = await container.read(feedProvider.future);
+
+      expect(result.items.first.id, 'cached-1');
+      expect(result.nextCursor, isNull);
+    });
+
+    test('cache hit → SWR: フレッシュデータで更新される', () async {
+      final container = _container(_FakeFeedRepository());
+      addTearDown(container.dispose);
+
+      container.listen(feedProvider, (_, _) {});
+
+      await container.read(feedProvider.future);
+      expect(container.read(feedProvider).value!.items.first.id, 'cached-1');
+
+      await _pumpMicrotasks();
+
+      expect(container.read(feedProvider).value!.items.first.id, 'fresh-1');
+    });
+
+    test('cache miss: ネットワークから直接取得', () async {
+      final container = _container(_CacheMissFeedRepository());
+      addTearDown(container.dispose);
+
+      final result = await container.read(feedProvider.future);
+
+      expect(result.items.first.id, 'fresh-1');
+    });
+
+    test('FeedNotifierState の shape が正しい', () async {
+      final container = _container(_FakeFeedRepository());
+      addTearDown(container.dispose);
+
+      final result = await container.read(feedProvider.future);
+
+      expect(result.items, isA<List<FeedItem>>());
+      expect(result.nextCursor, isNull);
+      expect(result.hasNext, isFalse);
+    });
+  });
+}

--- a/docs/superpowers/plans/2026-07-07-swr-cache-lists.md
+++ b/docs/superpowers/plans/2026-07-07-swr-cache-lists.md
@@ -1,0 +1,482 @@
+# 一覧のSWRキャッシュ化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 地震履歴一覧タブ・お知らせ一覧タブ・Home フィードシートを cache-first (キャッシュ即返し → 裏で revalidate → 更新) にし、オフライン/初回で timeout エラーにならずキャッシュを表示する。
+
+**Architecture:** paging_view の 2 DataSource (Feed 一覧・地震履歴一覧) は共通ヘルパー `cacheFirstRefresh` で初回 Refresh を cache-first 化し背景 revalidate で in-place upsert。Home フィードシートの `FeedNotifier` は既存 `CachedNotifier` mixin を適用。cache-only クライアントは `cacheOnlyApiClientProvider`。
+
+**Tech Stack:** Flutter / Dart, Riverpod (riverpod_annotation), paging_view (`DataSource`/`GroupedDataSource`/`LoadResult`/`PageData`), flutter_test。
+
+## Global Constraints
+
+- コード生成は使わない (build_runner がリポジトリ全体で恒常故障: drift_dev/analyzer 非互換, freezed↔riverpod_generator の analyzer 版数非互換)。mixin 付与・オプション引数追加は riverpod 生成物 (`*.g.dart`) の署名を変えないため regenerate 不要。生成物を手編集しない。
+- `dart analyze` はこのリポジトリで非常に遅く (数分) ハングし得る (eqmonitor-lints プラグイン競合)。コンパイル検証は `flutter test` を主軸にする。パイプで exit code を隠さない。
+- Riverpod 公開 Provider は 1 ファイル 1 つ。コメントは「なぜ」のみ。YAGNI。package import。例外を握りつぶさない (背景 revalidate 失敗は `talker.error` に記録)。
+- テストは緑にしてからコミット。作業は git worktree 内 (`cd` を毎コマンド前置し、コミット前に `git branch --show-current` が `worktree-swr-cache-lists` であることを確認)。
+- コミットメッセージ末尾に `Claude-Session: https://claude.ai/code/session_016kNc5tMmW5x7a4A4ms83EB` を付ける。
+
+## File Structure
+
+- `app/lib/core/paging/cache_first_refresh.dart` (新規): paging DataSource 用 cache-first ヘルパー。
+- `app/lib/feature/feed/data/repository/feed_repository.dart` (変更): `fetch` に `ApiClient? client`。
+- `app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart` (変更): `fetchEarthquakeList` に `ApiClient? client`。
+- `app/lib/feature/feed/data/notifier/feed_data_source.dart` (変更): cache-first + `upsertItems(byid)` + `isRevalidating`。
+- `app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart` (変更): 既定 All の cache-first + `isRevalidating`。
+- `app/lib/feature/feed/data/notifier/feed_notifier.dart` (変更): `CachedNotifier` 適用。
+- `app/lib/feature/feed/ui/page/feed_page.dart` / `app/lib/feature/earthquake_history/ui/earthquake_history_page.dart` (変更): 「更新中」バナー。
+
+---
+
+### Task 1: cacheFirstRefresh ヘルパー
+
+**Files:**
+- Create: `app/lib/core/paging/cache_first_refresh.dart`
+- Test: `app/test/core/paging/cache_first_refresh_test.dart`
+
+**Interfaces:**
+- Consumes: paging_view の `LoadResult`/`PageData`/`Success`/`Failure`。
+- Produces:
+  ```dart
+  Future<LoadResult<String?, V>> cacheFirstRefresh<V>({
+    required Future<PageData<String?, V>> Function({required bool cacheOnly}) fetchPage,
+    required void Function(List<V> fresh) upsert,
+    required bool Function() isActive,
+    ValueNotifier<bool>? isRevalidating,
+    void Function(Object error, StackTrace stackTrace)? onRevalidateError,
+  })
+  ```
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/test/core/paging/cache_first_refresh_test.dart`:
+
+```dart
+import 'package:eqmonitor/core/paging/cache_first_refresh.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paging_view/paging_view.dart';
+
+PageData<String?, int> _page(List<int> data) =>
+    PageData(data: data, appendKey: null);
+
+void main() {
+  test('cache hit: Success を即返し、背景で upsert が呼ばれる', () async {
+    final upserted = <int>[];
+    final result = await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async =>
+          _page(cacheOnly ? [1, 2] : [1, 2, 3]),
+      upsert: upserted.addAll,
+      isActive: () => true,
+    );
+    expect(result, isA<Success<String?, int>>());
+    expect((result as Success<String?, int>).page.data, [1, 2]);
+    await Future<void>.delayed(Duration.zero);
+    expect(upserted, [1, 2, 3]); // 背景 revalidate の fresh
+  });
+
+  test('cache miss: 通常取得の Success を返す', () async {
+    final result = await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async {
+        if (cacheOnly) throw Exception('cache miss');
+        return _page([9]);
+      },
+      upsert: (_) {},
+      isActive: () => true,
+    );
+    expect((result as Success<String?, int>).page.data, [9]);
+  });
+
+  test('cache miss かつ通常取得も失敗 → Failure', () async {
+    final result = await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async => throw Exception('offline'),
+      upsert: (_) {},
+      isActive: () => true,
+    );
+    expect(result, isA<Failure<String?, int>>());
+  });
+
+  test('isActive()==false なら背景 upsert をスキップ', () async {
+    final upserted = <int>[];
+    await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async => _page([1]),
+      upsert: upserted.addAll,
+      isActive: () => false,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(upserted, isEmpty);
+  });
+
+  test('cache hit で isRevalidating が true→false に遷移', () async {
+    final flag = ValueNotifier(false);
+    await cacheFirstRefresh<int>(
+      fetchPage: ({required cacheOnly}) async => _page([1]),
+      upsert: (_) {},
+      isActive: () => true,
+      isRevalidating: flag,
+    );
+    expect(flag.value, isTrue); // 即返し直後は revalidate 中
+    await Future<void>.delayed(Duration.zero);
+    expect(flag.value, isFalse); // 背景完了で false
+  });
+}
+```
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd /Users/ryotaro.onoue/dev/github.com/YumNumm/EQMonitor/.claude/worktrees/swr-cache-lists && cd app && flutter test test/core/paging/cache_first_refresh_test.dart`
+Expected: FAIL (`cacheFirstRefresh` 未定義)
+
+- [ ] **Step 3: 実装**
+
+`app/lib/core/paging/cache_first_refresh.dart`:
+
+```dart
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:paging_view/paging_view.dart';
+
+/// paging_view DataSource の初回ページ (Refresh) を cache-first にする。
+///
+/// cache-only 取得がヒットしたら即 [Success] を返し、背景で通常取得して
+/// [upsert] で in-place 更新する。cache-only が失敗 (miss/corrupt) したら
+/// 通常取得にフォールバックし、それも失敗すれば [Failure]。
+///
+/// 背景更新は [isActive] が false (DataSource 破棄後・再 Refresh 後) ならスキップし、
+/// 失敗は [onRevalidateError] に渡して握りつぶさない。
+Future<LoadResult<String?, V>> cacheFirstRefresh<V>({
+  required Future<PageData<String?, V>> Function({required bool cacheOnly})
+  fetchPage,
+  required void Function(List<V> fresh) upsert,
+  required bool Function() isActive,
+  ValueNotifier<bool>? isRevalidating,
+  void Function(Object error, StackTrace stackTrace)? onRevalidateError,
+}) async {
+  try {
+    final cached = await fetchPage(cacheOnly: true);
+    isRevalidating?.value = true;
+    unawaited(
+      Future.microtask(() async {
+        try {
+          final fresh = await fetchPage(cacheOnly: false);
+          if (isActive()) {
+            upsert(fresh.data);
+          }
+        } on Object catch (error, stackTrace) {
+          onRevalidateError?.call(error, stackTrace);
+        } finally {
+          if (isActive()) {
+            isRevalidating?.value = false;
+          }
+        }
+      }),
+    );
+    return Success(page: cached);
+  } on Object catch (_) {
+    try {
+      final fresh = await fetchPage(cacheOnly: false);
+      return Success(page: fresh);
+    } on Exception catch (error, stackTrace) {
+      return Failure(error: error, stackTrace: stackTrace);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: テスト成功を確認**
+
+Run: `cd <worktree> && cd app && flutter test test/core/paging/cache_first_refresh_test.dart`
+Expected: PASS (5 件)
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/lib/core/paging/cache_first_refresh.dart app/test/core/paging/cache_first_refresh_test.dart
+git commit -m "feat: paging DataSource 用 cacheFirstRefresh ヘルパーを追加"
+```
+
+---
+
+### Task 2: リポジトリの client 上書き
+
+**Files:**
+- Modify: `app/lib/feature/feed/data/repository/feed_repository.dart`
+- Modify: `app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart`
+
+**Interfaces:**
+- Produces:
+  - `FeedRepository.fetch({String? after, api.ApiClient? client})` — `(client ?? _api)` を使う。
+  - `EarthquakeHistoryRepository.fetchEarthquakeList(..., {api.ApiClient? client})` — 既存の全引数 + `client`。内部で `(client ?? <既存の client フィールド>)` を使う。
+
+**実装メモ:** `FeedRepository.fetchByTelegramHash` が既に `{ApiClient? client}` → `(client ?? _api)` の形。これに倣う。`earthquake_history_repository.dart` を読み、`fetchEarthquakeList` が使っている ApiClient フィールド名を確認し `(client ?? そのフィールド)` にする。**署名変更は生成に影響しない** (これらは通常クラスのメソッド)。
+
+- [ ] **Step 1: feed_repository.dart を変更**
+
+`fetch` を次のように変更 (既存の `toFeedListResponse()` 変換は保持):
+
+```dart
+Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
+  final response = await (client ?? _api).feed.getV2Feeds(after: after);
+  return response.data.toFeedListResponse();
+}
+```
+
+- [ ] **Step 2: earthquake_history_repository.dart を変更**
+
+`earthquake_history_repository.dart` を読み、`fetchEarthquakeList(...)` の末尾に `api.ApiClient? client` を追加し、実際の API 呼び出しで使っているクライアント (例 `_apiClient` / `_client`) を `(client ?? そのフィールド)` に置換する。他の引数・戻り値は不変。
+
+- [ ] **Step 3: コンパイル確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/feed/ test/feature/earthquake_history/`
+Expected: 既存テストが PASS (署名追加のみで挙動不変)。テストが無いディレクトリはスキップされる。少なくともコンパイルが通ること。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add app/lib/feature/feed/data/repository/feed_repository.dart app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart
+git commit -m "feat: Feed/地震履歴リポジトリに ApiClient 上書きを追加"
+```
+
+---
+
+### Task 3: FeedDataSource を cache-first 化
+
+**Files:**
+- Modify: `app/lib/feature/feed/data/notifier/feed_data_source.dart`
+- Test: `app/test/feature/feed/feed_data_source_test.dart`
+
+**Interfaces:**
+- Consumes: `cacheFirstRefresh` (Task 1), `FeedRepository.fetch({after, client})` (Task 2), `cacheOnlyApiClientProvider`。
+- Produces:
+  - `FeedDataSource({required FeedRepository repository, required api.ApiClient cacheOnlyClient})`
+  - `void upsertItems(List<FeedItem> fresh)` — `FeedItem.id` で update/insert。
+  - `final ValueNotifier<bool> isRevalidating`
+  - `feedDataSource` provider が cache-only クライアントを注入。
+
+**実装メモ:** paging_view の `DataSource` の items 変更 API (`notifier.values` / `updateItem` / `insertItem`) は `EarthquakeHistoryDataSource.upsertItems` (GroupedDataSource) の実装を参照し、`FeedItem.id` (`required String id`) 一致で update、無ければ末尾 append (Feed は時系列順・cursor 追加なので新規は末尾で可) にする。plain `DataSource` に該当 API が無ければ paging_view のドキュメント/型定義を確認して等価操作にする。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/test/feature/feed/feed_data_source_test.dart` — `upsertItems` の id マージを検証する単体テスト (DataSource の items 操作を最小構成で確認)。実際の paging_view `DataSource` の items 参照 API に合わせてテストを書く。最低限:
+- 既存 items に同 id → 中身が更新される。
+- 新規 id → 追加される。
+
+(注: `load()` の cache-first 経路は `cacheFirstRefresh` (Task 1) 側で検証済みのため、ここでは `upsertItems` の id マージに集中する。paging_view の内部状態を直接検証しづらい場合は、`upsertItems` に渡す前後で公開 getter (`notifier.values` 等) を突き合わせる。)
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/feed/feed_data_source_test.dart`
+Expected: FAIL (`upsertItems` 未定義 / コンストラクタ引数不一致)
+
+- [ ] **Step 3: FeedDataSource を実装**
+
+- コンストラクタに `required api.ApiClient cacheOnlyClient` を追加し保持。`final ValueNotifier<bool> isRevalidating = ValueNotifier(false);` と `bool _disposed = false;` を追加。`dispose()` をオーバーライドして `_disposed = true; isRevalidating.dispose();` 後に `super.dispose()`。
+- `load(Refresh)` を `cacheFirstRefresh` 経由に変更:
+  ```dart
+  Refresh() => await cacheFirstRefresh<FeedItem>(
+    fetchPage: ({required cacheOnly}) async {
+      final response = await _repository.fetch(
+        after: null,
+        client: cacheOnly ? _cacheOnlyClient : null,
+      );
+      return PageData(data: response.feeds, appendKey: response.nextCursor);
+    },
+    upsert: upsertItems,
+    isActive: () => !_disposed,
+    isRevalidating: isRevalidating,
+    onRevalidateError: (e, st) => talker.error(e, st),
+  ),
+  ```
+  `Append(:final key)` / `Prepend()` は従来通り。
+- `upsertItems(List<FeedItem> fresh)` を追加 (id マージ)。
+- `feedDataSource` provider で `final cacheOnly = await ref.watch(cacheOnlyApiClientProvider.future);` を取得し `FeedDataSource(repository: repository, cacheOnlyClient: cacheOnly)` に渡す。
+- import 追加: `cacheFirstRefresh`, `cacheOnlyApiClientProvider`, `talker`, `flutter/foundation` (ValueNotifier)。
+
+- [ ] **Step 4: テスト成功を確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/feed/`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/lib/feature/feed/data/notifier/feed_data_source.dart app/test/feature/feed/feed_data_source_test.dart
+git commit -m "feat: お知らせ一覧を cache-first 化 (FeedDataSource)"
+```
+
+---
+
+### Task 4: EarthquakeHistoryDataSource を cache-first 化 (既定 All のみ)
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart`
+- Test: `app/test/feature/earthquake_history/earthquake_history_data_source_cache_test.dart`
+
+**Interfaces:**
+- Consumes: `cacheFirstRefresh` (Task 1), `EarthquakeHistoryRepository.fetchEarthquakeList({client})` (Task 2), `cacheOnlyApiClientProvider`。
+- Produces:
+  - `EarthquakeHistoryDataSource({..., required api.ApiClient cacheOnlyClient})`
+  - `final ValueNotifier<bool> isRevalidating`
+  - 既定 All 判定 `bool _isDefaultAll(EarthquakeHistoryParameter)`。
+
+**実装メモ:** 既存の `_fetch({limit, cursor})` に `api.ApiClient? client` を追加し、`EarthquakeHistoryParameterAll()` 分岐で `_repository.fetchEarthquakeList(..., client: client)` を渡す (他分岐は client 不要)。`upsertItems` は既存を再利用。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/test/feature/earthquake_history/earthquake_history_data_source_cache_test.dart` — `_isDefaultAll` 相当の判定を検証。`EarthquakeHistoryDataSource` に `@visibleForTesting bool isDefaultAll(p)` を公開するか、トップレベル関数として切り出して検証する:
+```dart
+test('既定 All は true、フィルタ付き/検索は false', () {
+  expect(isDefaultAllParameter(
+    const EarthquakeHistoryParameter.all(sortBy: EarthquakeSortBy.eventId, sortOrder: SortOrder.desc)), isTrue);
+  expect(isDefaultAllParameter(
+    const EarthquakeHistoryParameter.all(sortBy: EarthquakeSortBy.eventId, sortOrder: SortOrder.desc, magnitudeGte: 5)), isFalse);
+  expect(isDefaultAllParameter(
+    const EarthquakeHistoryParameter.prefecture(sortBy: EarthquakeSortBy.eventId, sortOrder: SortOrder.desc, prefectureCode: '13')), isFalse);
+});
+```
+判定はトップレベル関数 `bool isDefaultAllParameter(EarthquakeHistoryParameter p) => p == const EarthquakeHistoryParameter.all(sortBy: EarthquakeSortBy.eventId, sortOrder: SortOrder.desc);` として `earthquake_history_data_source.dart` に定義する (freezed 値等価)。
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/earthquake_history/earthquake_history_data_source_cache_test.dart`
+Expected: FAIL (`isDefaultAllParameter` 未定義)
+
+- [ ] **Step 3: 実装**
+
+- トップレベル `isDefaultAllParameter` を定義。
+- コンストラクタに `required api.ApiClient cacheOnlyClient`、`final ValueNotifier<bool> isRevalidating = ValueNotifier(false);`、`bool _disposed = false;`、`dispose()` オーバーライドを追加。
+- `_fetch` に `api.ApiClient? client` を追加し `EarthquakeHistoryParameterAll()` 分岐で `client: client` を渡す。
+- `load(Refresh)` を変更: `isDefaultAllParameter(_parameter)` なら `cacheFirstRefresh<EarthquakePartial>(fetchPage: ({required cacheOnly}) async { final page = await _fetch(limit: 10, cursor: null, client: cacheOnly ? _cacheOnlyClient : null); return PageData(data: page.items, appendKey: page.nextToken); }, upsert: upsertItems, isActive: () => !_disposed, isRevalidating: isRevalidating, onRevalidateError: (e, st) => talker.error(e, st))`。それ以外は従来の `_load(limit: _parameter is EarthquakeHistoryParameterAll ? 10 : 50, cursor: null)`。`Append` は不変。
+- `earthquakeHistoryDataSource` provider で cache-only を取得し DataSource に注入。既存の timer/realtime/appResume setup は不変。
+- import 追加: `cacheFirstRefresh`, `cacheOnlyApiClientProvider`, `flutter/foundation`。`talker` は既に import 済み。
+
+- [ ] **Step 4: テスト成功を確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/earthquake_history/`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart app/test/feature/earthquake_history/earthquake_history_data_source_cache_test.dart
+git commit -m "feat: 地震履歴の既定一覧を cache-first 化 (EarthquakeHistoryDataSource)"
+```
+
+---
+
+### Task 5: Home フィードシートの FeedNotifier を SWR 化
+
+**Files:**
+- Modify: `app/lib/feature/feed/data/notifier/feed_notifier.dart`
+- Test: `app/test/feature/feed/feed_notifier_test.dart`
+
+**Interfaces:**
+- Consumes: `CachedNotifier` (既存), `FeedRepository.fetch({after, client})` (Task 2)。
+- Produces: `FeedNotifier extends _$FeedNotifier with CachedNotifier<FeedNotifierState>`。`fetch(ApiClient)` / `build() => cachedBuild()`。
+
+**実装メモ:** `start_notifier.dart` の形に倣う。`fetchNextData` は不変。**mixin 付与は `feed_notifier.g.dart` を変えない** (build_runner 不要)。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/test/feature/feed/feed_notifier_test.dart` — cache-only ヒット時に即データが返ること (fake repository/クライアントで検証)。既存の CachedNotifier 系テストがあればそのパターンに倣う。無ければ、`ProviderContainer` で `feedRepositoryProvider` と `cacheOnlyApiClientProvider`/`apiClientProvider` を override して `feedProvider` の初回値がキャッシュ由来になることを検証する。
+
+- [ ] **Step 2: 失敗を確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/feed/feed_notifier_test.dart`
+Expected: FAIL
+
+- [ ] **Step 3: 実装**
+
+`feed_notifier.dart`:
+```dart
+@riverpod
+class FeedNotifier extends _$FeedNotifier with CachedNotifier<FeedNotifierState> {
+  @override
+  Future<FeedNotifierState> fetch(ApiClient client) async {
+    final repository = await ref.read(feedRepositoryProvider.future);
+    final response = await repository.fetch(client: client);
+    return (items: response.feeds, nextCursor: response.nextCursor);
+  }
+
+  @override
+  Future<FeedNotifierState> build() => cachedBuild();
+
+  Future<void> fetchNextData() async { /* 既存のまま */ }
+}
+```
+import 追加: `cached_notifier.dart`, `eqmonitor_api` (ApiClient)。既存の `async_value.dart` import 等は保持。
+
+- [ ] **Step 4: テスト成功を確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/feed/`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add app/lib/feature/feed/data/notifier/feed_notifier.dart app/test/feature/feed/feed_notifier_test.dart
+git commit -m "feat: Home フィードシート (FeedNotifier) を SWR 化"
+```
+
+---
+
+### Task 6: 一覧ページに「更新中」バナー
+
+**Files:**
+- Modify: `app/lib/feature/feed/ui/page/feed_page.dart`
+- Modify: `app/lib/feature/earthquake_history/ui/earthquake_history_page.dart`
+
+**Interfaces:**
+- Consumes: `FeedDataSource.isRevalidating` / `EarthquakeHistoryDataSource.isRevalidating` (Task 3/4), `CachedDataBanner` (既存)。
+
+**実装メモ:** 両ページは `dataSourceAsync.when(data: (dataSource) => ...)` の形。`data` で得た DataSource の `isRevalidating` (`ValueListenable<bool>`) を `ValueListenableBuilder` で購読し、true の時に詳細ページ等と同じ見た目の「更新中」表示を出す。`CachedDataBanner` は `AsyncValue` ベースだが、同等の見た目 (同じ文言/スタイル) を出せば良い。`cached_data_banner.dart` を読み、内部の表示 Widget を再利用できるなら再利用、できなければ同等の小さな表示を追加する。バナーはリストの上部 (既存レイアウトの邪魔にならない位置) に置く。
+
+- [ ] **Step 1: feed_page.dart にバナーを追加**
+
+`feed_page.dart` の `data: (dataSource) => ...` 内で、リスト本体の上に `ValueListenableBuilder<bool>(valueListenable: dataSource.isRevalidating, builder: (_, revalidating, _) => revalidating ? <更新中バナー> : const SizedBox.shrink())` を重ねる (既存の `CachedDataBanner` の見た目に合わせる)。
+
+- [ ] **Step 2: earthquake_history_page.dart にバナーを追加**
+
+同様に `_PagingBody` (または `data:` 直下) で `dataSource.isRevalidating` を購読しバナーを出す。既存レイアウト (RefreshIndicator/paging list) を壊さない位置に置く。
+
+- [ ] **Step 3: コンパイル確認**
+
+Run: `cd <worktree> && cd app && flutter test test/feature/feed/ test/feature/earthquake_history/`
+Expected: PASS (コンパイルが通ること)。UI の目視確認は実機/レビューで行う。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add app/lib/feature/feed/ui/page/feed_page.dart app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
+git commit -m "feat: 地震履歴・お知らせ一覧に更新中バナーを追加"
+```
+
+---
+
+### Task 7: 仕上げ (format + 統合テスト)
+
+**Files:** 上記変更ファイル
+
+- [ ] **Step 1: 変更 dart ファイルを format**
+
+Run: `cd <worktree> && cd app && dart format $(git -C .. diff --name-only <merge-base>..HEAD | grep '^app/.*\.dart$' | sed 's|^app/||')`
+(merge-base = このブランチの分岐元。`git merge-base origin/develop HEAD` で取得。) 差分が出たら次でコミット。
+
+- [ ] **Step 2: 関連テストを統合実行**
+
+Run: `cd <worktree> && cd app && flutter test test/core/paging/ test/feature/feed/ test/feature/earthquake_history/`
+Expected: すべて PASS (既存 pre-existing 失敗 `parameter_repository_refresh_test.dart` の SHINDO_DB_STATIONS は本 PR 無関係)。
+
+- [ ] **Step 3: format 差分をコミット**
+
+```bash
+git add -A -- '*.dart'
+git commit -m "style: dart format 適用"
+```
+
+---
+
+## 補足: PR とデプロイ
+
+全 Task 完了後、`develop` ベースで PR を作成し (`--repo YumNumm/EQMonitor`)、Issue #1452 を close する。PR には build_runner 不使用の旨と、cache-first の対象 (両一覧タブ + Home フィードシート) を明記する。

--- a/docs/superpowers/specs/2026-07-07-swr-cache-lists-design.md
+++ b/docs/superpowers/specs/2026-07-07-swr-cache-lists-design.md
@@ -1,0 +1,128 @@
+# 一覧のSWRキャッシュ化 (地震履歴・お知らせ) 設計書
+
+- 日付: 2026-07-07
+- 対象: Flutter アプリ (`app/`)
+- 関連: 静的データの SWR 化 (地震詳細・最高震度・電文詳細など) は実装済み。本件はその一覧版。
+
+## 背景・目的
+
+機内モード (オフライン) でアプリを起動すると、地震履歴一覧とお知らせ (Feed) 一覧が timeout でエラー表示になる。原因は、既存の SWR 基盤 `CachedNotifier` (キャッシュ即返し → 裏で revalidate → 前値保持) が、この 2 つの一覧 Notifier に適用されていないため。他の多くの Notifier (地震詳細・県別/市別最高震度・電文詳細・お知らせ詳細・パラメータ等) は既に SWR 化済み。
+
+目的は、地震履歴の**デフォルト一覧**とお知らせ一覧に `CachedNotifier` を適用し、オフライン/初回でも「キャッシュがあれば即表示し、裏で再取得して更新する」挙動にすること。差分取得 API (計画 A〜E) は非対象で、従来通り全件取得のまま。
+
+## 現状 (調査結果)
+
+### 既存 SWR 基盤 `CachedNotifier`
+`app/lib/core/provider/cached_notifier.dart`。`mixin CachedNotifier<T> on $AsyncNotifier<T>`。
+
+- `Future<T> fetch(ApiClient client)` を実装側が定義。
+- `cachedBuild()`: cache-only クライアントで取得 → 即 return → マイクロタスクで背景 revalidate 予約。cache miss → 通常クライアントで取得。corrupt cache → force-fresh。
+- `_revalidateInBackground(gen, cached)`: `state = AsyncLoading.copyWithPrevious(AsyncData(cache, kind: cache))` → fresh 取得 → `AsyncData(fresh)`。失敗時は `AsyncError.copyWithPrevious(state)` で前値保持。`_generation` ガードで古い revalidate の上書きを防止。
+- `revalidateOnAppResume` (既定 false): app 復帰時に `invalidateSelf`。
+
+定型パターン (`start_notifier.dart`):
+```dart
+class StartNotifier extends _$StartNotifier with CachedNotifier<StartResponse> {
+  @override
+  Future<StartResponse> fetch(ApiClient client) async =>
+      (await client.start.getV1Start()).data;
+  @override
+  Future<StartResponse> build() => cachedBuild();
+}
+```
+family notifier への適用実績あり (`earthquake_history_details_notifier` 等)。
+
+リポジトリ側は client 上書きを受ける形が既存 (`FeedRepository.fetchByTelegramHash(hash, {ApiClient? client})` → `(client ?? _api)`)。
+
+### 対象 Notifier (未 SWR 化)
+- `app/lib/feature/feed/data/notifier/feed_notifier.dart`: `@riverpod class FeedNotifier`。`build()` で `repository.fetch()`。ページネーション (`fetchNextData`, nextCursor) あり。
+- `app/lib/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart`: `@riverpod class EarthquakeHistoryNotifier`。`build(EarthquakeHistoryParameter parameter)` (family)。`EarthquakeHistoryParameterAll` 時に 5 分タイマー (`invalidateSelf`)・リアルタイム upsert・app 復帰時 `_revalidateLatest` を設定。`_fetch(parameter, limit, cursor)` で取得。ページネーション (`fetchNextData`)・`_upsertItems` あり。parameter は All / Region / Prefecture / City / Station と各種フィルタ (magnitude/depth/intensity/… ・sort) を持つ。
+
+### UI 表示基盤
+`app/lib/core/component/cached_data_banner.dart`: `CachedDataBanner(values: [asyncValue...])`。いずれかが `isFromCache` (DataKind.cache) の時「更新中」バナーを表示。既に地震詳細・お知らせ詳細・強度履歴・電文一覧ページで使用。
+
+## 設計
+
+### 方針
+既存 `CachedNotifier` を、お知らせ一覧と地震履歴の**デフォルト一覧のみ**に適用する。地震履歴の既存更新機構 (タイマー・リアルタイム・app 復帰) は**維持**し、初回ロードを cache-first にする「上乗せ」。
+
+**コード生成不要**: mixin の付与とリポジトリメソッドへのオプション引数追加は、riverpod 生成物 (`*.g.dart`) の署名を変えないため build_runner を回さない (本リポジトリは build_runner が恒常故障のため重要)。
+
+### 1. お知らせ (Feed)
+
+**`FeedRepository.fetch`** に client 上書きを追加:
+```dart
+Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
+  final response = await (client ?? _api).feed.getV2Feeds(after: after);
+  return response.data.toFeedListResponse();
+}
+```
+
+**`FeedNotifier`** を SWR 化:
+```dart
+@riverpod
+class FeedNotifier extends _$FeedNotifier with CachedNotifier<FeedNotifierState> {
+  @override
+  Future<FeedNotifierState> fetch(ApiClient client) async {
+    final repository = await ref.read(feedRepositoryProvider.future);
+    final response = await repository.fetch(client: client);
+    return (items: response.feeds, nextCursor: response.nextCursor);
+  }
+
+  @override
+  Future<FeedNotifierState> build() => cachedBuild();
+
+  Future<void> fetchNextData() async { /* 既存のまま (ネットワーク専用) */ }
+}
+```
+ページネーションはオフライン非対応のまま (仕様)。
+
+### 2. 地震履歴 (デフォルト一覧のみ)
+
+**`EarthquakeHistoryRepository.fetchEarthquakeList`** と Notifier の **`_fetch`** に オプション `api.ApiClient? client` を追加し、`(client ?? 既定)` で使う。SWR はデフォルト All のみに適用するため、client 上書きが実際に渡るのは `fetchEarthquakeList` 経由のデフォルト All パスのみ。他パスは `client` を渡さず従来通り。
+
+**`EarthquakeHistoryNotifier`** に `with CachedNotifier<PaginatedResponse<EarthquakePartial>>` を付与:
+```dart
+@override
+Future<PaginatedResponse<EarthquakePartial>> fetch(ApiClient client) =>
+    _fetch(parameter: parameter, limit: 10, cursor: null, client: client);
+
+@override
+Future<PaginatedResponse<EarthquakePartial>> build(
+  EarthquakeHistoryParameter parameter,
+) async {
+  if (parameter is EarthquakeHistoryParameterAll) {
+    // 既存の 5 分タイマー・リアルタイム upsert・app 復帰 revalidate をそのまま設定
+    ...
+  }
+  if (_isDefaultAll(parameter)) {
+    return cachedBuild();
+  }
+  return _fetch(parameter: parameter, limit: ..., cursor: null);
+}
+```
+
+- `_isDefaultAll(parameter)`: フィルタ未適用・既定ソートの `EarthquakeHistoryParameterAll` を判定する述語。既定インスタンスとの等価判定、または全フィルタ null + 既定 sort の確認で実装する (正確な定義は実装計画で確定)。
+- `limit`: 既存に合わせ、All は 10、検索系は 50。
+- `_revalidateLatest`・`fetchNextData`・`_upsertItems` は不変。`revalidateOnAppResume` は有効化しない (既存の軽量 `_revalidateLatest` を app 復帰時に使い続ける)。
+
+### 3. UI
+
+地震履歴一覧ページとお知らせ一覧ページに `CachedDataBanner(values: [asyncValue])` を追加 (詳細ページ等と一貫)。デフォルト All のキャッシュ表示時のみバナーが出る (フィルタ時は `isFromCache=false` で非表示)。
+
+### 4. 相互作用の扱い
+
+背景 revalidate・5 分タイマー `invalidateSelf`・リアルタイム `_upsertItems` はいずれも最終的に `AsyncData` を生成する。`CachedNotifier` の `_generation` ガードが古い revalidate による上書きを防ぐ。既存コードに既にあるレース (timer invalidate vs upsert) と同程度で、新たな根本問題は増やさない。背景 revalidate 完了時に `AsyncData(fresh)` がリアルタイム upsert 直後の値を一時的に上書きしうるが、fresh は最新のサーバ値のため実害は軽微 (許容)。
+
+## テスト方針
+
+- `FeedNotifier`: cache-only ヒットで即データを返す / cache miss で通常取得へフォールバック / 背景 revalidate で fresh に更新。
+- `EarthquakeHistoryNotifier`: デフォルト All は cache-first になる / フィルタ付き All・検索系は従来のネットワーク経路のまま (cache-only を使わない)。
+- オフライン (cache-only ヒット) 時に `AsyncError` にならずデータが表示される。
+- 既存の CachedNotifier 系テストのパターンに倣う。
+
+## 非対象 (Out of Scope)
+
+- 差分取得 API (backend, 計画 A〜E)。
+- 地震履歴のフィルタ/検索クエリのオフラインキャッシュ (デフォルト All のみ SWR 化)。
+- オフラインでのページネーション。

--- a/docs/superpowers/specs/2026-07-07-swr-cache-lists-design.md
+++ b/docs/superpowers/specs/2026-07-07-swr-cache-lists-design.md
@@ -3,120 +3,91 @@
 - 日付: 2026-07-07
 - 対象: Flutter アプリ (`app/`)
 - 関連: 静的データの SWR 化 (地震詳細・最高震度・電文詳細など) は実装済み。本件はその一覧版。
+- Issue: YumNumm/EQMonitor#1452
 
 ## 背景・目的
 
-機内モード (オフライン) でアプリを起動すると、地震履歴一覧とお知らせ (Feed) 一覧が timeout でエラー表示になる。原因は、既存の SWR 基盤 `CachedNotifier` (キャッシュ即返し → 裏で revalidate → 前値保持) が、この 2 つの一覧 Notifier に適用されていないため。他の多くの Notifier (地震詳細・県別/市別最高震度・電文詳細・お知らせ詳細・パラメータ等) は既に SWR 化済み。
+機内モード (オフライン) でアプリを起動すると、地震履歴一覧とお知らせ (Feed) 一覧が timeout でエラー表示になる。原因は、これらの一覧が「キャッシュがあれば即表示 → 裏で再取得して更新」になっておらず、オフライン/初回で通常取得が失敗すると即エラーになるため。
 
-目的は、地震履歴の**デフォルト一覧**とお知らせ一覧に `CachedNotifier` を適用し、オフライン/初回でも「キャッシュがあれば即表示し、裏で再取得して更新する」挙動にすること。差分取得 API (計画 A〜E) は非対象で、従来通り全件取得のまま。
+目的は、地震履歴一覧・お知らせ一覧・Home フィードシートに cache-first (キャッシュ即返し → 裏で revalidate → 更新) を導入し、オフライン/初回でもキャッシュを表示すること。差分取得 API (計画 A〜E) は非対象で従来通り全件取得。
 
 ## 現状 (調査結果)
 
-### 既存 SWR 基盤 `CachedNotifier`
-`app/lib/core/provider/cached_notifier.dart`。`mixin CachedNotifier<T> on $AsyncNotifier<T>`。
+### 一覧の実データフロー
+- **お知らせ一覧タブ** (`app/lib/feature/feed/ui/page/feed_page.dart`) → `feedDataSourceProvider` → `FeedDataSource extends DataSource<String?, FeedItem>` (paging_view, `feed_data_source.dart`)。`load(Refresh)` → `_fetch(null)` → `repository.fetch(after:)` → `Success`/`Failure`。
+- **地震履歴一覧タブ** (`app/lib/feature/earthquake_history/ui/earthquake_history_page.dart`) → `earthquakeHistoryDataSourceProvider(parameter)` → `EarthquakeHistoryDataSource extends GroupedDataSource<String?, String, EarthquakePartial>` (paging_view, `earthquake_history_data_source.dart`)。`EarthquakeHistoryParameterAll` 時に provider 側で 5 分タイマー・リアルタイム `upsertItems`・app 復帰 `revalidateLatest` を設定。既定一覧 parameter は `const EarthquakeHistoryParameter.all(sortBy: .eventId, sortOrder: .desc)`。`upsertItems(byeventId)` を保持。
+- **Home フィードシート** (`app/lib/feature/home/ui/component/sheet/home_feed_sheet.dart`) → `feedProvider` (`FeedNotifier`, `@riverpod` AsyncNotifier)。素の `build()` で `repository.fetch()`。ページネーション (`fetchNextData`) あり。
+- `EarthquakeHistoryNotifier` (`earthquake_history_notifier.dart`) は**消費者ゼロの死んだコード** (SWR 対象外。別途削除可)。
 
-- `Future<T> fetch(ApiClient client)` を実装側が定義。
-- `cachedBuild()`: cache-only クライアントで取得 → 即 return → マイクロタスクで背景 revalidate 予約。cache miss → 通常クライアントで取得。corrupt cache → force-fresh。
-- `_revalidateInBackground(gen, cached)`: `state = AsyncLoading.copyWithPrevious(AsyncData(cache, kind: cache))` → fresh 取得 → `AsyncData(fresh)`。失敗時は `AsyncError.copyWithPrevious(state)` で前値保持。`_generation` ガードで古い revalidate の上書きを防止。
-- `revalidateOnAppResume` (既定 false): app 復帰時に `invalidateSelf`。
-
-定型パターン (`start_notifier.dart`):
-```dart
-class StartNotifier extends _$StartNotifier with CachedNotifier<StartResponse> {
-  @override
-  Future<StartResponse> fetch(ApiClient client) async =>
-      (await client.start.getV1Start()).data;
-  @override
-  Future<StartResponse> build() => cachedBuild();
-}
-```
-family notifier への適用実績あり (`earthquake_history_details_notifier` 等)。
-
-リポジトリ側は client 上書きを受ける形が既存 (`FeedRepository.fetchByTelegramHash(hash, {ApiClient? client})` → `(client ?? _api)`)。
-
-### 対象 (未 SWR 化)
-- **お知らせ**: `app/lib/feature/feed/data/notifier/feed_notifier.dart`: `@riverpod class FeedNotifier`。`build()` で `repository.fetch()`。ページネーション (`fetchNextData`, nextCursor) あり。`feedProvider` として Home フィードシート・お知らせ一覧ページで使用中 (実利用あり)。
-- **地震履歴**: 実際の一覧は `app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart` の **`earthquakeHistoryDataSourceProvider(parameter)`** (family) が返す `EarthquakeHistoryDataSource extends GroupedDataSource<String?, String, EarthquakePartial>` (paging_view)。`earthquake_history_page.dart` が唯一の消費者。`load(Refresh/Append)` → `_load` → `_fetch` → repository。`EarthquakeHistoryParameterAll` 時に 5 分タイマー (`invalidateSelf`)・リアルタイム `upsertItems`・app 復帰時 `revalidateLatest` を provider 側で設定。既定一覧の parameter は `const EarthquakeHistoryParameter.all(sortBy: .eventId, sortOrder: .desc)`。
-  - 注: `earthquake_history_notifier.dart` (`EarthquakeHistoryNotifier`) は**消費者ゼロの死んだコード**。SWR 対象ではない (別途削除可)。
-- `CachedNotifier` は `$AsyncNotifier<T>` 用の mixin。Feed には適用できるが、地震履歴の `GroupedDataSource` には適用できないため、地震履歴は DataSource 内に cache-first を作り込む。
-
-### UI 表示基盤
-`app/lib/core/component/cached_data_banner.dart`: `CachedDataBanner(values: [asyncValue...])`。いずれかが `isFromCache` (DataKind.cache) の時「更新中」バナーを表示。既に地震詳細・お知らせ詳細・強度履歴・電文一覧ページで使用。
+### 既存 SWR 基盤・UI
+- `CachedNotifier` (`app/lib/core/provider/cached_notifier.dart`): `mixin on $AsyncNotifier<T>`。`fetch(ApiClient)` 実装 → `cachedBuild()` で cache-only 即返し → 背景 revalidate。**AsyncNotifier 専用** (paging DataSource には使えない)。参照実装 `start_notifier.dart`。
+- cache-only クライアント: `cacheOnlyApiClientProvider` (`app/lib/core/api/cache_only_api_client_provider.dart`)。miss 時 `CacheMissException` を投げる。通常クライアント: `apiClientProvider`。
+- リポジトリの client 上書きパターン既存: `FeedRepository.fetchByTelegramHash(hash, {ApiClient? client})` → `(client ?? _api)`。
+- `CachedDataBanner` (`app/lib/core/component/cached_data_banner.dart`): `CachedDataBanner(values: [asyncValue...])`。いずれかが `isFromCache` (DataKind.cache) の時「更新中」表示。
 
 ## 設計
 
-### 方針
-既存 `CachedNotifier` を、お知らせ一覧と地震履歴の**デフォルト一覧のみ**に適用する。地震履歴の既存更新機構 (タイマー・リアルタイム・app 復帰) は**維持**し、初回ロードを cache-first にする「上乗せ」。
+3 つの表面に cache-first を導入する。paging DataSource 2 つ (Feed 一覧・地震履歴一覧) は同じ cache-first パターンなので**共通ヘルパーに切り出す** (DRY)。Home フィードシートは AsyncNotifier なので既存 `CachedNotifier` を適用。**コード生成不要** (mixin 付与・オプション引数追加は riverpod 生成物の署名を変えない。本リポジトリは build_runner が恒常故障のため重要)。
 
-**コード生成不要**: mixin の付与とリポジトリメソッドへのオプション引数追加は、riverpod 生成物 (`*.g.dart`) の署名を変えないため build_runner を回さない (本リポジトリは build_runner が恒常故障のため重要)。
+### 0. 共通: paging cache-first ヘルパー
 
-### 1. お知らせ (Feed)
+`app/lib/feature/.../` もしくは共通の場所に、paging DataSource の初回ページ (Refresh) を cache-first にするヘルパーを新設する。責務: cache-only で 1 ページ目を取得 → ヒットなら即 `Success` を返し、背景で通常取得して in-place 更新 (upsert) を予約 → miss/エラーなら通常取得。
 
-**`FeedRepository.fetch`** に client 上書きを追加:
+インターフェース案 (ジェネリック関数):
 ```dart
-Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
-  final response = await (client ?? _api).feed.getV2Feeds(after: after);
-  return response.data.toFeedListResponse();
-}
+Future<LoadResult<String?, V>> cacheFirstRefresh<V>({
+  required Future<PageData<String?, V>> Function(ApiClient client) fetchPage,
+  required ApiClient cacheOnlyClient,
+  required ApiClient normalClient,
+  required void Function(List<V> fresh) upsert, // 背景 revalidate 成功時の in-place 更新
+  required bool Function() isActive,            // disposal / 世代ガード
+});
 ```
+- cache-only `fetchPage` がヒット → その `PageData` で `Success` を即返し、`Future.microtask` で通常 `fetchPage` を実行 → 成功かつ `isActive()` なら `upsert(fresh.data)`。
+- cache-only が `CacheMissException` (または cache 系エラー) → 通常 `fetchPage` で `Success`/`Failure`。
+- 背景 revalidate の失敗は握りつぶさず log。
 
-**`FeedNotifier`** を SWR 化:
-```dart
-@riverpod
-class FeedNotifier extends _$FeedNotifier with CachedNotifier<FeedNotifierState> {
-  @override
-  Future<FeedNotifierState> fetch(ApiClient client) async {
-    final repository = await ref.read(feedRepositoryProvider.future);
-    final response = await repository.fetch(client: client);
-    return (items: response.feeds, nextCursor: response.nextCursor);
-  }
+### 1. お知らせ一覧タブ (`FeedDataSource`)
 
-  @override
-  Future<FeedNotifierState> build() => cachedBuild();
+- `FeedRepository.fetch({String? after, ApiClient? client})` に client 上書きを追加 (`(client ?? _api)`)。
+- `feedDataSource` provider で cache-only / 通常クライアントを取得し `FeedDataSource` に渡す。
+- `FeedDataSource.load(Refresh)` を `cacheFirstRefresh` 経由に変更。`fetchPage(client)` = `repository.fetch(client: client)` を `PageData(data: feeds, appendKey: nextCursor)` に変換。`upsert` = 新設する `upsertItems(byid)` (FeedItem の一意 id でマージ; 既存を update / 新規を挿入)。`Append` は従来通り通常クライアント。
+- 「更新中」を表す `ValueListenable<bool> isRevalidating` を公開 (cache 即返し〜背景 revalidate 完了で true)。
 
-  Future<void> fetchNextData() async { /* 既存のまま (ネットワーク専用) */ }
-}
-```
-ページネーションはオフライン非対応のまま (仕様)。
+### 2. 地震履歴一覧タブ (`EarthquakeHistoryDataSource`)
 
-### 2. 地震履歴 (デフォルト一覧のみ / paging_view DataSource に cache-first を作り込み)
+- `EarthquakeHistoryRepository.fetchEarthquakeList(..., {ApiClient? client})` に client 上書きを追加 (`(client ?? _api)`)。
+- `earthquakeHistoryDataSource` provider で cache-only / 通常クライアントを取得し DataSource に渡す。既存のタイマー・リアルタイム・app 復帰 setup は不変。
+- `_isDefaultAll(parameter)` = `parameter == const EarthquakeHistoryParameter.all(sortBy: EarthquakeSortBy.eventId, sortOrder: SortOrder.desc)` (freezed 値等価)。
+- `load(Refresh)` が `_isDefaultAll` の場合のみ `cacheFirstRefresh` 経由。`fetchPage(client)` = `_fetch(limit: 10, cursor: null, client: client)` を `PageData` に変換。`upsert` = 既存 `upsertItems`。それ以外 (フィルタ付き All・検索系)・`Append` は従来通り通常クライアント。
+- `isRevalidating` を公開。既存 `revalidateLatest`・`upsertItems` は不変。
 
-`CachedNotifier` は使えないため、`EarthquakeHistoryDataSource` の初回ページ (Refresh) を cache-first にする。対象は **既定 All** (`_isDefaultAll`) のみ。フィルタ/検索は従来通り。
+### 3. Home フィードシート (`FeedNotifier`)
 
-**`EarthquakeHistoryRepository.fetchEarthquakeList`** に オプション `api.ApiClient? client` を追加し `(client ?? _api)` で使う。cache-only クライアントを渡せるようにする。
+- `FeedNotifier` に `with CachedNotifier<FeedNotifierState>` を付与。`fetch(ApiClient client)` → `repository.fetch(client: client)` を `(items, nextCursor)` に変換。`build() => cachedBuild()`。`fetchNextData` は不変 (ネットワーク専用)。
+- 1 の `FeedRepository.fetch` の client 上書きを共用。
 
-**`earthquakeHistoryDataSource` provider** (`earthquake_history_data_source.dart`): 通常クライアントに加え cache-only クライアントも取得し、DataSource に両方 (または 2 つの client) を渡す。既存のタイマー・リアルタイム・app 復帰 setup は不変。
+### 4. UI
 
-**`EarthquakeHistoryDataSource`**:
-- `_isDefaultAll(parameter)` = `parameter == const EarthquakeHistoryParameter.all(sortBy: EarthquakeSortBy.eventId, sortOrder: SortOrder.desc)` (freezed の値等価。既定一覧の構築値と一致)。
-- `load(Refresh)` が既定 All の場合:
-  1. まず cache-only クライアントで first page を取得。
-     - **cache ヒット** → `Success(cachedPage)` を即返す。加えて背景で通常クライアントの revalidate を予約し、成功したら fresh を `upsertItems` で反映 (失敗時はキャッシュ維持)。
-     - **cache miss (`CacheMissException`)** → 通常クライアントで取得 (従来通り。オフラインなら `Failure`)。
-  2. 既定 All 以外 (フィルタ付き All・検索系)・`Append` は従来通り通常クライアント。
-- 背景 revalidate: `_fetch(limit: 10, cursor: null, client: normalClient)` → `upsertItems(fresh.items)` (既存の upsert ロジックを再利用。sortBy=eventId のみ有効)。disposal ガードを入れる。
-- 既存の `revalidateLatest`・`upsertItems`・`Append` は不変。
+- **お知らせ一覧ページ / 地震履歴一覧ページ**: 各 DataSource の `isRevalidating` を購読し、キャッシュ由来の詳細ページ等と同じ見た目の「更新中」バナーを出す (`CachedDataBanner` と揃える。paging は `AsyncValue.DataKind.cache` を持たないため flag 駆動)。
+- **Home フィードシート**: `CachedNotifier` が revalidate 中に `DataKind.cache` を持つため、必要なら `CachedDataBanner(values: [feedAsyncValue])` を適用可 (任意)。
 
-### 3. UI
+### 5. 相互作用の扱い
 
-- **お知らせ一覧ページ**: `CachedDataBanner(values: [feedAsyncValue])` を追加 (詳細ページ等と一貫)。`CachedNotifier` が revalidate 中に `DataKind.cache` を持つため `isFromCache` で自然に表示される。
-- **地震履歴一覧ページ**: paging_view の DataSource は `AsyncValue` の `DataKind.cache` を持たないため、`CachedDataBanner(values:)` を直接は使えない。DataSource に「キャッシュ表示中/背景 revalidate 中」を表す `ValueListenable<bool>` (例 `isRevalidating`) を公開し、ページはそれを購読してキャッシュ由来の詳細ページ等と同じ見た目の「更新中」バナーを出す。バナー UI は `CachedDataBanner` と揃える (共通見た目を再利用 or 同等の軽量表示)。
-
-### 4. 相互作用の扱い
-
-- **Feed**: 背景 revalidate は `CachedNotifier` の `_generation` ガードで古い上書きを防止。
-- **地震履歴**: 背景 revalidate (`upsertItems`)・5 分タイマー `invalidateSelf`・リアルタイム `upsertItems` はいずれも DataSource の items を操作する。既存コードに既にあるレース (timer invalidate vs upsert) と同程度で、新たな根本問題は増やさない。cache ヒット時に予約する背景 revalidate は disposal / 世代ガードを入れ、DataSource 破棄後や再 Refresh 後に古い結果を反映しない。
+- paging DataSource の背景 revalidate・5 分タイマー `invalidateSelf`・リアルタイム `upsertItems` はいずれも items を操作する。既存のレース (timer invalidate vs upsert) と同程度。cache ヒット時に予約する背景 revalidate は `isActive` (disposal/世代) ガードで、DataSource 破棄後・再 Refresh 後に古い結果を反映しない。
+- Feed AsyncNotifier: `CachedNotifier` の `_generation` ガードで古い revalidate の上書きを防止。
 
 ## テスト方針
 
-- `FeedNotifier`: cache-only ヒットで即データを返す / cache miss で通常取得へフォールバック / 背景 revalidate で fresh に更新。
-- `EarthquakeHistoryDataSource`: 既定 All の Refresh で cache-only ヒット → `Success` を即返す / cache miss → 通常取得 / フィルタ付き All・検索系は cache-only を使わず従来経路。cache ヒット後の背景 revalidate で `upsertItems` が呼ばれ fresh が反映される。
-- `_isDefaultAll` の判定 (既定 All のみ true、フィルタ/検索は false)。
-- オフライン (cache-only ヒット) 時に `Failure`/`AsyncError` にならずデータが表示される。
-- 既存の CachedNotifier 系テストのパターンに倣う。
+- **共通ヘルパー `cacheFirstRefresh`**: cache-only ヒット → 即 `Success` + 背景で `upsert` 呼び出し / cache miss → 通常 `Success` / 通常も失敗 (オフライン) → `Failure` / `isActive()==false` で背景更新をスキップ。
+- **`FeedDataSource`**: Refresh が cache-first になる / `upsertItems(byid)` が id で update/insert する / `Append` は従来通り。
+- **`EarthquakeHistoryDataSource`**: `_isDefaultAll` の真偽 / 既定 All の Refresh のみ cache-first / フィルタ・検索・Append は従来経路。
+- **`FeedNotifier`**: cache ヒット即返し / miss フォールバック / 背景 revalidate 更新。
+- オフライン (cache ヒット) で `Failure`/`AsyncError` にならずデータ表示。
 
 ## 非対象 (Out of Scope)
 
 - 差分取得 API (backend, 計画 A〜E)。
-- 地震履歴のフィルタ/検索クエリのオフラインキャッシュ (デフォルト All のみ SWR 化)。
-- オフラインでのページネーション。
+- 一覧のフィルタ/検索クエリのオフラインキャッシュ (地震履歴は既定 All のみ)。
+- オフラインでのページネーション (Append)。
+- 死んだ `EarthquakeHistoryNotifier` の削除 (任意。本 PR に含めても別でも可)。

--- a/docs/superpowers/specs/2026-07-07-swr-cache-lists-design.md
+++ b/docs/superpowers/specs/2026-07-07-swr-cache-lists-design.md
@@ -34,9 +34,11 @@ family notifier への適用実績あり (`earthquake_history_details_notifier` 
 
 リポジトリ側は client 上書きを受ける形が既存 (`FeedRepository.fetchByTelegramHash(hash, {ApiClient? client})` → `(client ?? _api)`)。
 
-### 対象 Notifier (未 SWR 化)
-- `app/lib/feature/feed/data/notifier/feed_notifier.dart`: `@riverpod class FeedNotifier`。`build()` で `repository.fetch()`。ページネーション (`fetchNextData`, nextCursor) あり。
-- `app/lib/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart`: `@riverpod class EarthquakeHistoryNotifier`。`build(EarthquakeHistoryParameter parameter)` (family)。`EarthquakeHistoryParameterAll` 時に 5 分タイマー (`invalidateSelf`)・リアルタイム upsert・app 復帰時 `_revalidateLatest` を設定。`_fetch(parameter, limit, cursor)` で取得。ページネーション (`fetchNextData`)・`_upsertItems` あり。parameter は All / Region / Prefecture / City / Station と各種フィルタ (magnitude/depth/intensity/… ・sort) を持つ。
+### 対象 (未 SWR 化)
+- **お知らせ**: `app/lib/feature/feed/data/notifier/feed_notifier.dart`: `@riverpod class FeedNotifier`。`build()` で `repository.fetch()`。ページネーション (`fetchNextData`, nextCursor) あり。`feedProvider` として Home フィードシート・お知らせ一覧ページで使用中 (実利用あり)。
+- **地震履歴**: 実際の一覧は `app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart` の **`earthquakeHistoryDataSourceProvider(parameter)`** (family) が返す `EarthquakeHistoryDataSource extends GroupedDataSource<String?, String, EarthquakePartial>` (paging_view)。`earthquake_history_page.dart` が唯一の消費者。`load(Refresh/Append)` → `_load` → `_fetch` → repository。`EarthquakeHistoryParameterAll` 時に 5 分タイマー (`invalidateSelf`)・リアルタイム `upsertItems`・app 復帰時 `revalidateLatest` を provider 側で設定。既定一覧の parameter は `const EarthquakeHistoryParameter.all(sortBy: .eventId, sortOrder: .desc)`。
+  - 注: `earthquake_history_notifier.dart` (`EarthquakeHistoryNotifier`) は**消費者ゼロの死んだコード**。SWR 対象ではない (別途削除可)。
+- `CachedNotifier` は `$AsyncNotifier<T>` 用の mixin。Feed には適用できるが、地震履歴の `GroupedDataSource` には適用できないため、地震履歴は DataSource 内に cache-first を作り込む。
 
 ### UI 表示基盤
 `app/lib/core/component/cached_data_banner.dart`: `CachedDataBanner(values: [asyncValue...])`。いずれかが `isFromCache` (DataKind.cache) の時「更新中」バナーを表示。既に地震詳細・お知らせ詳細・強度履歴・電文一覧ページで使用。
@@ -77,48 +79,40 @@ class FeedNotifier extends _$FeedNotifier with CachedNotifier<FeedNotifierState>
 ```
 ページネーションはオフライン非対応のまま (仕様)。
 
-### 2. 地震履歴 (デフォルト一覧のみ)
+### 2. 地震履歴 (デフォルト一覧のみ / paging_view DataSource に cache-first を作り込み)
 
-**`EarthquakeHistoryRepository.fetchEarthquakeList`** と Notifier の **`_fetch`** に オプション `api.ApiClient? client` を追加し、`(client ?? 既定)` で使う。SWR はデフォルト All のみに適用するため、client 上書きが実際に渡るのは `fetchEarthquakeList` 経由のデフォルト All パスのみ。他パスは `client` を渡さず従来通り。
+`CachedNotifier` は使えないため、`EarthquakeHistoryDataSource` の初回ページ (Refresh) を cache-first にする。対象は **既定 All** (`_isDefaultAll`) のみ。フィルタ/検索は従来通り。
 
-**`EarthquakeHistoryNotifier`** に `with CachedNotifier<PaginatedResponse<EarthquakePartial>>` を付与:
-```dart
-@override
-Future<PaginatedResponse<EarthquakePartial>> fetch(ApiClient client) =>
-    _fetch(parameter: parameter, limit: 10, cursor: null, client: client);
+**`EarthquakeHistoryRepository.fetchEarthquakeList`** に オプション `api.ApiClient? client` を追加し `(client ?? _api)` で使う。cache-only クライアントを渡せるようにする。
 
-@override
-Future<PaginatedResponse<EarthquakePartial>> build(
-  EarthquakeHistoryParameter parameter,
-) async {
-  if (parameter is EarthquakeHistoryParameterAll) {
-    // 既存の 5 分タイマー・リアルタイム upsert・app 復帰 revalidate をそのまま設定
-    ...
-  }
-  if (_isDefaultAll(parameter)) {
-    return cachedBuild();
-  }
-  return _fetch(parameter: parameter, limit: ..., cursor: null);
-}
-```
+**`earthquakeHistoryDataSource` provider** (`earthquake_history_data_source.dart`): 通常クライアントに加え cache-only クライアントも取得し、DataSource に両方 (または 2 つの client) を渡す。既存のタイマー・リアルタイム・app 復帰 setup は不変。
 
-- `_isDefaultAll(parameter)`: フィルタ未適用・既定ソートの `EarthquakeHistoryParameterAll` を判定する述語。既定インスタンスとの等価判定、または全フィルタ null + 既定 sort の確認で実装する (正確な定義は実装計画で確定)。
-- `limit`: 既存に合わせ、All は 10、検索系は 50。
-- `_revalidateLatest`・`fetchNextData`・`_upsertItems` は不変。`revalidateOnAppResume` は有効化しない (既存の軽量 `_revalidateLatest` を app 復帰時に使い続ける)。
+**`EarthquakeHistoryDataSource`**:
+- `_isDefaultAll(parameter)` = `parameter == const EarthquakeHistoryParameter.all(sortBy: EarthquakeSortBy.eventId, sortOrder: SortOrder.desc)` (freezed の値等価。既定一覧の構築値と一致)。
+- `load(Refresh)` が既定 All の場合:
+  1. まず cache-only クライアントで first page を取得。
+     - **cache ヒット** → `Success(cachedPage)` を即返す。加えて背景で通常クライアントの revalidate を予約し、成功したら fresh を `upsertItems` で反映 (失敗時はキャッシュ維持)。
+     - **cache miss (`CacheMissException`)** → 通常クライアントで取得 (従来通り。オフラインなら `Failure`)。
+  2. 既定 All 以外 (フィルタ付き All・検索系)・`Append` は従来通り通常クライアント。
+- 背景 revalidate: `_fetch(limit: 10, cursor: null, client: normalClient)` → `upsertItems(fresh.items)` (既存の upsert ロジックを再利用。sortBy=eventId のみ有効)。disposal ガードを入れる。
+- 既存の `revalidateLatest`・`upsertItems`・`Append` は不変。
 
 ### 3. UI
 
-地震履歴一覧ページとお知らせ一覧ページに `CachedDataBanner(values: [asyncValue])` を追加 (詳細ページ等と一貫)。デフォルト All のキャッシュ表示時のみバナーが出る (フィルタ時は `isFromCache=false` で非表示)。
+- **お知らせ一覧ページ**: `CachedDataBanner(values: [feedAsyncValue])` を追加 (詳細ページ等と一貫)。`CachedNotifier` が revalidate 中に `DataKind.cache` を持つため `isFromCache` で自然に表示される。
+- **地震履歴一覧ページ**: paging_view の DataSource は `AsyncValue` の `DataKind.cache` を持たないため、`CachedDataBanner(values:)` を直接は使えない。DataSource に「キャッシュ表示中/背景 revalidate 中」を表す `ValueListenable<bool>` (例 `isRevalidating`) を公開し、ページはそれを購読してキャッシュ由来の詳細ページ等と同じ見た目の「更新中」バナーを出す。バナー UI は `CachedDataBanner` と揃える (共通見た目を再利用 or 同等の軽量表示)。
 
 ### 4. 相互作用の扱い
 
-背景 revalidate・5 分タイマー `invalidateSelf`・リアルタイム `_upsertItems` はいずれも最終的に `AsyncData` を生成する。`CachedNotifier` の `_generation` ガードが古い revalidate による上書きを防ぐ。既存コードに既にあるレース (timer invalidate vs upsert) と同程度で、新たな根本問題は増やさない。背景 revalidate 完了時に `AsyncData(fresh)` がリアルタイム upsert 直後の値を一時的に上書きしうるが、fresh は最新のサーバ値のため実害は軽微 (許容)。
+- **Feed**: 背景 revalidate は `CachedNotifier` の `_generation` ガードで古い上書きを防止。
+- **地震履歴**: 背景 revalidate (`upsertItems`)・5 分タイマー `invalidateSelf`・リアルタイム `upsertItems` はいずれも DataSource の items を操作する。既存コードに既にあるレース (timer invalidate vs upsert) と同程度で、新たな根本問題は増やさない。cache ヒット時に予約する背景 revalidate は disposal / 世代ガードを入れ、DataSource 破棄後や再 Refresh 後に古い結果を反映しない。
 
 ## テスト方針
 
 - `FeedNotifier`: cache-only ヒットで即データを返す / cache miss で通常取得へフォールバック / 背景 revalidate で fresh に更新。
-- `EarthquakeHistoryNotifier`: デフォルト All は cache-first になる / フィルタ付き All・検索系は従来のネットワーク経路のまま (cache-only を使わない)。
-- オフライン (cache-only ヒット) 時に `AsyncError` にならずデータが表示される。
+- `EarthquakeHistoryDataSource`: 既定 All の Refresh で cache-only ヒット → `Success` を即返す / cache miss → 通常取得 / フィルタ付き All・検索系は cache-only を使わず従来経路。cache ヒット後の背景 revalidate で `upsertItems` が呼ばれ fresh が反映される。
+- `_isDefaultAll` の判定 (既定 All のみ true、フィルタ/検索は false)。
+- オフライン (cache-only ヒット) 時に `Failure`/`AsyncError` にならずデータが表示される。
 - 既存の CachedNotifier 系テストのパターンに倣う。
 
 ## 非対象 (Out of Scope)


### PR DESCRIPTION
## 概要

機内モード (オフライン) でアプリ起動時に、**地震履歴一覧**と**お知らせ (Feed) 一覧**が timeout でエラーになる問題を解消します。既存の cache-first (キャッシュ即返し → 裏で revalidate → 更新) を、これらの一覧に導入します。

Closes #1452

- 設計: `docs/superpowers/specs/2026-07-07-swr-cache-lists-design.md`
- 計画: `docs/superpowers/plans/2026-07-07-swr-cache-lists.md`

## 背景 (調査で判明した実態)

一覧タブの実データフローは AsyncNotifier ではなく **paging_view の DataSource** でした:

| 画面 | データソース | 対応 |
|---|---|---|
| お知らせ一覧タブ | `FeedDataSource` (paging) | cache-first 作り込み |
| 地震履歴一覧タブ | `EarthquakeHistoryDataSource` (paging) | cache-first 作り込み (既定 All のみ) |
| Home フィードシート | `FeedNotifier` (AsyncNotifier) | 既存 `CachedNotifier` 適用 |

(`EarthquakeHistoryNotifier` は消費者ゼロの死んだコードで対象外)

## 変更点

- **共通ヘルパー `cacheFirstRefresh`** (`app/lib/core/paging/cache_first_refresh.dart`): paging DataSource の初回 Refresh を cache-only で即返し → 背景で通常取得 → `upsert` で in-place 更新。破棄/世代ガード付き。2 つの DataSource で共有 (重複なし)。
- **`FeedDataSource`**: Refresh を cache-first 化。`FeedItem.id` マージの `upsertItems` を追加。`isRevalidating` を公開。
- **`EarthquakeHistoryDataSource`**: `isDefaultAllParameter` (フィルタ未適用の既定 All) の Refresh のみ cache-first 化。既存の 5 分タイマー・リアルタイム upsert・app 復帰 revalidate は不変。フィルタ/検索・ページネーションは従来通り。
- **`FeedNotifier`** (Home フィードシート): `with CachedNotifier` を適用。
- **リポジトリ**: `FeedRepository.fetch` に `ApiClient? client` を追加 (cache-only クライアント注入用。地震履歴リポジトリは develop で既に対応済み)。
- **UI**: 両一覧ページに `RevalidatingBanner` (「更新中」表示) を追加。既存 `CachedDataBanner` の再検証表示と同一見た目を再利用。

## 検証

- 新規/対象テスト green: `cache_first_refresh` (5) / `feed_data_source` / `feed_notifier` / `earthquake_history_data_source_cache` ほか、私の変更した 133 テストが pass。
- `dart format` 適用済み。
- 既知 pre-existing 失敗 (`depth_text_test.dart` x5, `earthquake_history_config_test.dart` x3) は本 PR 無関係 (該当ファイル未変更)。

## 実装メモ

- 本リポジトリは build_runner が恒常故障のため、**コード生成不要**な設計 (mixin 付与・オプション引数追加は riverpod 生成物の署名を変えない) にしています。
- レビュー: 各タスクごとの spec/品質レビュー + 全ブランチレビュー (最終判定 READY WITH MINOR NOTES) を実施。

## フォローアップ (本 PR ではスコープ外)

- Feed の新規アイテムは背景 revalidate 時に暫定的に末尾へ追加されます (新しい順一覧では本来先頭寄り)。低頻度・次の定期/手動リフレッシュで是正。厳密な先頭挿入は follow-up。
- 一覧のフィルタ/検索クエリのオフラインキャッシュ、差分取得 API (計画 A〜E) は非対象。

https://claude.ai/code/session_016kNc5tMmW5x7a4A4ms83EB
