### PR TITLE
feat: テーマ編集画面に各配色の使用箇所説明を追加

### DIFF
--- a/app/lib/core/theme/model/intensity_field_def.dart
+++ b/app/lib/core/theme/model/intensity_field_def.dart
@@ -1,7 +1,18 @@
 import 'package:eqmonitor/core/theme/model/intensity_color_entry.dart';
 import 'package:eqmonitor/core/theme/model/theme_color_set.dart';
 
-enum IntensityFieldGroup { intensity, estimatedIntensity }
+enum IntensityFieldGroup {
+  intensity(
+    description: '観測された震度の表示色。震度アイコンや地震履歴・地図上の震度塗りつぶしなど、震度表示のすべてに使用されます。',
+  ),
+  estimatedIntensity(
+    description: '緊急地震速報の予想震度の表示色。観測値が確定する前に、地図上の推計震度の塗りつぶしに使用されます。',
+  );
+
+  const IntensityFieldGroup({required this.description});
+
+  final String description;
+}
 
 class IntensityFieldDef {
   const IntensityFieldDef({

--- a/app/lib/core/theme/model/theme_color_field_def.dart
+++ b/app/lib/core/theme/model/theme_color_field_def.dart
@@ -15,12 +15,18 @@ class ThemeColorFieldDef {
   const ThemeColorFieldDef({
     required this.label,
     required this.category,
+    required this.description,
     required this.getter,
     required this.setter,
   });
 
   final String label;
   final ThemeColorFieldCategory category;
+
+  /// この色がアプリのどこで使われるかを説明する文。
+  ///
+  /// エディタUIのsubtitleに表示される。
+  final String description;
   final Color Function(ThemeColorSet colorSet) getter;
   final ThemeColorSet Function(ThemeColorSet colorSet, Color color) setter;
 }
@@ -36,48 +42,56 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'プライマリ',
       category: ThemeColorFieldCategory.primary,
+      description: 'アプリの基調色。スイッチやチェックアイコンなど、主要な操作要素の色として使用されます。',
       getter: (colorSet) => colorSet.primary,
       setter: (colorSet, color) => colorSet.copyWith(primary: color),
     ),
     ThemeColorFieldDef(
       label: 'オンプライマリ',
       category: ThemeColorFieldCategory.primary,
+      description: 'プライマリ色の上に重ねる文字・アイコンの色。ボタンのラベルなどに使用されます。',
       getter: (colorSet) => colorSet.onPrimary,
       setter: (colorSet, color) => colorSet.copyWith(onPrimary: color),
     ),
     ThemeColorFieldDef(
       label: 'プライマリコンテナ',
       category: ThemeColorFieldCategory.primary,
+      description: 'プライマリ系の淡い背景色。選択状態の要素の背景などに使用されます。',
       getter: (colorSet) => colorSet.primaryContainer,
       setter: (colorSet, color) => colorSet.copyWith(primaryContainer: color),
     ),
     ThemeColorFieldDef(
       label: 'オンプライマリコンテナ',
       category: ThemeColorFieldCategory.primary,
+      description: 'プライマリコンテナの上に重ねる文字・アイコンの色。',
       getter: (colorSet) => colorSet.onPrimaryContainer,
       setter: (colorSet, color) => colorSet.copyWith(onPrimaryContainer: color),
     ),
     ThemeColorFieldDef(
       label: 'セカンダリ',
       category: ThemeColorFieldCategory.secondary,
+      description: '補助的なアクセント色。一部のスイッチやコントロールの強調に使用されます。',
       getter: (colorSet) => colorSet.secondary,
       setter: (colorSet, color) => colorSet.copyWith(secondary: color),
     ),
     ThemeColorFieldDef(
       label: 'オンセカンダリ',
       category: ThemeColorFieldCategory.secondary,
+      description: 'セカンダリ色の上に重ねる文字・アイコンの色。',
       getter: (colorSet) => colorSet.onSecondary,
       setter: (colorSet, color) => colorSet.copyWith(onSecondary: color),
     ),
     ThemeColorFieldDef(
       label: 'セカンダリコンテナ',
       category: ThemeColorFieldCategory.secondary,
+      description: '地震履歴のフィルタチップ（深さ・マグニチュードなど）の選択時の背景色として使用されます。',
       getter: (colorSet) => colorSet.secondaryContainer,
       setter: (colorSet, color) => colorSet.copyWith(secondaryContainer: color),
     ),
     ThemeColorFieldDef(
       label: 'オンセカンダリコンテナ',
       category: ThemeColorFieldCategory.secondary,
+      description: 'セカンダリコンテナの上に重ねる文字・アイコンの色。選択中チップの文字色などに使用されます。',
       getter: (colorSet) => colorSet.onSecondaryContainer,
       setter: (colorSet, color) =>
           colorSet.copyWith(onSecondaryContainer: color),
@@ -85,24 +99,28 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'ターシャリ',
       category: ThemeColorFieldCategory.tertiary,
+      description: '第3のアクセント色。バッジや一部のカードの強調に使用されます。',
       getter: (colorSet) => colorSet.tertiary,
       setter: (colorSet, color) => colorSet.copyWith(tertiary: color),
     ),
     ThemeColorFieldDef(
       label: 'オンターシャリ',
       category: ThemeColorFieldCategory.tertiary,
+      description: 'ターシャリ色の上に重ねる文字・アイコンの色。',
       getter: (colorSet) => colorSet.onTertiary,
       setter: (colorSet, color) => colorSet.copyWith(onTertiary: color),
     ),
     ThemeColorFieldDef(
       label: 'ターシャリコンテナ',
       category: ThemeColorFieldCategory.tertiary,
+      description: 'ターシャリ系の淡い背景色。一部のバッジやカードの背景に使用されます。',
       getter: (colorSet) => colorSet.tertiaryContainer,
       setter: (colorSet, color) => colorSet.copyWith(tertiaryContainer: color),
     ),
     ThemeColorFieldDef(
       label: 'オンターシャリコンテナ',
       category: ThemeColorFieldCategory.tertiary,
+      description: 'ターシャリコンテナの上に重ねる文字・アイコンの色。',
       getter: (colorSet) => colorSet.onTertiaryContainer,
       setter: (colorSet, color) =>
           colorSet.copyWith(onTertiaryContainer: color),
@@ -110,48 +128,56 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'エラー',
       category: ThemeColorFieldCategory.error,
+      description: 'エラーを示す色。エラー画面のアイコンや通信切断時のステータス表示などに使用されます。',
       getter: (colorSet) => colorSet.error,
       setter: (colorSet, color) => colorSet.copyWith(error: color),
     ),
     ThemeColorFieldDef(
       label: 'オンエラー',
       category: ThemeColorFieldCategory.error,
+      description: 'エラー色の上に重ねる文字・アイコンの色。',
       getter: (colorSet) => colorSet.onError,
       setter: (colorSet, color) => colorSet.copyWith(onError: color),
     ),
     ThemeColorFieldDef(
       label: 'エラーコンテナ',
       category: ThemeColorFieldCategory.error,
+      description: 'エラー通知（スナックバーなど）の背景色として使用されます。',
       getter: (colorSet) => colorSet.errorContainer,
       setter: (colorSet, color) => colorSet.copyWith(errorContainer: color),
     ),
     ThemeColorFieldDef(
       label: 'オンエラーコンテナ',
       category: ThemeColorFieldCategory.error,
+      description: 'エラーコンテナの上に重ねる文字・アイコンの色。',
       getter: (colorSet) => colorSet.onErrorContainer,
       setter: (colorSet, color) => colorSet.copyWith(onErrorContainer: color),
     ),
     ThemeColorFieldDef(
       label: 'サーフェス',
       category: ThemeColorFieldCategory.surface,
+      description: 'カードやダイアログの基本の背景色として使用されます。',
       getter: (colorSet) => colorSet.surface,
       setter: (colorSet, color) => colorSet.copyWith(surface: color),
     ),
     ThemeColorFieldDef(
       label: 'オンサーフェス',
       category: ThemeColorFieldCategory.surface,
+      description: 'アプリ全体の標準の文字・アイコンの色。アプリバーの文字色にも使用されます。',
       getter: (colorSet) => colorSet.onSurface,
       setter: (colorSet, color) => colorSet.copyWith(onSurface: color),
     ),
     ThemeColorFieldDef(
       label: 'オンサーフェスバリアント',
       category: ThemeColorFieldCategory.surface,
+      description: '補足説明やキャプションなど、控えめな文字・アイコンの色として広く使用されます。',
       getter: (colorSet) => colorSet.onSurfaceVariant,
       setter: (colorSet, color) => colorSet.copyWith(onSurfaceVariant: color),
     ),
     ThemeColorFieldDef(
       label: 'サーフェスコンテナ(最低)',
       category: ThemeColorFieldCategory.surface,
+      description: '最も低い階層のコンテナ背景色。',
       getter: (colorSet) => colorSet.surfaceContainerLowest,
       setter: (colorSet, color) =>
           colorSet.copyWith(surfaceContainerLowest: color),
@@ -159,6 +185,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'サーフェスコンテナ(低)',
       category: ThemeColorFieldCategory.surface,
+      description: '画面全体の背景色とアプリバーの背景色として使用されます。',
       getter: (colorSet) => colorSet.surfaceContainerLow,
       setter: (colorSet, color) =>
           colorSet.copyWith(surfaceContainerLow: color),
@@ -166,12 +193,14 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'サーフェスコンテナ',
       category: ThemeColorFieldCategory.surface,
+      description: '中間階層のコンテナ背景色。',
       getter: (colorSet) => colorSet.surfaceContainer,
       setter: (colorSet, color) => colorSet.copyWith(surfaceContainer: color),
     ),
     ThemeColorFieldDef(
       label: 'サーフェスコンテナ(高)',
       category: ThemeColorFieldCategory.surface,
+      description: 'カードや接続状態表示などのコンテナ背景色として使用されます。',
       getter: (colorSet) => colorSet.surfaceContainerHigh,
       setter: (colorSet, color) =>
           colorSet.copyWith(surfaceContainerHigh: color),
@@ -179,6 +208,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'サーフェスコンテナ(最高)',
       category: ThemeColorFieldCategory.surface,
+      description: '最も高い階層のコンテナ背景色。',
       getter: (colorSet) => colorSet.surfaceContainerHighest,
       setter: (colorSet, color) =>
           colorSet.copyWith(surfaceContainerHighest: color),
@@ -186,48 +216,56 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'アウトライン',
       category: ThemeColorFieldCategory.surface,
+      description: '枠線の色。色見本の縁取りや入力欄の枠線などに使用されます。',
       getter: (colorSet) => colorSet.outline,
       setter: (colorSet, color) => colorSet.copyWith(outline: color),
     ),
     ThemeColorFieldDef(
       label: 'アウトラインバリアント',
       category: ThemeColorFieldCategory.surface,
+      description: '控えめな枠線・区切り線の色。カードの縁取りやモーダルシートのつまみなどに使用されます。',
       getter: (colorSet) => colorSet.outlineVariant,
       setter: (colorSet, color) => colorSet.copyWith(outlineVariant: color),
     ),
     ThemeColorFieldDef(
       label: 'インバースサーフェス',
       category: ThemeColorFieldCategory.surface,
+      description: '反転背景色。スナックバーの背景などに使用されます。',
       getter: (colorSet) => colorSet.inverseSurface,
       setter: (colorSet, color) => colorSet.copyWith(inverseSurface: color),
     ),
     ThemeColorFieldDef(
       label: 'オンインバースサーフェス',
       category: ThemeColorFieldCategory.surface,
+      description: '反転背景の上に重ねる文字・アイコンの色。',
       getter: (colorSet) => colorSet.onInverseSurface,
       setter: (colorSet, color) => colorSet.copyWith(onInverseSurface: color),
     ),
     ThemeColorFieldDef(
       label: 'インバースプライマリ',
       category: ThemeColorFieldCategory.surface,
+      description: '反転背景上でのプライマリ色。',
       getter: (colorSet) => colorSet.inversePrimary,
       setter: (colorSet, color) => colorSet.copyWith(inversePrimary: color),
     ),
     ThemeColorFieldDef(
       label: 'シャドウ',
       category: ThemeColorFieldCategory.surface,
+      description: '影の色。',
       getter: (colorSet) => colorSet.shadow,
       setter: (colorSet, color) => colorSet.copyWith(shadow: color),
     ),
     ThemeColorFieldDef(
       label: 'スクリム',
       category: ThemeColorFieldCategory.surface,
+      description: 'モーダル表示時に背面を覆う半透明レイヤーの色。',
       getter: (colorSet) => colorSet.scrim,
       setter: (colorSet, color) => colorSet.copyWith(scrim: color),
     ),
     ThemeColorFieldDef(
       label: '成功',
       category: ThemeColorFieldCategory.status,
+      description: '成功・正常を示す色。強震モニタの接続状態や設定完了のチェックマークなどに使用されます。',
       getter: (colorSet) => colorSet.status.success,
       setter: (colorSet, color) =>
           colorSet.copyWith(status: colorSet.status.copyWith(success: color)),
@@ -235,6 +273,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: '警告',
       category: ThemeColorFieldCategory.status,
+      description: '警告を示す色。ベータ版の注意喚起や接続が不安定なときの表示に使用されます。',
       getter: (colorSet) => colorSet.status.warning,
       setter: (colorSet, color) =>
           colorSet.copyWith(status: colorSet.status.copyWith(warning: color)),
@@ -242,6 +281,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: '情報',
       category: ThemeColorFieldCategory.status,
+      description: '情報表示用の色。（現在は未使用・将来のために予約されています）',
       getter: (colorSet) => colorSet.status.info,
       setter: (colorSet, color) =>
           colorSet.copyWith(status: colorSet.status.copyWith(info: color)),
@@ -249,6 +289,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'マップ背景',
       category: ThemeColorFieldCategory.map,
+      description: '地図の背景色。海域など地物のない部分の色として使用されます。',
       getter: (colorSet) => colorSet.mapColors.background,
       setter: (colorSet, color) => colorSet.copyWith(
         mapColors: colorSet.mapColors.copyWith(background: color),
@@ -257,6 +298,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: '世界の陸地',
       category: ThemeColorFieldCategory.map,
+      description: '日本以外の陸地の塗りつぶし色。',
       getter: (colorSet) => colorSet.mapColors.worldLand,
       setter: (colorSet, color) => colorSet.copyWith(
         mapColors: colorSet.mapColors.copyWith(worldLand: color),
@@ -265,6 +307,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: '世界の国境線',
       category: ThemeColorFieldCategory.map,
+      description: '日本以外の国境・海岸線の線の色。',
       getter: (colorSet) => colorSet.mapColors.worldLine,
       setter: (colorSet, color) => colorSet.copyWith(
         mapColors: colorSet.mapColors.copyWith(worldLine: color),
@@ -273,6 +316,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: '日本の陸地',
       category: ThemeColorFieldCategory.map,
+      description: '日本の陸地の塗りつぶし色。',
       getter: (colorSet) => colorSet.mapColors.japanLand,
       setter: (colorSet, color) => colorSet.copyWith(
         mapColors: colorSet.mapColors.copyWith(japanLand: color),
@@ -281,6 +325,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: '日本の県境線',
       category: ThemeColorFieldCategory.map,
+      description: '日本国内の境界線の色。都道府県境・市区町村境・緊急地震速報の予想区域の境界線に使用されます。',
       getter: (colorSet) => colorSet.mapColors.japanLine,
       setter: (colorSet, color) => colorSet.copyWith(
         mapColors: colorSet.mapColors.copyWith(japanLine: color),

--- a/app/lib/core/theme/model/theme_color_field_def.dart
+++ b/app/lib/core/theme/model/theme_color_field_def.dart
@@ -223,7 +223,7 @@ class ThemeColorFieldDefs {
     ThemeColorFieldDef(
       label: 'アウトラインバリアント',
       category: ThemeColorFieldCategory.surface,
-      description: '控えめな枠線・区切り線の色。カードの縁取りやモーダルシートのつまみなどに使用されます。',
+      description: '控えめな枠線・区切り線の色。カードやモーダルシートの縁取りなどに使用されます。',
       getter: (colorSet) => colorSet.outlineVariant,
       setter: (colorSet, color) => colorSet.copyWith(outlineVariant: color),
     ),

--- a/app/lib/feature/settings/features/display_settings/ui/theme/theme_editor_page.dart
+++ b/app/lib/feature/settings/features/display_settings/ui/theme/theme_editor_page.dart
@@ -83,6 +83,7 @@ class ThemeEditorPage extends ConsumerWidget {
           ),
           ExpansionTile(
             title: const Text('震度配色'),
+            subtitle: Text(IntensityFieldGroup.intensity.description),
             children: IntensityFieldDefs.all
                 .where((def) => def.group == IntensityFieldGroup.intensity)
                 .map(
@@ -97,6 +98,7 @@ class ThemeEditorPage extends ConsumerWidget {
           ),
           ExpansionTile(
             title: const Text('推計震度配色'),
+            subtitle: Text(IntensityFieldGroup.estimatedIntensity.description),
             children: IntensityFieldDefs.all
                 .where(
                   (def) => def.group == IntensityFieldGroup.estimatedIntensity,
@@ -133,6 +135,7 @@ class _ColorFieldTile extends StatelessWidget {
     return ListTile(
       key: ValueKey('theme_color_field_${def.label}'),
       title: Text(def.label),
+      subtitle: Text(def.description),
       trailing: GestureDetector(
         onTap: () async {
           final picked = await ThemeEditorPage._pickColor(

--- a/app/test/core/theme/model/intensity_field_def_test.dart
+++ b/app/test/core/theme/model/intensity_field_def_test.dart
@@ -41,4 +41,14 @@ void main() {
       }
     },
   );
+
+  test('IntensityFieldGroup の全値について description が空でない', () {
+    for (final group in IntensityFieldGroup.values) {
+      expect(
+        group.description,
+        isNotEmpty,
+        reason: '$group の description が空です',
+      );
+    }
+  });
 }

--- a/app/test/core/theme/model/theme_color_field_def_test.dart
+++ b/app/test/core/theme/model/theme_color_field_def_test.dart
@@ -13,6 +13,16 @@ void main() {
     expect(ThemeColorFieldDefs.all.length, 39);
   });
 
+  test('全定義について description が空でない', () {
+    for (final def in ThemeColorFieldDefs.all) {
+      expect(
+        def.description,
+        isNotEmpty,
+        reason: '${def.label} の description が空です',
+      );
+    }
+  });
+
   test('各定義について setter(base, probe) 後に getter が probe を返す', () {
     for (final def in ThemeColorFieldDefs.all) {
       final updated = def.setter(base, probe);


### PR DESCRIPTION
## 概要

テーマ編集画面で、それぞれの配色がアプリのどの場所で利用されるのかをユーザーに分かるように説明文を表示します。

| コミット | 内容 |
|---|---|
| a7b42669 | モデル層: `ThemeColorFieldDef` に `description` フィールドを追加し、全39項目に実際の使用箇所に基づく説明を設定。`IntensityFieldGroup` を enhanced enum 化し、震度配色/推計震度配色のグループ説明を追加 |
| e4378e4e | UI層: テーマエディタの各色の行（`_ColorFieldTile`）に説明をsubtitleとして表示。震度/推計震度セクションの `ExpansionTile` にグループ説明を表示 |
| 2240f17a | レビュー指摘の修正: `outlineVariant` の説明文を実際の使用箇所（モーダルシートの縁取り）に合わせて修正 |

## 説明文の正確性について

説明文は実際のコードの使用箇所を調査して作成しています（例: `mapColors.japanLine` → `map_style_util.dart` の都道府県境・市区町村境・EEW予想区域境界の3レイヤー、`status.warning` → ベータ版注意喚起・接続状態表示 など）。レビューで8項目のスポットチェックを実施し、事実誤認1件を修正済みです。

## テスト

- `flutter test test/core/theme` — 42/42 パス（説明文が空でないことを検証するテストを追加）
- `dart analyze`（変更ディレクトリスコープ）— 変更ファイルの指摘ゼロ
  - 注: 未変更の `theme_settings_page.dart:81` に既存の deprecation info（`RadioListTile.onChanged`）が残っていますが、developに元から存在するため本PRのスコープ外です

## 備考

- 説明文はUIメタデータ（const）であり、テーマのJSON入出力・SharedPreferences永続化には影響しません
- 一部の説明文（約50文字）は狭い画面で2〜3行に折り返されますが、`ListTile`/`ExpansionTile` のsubtitleは複数行を標準サポートしており表示崩れはありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
