### PR TITLE
feat: 通知プリセット4択とOS権限制御

### DIFF
--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -1,0 +1,65 @@
+# Task 5 Report: NotificationPresetSelector Shared UI
+
+## Status
+
+DONE
+
+## Commits
+
+- `e4197bfea` feat: NotificationPresetSelector共有UIを追加
+
+## Summary
+
+4択通知プリセット選択の共有 UI コンポーネント `NotificationPresetSelector` を実装した。オンボーディング（カード型ラジオ）と設定画面（`Card.outlined` リスト）の2スタイルに対応し、OS 通知権限・重大な通知権限の制御を集約する。
+
+## Changes
+
+### Added
+
+- `app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart`
+  - `NotificationPresetSelectorStyle` enum（`onboarding` / `settings`）
+  - `NotificationPresetSelector`（`HookConsumerWidget`）
+  - 4プリセット表示順: 推奨設定 → すべて → カスタム → 通知しない
+  - spec 準拠の説明テキスト
+  - OS 権限オフ時: 推奨/すべて/カスタムは無効表示、タップで `showOsNotificationPermissionDialog`
+  - `useEffect`: OS 権限オフ + 他プリセット選択中 → `onChanged(none)` 自動切り替え
+  - 推奨/すべて選択中 + criticalAlert 未許可: `Text.rich` リンク「重大な通知が許可されていません」
+  - 設定スタイルのカスタム行: `_CustomPresetTrailing`（chevron + settings）を維持
+
+- `app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart`
+  - OS 権限オフで無効プリセットタップ → 通知権限ダイアログ表示
+  - 重大通知未許可時の警告リンク表示
+  - 重大通知非対応端末ではリンク非表示
+  - OS 権限オフ時の自動 `none` 切り替え
+
+### Not Changed (Task 6/7 scope)
+
+- `notification_settings_step_page.dart`（オンボーディング統合）
+- `notification_settings_page.dart`（設定画面統合）
+
+## Tests
+
+```
+flutter test test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
+00:01 +4: All tests passed!
+```
+
+## Self-Review
+
+### Correctness
+
+- design spec の4プリセット順序・説明テキストに準拠
+- `osNotificationPermissionProvider` を watch して権限制御
+- Task 4 の `showOsNotificationPermissionDialog` / `showCriticalAlertPermissionDialog` を利用
+- 既存 `_PresetCard` / `_PresetOptionGroup` のビジュアルパターンを踏襲
+
+### Architecture
+
+- プライベートメソッドではなく private Widget クラスで UI を分割
+- `_CriticalAlertWarningLink` は `HookWidget` で `TapGestureRecognizer` を適切に dispose
+
+## Concerns
+
+- 権限 Provider の loading 中は `isOsGranted = false` として扱い、推奨/すべて/カスタムを無効表示する。loading 完了後に権限があれば有効化されるが、短い間 UI がちらつく可能性がある（Task 6/7 統合時に要確認）。
+- オンボーディング統合時は親が `selectedPreset` state を持つため、`useEffect` による `onChanged(none)` が親 state 更新をトリガーする。親側で `selectedPreset` を正しく反映する必要がある。
+- `_CriticalAlertWarningLink` の全文がリンクスタイル（primary + 下線）。spec の例に合わせたが、通常テキスト + リンク部分の2色分けは未採用。

--- a/app/lib/core/provider/notification/os_notification_permission.dart
+++ b/app/lib/core/provider/notification/os_notification_permission.dart
@@ -1,0 +1,46 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+class OsNotificationPermission {
+  const OsNotificationPermission._({
+    required this.authorizationStatus,
+    required AppleNotificationSetting criticalAlert,
+  }) : _criticalAlert = criticalAlert;
+
+  factory OsNotificationPermission.fromNotificationSettings(
+    NotificationSettings settings,
+  ) {
+    return OsNotificationPermission._(
+      authorizationStatus: settings.authorizationStatus,
+      criticalAlert: settings.criticalAlert,
+    );
+  }
+
+  final AuthorizationStatus authorizationStatus;
+  final AppleNotificationSetting _criticalAlert;
+
+  bool get isOsNotificationGranted =>
+      authorizationStatus == AuthorizationStatus.authorized ||
+      authorizationStatus == AuthorizationStatus.provisional;
+
+  bool get isCriticalAlertSupported =>
+      _criticalAlert != AppleNotificationSetting.notSupported;
+
+  bool get isCriticalAlertGranted =>
+      _criticalAlert == AppleNotificationSetting.enabled;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is OsNotificationPermission &&
+            authorizationStatus == other.authorizationStatus &&
+            _criticalAlert == other._criticalAlert;
+  }
+
+  @override
+  int get hashCode => Object.hash(authorizationStatus, _criticalAlert);
+}
+
+extension NotificationSettingsOsPermissionExtension on NotificationSettings {
+  OsNotificationPermission toOsNotificationPermission() =>
+      OsNotificationPermission.fromNotificationSettings(this);
+}

--- a/app/lib/core/provider/notification/os_notification_permission_provider.dart
+++ b/app/lib/core/provider/notification/os_notification_permission_provider.dart
@@ -1,0 +1,12 @@
+import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'os_notification_permission_provider.g.dart';
+
+@riverpod
+Future<OsNotificationPermission> osNotificationPermission(Ref ref) async {
+  final messaging = ref.watch(firebaseMessagingProvider);
+  final settings = await messaging.getNotificationSettings();
+  return settings.toOsNotificationPermission();
+}

--- a/app/lib/core/provider/notification/os_notification_permission_provider.g.dart
+++ b/app/lib/core/provider/notification/os_notification_permission_provider.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'os_notification_permission_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(osNotificationPermission)
+final osNotificationPermissionProvider = OsNotificationPermissionProvider._();
+
+final class OsNotificationPermissionProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<OsNotificationPermission>,
+          OsNotificationPermission,
+          FutureOr<OsNotificationPermission>
+        >
+    with
+        $FutureModifier<OsNotificationPermission>,
+        $FutureProvider<OsNotificationPermission> {
+  OsNotificationPermissionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'osNotificationPermissionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$osNotificationPermissionHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<OsNotificationPermission> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<OsNotificationPermission> create(Ref ref) {
+    return osNotificationPermission(ref);
+  }
+}
+
+String _$osNotificationPermissionHash() =>
+    r'596815cffcd5b1230ea4a422dcc80df1c5ea740f';

--- a/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
@@ -97,7 +97,7 @@ class _NewUserNotificationSettingsStepPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final scope = _OnboardingScope.of(context);
     final designSystem = context.designSystem;
-    final selectedPreset = useState<_NotificationPreset?>(null);
+    final selectedPreset = useState<NotificationPreset?>(null);
     final saveError = useState<String?>(null);
     final isProcessing = useState(false);
 
@@ -162,6 +162,9 @@ class _NewUserNotificationSettingsStepPage extends HookConsumerWidget {
           if (context.mounted) {
             await scope.nextPage();
           }
+        case .all:
+        case .none:
+          break;
         case null:
           break;
       }

