### PR TITLE
fix: 再起動時にオンボーディング/ベータ版注意事項が再表示される不具合を修正

### DIFF
--- a/app/lib/page/splash_page.dart
+++ b/app/lib/page/splash_page.dart
@@ -1,10 +1,13 @@
 import 'package:eqmonitor/core/fcm/notification_deep_link.dart';
 import 'package:eqmonitor/core/provider/app_links_interaction.dart';
+import 'package:eqmonitor/core/provider/environment/environment.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging_interaction.dart';
 import 'package:eqmonitor/core/provider/kmoni_observation_points/provider/kyoshin_observation_points_provider.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
 import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/beta_testing/data/notifier/beta_testing_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_config_notifier.dart';
+import 'package:eqmonitor/feature/onboarding/data/notifier/onboarding_notifier.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -29,6 +32,19 @@ class SplashPage extends HookConsumerWidget {
         ..read(earthquakeHistoryConfigProvider)
         ..read(startProvider);
       WidgetsBinding.instance.addPostFrameCallback((_) async {
+        // オンボーディング / ベータ版同意のゲーティング状態は
+        // GoRouter の redirect が同期的に `.value` を参照するため、
+        // 遷移前にここで解決しておく。これらは keepAlive なので一度
+        // 解決すればキャッシュされ、redirect が正しい値を参照できる。
+        // (解決前に遷移すると AsyncLoading -> false と誤判定され、
+        //  完了済みでも再起動のたびにオンボーディングが再表示される)
+        await ref.read(onboardingCompletedProvider.future);
+        if (ref.read(buildConfigProvider).isBetaTesting) {
+          await ref.read(betaTestingAgreedProvider.future);
+        }
+        if (!context.mounted) {
+          return;
+        }
         context.go(const HomeRoute().location);
         final pending =
             consumePendingNotificationDeepLink() ?? consumePendingAppLink();


### PR DESCRIPTION
## 概要

オンボーディングを完了したりベータ版注意事項に同意しても、アプリを再起動すると再び表示されてしまう不具合を修正します。

## 原因

完了状態自体は SharedPreferences (`onboarding_completed` / `beta_testing_agreed`) に正しく保存されていました。問題は**起動時のルーティング判定のタイミング**です。

- `onboardingCompletedProvider` / `betaTestingAgreedProvider` は非同期 (`Future<bool>`) で値を読み込む。
- `router.dart` の `redirect` はこれを同期的に `ref.read(...).value ?? false` で参照している。
- さらに `refreshListenable` が無いため、値が解決したあとに再判定されない。

起動直後はこれらのプロバイダーが必ず `AsyncLoading`（`.value == null`）なので `false` と誤判定され、**完了済みでも毎回オンボーディング／ベータ注意事項へリダイレクト**されていました。

## 修正内容

`app/lib/page/splash_page.dart` で、ホーム画面へ遷移する**前に**これらのゲーティング状態を `await` して解決するようにしました。これらのプロバイダーは `keepAlive` なので一度解決すればキャッシュされ、`redirect` が正しい値を参照できます（画面のちらつきも発生しません）。

```dart
await ref.read(onboardingCompletedProvider.future);
if (ref.read(buildConfigProvider).isBetaTesting) {
  await ref.read(betaTestingAgreedProvider.future);
}
if (!context.mounted) return;
context.go(const HomeRoute().location);
```

## 動作確認

- [ ] オンボーディング完了 → 再起動 → ホームが表示される（オンボーディングが再表示されない）
- [ ] ベータ版注意事項に同意 → 再起動 → ホームが表示される（注意事項が再表示されない）
- [ ] 初回起動（未完了）ではオンボーディングが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)