### PR TITLE
fix: オンボーディング完了フラグが保存されない問題を修正

### DIFF
--- a/app/lib/feature/onboarding/data/notifier/onboarding_notifier.dart
+++ b/app/lib/feature/onboarding/data/notifier/onboarding_notifier.dart
@@ -5,7 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'onboarding_notifier.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 class OnboardingCompleted extends _$OnboardingCompleted {
   static final completeMutation = Mutation<void>();
   static final resetMutation = Mutation<void>();

--- a/app/lib/feature/onboarding/data/notifier/onboarding_notifier.g.dart
+++ b/app/lib/feature/onboarding/data/notifier/onboarding_notifier.g.dart
@@ -22,7 +22,7 @@ final class OnboardingCompletedProvider
         argument: null,
         retry: null,
         name: r'onboardingCompletedProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -36,7 +36,7 @@ final class OnboardingCompletedProvider
 }
 
 String _$onboardingCompletedHash() =>
-    r'61cab6c33d4c32301f79afa5eef6fbf229c5b579';
+    r'ee5932f01995ea71ff62d17cacc1875480642879';
 
 abstract class _$OnboardingCompleted extends $AsyncNotifier<bool> {
   FutureOr<bool> build();

--- a/app/lib/feature/onboarding/ui/components/complete_step_page.dart
+++ b/app/lib/feature/onboarding/ui/components/complete_step_page.dart
@@ -22,9 +22,6 @@ class _CompleteStepPage extends HookConsumerWidget {
     }
 
     useEffect(() {
-      if (!navigation.isActive) {
-        return null;
-      }
       navigation.register(
         _StepNavigationState(
           buttonLabel: 'はじめる',
@@ -34,7 +31,7 @@ class _CompleteStepPage extends HookConsumerWidget {
         ),
       );
       return null;
-    }, [navigation, navigation.isActive, isProcessing]);
+    }, [navigation, isProcessing]);
 
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: designSystem.spacing.lg),

--- a/app/lib/feature/onboarding/ui/page/onboarding_page.dart
+++ b/app/lib/feature/onboarding/ui/page/onboarding_page.dart
@@ -170,7 +170,7 @@ class _StepNavigationState {
           _OnboardingStep.welcome => false,
           _OnboardingStep.permissions => false,
           _OnboardingStep.notificationSettings => false,
-          _ => true,
+          _OnboardingStep.complete => false,
         },
         isProcessing: false,
         onNext: null,


### PR DESCRIPTION
## Summary
- 完了ステップの `useEffect` から `isActive` ガードを削除し、`completeOnboarding` が確実に `onNext` として登録されるようにした
- 完了ステップ表示直後に `onPageChanged` で `onNext: null` かつ `isNextEnabled: true` になる競合を解消し、登録前は「はじめる」ボタンを無効化
- ルーターで参照する `OnboardingCompleted` を `keepAlive` に変更

## 原因
前回のリファクタで追加した `navigation.isActive` チェックにより、完了ステップで `completeOnboarding` がボトムバーに登録されないケースがあり、「はじめる」ボタンが有効でもタップしても `onboarding_completed` が保存されなかった。

## Test plan
- [ ] オンボーディング最終ステップで「はじめる」をタップし、ホームへ遷移すること
- [ ] アプリ再起動後にオンボーディングが再表示されないこと


Made with [Cursor](https://cursor.com)