--- a/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
@@ -98,60 +98,26 @@ class _NewUserNotificationSettingsStepPage extends HookConsumerWidget {
     final scope = _OnboardingScope.of(context);
     final designSystem = context.designSystem;
     final selectedPreset = useState<NotificationPreset?>(null);
-    final saveError = useState<String?>(null);
+    final hasSaveError = useState(false);
     final isProcessing = useState(false);
 
-    Future<void> createCurrentLocationSlot() async {
-      final notifier = ref.read(notificationSlotsProvider.notifier);
-      await notifier.putCurrentLocation(
-        eewEnabled: true,
-        eewMinIntensity: JmaIntensity.four,
-        earthquakeEnabled: true,
-        earthquakeMinIntensity: JmaIntensity.one,
-      );
-    }
-
-    Future<void> saveRecommendedSettings() async {
-      isProcessing.value = true;
-      saveError.value = null;
-      try {
-        await createCurrentLocationSlot();
-        if (context.mounted) {
-          isProcessing.value = false;
-          ref
-              .read(notificationPresetProvider.notifier)
-              .select(NotificationPreset.recommended);
-          await scope.nextPage();
-        }
-      } on Exception catch (e) {
-        if (context.mounted) {
-          isProcessing.value = false;
-          saveError.value = e.toString();
-        }
-      }
-    }
-
     Future<void> onNext() async {
-      switch (selectedPreset.value) {
-        case .recommended:
-          await saveRecommendedSettings();
-        case .custom:
-          isProcessing.value = true;
-          saveError.value = null;
-          try {
-            await createCurrentLocationSlot();
-          } on Exception catch (e) {
-            if (context.mounted) {
-              isProcessing.value = false;
-              saveError.value = e.toString();
-            }
-            return;
-          }
-          if (!context.mounted) {
-            return;
-          }
+      final preset = selectedPreset.value;
+      if (preset == null) {
+        return;
+      }
+
+      isProcessing.value = true;
+      hasSaveError.value = false;
+      try {
+        await ref.read(notificationPresetApplierProvider).apply(preset);
+        if (!context.mounted) {
+          return;
+        }
+
+        if (preset == NotificationPreset.custom) {
           isProcessing.value = false;
-          ref
+          await ref
               .read(notificationPresetProvider.notifier)
               .select(NotificationPreset.custom);
           await Navigator.of(context).push<void>(
@@ -162,11 +128,15 @@ class _NewUserNotificationSettingsStepPage extends HookConsumerWidget {
           if (context.mounted) {
             await scope.nextPage();
           }
-        case .all:
-        case .none:
-          break;
-        case null:
-          break;
+        } else {
+          isProcessing.value = false;
+          await scope.nextPage();
+        }
+      } on Exception catch (_) {
+        if (context.mounted) {
+          isProcessing.value = false;
+          hasSaveError.value = true;
+        }
       }
     }
 
@@ -204,48 +174,16 @@ class _NewUserNotificationSettingsStepPage extends HookConsumerWidget {
               ),
             ),
             SizedBox(height: designSystem.spacing.xl),
-            _PresetCard(
-              title: '推奨設定',
-              isSelected: selectedPreset.value == .recommended,
-              onTap: () => selectedPreset.value = .recommended,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _BulletItem(
-                    text: '現在地の緊急地震速報(警報)',
-                    designSystem: designSystem,
-                  ),
-                  _BulletItem(
-                    text: '現在地で予想震度4以上の緊急地震速報(予報)',
-                    designSystem: designSystem,
-                  ),
-                  _BulletItem(
-                    text: '現在地で震度1以上の地震情報',
-                    designSystem: designSystem,
-                  ),
-                ],
-              ),
+            NotificationPresetSelector(
+              selectedPreset:
+                  selectedPreset.value ?? NotificationPreset.recommended,
+              onChanged: (preset) {
+                selectedPreset.value = preset;
+                hasSaveError.value = false;
+              },
+              style: NotificationPresetSelectorStyle.onboarding,
             ),
-            SizedBox(height: designSystem.spacing.md),
-            _PresetCard(
-              title: 'カスタム',
-              isSelected: selectedPreset.value == .custom,
-              onTap: () => selectedPreset.value = .custom,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _BulletItem(
-                    text: '通知する地域や震度を細かく設定できます',
-                    designSystem: designSystem,
-                  ),
-                  _BulletItem(
-                    text: 'Proではさらに通知音や割り込みレベルを設定できます',
-                    designSystem: designSystem,
-                  ),
-                ],
-              ),
-            ),
-            if (saveError.value != null) ...[
+            if (hasSaveError.value) ...[
               SizedBox(height: designSystem.spacing.md),
               Text(
                 '設定の保存に失敗しました。もう一度お試しください。',
@@ -268,112 +206,5 @@ class _OnboardingCustomSettingsWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const NotificationSettingsPage();
-  }
-}
-
-class _PresetCard extends StatelessWidget {
-  const _PresetCard({
-    required this.title,
-    required this.isSelected,
-    required this.onTap,
-    required this.child,
-  });
-
-  final String title;
-  final bool isSelected;
-  final VoidCallback onTap;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    final designSystem = context.designSystem;
-
-    return GestureDetector(
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOutCubic,
-        padding: EdgeInsets.all(designSystem.spacing.md),
-        decoration: BoxDecoration(
-          color: designSystem.colorTheme.surfaceContainerHigh,
-          borderRadius: BorderRadius.circular(designSystem.shape.card),
-          border: Border.all(
-            color: isSelected
-                ? designSystem.colorTheme.primary
-                : designSystem.colorTheme.outlineVariant,
-            width: isSelected ? 2 : 0,
-            strokeAlign: BorderSide.strokeAlignOutside,
-          ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(
-                  isSelected
-                      ? Icons.radio_button_checked
-                      : Icons.radio_button_unchecked,
-                  color: isSelected
-                      ? designSystem.colorTheme.primary
-                      : designSystem.colorTheme.outline,
-                  size: 20,
-                ),
-                SizedBox(width: designSystem.spacing.sm),
-                Expanded(
-                  child: Text(
-                    title,
-                    style: designSystem.typography.titleMedium,
-                  ),
-                ),
-              ],
-            ),
-            SizedBox(height: designSystem.spacing.sm),
-            Padding(
-              padding: EdgeInsets.only(
-                left: designSystem.spacing.lg + designSystem.spacing.xs,
-              ),
-              child: child,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _BulletItem extends StatelessWidget {
-  const _BulletItem({
-    required this.text,
-    required this.designSystem,
-  });
-
-  final String text;
-  final DesignSystemThemeExtension designSystem;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.only(bottom: designSystem.spacing.xs),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '・',
-            style: designSystem.typography.bodySmall.copyWith(
-              color: designSystem.colorTheme.onSurfaceVariant,
-            ),
-          ),
-          Expanded(
-            child: Text(
-              text,
-              style: designSystem.typography.bodySmall.copyWith(
-                color: designSystem.colorTheme.onSurfaceVariant,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart
@@ -175,8 +175,7 @@ class _NewUserNotificationSettingsStepPage extends HookConsumerWidget {
             ),
             SizedBox(height: designSystem.spacing.xl),
             NotificationPresetSelector(
-              selectedPreset:
-                  selectedPreset.value ?? NotificationPreset.recommended,
+              selectedPreset: selectedPreset.value,
               onChanged: (preset) {
                 selectedPreset.value = preset;
                 hasSaveError.value = false;

--- a/app/lib/feature/onboarding/ui/model/onboarding_permission_status.dart
+++ b/app/lib/feature/onboarding/ui/model/onboarding_permission_status.dart
@@ -1,5 +1,3 @@
 part of '../page/onboarding_page.dart';
 
 enum _PermissionState { notRequested, granted, denied, deniedForever }
-
-enum _NotificationPreset { recommended, custom }

--- a/app/lib/feature/onboarding/ui/page/onboarding_page.dart
+++ b/app/lib/feature/onboarding/ui/page/onboarding_page.dart
@@ -4,16 +4,15 @@ import 'dart:async';
 
 import 'package:eqmonitor/core/component/error/error_details_sheet.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
-import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
 import 'package:eqmonitor/core/gen/assets.gen.dart';
-import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
 import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
 import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
-import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/gestures.dart';

--- a/app/lib/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart
@@ -1,0 +1,110 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/notification/data/notifier/general_notification_settings_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_preset_applier.g.dart';
+
+@riverpod
+NotificationPresetApplier notificationPresetApplier(Ref ref) =>
+    NotificationPresetApplier(ref);
+
+class NotificationPresetApplier {
+  NotificationPresetApplier(this._ref);
+
+  final Ref _ref;
+
+  Future<void> apply(NotificationPreset preset) async {
+    switch (preset) {
+      case NotificationPreset.recommended:
+        await NotificationSlotsNotifier.putCurrentLocationMutation.run(
+          _ref,
+          (tsx) async {
+            await tsx
+                .get(notificationSlotsProvider.notifier)
+                .putCurrentLocation(
+                  eewEnabled: true,
+                  eewMinIntensity: JmaIntensity.four,
+                  earthquakeEnabled: true,
+                  earthquakeMinIntensity: JmaIntensity.one,
+                );
+          },
+        );
+        await GeneralNotificationSettingsNotifier.updateSettingsMutation.run(
+          _ref,
+          (tsx) async {
+            await tsx
+                .get(generalNotificationSettingsProvider.notifier)
+                .updateSettings(notificationEnabled: true);
+          },
+        );
+        await _ref
+            .read(notificationPresetProvider.notifier)
+            .select(NotificationPreset.recommended);
+      case NotificationPreset.all:
+        await NotificationSlotsNotifier.putCurrentLocationMutation.run(
+          _ref,
+          (tsx) async {
+            await tsx
+                .get(notificationSlotsProvider.notifier)
+                .putCurrentLocation(
+                  eewEnabled: true,
+                  eewMinIntensity: JmaIntensity.four,
+                  earthquakeEnabled: true,
+                  earthquakeMinIntensity: JmaIntensity.one,
+                );
+          },
+        );
+        await NotificationSlotsNotifier.putNationwideMutation.run(
+          _ref,
+          (tsx) async {
+            await tsx.get(notificationSlotsProvider.notifier).putNationwide(
+                  eewEnabled: true,
+                  eewMinIntensity: defaultNotificationSlotMinIntensity,
+                  earthquakeEnabled: true,
+                  earthquakeMinIntensity: defaultNotificationSlotMinIntensity,
+                );
+          },
+        );
+        await GeneralNotificationSettingsNotifier.updateSettingsMutation.run(
+          _ref,
+          (tsx) async {
+            await tsx
+                .get(generalNotificationSettingsProvider.notifier)
+                .updateSettings(notificationEnabled: true);
+          },
+        );
+        await _ref
+            .read(notificationPresetProvider.notifier)
+            .select(NotificationPreset.all);
+      case NotificationPreset.none:
+        await GeneralNotificationSettingsNotifier.updateSettingsMutation.run(
+          _ref,
+          (tsx) async {
+            await tsx
+                .get(generalNotificationSettingsProvider.notifier)
+                .updateSettings(notificationEnabled: false);
+          },
+        );
+        await _ref
+            .read(notificationPresetProvider.notifier)
+            .select(NotificationPreset.none);
+      case NotificationPreset.custom:
+        await NotificationSlotsNotifier.putCurrentLocationMutation.run(
+          _ref,
+          (tsx) async {
+            await tsx
+                .get(notificationSlotsProvider.notifier)
+                .putCurrentLocation(
+                  eewEnabled: true,
+                  eewMinIntensity: JmaIntensity.four,
+                  earthquakeEnabled: true,
+                  earthquakeMinIntensity: JmaIntensity.one,
+                );
+          },
+        );
+    }
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/data/action/notification_preset_applier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/action/notification_preset_applier.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'notification_preset_applier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(notificationPresetApplier)
+final notificationPresetApplierProvider = NotificationPresetApplierProvider._();
+
+final class NotificationPresetApplierProvider
+    extends
+        $FunctionalProvider<
+          NotificationPresetApplier,
+          NotificationPresetApplier,
+          NotificationPresetApplier
+        >
+    with $Provider<NotificationPresetApplier> {
+  NotificationPresetApplierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationPresetApplierProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationPresetApplierHash();
+
+  @$internal
+  @override
+  $ProviderElement<NotificationPresetApplier> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NotificationPresetApplier create(Ref ref) {
+    return notificationPresetApplier(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationPresetApplier value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationPresetApplier>(value),
+    );
+  }
+}
+
+String _$notificationPresetApplierHash() =>
+    r'14f591f559a3151c821e9c5ca17a07168ec05a8e';

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart
@@ -4,7 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'notification_preset_notifier.g.dart';
 
-enum NotificationPreset { recommended, custom }
+enum NotificationPreset { recommended, all, custom, none }
 
 @Riverpod(keepAlive: true)
 class NotificationPresetNotifier extends _$NotificationPresetNotifier {
@@ -16,9 +16,12 @@ class NotificationPresetNotifier extends _$NotificationPresetNotifier {
     final stored = await dataSource.getString(
       key: SharedPreferencesKey.notificationPreset,
     );
-    return stored == NotificationPreset.custom.name
-        ? NotificationPreset.custom
-        : NotificationPreset.recommended;
+    return switch (stored) {
+      'custom' => NotificationPreset.custom,
+      'all' => NotificationPreset.all,
+      'none' => NotificationPreset.none,
+      _ => NotificationPreset.recommended,
+    };
   }
 
   Future<void> select(NotificationPreset preset) async {

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
@@ -37,7 +37,7 @@ final class NotificationPresetNotifierProvider
 }
 
 String _$notificationPresetNotifierHash() =>
-    r'68aca95c0ad12e29e0dd47eed0e8cd18777481b3';
+    r'0a975d92f5c8bf5629e1140cf813081ad4bed805';
 
 abstract class _$NotificationPresetNotifier
     extends $AsyncNotifier<NotificationPreset> {

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
@@ -19,7 +19,7 @@ class NotificationPresetSelector extends HookConsumerWidget {
     super.key,
   });
 
-  final NotificationPreset selectedPreset;
+  final NotificationPreset? selectedPreset;
   final ValueChanged<NotificationPreset> onChanged;
   final NotificationPresetSelectorStyle style;
   final VoidCallback? onCustomSettingsTap;
@@ -118,7 +118,7 @@ class _OnboardingPresetList extends StatelessWidget {
   });
 
   final List<NotificationPreset> presets;
-  final NotificationPreset selectedPreset;
+  final NotificationPreset? selectedPreset;
   final bool Function(NotificationPreset preset) isPresetEnabled;
   final bool Function(NotificationPreset preset) shouldShowCriticalWarning;
   final ValueChanged<NotificationPreset> onPresetTap;
@@ -337,7 +337,7 @@ class _SettingsPresetGroup extends StatelessWidget {
   });
 
   final List<NotificationPreset> presets;
-  final NotificationPreset selectedPreset;
+  final NotificationPreset? selectedPreset;
   final bool Function(NotificationPreset preset) isPresetEnabled;
   final bool Function(NotificationPreset preset) shouldShowCriticalWarning;
   final ValueChanged<NotificationPreset> onPresetTap;

--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
@@ -1,0 +1,582 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission_provider.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/dialog/notification_permission_dialog.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+enum NotificationPresetSelectorStyle { onboarding, settings }
+
+class NotificationPresetSelector extends HookConsumerWidget {
+  const NotificationPresetSelector({
+    required this.selectedPreset,
+    required this.onChanged,
+    required this.style,
+    this.onCustomSettingsTap,
+    super.key,
+  });
+
+  final NotificationPreset selectedPreset;
+  final ValueChanged<NotificationPreset> onChanged;
+  final NotificationPresetSelectorStyle style;
+  final VoidCallback? onCustomSettingsTap;
+
+  static const _presetOrder = <NotificationPreset>[
+    NotificationPreset.recommended,
+    NotificationPreset.all,
+    NotificationPreset.custom,
+    NotificationPreset.none,
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final permissionAsync = ref.watch(osNotificationPermissionProvider);
+    final permission = switch (permissionAsync) {
+      AsyncData(:final value) => value,
+      _ => null,
+    };
+    final isOsGranted = permission?.isOsNotificationGranted ?? false;
+
+    useEffect(
+      () {
+        if (permission != null &&
+            !permission.isOsNotificationGranted &&
+            selectedPreset != NotificationPreset.none) {
+          onChanged(NotificationPreset.none);
+        }
+        return null;
+      },
+      [permission, selectedPreset],
+    );
+
+    void handlePresetTap(NotificationPreset preset) {
+      if (!isOsGranted && preset != NotificationPreset.none) {
+        showOsNotificationPermissionDialog(context, ref);
+        return;
+      }
+
+      if (style == NotificationPresetSelectorStyle.settings &&
+          preset == NotificationPreset.custom &&
+          selectedPreset == NotificationPreset.custom) {
+        onCustomSettingsTap?.call();
+        return;
+      }
+
+      onChanged(preset);
+    }
+
+    bool isPresetEnabled(NotificationPreset preset) {
+      return isOsGranted || preset == NotificationPreset.none;
+    }
+
+    bool shouldShowCriticalWarning(NotificationPreset preset) {
+      if (permission == null) {
+        return false;
+      }
+      return selectedPreset == preset &&
+          (preset == NotificationPreset.recommended ||
+              preset == NotificationPreset.all) &&
+          permission.isCriticalAlertSupported &&
+          !permission.isCriticalAlertGranted;
+    }
+
+    return switch (style) {
+      NotificationPresetSelectorStyle.onboarding => _OnboardingPresetList(
+        presets: _presetOrder,
+        selectedPreset: selectedPreset,
+        isPresetEnabled: isPresetEnabled,
+        shouldShowCriticalWarning: shouldShowCriticalWarning,
+        onPresetTap: handlePresetTap,
+        onCriticalWarningTap: () =>
+            showCriticalAlertPermissionDialog(context, ref),
+      ),
+      NotificationPresetSelectorStyle.settings => _SettingsPresetGroup(
+        presets: _presetOrder,
+        selectedPreset: selectedPreset,
+        isPresetEnabled: isPresetEnabled,
+        shouldShowCriticalWarning: shouldShowCriticalWarning,
+        onPresetTap: handlePresetTap,
+        onCustomSettingsTap: onCustomSettingsTap,
+        onCriticalWarningTap: () =>
+            showCriticalAlertPermissionDialog(context, ref),
+      ),
+    };
+  }
+}
+
+class _OnboardingPresetList extends StatelessWidget {
+  const _OnboardingPresetList({
+    required this.presets,
+    required this.selectedPreset,
+    required this.isPresetEnabled,
+    required this.shouldShowCriticalWarning,
+    required this.onPresetTap,
+    required this.onCriticalWarningTap,
+  });
+
+  final List<NotificationPreset> presets;
+  final NotificationPreset selectedPreset;
+  final bool Function(NotificationPreset preset) isPresetEnabled;
+  final bool Function(NotificationPreset preset) shouldShowCriticalWarning;
+  final ValueChanged<NotificationPreset> onPresetTap;
+  final VoidCallback onCriticalWarningTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (var index = 0; index < presets.length; index++) ...[
+          if (index > 0) SizedBox(height: designSystem.spacing.md),
+          _OnboardingPresetCard(
+            preset: presets[index],
+            isSelected: selectedPreset == presets[index],
+            isEnabled: isPresetEnabled(presets[index]),
+            showCriticalWarning: shouldShowCriticalWarning(presets[index]),
+            onTap: () => onPresetTap(presets[index]),
+            onCriticalWarningTap: onCriticalWarningTap,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _OnboardingPresetCard extends StatelessWidget {
+  const _OnboardingPresetCard({
+    required this.preset,
+    required this.isSelected,
+    required this.isEnabled,
+    required this.showCriticalWarning,
+    required this.onTap,
+    required this.onCriticalWarningTap,
+  });
+
+  final NotificationPreset preset;
+  final bool isSelected;
+  final bool isEnabled;
+  final bool showCriticalWarning;
+  final VoidCallback onTap;
+  final VoidCallback onCriticalWarningTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+    final colorTheme = designSystem.colorTheme;
+
+    return Opacity(
+      opacity: isEnabled ? 1 : 0.5,
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOutCubic,
+          padding: EdgeInsets.all(designSystem.spacing.md),
+          decoration: BoxDecoration(
+            color: colorTheme.surfaceContainerHigh,
+            borderRadius: BorderRadius.circular(designSystem.shape.card),
+            border: Border.all(
+              color: isSelected
+                  ? colorTheme.primary
+                  : colorTheme.outlineVariant,
+              width: isSelected ? 2 : 0,
+              strokeAlign: BorderSide.strokeAlignOutside,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    isSelected
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
+                    color: isSelected
+                        ? colorTheme.primary
+                        : colorTheme.outline,
+                    size: 20,
+                  ),
+                  SizedBox(width: designSystem.spacing.sm),
+                  Expanded(
+                    child: Text(
+                      _presetTitle(preset),
+                      style: designSystem.typography.titleMedium,
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: designSystem.spacing.sm),
+              Padding(
+                padding: EdgeInsets.only(
+                  left: designSystem.spacing.lg + designSystem.spacing.xs,
+                ),
+                child: _OnboardingPresetDescription(preset: preset),
+              ),
+              if (showCriticalWarning) ...[
+                SizedBox(height: designSystem.spacing.sm),
+                Padding(
+                  padding: EdgeInsets.only(
+                    left: designSystem.spacing.lg + designSystem.spacing.xs,
+                  ),
+                  child: _CriticalAlertWarningLink(
+                    onTap: onCriticalWarningTap,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OnboardingPresetDescription extends StatelessWidget {
+  const _OnboardingPresetDescription({required this.preset});
+
+  final NotificationPreset preset;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+
+    return switch (preset) {
+      NotificationPreset.recommended => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _PresetBulletItem(
+            text: '現在地の緊急地震速報(警報)',
+            designSystem: designSystem,
+          ),
+          _PresetBulletItem(
+            text: '現在地で予想震度4以上の緊急地震速報(予報)',
+            designSystem: designSystem,
+          ),
+          _PresetBulletItem(
+            text: '現在地で震度1以上を観測した地震情報',
+            designSystem: designSystem,
+          ),
+        ],
+      ),
+      NotificationPreset.all => _PresetBulletItem(
+        text: '推奨設定に加え、全国の緊急地震速報・地震情報も通知します',
+        designSystem: designSystem,
+      ),
+      NotificationPreset.custom => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _PresetBulletItem(
+            text: '通知する地域や震度を細かく設定できます',
+            designSystem: designSystem,
+          ),
+          _PresetBulletItem(
+            text: 'Proではさらに通知音や割り込みレベルを設定できます',
+            designSystem: designSystem,
+          ),
+        ],
+      ),
+      NotificationPreset.none => _PresetBulletItem(
+        text: '通知を受け取りません。後から設定で変更できます',
+        designSystem: designSystem,
+      ),
+    };
+  }
+}
+
+class _PresetBulletItem extends StatelessWidget {
+  const _PresetBulletItem({
+    required this.text,
+    required this.designSystem,
+  });
+
+  final String text;
+  final DesignSystemThemeExtension designSystem;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: designSystem.spacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '・',
+            style: designSystem.typography.bodySmall.copyWith(
+              color: designSystem.colorTheme.onSurfaceVariant,
+            ),
+          ),
+          Expanded(
+            child: Text(
+              text,
+              style: designSystem.typography.bodySmall.copyWith(
+                color: designSystem.colorTheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsPresetGroup extends StatelessWidget {
+  const _SettingsPresetGroup({
+    required this.presets,
+    required this.selectedPreset,
+    required this.isPresetEnabled,
+    required this.shouldShowCriticalWarning,
+    required this.onPresetTap,
+    required this.onCustomSettingsTap,
+    required this.onCriticalWarningTap,
+  });
+
+  final List<NotificationPreset> presets;
+  final NotificationPreset selectedPreset;
+  final bool Function(NotificationPreset preset) isPresetEnabled;
+  final bool Function(NotificationPreset preset) shouldShowCriticalWarning;
+  final ValueChanged<NotificationPreset> onPresetTap;
+  final VoidCallback? onCustomSettingsTap;
+  final VoidCallback onCriticalWarningTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+    final colorTheme = designSystem.colorTheme;
+    final spacing = designSystem.spacing;
+    final shape = designSystem.shape;
+
+    return Card.outlined(
+      margin: EdgeInsets.fromLTRB(
+        spacing.lg,
+        spacing.sm,
+        spacing.lg,
+        spacing.md,
+      ),
+      color: colorTheme.surfaceContainerHigh,
+      clipBehavior: Clip.antiAlias,
+      elevation: 0,
+      shape: RoundedSuperellipseBorder(
+        borderRadius: BorderRadius.circular(shape.card),
+        side: BorderSide(color: colorTheme.outlineVariant),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (var index = 0; index < presets.length; index++) ...[
+            if (index > 0) const Divider(height: 1),
+            _SettingsPresetTile(
+              preset: presets[index],
+              isSelected: selectedPreset == presets[index],
+              isEnabled: isPresetEnabled(presets[index]),
+              showCriticalWarning: shouldShowCriticalWarning(presets[index]),
+              onTap: () => onPresetTap(presets[index]),
+              onCustomSettingsTap: onCustomSettingsTap,
+              onCriticalWarningTap: onCriticalWarningTap,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsPresetTile extends StatelessWidget {
+  const _SettingsPresetTile({
+    required this.preset,
+    required this.isSelected,
+    required this.isEnabled,
+    required this.showCriticalWarning,
+    required this.onTap,
+    required this.onCustomSettingsTap,
+    required this.onCriticalWarningTap,
+  });
+
+  final NotificationPreset preset;
+  final bool isSelected;
+  final bool isEnabled;
+  final bool showCriticalWarning;
+  final VoidCallback onTap;
+  final VoidCallback? onCustomSettingsTap;
+  final VoidCallback onCriticalWarningTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+    final spacing = designSystem.spacing;
+    final colorTheme = designSystem.colorTheme;
+    final titleColor = isEnabled
+        ? colorTheme.onSurface
+        : Theme.of(context).disabledColor;
+    final subtitleColor = isEnabled
+        ? colorTheme.onSurfaceVariant
+        : Theme.of(context).disabledColor;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: spacing.lg,
+          vertical: spacing.md,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _PresetSelectionMark(isSelected: isSelected && isEnabled),
+            SizedBox(width: spacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _presetTitle(preset),
+                    style: designSystem.typography.titleMedium.copyWith(
+                      color: titleColor,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  SizedBox(height: spacing.xs),
+                  Text(
+                    _settingsSubtitle(preset),
+                    style: designSystem.typography.bodySmall.copyWith(
+                      color: subtitleColor,
+                    ),
+                  ),
+                  if (showCriticalWarning) ...[
+                    SizedBox(height: spacing.xs),
+                    _CriticalAlertWarningLink(onTap: onCriticalWarningTap),
+                  ],
+                ],
+              ),
+            ),
+            if (preset == NotificationPreset.custom &&
+                onCustomSettingsTap != null) ...[
+              SizedBox(width: spacing.sm),
+              _CustomPresetTrailing(
+                enabled: isSelected && isEnabled,
+                onTap: onCustomSettingsTap!,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PresetSelectionMark extends StatelessWidget {
+  const _PresetSelectionMark({required this.isSelected});
+
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+    final colorTheme = designSystem.colorTheme;
+
+    return Container(
+      width: 24,
+      height: 24,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: isSelected ? colorTheme.primary : colorTheme.outline,
+          width: isSelected ? 6 : 3,
+        ),
+      ),
+    );
+  }
+}
+
+class _CustomPresetTrailing extends StatelessWidget {
+  const _CustomPresetTrailing({
+    required this.enabled,
+    required this.onTap,
+  });
+
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          Icons.chevron_right,
+          color: enabled ? null : Theme.of(context).disabledColor,
+        ),
+        SizedBox(
+          height: 40,
+          child: VerticalDivider(
+            color: designSystem.colorTheme.outlineVariant,
+            thickness: 1,
+          ),
+        ),
+        IconButton(
+          tooltip: 'カスタム設定',
+          onPressed: enabled ? onTap : null,
+          icon: const Icon(Icons.settings_outlined),
+        ),
+      ],
+    );
+  }
+}
+
+class _CriticalAlertWarningLink extends HookWidget {
+  const _CriticalAlertWarningLink({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final designSystem = context.designSystem;
+    final recognizer = useMemoized(TapGestureRecognizer.new);
+
+    useEffect(
+      () {
+        recognizer.onTap = onTap;
+        return recognizer.dispose;
+      },
+      [recognizer, onTap],
+    );
+
+    return Text.rich(
+      TextSpan(
+        text: '重大な通知が許可されていません',
+        style: designSystem.typography.bodySmall.copyWith(
+          color: designSystem.colorTheme.primary,
+          decoration: TextDecoration.underline,
+        ),
+        recognizer: recognizer,
+      ),
+    );
+  }
+}
+
+String _presetTitle(NotificationPreset preset) {
+  return switch (preset) {
+    NotificationPreset.recommended => '推奨設定',
+    NotificationPreset.all => 'すべて',
+    NotificationPreset.custom => 'カスタム',
+    NotificationPreset.none => '通知しない',
+  };
+}
+
+String _settingsSubtitle(NotificationPreset preset) {
+  return switch (preset) {
+    NotificationPreset.recommended =>
+      '現在地の震度に応じて、EEWと地震情報を自動で通知します',
+    NotificationPreset.all =>
+      '推奨設定に加え、全国の緊急地震速報・地震情報も通知します',
+    NotificationPreset.custom => '通知の種類ごとに条件を細かく設定します',
+    NotificationPreset.none => '通知を受け取りません。後から設定で変更できます',
+  };
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/dialog/notification_permission_dialog.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/dialog/notification_permission_dialog.dart
@@ -1,0 +1,136 @@
+import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission_provider.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+Future<void> showOsNotificationPermissionDialog(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final permission = await ref.read(osNotificationPermissionProvider.future);
+  if (!context.mounted) {
+    return;
+  }
+
+  final openSettings = _NotificationPermissionDialogPolicy.shouldOpenSettingsForOs(
+    permission: permission,
+  );
+
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) => _NotificationPermissionDialog(
+      title: '通知権限が無効です',
+      body: '通知を受け取るには、通知の許可が必要です。許可しますか？',
+      primaryActionLabel: openSettings ? '設定を開く' : '許可する',
+      onPrimaryAction: () async {
+        Navigator.of(dialogContext).pop();
+        if (openSettings) {
+          await Geolocator.openAppSettings();
+          return;
+        }
+        await _NotificationPermissionRequester.requestAndRefresh(ref: ref);
+      },
+    ),
+  );
+}
+
+Future<void> showCriticalAlertPermissionDialog(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final permission = await ref.read(osNotificationPermissionProvider.future);
+  if (!context.mounted) {
+    return;
+  }
+
+  final openSettings =
+      _NotificationPermissionDialogPolicy.shouldOpenSettingsForCriticalAlert(
+        permission: permission,
+      );
+
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) => _NotificationPermissionDialog(
+      title: '重大な通知が許可されていません',
+      body:
+          '緊急地震速報(警報)を確実に受け取るには、重大な通知の許可が必要です。許可しますか？',
+      primaryActionLabel: openSettings ? '設定を開く' : '許可する',
+      onPrimaryAction: () async {
+        Navigator.of(dialogContext).pop();
+        if (openSettings) {
+          await Geolocator.openAppSettings();
+          return;
+        }
+        await _NotificationPermissionRequester.requestAndRefresh(ref: ref);
+      },
+    ),
+  );
+}
+
+class _NotificationPermissionDialogPolicy {
+  static bool shouldOpenSettingsForOs({
+    required OsNotificationPermission permission,
+  }) {
+    return permission.authorizationStatus == AuthorizationStatus.denied &&
+        _isApplePlatform;
+  }
+
+  static bool shouldOpenSettingsForCriticalAlert({
+    required OsNotificationPermission permission,
+  }) {
+    if (!permission.isCriticalAlertSupported ||
+        permission.isCriticalAlertGranted) {
+      return false;
+    }
+
+    return permission.isOsNotificationGranted && _isApplePlatform;
+  }
+
+  static bool get _isApplePlatform =>
+      defaultTargetPlatform == TargetPlatform.iOS ||
+      defaultTargetPlatform == TargetPlatform.macOS;
+}
+
+class _NotificationPermissionRequester {
+  static Future<void> requestAndRefresh({required WidgetRef ref}) async {
+    final messaging = ref.read(firebaseMessagingProvider);
+    await messaging.requestPermission(criticalAlert: true);
+    ref.invalidate(osNotificationPermissionProvider);
+  }
+}
+
+class _NotificationPermissionDialog extends StatelessWidget {
+  const _NotificationPermissionDialog({
+    required this.title,
+    required this.body,
+    required this.primaryActionLabel,
+    required this.onPrimaryAction,
+  });
+
+  final String title;
+  final String body;
+  final String primaryActionLabel;
+  final Future<void> Function() onPrimaryAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(body),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('閉じる'),
+        ),
+        FilledButton(
+          onPressed: () async => onPrimaryAction(),
+          child: Text(primaryActionLabel),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -16,10 +16,12 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/m
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/earthquake_global_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_global_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/eew_warning_config_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/info_notification_tile.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/pro_feature_widgets.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/earthquake_info_settings_page.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/eew_forecast_settings_page.dart';
@@ -100,10 +102,17 @@ class _Body extends HookConsumerWidget {
         ),
         if (notificationsEnabled) ...[
           const SettingsSectionHeader(text: '通知プリセット'),
-          _PresetOptionGroup(
+          NotificationPresetSelector(
             selectedPreset: selectedPreset,
-            onChanged: (preset) =>
-                ref.read(notificationPresetProvider.notifier).select(preset),
+            onChanged: (preset) async {
+              await ref.read(notificationPresetApplierProvider).apply(preset);
+              if (preset == NotificationPreset.custom) {
+                await ref
+                    .read(notificationPresetProvider.notifier)
+                    .select(NotificationPreset.custom);
+              }
+            },
+            style: NotificationPresetSelectorStyle.settings,
             onCustomSettingsTap: () async {
               if (selectedPreset != NotificationPreset.custom) {
                 return;
@@ -183,134 +192,6 @@ class _MasterNotificationControl extends StatelessWidget {
   }
 }
 
-class _PresetOptionGroup extends StatelessWidget {
-  const _PresetOptionGroup({
-    required this.selectedPreset,
-    required this.onChanged,
-    required this.onCustomSettingsTap,
-  });
-
-  final NotificationPreset selectedPreset;
-  final ValueChanged<NotificationPreset> onChanged;
-  final VoidCallback onCustomSettingsTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final designSystem = context.designSystem;
-    final colorTheme = designSystem.colorTheme;
-    final spacing = designSystem.spacing;
-    final shape = designSystem.shape;
-
-    return Card.outlined(
-      margin: EdgeInsets.fromLTRB(
-        spacing.lg,
-        spacing.sm,
-        spacing.lg,
-        spacing.md,
-      ),
-      color: colorTheme.surfaceContainerHigh,
-      clipBehavior: Clip.antiAlias,
-      elevation: 0,
-      shape: RoundedSuperellipseBorder(
-        borderRadius: BorderRadius.circular(shape.card),
-        side: BorderSide(color: colorTheme.outlineVariant),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _PresetOptionTile(
-            title: '推奨設定',
-            subtitle: '現在地の震度に応じて、EEWと地震情報を自動で通知します',
-            isSelected: selectedPreset == NotificationPreset.recommended,
-            onTap: () => onChanged(NotificationPreset.recommended),
-          ),
-          const Divider(height: 1),
-          _PresetOptionTile(
-            title: 'カスタム',
-            subtitle: '通知の種類ごとに条件を細かく設定します',
-            isSelected: selectedPreset == NotificationPreset.custom,
-            onTap: () {
-              if (selectedPreset == NotificationPreset.custom) {
-                onCustomSettingsTap();
-              } else {
-                onChanged(NotificationPreset.custom);
-              }
-            },
-            trailing: _CustomPresetTrailing(
-              enabled: selectedPreset == NotificationPreset.custom,
-              onTap: onCustomSettingsTap,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _PresetOptionTile extends StatelessWidget {
-  const _PresetOptionTile({
-    required this.title,
-    required this.subtitle,
-    required this.isSelected,
-    required this.onTap,
-    this.trailing,
-  });
-
-  final String title;
-  final String subtitle;
-  final bool isSelected;
-  final VoidCallback onTap;
-  final Widget? trailing;
-
-  @override
-  Widget build(BuildContext context) {
-    final designSystem = context.designSystem;
-    final spacing = designSystem.spacing;
-    final colorTheme = designSystem.colorTheme;
-
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: EdgeInsets.symmetric(
-          horizontal: spacing.lg,
-          vertical: spacing.md,
-        ),
-        child: Row(
-          children: [
-            _PresetSelectionMark(isSelected: isSelected),
-            SizedBox(width: spacing.sm),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: designSystem.typography.titleMedium.copyWith(
-                      color: colorTheme.onSurface,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  SizedBox(height: spacing.xs),
-                  Text(
-                    subtitle,
-                    style: designSystem.typography.bodySmall.copyWith(
-                      color: colorTheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            if (trailing != null) ...[
-              SizedBox(width: spacing.sm),
-              trailing!,
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 class _PresetSelectionMark extends StatelessWidget {
   const _PresetSelectionMark({required this.isSelected});
 
@@ -331,43 +212,6 @@ class _PresetSelectionMark extends StatelessWidget {
           width: isSelected ? 6 : 3,
         ),
       ),
-    );
-  }
-}
-
-class _CustomPresetTrailing extends StatelessWidget {
-  const _CustomPresetTrailing({
-    required this.enabled,
-    required this.onTap,
-  });
-
-  final bool enabled;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final designSystem = context.designSystem;
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(
-          Icons.chevron_right,
-          color: enabled ? null : Theme.of(context).disabledColor,
-        ),
-        SizedBox(
-          height: 40,
-          child: VerticalDivider(
-            color: designSystem.colorTheme.outlineVariant,
-            thickness: 1,
-          ),
-        ),
-        IconButton(
-          tooltip: 'カスタム設定',
-          onPressed: enabled ? onTap : null,
-          icon: const Icon(Icons.settings_outlined),
-        ),
-      ],
     );
   }
 }

--- a/app/test/core/provider/notification/os_notification_permission_test.dart
+++ b/app/test/core/provider/notification/os_notification_permission_test.dart
@@ -1,0 +1,158 @@
+import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission_provider.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mockito/mockito.dart';
+
+class _FakeFirebaseMessaging extends Fake implements FirebaseMessaging {
+  _FakeFirebaseMessaging(this._settings);
+
+  final NotificationSettings _settings;
+
+  @override
+  Future<NotificationSettings> getNotificationSettings() async => _settings;
+}
+
+NotificationSettings _notificationSettings({
+  AuthorizationStatus authorizationStatus = AuthorizationStatus.notDetermined,
+  AppleNotificationSetting criticalAlert =
+      AppleNotificationSetting.notSupported,
+}) {
+  return NotificationSettings(
+    alert: AppleNotificationSetting.notSupported,
+    announcement: AppleNotificationSetting.notSupported,
+    authorizationStatus: authorizationStatus,
+    badge: AppleNotificationSetting.notSupported,
+    carPlay: AppleNotificationSetting.notSupported,
+    lockScreen: AppleNotificationSetting.notSupported,
+    notificationCenter: AppleNotificationSetting.notSupported,
+    showPreviews: AppleShowPreviewSetting.notSupported,
+    timeSensitive: AppleNotificationSetting.notSupported,
+    criticalAlert: criticalAlert,
+    sound: AppleNotificationSetting.notSupported,
+    providesAppNotificationSettings: AppleNotificationSetting.notSupported,
+  );
+}
+
+ProviderContainer _container(FirebaseMessaging messaging) {
+  final container = ProviderContainer(
+    overrides: [
+      firebaseMessagingProvider.overrideWithValue(messaging),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('OsNotificationPermission.fromNotificationSettings', () {
+    test('authorized のとき isOsNotificationGranted が true', () {
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.authorized,
+        ),
+      );
+
+      expect(permission.isOsNotificationGranted, isTrue);
+      expect(permission.authorizationStatus, AuthorizationStatus.authorized);
+    });
+
+    test('provisional のとき isOsNotificationGranted が true', () {
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.provisional,
+        ),
+      );
+
+      expect(permission.isOsNotificationGranted, isTrue);
+      expect(permission.authorizationStatus, AuthorizationStatus.provisional);
+    });
+
+    test('denied のとき isOsNotificationGranted が false', () {
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.denied,
+        ),
+      );
+
+      expect(permission.isOsNotificationGranted, isFalse);
+    });
+
+    test('notDetermined のとき isOsNotificationGranted が false', () {
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.notDetermined,
+        ),
+      );
+
+      expect(permission.isOsNotificationGranted, isFalse);
+    });
+
+    test('criticalAlert が notSupported 以外のとき isCriticalAlertSupported が true', () {
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          criticalAlert: AppleNotificationSetting.disabled,
+        ),
+      );
+
+      expect(permission.isCriticalAlertSupported, isTrue);
+      expect(permission.isCriticalAlertGranted, isFalse);
+    });
+
+    test('criticalAlert が enabled のとき isCriticalAlertGranted が true', () {
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          criticalAlert: AppleNotificationSetting.enabled,
+        ),
+      );
+
+      expect(permission.isCriticalAlertSupported, isTrue);
+      expect(permission.isCriticalAlertGranted, isTrue);
+    });
+
+    test('criticalAlert が notSupported のとき isCriticalAlertSupported が false', () {
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          criticalAlert: AppleNotificationSetting.notSupported,
+        ),
+      );
+
+      expect(permission.isCriticalAlertSupported, isFalse);
+      expect(permission.isCriticalAlertGranted, isFalse);
+    });
+  });
+
+  group('NotificationSettingsOsPermissionExtension', () {
+    test('toOsNotificationPermission が fromNotificationSettings と同等', () {
+      final settings = _notificationSettings(
+        authorizationStatus: AuthorizationStatus.authorized,
+        criticalAlert: AppleNotificationSetting.enabled,
+      );
+
+      expect(
+        settings.toOsNotificationPermission(),
+        OsNotificationPermission.fromNotificationSettings(settings),
+      );
+    });
+  });
+
+  group('osNotificationPermissionProvider', () {
+    test('FirebaseMessaging の設定を OsNotificationPermission に変換して返す', () async {
+      final settings = _notificationSettings(
+        authorizationStatus: AuthorizationStatus.authorized,
+        criticalAlert: AppleNotificationSetting.enabled,
+      );
+      final messaging = _FakeFirebaseMessaging(settings);
+
+      final container = _container(messaging);
+      final permission = await container.read(
+        osNotificationPermissionProvider.future,
+      );
+
+      expect(permission.isOsNotificationGranted, isTrue);
+      expect(permission.isCriticalAlertGranted, isTrue);
+    });
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
@@ -1,0 +1,265 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/notification/data/model/general_notification_settings.dart';
+import 'package:eqmonitor/feature/notification/data/notifier/general_notification_settings_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_override.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/notification_slot.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final class _PutCurrentLocationCall {
+  const _PutCurrentLocationCall({
+    required this.eewEnabled,
+    required this.eewMinIntensity,
+    required this.earthquakeEnabled,
+    required this.earthquakeMinIntensity,
+  });
+
+  final bool? eewEnabled;
+  final JmaIntensity? eewMinIntensity;
+  final bool? earthquakeEnabled;
+  final JmaIntensity? earthquakeMinIntensity;
+}
+
+final class _PutNationwideCall {
+  const _PutNationwideCall({
+    required this.eewEnabled,
+    required this.eewMinIntensity,
+    required this.earthquakeEnabled,
+    required this.earthquakeMinIntensity,
+  });
+
+  final bool? eewEnabled;
+  final JmaIntensity? eewMinIntensity;
+  final bool? earthquakeEnabled;
+  final JmaIntensity? earthquakeMinIntensity;
+}
+
+class _RecordingNotificationSlotsNotifier extends NotificationSlotsNotifier {
+  final putCurrentLocationCalls = <_PutCurrentLocationCall>[];
+  final putNationwideCalls = <_PutNationwideCall>[];
+
+  @override
+  Future<List<NotificationSlot>> build() async => const [];
+
+  @override
+  Future<void> putCurrentLocation({
+    bool? eewEnabled,
+    JmaIntensity? eewMinIntensity,
+    List<NotificationOverride>? eewOverrides,
+    bool? earthquakeEnabled,
+    JmaIntensity? earthquakeMinIntensity,
+    List<NotificationOverride>? earthquakeOverrides,
+  }) async {
+    putCurrentLocationCalls.add(
+      _PutCurrentLocationCall(
+        eewEnabled: eewEnabled,
+        eewMinIntensity: eewMinIntensity,
+        earthquakeEnabled: earthquakeEnabled,
+        earthquakeMinIntensity: earthquakeMinIntensity,
+      ),
+    );
+  }
+
+  @override
+  Future<void> putNationwide({
+    bool? eewEnabled,
+    JmaIntensity? eewMinIntensity,
+    List<NotificationOverride>? eewOverrides,
+    bool? earthquakeEnabled,
+    JmaIntensity? earthquakeMinIntensity,
+    List<NotificationOverride>? earthquakeOverrides,
+  }) async {
+    putNationwideCalls.add(
+      _PutNationwideCall(
+        eewEnabled: eewEnabled,
+        eewMinIntensity: eewMinIntensity,
+        earthquakeEnabled: earthquakeEnabled,
+        earthquakeMinIntensity: earthquakeMinIntensity,
+      ),
+    );
+  }
+}
+
+class _RecordingGeneralNotificationSettingsNotifier
+    extends GeneralNotificationSettingsNotifier {
+  final updateSettingsCalls = <bool?>[];
+
+  @override
+  Future<GeneralNotificationSettings> build() async =>
+      const GeneralNotificationSettings(
+        notificationEnabled: false,
+        tsunamiEnabled: false,
+        trainingEnabled: false,
+        nankaiExtraordinaryEnabled: false,
+        nankaiRegularEnabled: false,
+        hokkaido3renOffshoreEnabled: false,
+      );
+
+  @override
+  Future<void> updateSettings({
+    bool? notificationEnabled,
+    bool? tsunamiEnabled,
+    bool? trainingEnabled,
+    bool? nankaiExtraordinaryEnabled,
+    bool? nankaiRegularEnabled,
+    bool? hokkaido3renOffshoreEnabled,
+  }) async {
+    updateSettingsCalls.add(notificationEnabled);
+  }
+}
+
+class _RecordingNotificationPresetNotifier extends NotificationPresetNotifier {
+  final selectedPresets = <NotificationPreset>[];
+
+  @override
+  Future<NotificationPreset> build() async => NotificationPreset.recommended;
+
+  @override
+  Future<void> select(NotificationPreset preset) async {
+    selectedPresets.add(preset);
+    state = AsyncData(preset);
+  }
+}
+
+class _FakeDeviceProvisioningNotifier extends DeviceProvisioningNotifier {
+  @override
+  Future<DeviceProvisioningStatus> build() async =>
+      DeviceProvisioningStatus.notRequired;
+}
+
+ProviderContainer _container({
+  required _RecordingNotificationSlotsNotifier slotsNotifier,
+  required _RecordingGeneralNotificationSettingsNotifier settingsNotifier,
+  required _RecordingNotificationPresetNotifier presetNotifier,
+}) {
+  return ProviderContainer(
+    overrides: [
+      deviceProvisioningProvider.overrideWith(
+        _FakeDeviceProvisioningNotifier.new,
+      ),
+      notificationSlotsProvider.overrideWith(() => slotsNotifier),
+      generalNotificationSettingsProvider.overrideWith(
+        () => settingsNotifier,
+      ),
+      notificationPresetProvider.overrideWith(() => presetNotifier),
+    ],
+  );
+}
+
+void main() {
+  group('NotificationPresetApplier', () {
+    test('recommended applies current location, enables notifications, selects preset',
+        () async {
+      final slotsNotifier = _RecordingNotificationSlotsNotifier();
+      final settingsNotifier = _RecordingGeneralNotificationSettingsNotifier();
+      final presetNotifier = _RecordingNotificationPresetNotifier();
+      final container = _container(
+        slotsNotifier: slotsNotifier,
+        settingsNotifier: settingsNotifier,
+        presetNotifier: presetNotifier,
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(notificationPresetApplierProvider)
+          .apply(NotificationPreset.recommended);
+
+      expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
+      final recommendedCall = slotsNotifier.putCurrentLocationCalls.first;
+      expect(recommendedCall.eewEnabled, isTrue);
+      expect(recommendedCall.eewMinIntensity, JmaIntensity.four);
+      expect(recommendedCall.earthquakeEnabled, isTrue);
+      expect(recommendedCall.earthquakeMinIntensity, JmaIntensity.one);
+      expect(slotsNotifier.putNationwideCalls, isEmpty);
+      expect(settingsNotifier.updateSettingsCalls, [true]);
+      expect(presetNotifier.selectedPresets, [NotificationPreset.recommended]);
+    });
+
+    test('all applies recommended settings plus nationwide', () async {
+      final slotsNotifier = _RecordingNotificationSlotsNotifier();
+      final settingsNotifier = _RecordingGeneralNotificationSettingsNotifier();
+      final presetNotifier = _RecordingNotificationPresetNotifier();
+      final container = _container(
+        slotsNotifier: slotsNotifier,
+        settingsNotifier: settingsNotifier,
+        presetNotifier: presetNotifier,
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(notificationPresetApplierProvider)
+          .apply(NotificationPreset.all);
+
+      expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
+      final allCurrentLocationCall = slotsNotifier.putCurrentLocationCalls.first;
+      expect(allCurrentLocationCall.eewEnabled, isTrue);
+      expect(allCurrentLocationCall.eewMinIntensity, JmaIntensity.four);
+      expect(allCurrentLocationCall.earthquakeEnabled, isTrue);
+      expect(allCurrentLocationCall.earthquakeMinIntensity, JmaIntensity.one);
+      expect(slotsNotifier.putNationwideCalls, hasLength(1));
+      final nationwideCall = slotsNotifier.putNationwideCalls.first;
+      expect(nationwideCall.eewEnabled, isTrue);
+      expect(nationwideCall.eewMinIntensity, defaultNotificationSlotMinIntensity);
+      expect(nationwideCall.earthquakeEnabled, isTrue);
+      expect(
+        nationwideCall.earthquakeMinIntensity,
+        defaultNotificationSlotMinIntensity,
+      );
+      expect(settingsNotifier.updateSettingsCalls, [true]);
+      expect(presetNotifier.selectedPresets, [NotificationPreset.all]);
+    });
+
+    test('none disables notifications without creating slots', () async {
+      final slotsNotifier = _RecordingNotificationSlotsNotifier();
+      final settingsNotifier = _RecordingGeneralNotificationSettingsNotifier();
+      final presetNotifier = _RecordingNotificationPresetNotifier();
+      final container = _container(
+        slotsNotifier: slotsNotifier,
+        settingsNotifier: settingsNotifier,
+        presetNotifier: presetNotifier,
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(notificationPresetApplierProvider)
+          .apply(NotificationPreset.none);
+
+      expect(slotsNotifier.putCurrentLocationCalls, isEmpty);
+      expect(slotsNotifier.putNationwideCalls, isEmpty);
+      expect(settingsNotifier.updateSettingsCalls, [false]);
+      expect(presetNotifier.selectedPresets, [NotificationPreset.none]);
+    });
+
+    test('custom applies current location only without selecting preset',
+        () async {
+      final slotsNotifier = _RecordingNotificationSlotsNotifier();
+      final settingsNotifier = _RecordingGeneralNotificationSettingsNotifier();
+      final presetNotifier = _RecordingNotificationPresetNotifier();
+      final container = _container(
+        slotsNotifier: slotsNotifier,
+        settingsNotifier: settingsNotifier,
+        presetNotifier: presetNotifier,
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(notificationPresetApplierProvider)
+          .apply(NotificationPreset.custom);
+
+      expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
+      final customCall = slotsNotifier.putCurrentLocationCalls.first;
+      expect(customCall.eewEnabled, isTrue);
+      expect(customCall.eewMinIntensity, JmaIntensity.four);
+      expect(customCall.earthquakeEnabled, isTrue);
+      expect(customCall.earthquakeMinIntensity, JmaIntensity.one);
+      expect(slotsNotifier.putNationwideCalls, isEmpty);
+      expect(settingsNotifier.updateSettingsCalls, isEmpty);
+      expect(presetNotifier.selectedPresets, isEmpty);
+    });
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_preset_notifier_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_notifier_test.dart
@@ -1,0 +1,63 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ProviderContainer _container(Map<String, Object> initialPrefs) {
+  SharedPreferences.setMockInitialValues(initialPrefs);
+  return ProviderContainer(
+    overrides: [
+      sharedPreferencesProvider.overrideWith(
+        (ref) => SharedPreferences.getInstance(),
+      ),
+    ],
+  );
+}
+
+void main() {
+  group('NotificationPresetNotifier', () {
+    test('loads all and none from preferences', () async {
+      final allContainer = _container({
+        SharedPreferencesKey.notificationPreset.key: 'all',
+      });
+      addTearDown(allContainer.dispose);
+
+      final allPreset = await allContainer.read(
+        notificationPresetProvider.future,
+      );
+      expect(allPreset, NotificationPreset.all);
+
+      final noneContainer = _container({
+        SharedPreferencesKey.notificationPreset.key: 'none',
+      });
+      addTearDown(noneContainer.dispose);
+
+      final nonePreset = await noneContainer.read(
+        notificationPresetProvider.future,
+      );
+      expect(nonePreset, NotificationPreset.none);
+    });
+
+    test('defaults unknown values to recommended', () async {
+      final unknownContainer = _container({
+        SharedPreferencesKey.notificationPreset.key: 'legacy_value',
+      });
+      addTearDown(unknownContainer.dispose);
+
+      final unknownPreset = await unknownContainer.read(
+        notificationPresetProvider.future,
+      );
+      expect(unknownPreset, NotificationPreset.recommended);
+
+      final emptyContainer = _container({});
+      addTearDown(emptyContainer.dispose);
+
+      final defaultPreset = await emptyContainer.read(
+        notificationPresetProvider.future,
+      );
+      expect(defaultPreset, NotificationPreset.recommended);
+    });
+  });
+}

--- a/app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
@@ -1,0 +1,195 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission_provider.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart';
+import 'package:eqmonitor/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+Widget _buildTestWidget({
+  required Widget child,
+  required FirebaseMessaging messaging,
+  required OsNotificationPermission permission,
+}) {
+  final theme = ThemeData.light().copyWith(
+    extensions: [
+      DesignSystemThemeExtension.light(),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      firebaseMessagingProvider.overrideWithValue(messaging),
+      osNotificationPermissionProvider.overrideWith(
+        (ref) async => permission,
+      ),
+    ],
+    child: MaterialApp(theme: theme, home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  group('NotificationPresetSelector', () {
+    testWidgets('OS権限オフで無効プリセットをタップすると通知権限ダイアログを表示する', (
+      tester,
+    ) async {
+      final messaging = _FakeFirebaseMessaging(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.denied,
+        ),
+      );
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.denied,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          messaging: messaging,
+          permission: permission,
+          child: NotificationPresetSelector(
+            selectedPreset: NotificationPreset.none,
+            onChanged: (_) {},
+            style: NotificationPresetSelectorStyle.onboarding,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('推奨設定'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('通知権限が無効です'), findsOneWidget);
+      expect(
+        find.text('通知を受け取るには、通知の許可が必要です。許可しますか？'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('推奨設定選択中かつ重大通知未許可のとき警告リンクを表示する', (
+      tester,
+    ) async {
+      final messaging = _FakeFirebaseMessaging(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.authorized,
+          criticalAlert: AppleNotificationSetting.disabled,
+        ),
+      );
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.authorized,
+          criticalAlert: AppleNotificationSetting.disabled,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          messaging: messaging,
+          permission: permission,
+          child: NotificationPresetSelector(
+            selectedPreset: NotificationPreset.recommended,
+            onChanged: (_) {},
+            style: NotificationPresetSelectorStyle.settings,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('重大な通知が許可されていません'), findsOneWidget);
+    });
+
+    testWidgets('重大通知非対応端末では警告リンクを表示しない', (tester) async {
+      final messaging = _FakeFirebaseMessaging(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.authorized,
+          criticalAlert: AppleNotificationSetting.notSupported,
+        ),
+      );
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.authorized,
+          criticalAlert: AppleNotificationSetting.notSupported,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          messaging: messaging,
+          permission: permission,
+          child: NotificationPresetSelector(
+            selectedPreset: NotificationPreset.recommended,
+            onChanged: (_) {},
+            style: NotificationPresetSelectorStyle.onboarding,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('重大な通知が許可されていません'), findsNothing);
+    });
+
+    testWidgets('OS権限オフかつ推奨設定選択中は通知しないへ自動切り替えする', (
+      tester,
+    ) async {
+      NotificationPreset? changedPreset;
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        _notificationSettings(
+          authorizationStatus: AuthorizationStatus.denied,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          messaging: _FakeFirebaseMessaging(
+            _notificationSettings(
+              authorizationStatus: AuthorizationStatus.denied,
+            ),
+          ),
+          permission: permission,
+          child: NotificationPresetSelector(
+            selectedPreset: NotificationPreset.recommended,
+            onChanged: (preset) => changedPreset = preset,
+            style: NotificationPresetSelectorStyle.onboarding,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(changedPreset, NotificationPreset.none);
+    });
+  });
+}
+
+class _FakeFirebaseMessaging extends Fake implements FirebaseMessaging {
+  _FakeFirebaseMessaging(this._settings);
+
+  final NotificationSettings _settings;
+
+  @override
+  Future<NotificationSettings> getNotificationSettings() async => _settings;
+}
+
+NotificationSettings _notificationSettings({
+  AuthorizationStatus authorizationStatus = AuthorizationStatus.notDetermined,
+  AppleNotificationSetting criticalAlert =
+      AppleNotificationSetting.notSupported,
+}) {
+  return NotificationSettings(
+    alert: AppleNotificationSetting.notSupported,
+    announcement: AppleNotificationSetting.notSupported,
+    authorizationStatus: authorizationStatus,
+    badge: AppleNotificationSetting.notSupported,
+    carPlay: AppleNotificationSetting.notSupported,
+    lockScreen: AppleNotificationSetting.notSupported,
+    notificationCenter: AppleNotificationSetting.notSupported,
+    showPreviews: AppleShowPreviewSetting.notSupported,
+    timeSensitive: AppleNotificationSetting.notSupported,
+    criticalAlert: criticalAlert,
+    sound: AppleNotificationSetting.notSupported,
+    providesAppNotificationSettings: AppleNotificationSetting.notSupported,
+  );
+}

--- a/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
@@ -1,4 +1,7 @@
 import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission.dart';
+import 'package:eqmonitor/core/provider/notification/os_notification_permission_provider.dart';
 import 'package:eqmonitor/feature/notification/data/model/general_notification_settings.dart';
 import 'package:eqmonitor/feature/notification/data/notifier/general_notification_settings_notifier.dart';
 import 'package:eqmonitor/feature/settings/features/notification_settings/data/model/eew_global_settings.dart';
@@ -12,6 +15,7 @@ import 'package:eqmonitor/feature/settings/features/notification_settings/data/n
 import 'package:eqmonitor/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -23,6 +27,20 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          firebaseMessagingProvider.overrideWithValue(
+            _FakeFirebaseMessaging(
+              _notificationSettings(
+                authorizationStatus: AuthorizationStatus.authorized,
+              ),
+            ),
+          ),
+          osNotificationPermissionProvider.overrideWith(
+            (ref) async => OsNotificationPermission.fromNotificationSettings(
+              _notificationSettings(
+                authorizationStatus: AuthorizationStatus.authorized,
+              ),
+            ),
+          ),
           startProvider.overrideWith(_FakeStartNotifier.new),
           notificationPresetProvider.overrideWith(
             _FakeNotificationPresetNotifier.new,
@@ -51,7 +69,7 @@ void main() {
     await tester.tap(find.text('緊急地震速報(警報)'));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('緊急地震速報(警報)を通知'));
+    await tester.tap(find.text('通知を受け取る'));
     await tester.pumpAndSettle();
 
     expect(recorder.lastWarningEnabled, isFalse);
@@ -87,7 +105,7 @@ class _FakeStartNotifier extends StartNotifier {
 
 class _FakeNotificationPresetNotifier extends NotificationPresetNotifier {
   @override
-  NotificationPreset build() => NotificationPreset.custom;
+  Future<NotificationPreset> build() async => NotificationPreset.custom;
 }
 
 class _FakeGeneralNotificationSettingsNotifier
@@ -192,4 +210,34 @@ class _TestApp extends StatelessWidget {
     );
     return MaterialApp(theme: theme, home: home);
   }
+}
+
+class _FakeFirebaseMessaging extends Fake implements FirebaseMessaging {
+  _FakeFirebaseMessaging(this._settings);
+
+  final NotificationSettings _settings;
+
+  @override
+  Future<NotificationSettings> getNotificationSettings() async => _settings;
+}
+
+NotificationSettings _notificationSettings({
+  AuthorizationStatus authorizationStatus = AuthorizationStatus.notDetermined,
+  AppleNotificationSetting criticalAlert =
+      AppleNotificationSetting.notSupported,
+}) {
+  return NotificationSettings(
+    alert: AppleNotificationSetting.notSupported,
+    announcement: AppleNotificationSetting.notSupported,
+    authorizationStatus: authorizationStatus,
+    badge: AppleNotificationSetting.notSupported,
+    carPlay: AppleNotificationSetting.notSupported,
+    lockScreen: AppleNotificationSetting.notSupported,
+    notificationCenter: AppleNotificationSetting.notSupported,
+    showPreviews: AppleShowPreviewSetting.notSupported,
+    timeSensitive: AppleNotificationSetting.notSupported,
+    criticalAlert: criticalAlert,
+    sound: AppleNotificationSetting.notSupported,
+    providesAppNotificationSettings: AppleNotificationSetting.notSupported,
+  );
 }

--- a/docs/superpowers/plans/2026-07-08-notification-preset-four-options.md
+++ b/docs/superpowers/plans/2026-07-08-notification-preset-four-options.md
@@ -1,0 +1,233 @@
+# Notification Preset Four Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** オンボーディングと設定画面の通知プリセットを4択（推奨設定 / すべて / カスタム / 通知しない）に拡張し、OS通知権限・重大な通知権限に応じた選択制御を実装する。
+
+**Architecture:** `NotificationPreset` enum を4値に拡張し、OS権限 Provider・`NotificationPresetApplier` Action・共有 `NotificationPresetSelector` UI を新設。オンボーディングと設定画面の両方が共有コンポーネントを利用する。
+
+**Tech Stack:** Flutter 3.44 / Dart ^3.11、Riverpod 3、Firebase Messaging、flutter_hooks、mise exec 経由の flutter/dart コマンド
+
+**Spec:** `docs/superpowers/specs/2026-07-08-notification-preset-four-options-design.md`
+
+## Global Constraints
+
+- Flutter/Dart コマンドは常に `mise exec --` 経由
+- 生成ファイル（`*.g.dart`）は直接編集しない。`dart run build_runner build --delete-conflicting-outputs` で再生成
+- `dynamic` / `any` / `Object` 型は `Map<String,dynamic>` 以外禁止
+- `!` 演算子禁止。HookWidget / HookConsumerWidget を使用
+- Widget 内プライベートメソッド禁止。Action クラスに切り出し、`ref`/`context` はメソッド引数で渡す
+- top-level 関数禁止
+- プリセット表示順: 推奨設定 → すべて → カスタム → 通知しない
+- OS権限 `authorized`/`provisional` のみ4択可能。`denied`/`notDetermined` は **通知しない** のみ
+- 無効プリセットタップ時ダイアログ: タイトル「通知権限が無効です」、本文「通知を受け取るには、通知の許可が必要です。許可しますか？」
+- 重大通知リンク文言: 「重大な通知が許可されていません」（`Text.rich` + `TapGestureRecognizer`）
+- 重大通知ダイアログ: タイトル「重大な通知が許可されていません」、本文「緊急地震速報(警報)を確実に受け取るには、重大な通知の許可が必要です。許可しますか？」
+- 推奨設定: `putCurrentLocation(eewMinIntensity: JmaIntensity.four, earthquakeMinIntensity: JmaIntensity.one, eewEnabled: true, earthquakeEnabled: true)` + `notificationEnabled: true`
+- すべて: 上記 + `putNationwide(eewMinIntensity: defaultNotificationSlotMinIntensity, earthquakeMinIntensity: defaultNotificationSlotMinIntensity, eewEnabled: true, earthquakeEnabled: true)` + `notificationEnabled: true`
+- 通知しない: `notificationEnabled: false`、スロット作成しない（既存スロット削除しない）
+- 移行ユーザー `_MigratedNotificationSettingsStepPage` は変更しない
+- コミットメッセージ: 英語prefix + 日本語1行説明
+
+---
+
+### Task 1: NotificationPreset enum 拡張と Notifier 永続化
+
+**Files:**
+- Modify: `app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.dart`
+- Modify: `app/lib/feature/onboarding/ui/model/onboarding_permission_status.dart`（`_NotificationPreset` 削除）
+- Test: `app/test/feature/settings/features/notification_settings/notification_preset_notifier_test.dart`
+
+**Interfaces:**
+- Consumes: 既存 `SharedPreferencesKey.notificationPreset`
+- Produces:
+  ```dart
+  enum NotificationPreset { recommended, all, custom, none }
+  // notificationPresetProvider — AsyncNotifier<NotificationPreset>
+  // select(NotificationPreset preset) => Future<void>
+  // build(): custom→custom, all→all, none→none, その他→recommended
+  ```
+
+- [ ] **Step 1: Write failing tests**
+
+```dart
+// notification_preset_notifier_test.dart
+test('loads all and none from preferences', () async { ... });
+test('defaults unknown values to recommended', () async { ... });
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `cd app && mise exec -- flutter test test/feature/settings/features/notification_settings/notification_preset_notifier_test.dart -v`
+
+- [ ] **Step 3: Implement enum + notifier + remove _NotificationPreset**
+
+- [ ] **Step 4: Run build_runner**
+
+Run: `cd app && mise exec -- dart run build_runner build --delete-conflicting-outputs`
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/lib/feature/settings/features/notification_settings/data/notifier/ \
+  app/lib/feature/onboarding/ui/model/onboarding_permission_status.dart \
+  app/test/feature/settings/features/notification_settings/notification_preset_notifier_test.dart
+git commit -m "feat: NotificationPresetを4値に拡張"
+```
+
+---
+
+### Task 2: OS 通知権限 Provider
+
+**Files:**
+- Create: `app/lib/core/provider/notification/os_notification_permission_provider.dart`
+- Create: `app/lib/core/provider/notification/os_notification_permission.dart`（extension/model）
+- Test: `app/test/core/provider/notification/os_notification_permission_test.dart`
+
+**Interfaces:**
+- Consumes: `firebaseMessagingProvider`, `NotificationSettings` from FCM
+- Produces:
+  ```dart
+  @riverpod
+  Future<OsNotificationPermission> osNotificationPermission(Ref ref);
+
+  class OsNotificationPermission {
+    bool get isOsNotificationGranted; // authorized || provisional
+    bool get isCriticalAlertSupported; // criticalAlert != notSupported
+    bool get isCriticalAlertGranted; // criticalAlert == enabled
+    AuthorizationStatus get authorizationStatus;
+  }
+  ```
+
+- [ ] **Step 1–6:** TDD で Provider 実装、build_runner、テスト、コミット
+
+Run tests: `cd app && mise exec -- flutter test test/core/provider/notification/os_notification_permission_test.dart -v`
+
+Commit: `feat: OS通知権限Providerを追加`
+
+---
+
+### Task 3: NotificationPresetApplier Action
+
+**Files:**
+- Create: `app/lib/feature/settings/features/notification_settings/data/action/notification_preset_applier.dart`
+- Test: `app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart`
+
+**Interfaces:**
+- Consumes: `notificationSlotsProvider.notifier`, `generalNotificationSettingsProvider.notifier`, `notificationPresetProvider.notifier`
+- Produces:
+  ```dart
+  @riverpod
+  NotificationPresetApplier notificationPresetApplier(Ref ref);
+
+  class NotificationPresetApplier {
+    Future<void> apply(NotificationPreset preset);
+    // recommended/all/none: preset保存 + API
+    // custom: putCurrentLocationのみ（preset保存は呼び出し側）
+  }
+  ```
+
+- [ ] **Step 1–6:** TDD。各 preset のモック検証。コミット `feat: NotificationPresetApplierを追加`
+
+---
+
+### Task 4: 権限ダイアログ
+
+**Files:**
+- Create: `app/lib/feature/settings/features/notification_settings/ui/dialog/notification_permission_dialog.dart`
+
+**Interfaces:**
+- Consumes: `firebaseMessagingProvider`, `Geolocator.openAppSettings()` or `app_settings`
+- Produces:
+  ```dart
+  Future<void> showOsNotificationPermissionDialog(BuildContext context, WidgetRef ref);
+  Future<void> showCriticalAlertPermissionDialog(BuildContext context, WidgetRef ref);
+  ```
+
+- [ ] **Step 1:** ダイアログ実装（`showDialog` + `AlertDialog`）
+- [ ] **Step 2:** `requestPermission(criticalAlert: true)` 後 `ref.invalidate(osNotificationPermissionProvider)`
+- [ ] **Step 3:** `deniedForever` 時は「設定を開く」
+- [ ] **Step 4:** Commit `feat: 通知権限ダイアログを追加`
+
+---
+
+### Task 5: NotificationPresetSelector 共有 UI
+
+**Files:**
+- Create: `app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart`
+- Test: `app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart`
+
+**Interfaces:**
+- Consumes: `OsNotificationPermission`, `NotificationPreset`, dialog functions from Task 4
+- Produces:
+  ```dart
+  enum NotificationPresetSelectorStyle { onboarding, settings }
+
+  class NotificationPresetSelector extends HookConsumerWidget {
+    const NotificationPresetSelector({
+      required this.selectedPreset,
+      required this.onChanged,
+      required this.style,
+      this.onCustomSettingsTap,
+    });
+  }
+  ```
+
+**Behavior:**
+- 4カード/タイルを表示（順序: 推奨→すべて→カスタム→通知しない）
+- OS権限オフ: 推奨/すべて/カスタムは `enabled: false` 相当の見た目、タップで OS ダイアログ
+- OS権限オフ + 他プリセット選択中: `useEffect` で `none` に自動切り替え
+- 推奨/すべて選択中 + criticalAlert未許可(iOS): カード下部に `Text.rich` リンク
+- onboarding style: 既存 `_PresetCard` 相当
+- settings style: 既存 `_PresetOptionGroup` 相当（カスタム行に trailing）
+
+- [ ] **Step 1–6:** Widget test（権限オフでダイアログ、重大通知リンク表示）含め実装・コミット
+
+Commit: `feat: NotificationPresetSelector共有UIを追加`
+
+---
+
+### Task 6: オンボーディング統合
+
+**Files:**
+- Modify: `app/lib/feature/onboarding/ui/components/notification_settings_step_page.dart`
+
+**Interfaces:**
+- Consumes: `NotificationPresetSelector`, `NotificationPresetApplier`, `NotificationPreset`
+
+- [ ] **Step 1:** `_NewUserNotificationSettingsStepPage` を `NotificationPreset` + `NotificationPresetSelector` に置き換え
+- [ ] **Step 2:** `onNext` で `recommended`/`all`/`none` → applier.apply → nextPage
+- [ ] **Step 3:** `custom` → applier（putCurrentLocation）→ push custom → nextPage
+- [ ] **Step 4:** `_PresetCard` 削除（selector に移行済みなら）
+- [ ] **Step 5:** `mise exec -- flutter analyze` + 関連テスト
+- [ ] **Step 6:** Commit `feat: オンボーディング通知設定を4択に更新`
+
+---
+
+### Task 7: 設定画面統合
+
+**Files:**
+- Modify: `app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart`
+- Modify: `app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart`（fake preset 対応）
+
+**Interfaces:**
+- Consumes: `NotificationPresetSelector`, `NotificationPresetApplier`
+
+- [ ] **Step 1:** `_PresetOptionGroup` 等を `NotificationPresetSelector(style: settings)` に置換
+- [ ] **Step 2:** `onChanged` で `applier.apply(preset)` + preset notifier 更新
+- [ ] **Step 3:** 未使用 private widget 削除
+- [ ] **Step 4:** 既存 widget test 修正
+- [ ] **Step 5:** `mise exec -- flutter test test/feature/settings/features/notification_settings/ -v`
+- [ ] **Step 6:** Commit `feat: 設定画面の通知プリセットを4択に更新`
+
+---
+
+### Task 8: 最終検証
+
+**Files:** （変更なし、検証のみ）
+
+- [ ] **Step 1:** `cd app && mise exec -- dart analyze`
+- [ ] **Step 2:** `cd app && mise exec -- flutter test test/feature/settings/features/notification_settings/ test/core/provider/notification/ -v`
+- [ ] **Step 3:** 問題があれば修正コミット

--- a/docs/superpowers/specs/2026-07-08-notification-preset-four-options-design.md
+++ b/docs/superpowers/specs/2026-07-08-notification-preset-four-options-design.md
@@ -1,0 +1,206 @@
+# 通知プリセット4択 + OS権限制御 設計
+
+## 概要
+
+オンボーディングの通知設定ステップおよび設定画面の通知プリセットを、現行の2択（推奨設定 / カスタム）から4択に拡張する。OS 通知権限・重大な通知権限の状態に応じて選択可否と警告表示を制御する。
+
+## 背景
+
+- 現状: `NotificationPreset` は `recommended` / `custom` のみ
+- オンボーディング・設定画面で同じ2択 UI を個別実装している
+- ユーザーが「すべて受け取る」「通知しない」を初回から選べない
+- OS 通知権限がオフでも他プリセットを選べてしまい、保存後に通知が届かない
+
+## プリセット定義
+
+| プリセット | enum 値 | API 操作 |
+|---|---|---|
+| 推奨設定 | `recommended` | 現在地スロット作成（EEW警報 ON、予報 震度4+、地震 震度1+） |
+| すべて | `all` | 推奨設定 + 全国スロット（EEW・地震 震度3+、`defaultNotificationSlotMinIntensity`） |
+| カスタム | `custom` | 現在地スロット作成 → カスタム設定画面へ遷移 |
+| 通知しない | `none` | `notificationEnabled: false`、スロットは作成しない（既存スロットは削除しない） |
+
+### カード説明テキスト
+
+- **推奨設定**: 現状と同じ箇条書き
+  - 現在地の緊急地震速報(警報)
+  - 現在地で予想震度4以上の緊急地震速報(予報)
+  - 現在地で震度1以上を観測した地震情報
+- **すべて**: 「推奨設定に加え、全国の緊急地震速報・地震情報も通知します」
+- **カスタム**: 現状と同じ
+- **通知しない**: 「通知を受け取りません。後から設定で変更できます」
+
+### 表示順
+
+推奨設定 → すべて → カスタム → 通知しない
+
+## OS 権限制御
+
+### 判定
+
+`FirebaseMessaging.getNotificationSettings()` の `authorizationStatus` を Riverpod Provider で watch する。
+
+```dart
+bool get isOsNotificationGranted =>
+  status == AuthorizationStatus.authorized ||
+  status == AuthorizationStatus.provisional;
+```
+
+### 選択可否
+
+| OS 権限 | 選択可能 |
+|---|---|
+| `authorized` / `provisional` | 4つすべて |
+| `denied` / `notDetermined` | **通知しない** のみ |
+
+### 無効プリセットのタップ
+
+ダイアログを表示:
+
+- タイトル: 「通知権限が無効です」
+- 本文: 「通知を受け取るには、通知の許可が必要です。許可しますか？」
+- ボタン:
+  - `notDetermined` / `denied`: 「許可する」→ `requestPermission(criticalAlert: true)` → Provider を invalidate
+  - `deniedForever`（iOS）: 「設定を開く」→ `Geolocator.openAppSettings()` または同等
+
+### 自動切り替え
+
+OS 権限がオフの状態で推奨設定・すべて・カスタムが選択されている場合、**通知しない** に自動切り替える。
+
+### 適用範囲
+
+オンボーディング・設定画面の両方に同じ制御を適用する。
+
+## 重大な通知の警告リンク
+
+### 表示条件
+
+以下をすべて満たすとき、該当カード下部にリンクを表示:
+
+1. 推奨設定 or すべて が選択中
+2. iOS / macOS（`criticalAlert != notSupported`）
+3. `criticalAlert == disabled`
+
+Android では非表示（プラットフォーム非対応のため）。
+
+### UI
+
+`Text.rich` + `TapGestureRecognizer` でリンク表示:
+
+```
+重大な通知が許可されていません
+```
+
+- リンク部分: `primary` 色 + 下線
+- 通常テキスト: `onSurfaceVariant`
+
+### タップ時ダイアログ
+
+- タイトル: 「重大な通知が許可されていません」
+- 本文: 「緊急地震速報(警報)を確実に受け取るには、重大な通知の許可が必要です。許可しますか？」
+- 「許可する」→ `requestPermission(criticalAlert: true)` → Provider invalidate
+- 既に拒否済みで再要求不可の場合は「設定を開く」
+
+## アーキテクチャ
+
+### 新規ファイル
+
+```
+app/lib/core/provider/notification/
+  os_notification_permission_provider.dart
+
+app/lib/feature/settings/features/notification_settings/
+  data/action/notification_preset_applier.dart
+  ui/component/notification_preset_selector.dart
+  ui/dialog/notification_permission_dialog.dart
+```
+
+### 変更ファイル
+
+```
+data/notifier/notification_preset_notifier.dart   # enum 拡張 + 永続化マイグレーション
+ui/page/notification_settings_page.dart          # 共有コンポーネント利用
+feature/onboarding/ui/components/
+  notification_settings_step_page.dart             # 共有コンポーネント利用
+feature/onboarding/ui/model/
+  onboarding_permission_status.dart                # _NotificationPreset 削除
+```
+
+### enum 変更
+
+```dart
+enum NotificationPreset { recommended, all, custom, none }
+```
+
+オンボーディングローカルの `_NotificationPreset` は廃止し `NotificationPreset` に統一。
+
+### SharedPreferences 永続化
+
+既存キー `notification_preset` の値:
+
+| 保存値 | 読み込み結果 |
+|---|---|
+| `custom` | `NotificationPreset.custom` |
+| `all` | `NotificationPreset.all` |
+| `none` | `NotificationPreset.none` |
+| 未設定 / `recommended` / その他 | `NotificationPreset.recommended` |
+
+### NotificationPresetApplier
+
+プリセット選択時の API 呼び出しを集約する Action クラス（Riverpod DI）。
+
+| プリセット | 処理 |
+|---|---|
+| `recommended` | `putCurrentLocation(eew: 震度4, earthquake: 震度1)` + `notificationEnabled: true` |
+| `all` | 上記 + `putNationwide(eew: 震度3, earthquake: 震度3)` + `notificationEnabled: true` |
+| `custom` | `putCurrentLocation` のみ（詳細はカスタム画面） + preset を `custom` に保存 |
+| `none` | `notificationEnabled: false`、スロットは作成しない。設定画面で既存スロットがある場合は削除せず保持する |
+
+### NotificationPresetSelector
+
+共有 UI コンポーネント。props:
+
+- `selectedPreset: NotificationPreset`
+- `onChanged: ValueChanged<NotificationPreset>`
+- `onCustomSettingsTap: VoidCallback?`（カスタム詳細画面遷移、設定画面用）
+- `style: NotificationPresetSelectorStyle`（`onboarding` / `settings` でレイアウト差分）
+
+オンボーディング: 現行の `_PresetCard` スタイル（カード型ラジオ）
+設定画面: 現行の `_PresetOptionGroup` スタイル（Card.outlined 内リスト）
+
+## オンボーディング固有の挙動
+
+- プリセット未選択時: 「次へ」無効
+- 選択後「次へ」:
+  - `recommended` / `all` / `none`: Applier で保存 → 次ステップへ
+  - `custom`: 現在地スロット作成 → `NotificationSettingsPage` を push → pop 後に次ステップへ
+- 保存失敗時: エラーメッセージ表示、リトライ可能
+
+## 設定画面の変更
+
+- `_PresetOptionGroup` を `NotificationPresetSelector` に置き換え
+- 「通知を受け取る」マスタートグルは既存のまま維持
+- プリセット変更時は即座に Applier で API 保存（オンボーディングと同じロジック）
+- カスタム選択時の詳細画面遷移は既存の `_CustomNotificationSettingsPage` を維持
+
+## エラーハンドリング
+
+- API 保存失敗: ユーザーフレンドリーなエラーメッセージ（例外文字列は表示しない）
+- 権限要求失敗: ダイアログを閉じ、状態は変更しない
+- Mutation エラーは既存パターン（`showErrorDialog`）に従う
+
+## テスト
+
+| 対象 | 内容 |
+|---|---|
+| `NotificationPresetApplier` | 各プリセットの API 呼び出し内容 |
+| `NotificationPresetNotifier` | enum 永続化・読み込みマイグレーション |
+| OS 権限ロジック | 権限状態ごとの選択可否・自動切り替え |
+| 重大通知リンク | iOS で表示、Android で非表示 |
+| Widget テスト | 権限オフ時に無効カードタップでダイアログ表示 |
+
+## スコープ外
+
+- 津波・訓練・南海トラフ等の一般通知を「すべて」に含める（スロットのみ）
+- 権限ステップ（permissions）の UI 変更
+- 移行ユーザー（`_MigratedNotificationSettingsStepPage`）の変更


### PR DESCRIPTION
## Summary

- オンボーディング・設定画面の通知プリセットを4択（推奨設定 / すべて / カスタム / 通知しない）に拡張
- OS通知権限がオフのときは「通知しない」のみ選択可能にし、他プリセットタップ時は権限要求ダイアログを表示
- 推奨設定・すべて選択中に重大な通知が未許可（iOS）の場合、カード下部に `Text.rich` の警告リンクを表示
- `NotificationPresetApplier`・`NotificationPresetSelector`・`osNotificationPermissionProvider` を新設し、両画面で共有

## Test plan

- [ ] オンボーディング: 4プリセットが表示され、未選択時は「次へ」が無効
- [ ] オンボーディング: 推奨設定 / すべて / 通知しない 選択後に次ステップへ進める
- [ ] オンボーディング: カスタム選択 → カスタム設定画面 → 完了まで進める
- [ ] OS通知権限オフ: 推奨/すべて/カスタムが無効、タップで権限ダイアログ表示
- [ ] iOS: 推奨/すべて選択中に重大通知未許可で警告リンク表示、タップでダイアログ
- [ ] 設定画面: 4プリセット切り替えで API 設定が反映される
- [ ] `flutter test test/feature/settings/features/notification_settings/ test/core/provider/notification/` がパス


Made with [Cursor](https://cursor.com)