### PR TITLE
fix: デバッグ画面表示中のシェイクで再度デバッグ画面が開く問題を修正

### DIFF
--- a/app/lib/feature/debug/launcher/debug_launcher.dart
+++ b/app/lib/feature/debug/launcher/debug_launcher.dart
@@ -9,8 +9,24 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sensors_plus/sensors_plus.dart';
+
+/// 現在表示中の画面のロケーションを返す。
+///
+/// go_router は `push` (imperative navigation) でルートを積んでも
+/// [RouteMatchList.uri] を更新しないため、`currentConfiguration.uri` だけでは
+/// push で開いた画面（例: デバッグ画面）を検出できない。
+/// スタック最上段が [ImperativeRouteMatch] の場合はそのロケーションを参照する。
+String currentLocation(GoRouter router) {
+  final configuration = router.routerDelegate.currentConfiguration;
+  final lastMatch = configuration.matches.lastOrNull;
+  if (lastMatch is ImperativeRouteMatch) {
+    return lastMatch.matches.uri.toString();
+  }
+  return configuration.uri.toString();
+}
 
 /// 端末シェイクまたは Shift+D でデバッグページを開くラッパー。
 ///
@@ -53,9 +69,7 @@ class DebugLauncher extends HookConsumerWidget {
         }
         lastOpen.value = now;
         final router = ref.read(goRouterProvider);
-        final currentLocation = router.routerDelegate.currentConfiguration.uri
-            .toString();
-        if (currentLocation.startsWith(const DebugRoute().location)) {
+        if (currentLocation(router).startsWith(const DebugRoute().location)) {
           return;
         }
         unawaited(router.push<void>(const DebugRoute().location));


### PR DESCRIPTION
## 概要

デバッグ画面を表示している状態で端末をシェイク（または Shift+D）すると、既にデバッグ画面を開いているにもかかわらず、さらにデバッグ画面が push されてしまう問題を修正します。

## 原因

`DebugLauncher` の `openDebugPage()` は「既にデバッグ画面配下にいるか」を以下で判定していました。

```dart
final currentLocation = router.routerDelegate.currentConfiguration.uri.toString();
if (currentLocation.startsWith(const DebugRoute().location)) {
  return;
}
```

しかし go_router (17.3.0) の `RouteMatchList.push()` は、push したルートを `matches` に追加する一方で **`uri` フィールドを更新しません**（`match.dart:621`）。

そのため `router.push('/settings/debug')` で開いたデバッグ画面表示中でも `currentConfiguration.uri` は直近に `go` したベース画面のロケーションを指したままになり、`startsWith('/settings/debug')` が常に false となって、シェイクのたびにデバッグ画面が重ねて push されていました。

## 修正内容

`app/lib/feature/debug/launcher/debug_launcher.dart`

- スタック最上段が `ImperativeRouteMatch`（＝ `push` で開かれたルート）の場合は、そのルートのロケーションを参照する `currentLocation(GoRouter)` ヘルパーを追加。
- `openDebugPage()` のガード判定をこのヘルパー経由に変更し、既にデバッグ画面配下にいる場合は再 push しないようにした。

これにより、`push` / `go` いずれの遷移で開いたデバッグ画面でも正しく検出され、シェイクで重複表示されなくなります。

## 確認

- `dart format` : 差分なし
- ロジックを go_router 17.3.0 のソース（`ImperativeRouteMatch.matches.uri`）と突き合わせて検証

> [!NOTE]
> 同環境で別セッションの `dart analyze` がアナライザサーバをデッドロックさせていたため、ローカルでの `dart analyze` 完走は確認できていません。CI (`flutter.yaml`) の `dart analyze` で検証されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)