### PR TITLE
fix(notification): 通知設定APIのbackendスキーマ追従 (vyse60リネーム + VZSE40設定追加)

### DIFF
--- a/app/lib/core/gen/assets.gen.dart
+++ b/app/lib/core/gen/assets.gen.dart
@@ -37,10 +37,6 @@ class $AssetsDocsGen {
   List<String> get values => [aboutThisApp, privacyPolicy, termOfService];
 }
 
-class $AssetsFontsGen {
-  const $AssetsFontsGen();
-}
-
 class $AssetsImagesGen {
   const $AssetsImagesGen();
 
@@ -154,7 +150,6 @@ class Assets {
       'assets/KyoshinShindoColorMap.json';
   static const $AssetsDebugGen debug = $AssetsDebugGen();
   static const $AssetsDocsGen docs = $AssetsDocsGen();
-  static const $AssetsFontsGen fonts = $AssetsFontsGen();
   static const AssetGenImage header = AssetGenImage('assets/header.png');
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const String jmaCodeTable = 'assets/jma_code_table.pb';

--- a/app/lib/feature/beta_testing/data/notifier/beta_testing_notifier.g.dart
+++ b/app/lib/feature/beta_testing/data/notifier/beta_testing_notifier.g.dart
@@ -35,7 +35,7 @@ final class BetaTestingAgreedProvider
   BetaTestingAgreed create() => BetaTestingAgreed();
 }
 
-String _$betaTestingAgreedHash() => r'239eac780d912fc4a20b8fec8a002a9ab84dd7f0';
+String _$betaTestingAgreedHash() => r'1e9582f1783074f448788f4d8f6ef10274133404';
 
 abstract class _$BetaTestingAgreed extends $AsyncNotifier<bool> {
   FutureOr<bool> build();

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -69,9 +69,7 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
                     deviceId: deviceIdAsync.requireValue,
                   ),
                 if (deviceIdAsync.hasValue)
-                  _TestScenarioSection(
-                    deviceId: deviceIdAsync.requireValue,
-                  ),
+                  _TestScenarioSection(deviceId: deviceIdAsync.requireValue),
                 if (deviceIdAsync.hasValue)
                   _TestScenarioTypeSection(
                     deviceId: deviceIdAsync.requireValue,
@@ -170,10 +168,7 @@ class _ProvisioningStartupSection extends HookConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _KeyValueRow(
-            label: 'Device ID',
-            value: deviceIdAsync.value ?? '…',
-          ),
+          _KeyValueRow(label: 'Device ID', value: deviceIdAsync.value ?? '…'),
           _KeyValueRow(
             label: '保存済みフラグ',
             value: (isProvisioned.value ?? false)
@@ -283,9 +278,9 @@ class _StatusChip extends StatelessWidget {
           Flexible(
             child: Text(
               label,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: textColor,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.labelSmall?.copyWith(color: textColor),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -321,10 +316,7 @@ class _NotificationPermissionSection extends ConsumerWidget {
               label: '許可状態',
               value: _authLabel(value.authorizationStatus),
             ),
-            _KeyValueRow(
-              label: 'アラート',
-              value: _appleLabel(value.alert),
-            ),
+            _KeyValueRow(label: 'アラート', value: _appleLabel(value.alert)),
             _KeyValueRow(label: 'バッジ', value: _appleLabel(value.badge)),
             _KeyValueRow(label: 'サウンド', value: _appleLabel(value.sound)),
             if (!kIsWeb && (Platform.isIOS || Platform.isMacOS)) ...[
@@ -530,10 +522,7 @@ class _SettingsProviderStatusSection extends ConsumerWidget {
 }
 
 class _ProviderStatusRow extends StatelessWidget {
-  const _ProviderStatusRow({
-    required this.label,
-    required this.state,
-  });
+  const _ProviderStatusRow({required this.label, required this.state});
 
   final String label;
   final AsyncValue<Object?> state;
@@ -578,9 +567,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final settingsAsync = ref.watch(
-      _notificationSettingsProvider(deviceId),
-    );
+    final settingsAsync = ref.watch(_notificationSettingsProvider(deviceId));
     final settings = settingsAsync.value;
     final isBusy = useState(false);
     final notificationEnabled = useState(settings?.notificationEnabled ?? true);
@@ -590,9 +577,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
       settings?.nankaiExtraordinaryEnabled ?? false,
     );
     final nankaiRegular = useState(settings?.nankaiRegularEnabled ?? false);
-    final hokkaido3ren = useState(
-      settings?.hokkaido3renOffshoreEnabled ?? false,
-    );
+    final vyse60 = useState(settings?.vyse60Enabled ?? false);
 
     ref.listen(_notificationSettingsProvider(deviceId), (_, next) {
       if (next.value != null) {
@@ -602,7 +587,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
         nankaiExtraordinary.value =
             next.requireValue.nankaiExtraordinaryEnabled;
         nankaiRegular.value = next.requireValue.nankaiRegularEnabled;
-        hokkaido3ren.value = next.requireValue.hokkaido3renOffshoreEnabled;
+        vyse60.value = next.requireValue.vyse60Enabled;
       }
     });
 
@@ -623,7 +608,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
           trainingEnabled: training.value,
           nankaiExtraordinaryEnabled: nankaiExtraordinary.value,
           nankaiRegularEnabled: nankaiRegular.value,
-          hokkaido3renOffshoreEnabled: hokkaido3ren.value,
+          vyse60Enabled: vyse60.value,
         ),
       );
       isBusy.value = false;
@@ -636,9 +621,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
             _notificationSettingsProvider(deviceId),
             asReload: true,
           );
-          messenger.showSnackBar(
-            const SnackBar(content: Text('通知設定を更新しました')),
-          );
+          messenger.showSnackBar(const SnackBar(content: Text('通知設定を更新しました')));
         case Failure(:final exception):
           messenger.showSnackBar(
             SnackBar(
@@ -921,9 +904,7 @@ class _TestScenarioTypeSection extends HookConsumerWidget {
               content: SingleChildScrollView(
                 child: SelectableText(
                   value.prettyJson,
-                  style: const TextStyle(
-                    fontFamily: FontFamily.googleSansCode,
-                  ),
+                  style: const TextStyle(fontFamily: FontFamily.googleSansCode),
                 ),
               ),
               actions: [
@@ -1174,12 +1155,8 @@ class _SectionCard extends StatelessWidget {
                           const SizedBox(height: 4),
                           Text(
                             subtitle!,
-                            style:
-                                Theme.of(
-                                  context,
-                                ).textTheme.bodySmall?.copyWith(
-                                  color: colorTheme.onSurfaceVariant,
-                                ),
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: colorTheme.onSurfaceVariant),
                           ),
                         ],
                       ],

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -578,6 +578,9 @@ class _NotificationSettingsSection extends HookConsumerWidget {
     );
     final nankaiRegular = useState(settings?.nankaiRegularEnabled ?? false);
     final vyse60 = useState(settings?.vyse60Enabled ?? false);
+    final earthquakeNotice = useState(
+      settings?.earthquakeNoticeEnabled ?? false,
+    );
 
     ref.listen(_notificationSettingsProvider(deviceId), (_, next) {
       if (next.value != null) {
@@ -588,6 +591,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
             next.requireValue.nankaiExtraordinaryEnabled;
         nankaiRegular.value = next.requireValue.nankaiRegularEnabled;
         vyse60.value = next.requireValue.vyse60Enabled;
+        earthquakeNotice.value = next.requireValue.earthquakeNoticeEnabled;
       }
     });
 
@@ -609,6 +613,7 @@ class _NotificationSettingsSection extends HookConsumerWidget {
           nankaiExtraordinaryEnabled: nankaiExtraordinary.value,
           nankaiRegularEnabled: nankaiRegular.value,
           vyse60Enabled: vyse60.value,
+          earthquakeNoticeEnabled: earthquakeNotice.value,
         ),
       );
       isBusy.value = false;

--- a/app/lib/feature/feed/data/repository/feed_repository.dart
+++ b/app/lib/feature/feed/data/repository/feed_repository.dart
@@ -17,7 +17,7 @@ class FeedRepository {
   final api.ApiClient _api;
 
   Future<FeedListResponse> fetch({String? after, api.ApiClient? client}) async {
-    final response = await (client ?? _api).feed.getV2Feeds(after: after);
+    final response = await (client ?? _api).feed.getV2Feeds(cursor: after);
     return response.data.toFeedListResponse();
   }
 

--- a/app/lib/feature/notification/data/model/general_notification_settings.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.dart
@@ -12,6 +12,7 @@ abstract class GeneralNotificationSettings with _$GeneralNotificationSettings {
     required bool nankaiExtraordinaryEnabled,
     required bool nankaiRegularEnabled,
     required bool vyse60Enabled,
+    required bool earthquakeNoticeEnabled,
   }) = _GeneralNotificationSettings;
 }
 
@@ -25,5 +26,6 @@ extension GeneralNotificationSettingsApiExtension
         nankaiExtraordinaryEnabled: nankaiExtraordinaryEnabled,
         nankaiRegularEnabled: nankaiRegularEnabled,
         vyse60Enabled: vyse60Enabled,
+        earthquakeNoticeEnabled: earthquakeNoticeEnabled,
       );
 }

--- a/app/lib/feature/notification/data/model/general_notification_settings.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.dart
@@ -11,7 +11,7 @@ abstract class GeneralNotificationSettings with _$GeneralNotificationSettings {
     required bool trainingEnabled,
     required bool nankaiExtraordinaryEnabled,
     required bool nankaiRegularEnabled,
-    required bool hokkaido3renOffshoreEnabled,
+    required bool vyse60Enabled,
   }) = _GeneralNotificationSettings;
 }
 
@@ -24,6 +24,6 @@ extension GeneralNotificationSettingsApiExtension
         trainingEnabled: trainingEnabled,
         nankaiExtraordinaryEnabled: nankaiExtraordinaryEnabled,
         nankaiRegularEnabled: nankaiRegularEnabled,
-        hokkaido3renOffshoreEnabled: hokkaido3renOffshoreEnabled,
+        vyse60Enabled: vyse60Enabled,
       );
 }

--- a/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GeneralNotificationSettings {
 
- bool get notificationEnabled; bool get tsunamiEnabled; bool get trainingEnabled; bool get nankaiExtraordinaryEnabled; bool get nankaiRegularEnabled; bool get vyse60Enabled;
+ bool get notificationEnabled; bool get tsunamiEnabled; bool get trainingEnabled; bool get nankaiExtraordinaryEnabled; bool get nankaiRegularEnabled; bool get vyse60Enabled; bool get earthquakeNoticeEnabled;
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $GeneralNotificationSettingsCopyWith<GeneralNotificationSettings> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled)&&(identical(other.earthquakeNoticeEnabled, earthquakeNoticeEnabled) || other.earthquakeNoticeEnabled == earthquakeNoticeEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled,earthquakeNoticeEnabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled)';
+  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled, earthquakeNoticeEnabled: $earthquakeNoticeEnabled)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $GeneralNotificationSettingsCopyWith<$Res>  {
   factory $GeneralNotificationSettingsCopyWith(GeneralNotificationSettings value, $Res Function(GeneralNotificationSettings) _then) = _$GeneralNotificationSettingsCopyWithImpl;
 @useResult
 $Res call({
- bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool vyse60Enabled
+ bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool vyse60Enabled, bool earthquakeNoticeEnabled
 });
 
 
@@ -62,7 +62,7 @@ class _$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,Object? earthquakeNoticeEnabled = null,}) {
   return _then(_self.copyWith(
 notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
@@ -70,6 +70,7 @@ as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : train
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
 as bool,vyse60Enabled: null == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
+as bool,earthquakeNoticeEnabled: null == earthquakeNoticeEnabled ? _self.earthquakeNoticeEnabled : earthquakeNoticeEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled,  bool earthquakeNoticeEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled,  bool earthquakeNoticeEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings():
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled,  bool earthquakeNoticeEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   return null;
 
 }
@@ -211,7 +212,7 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 
 
 class _GeneralNotificationSettings implements GeneralNotificationSettings {
-  const _GeneralNotificationSettings({required this.notificationEnabled, required this.tsunamiEnabled, required this.trainingEnabled, required this.nankaiExtraordinaryEnabled, required this.nankaiRegularEnabled, required this.vyse60Enabled});
+  const _GeneralNotificationSettings({required this.notificationEnabled, required this.tsunamiEnabled, required this.trainingEnabled, required this.nankaiExtraordinaryEnabled, required this.nankaiRegularEnabled, required this.vyse60Enabled, required this.earthquakeNoticeEnabled});
   
 
 @override final  bool notificationEnabled;
@@ -220,6 +221,7 @@ class _GeneralNotificationSettings implements GeneralNotificationSettings {
 @override final  bool nankaiExtraordinaryEnabled;
 @override final  bool nankaiRegularEnabled;
 @override final  bool vyse60Enabled;
+@override final  bool earthquakeNoticeEnabled;
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
@@ -231,16 +233,16 @@ _$GeneralNotificationSettingsCopyWith<_GeneralNotificationSettings> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled)&&(identical(other.earthquakeNoticeEnabled, earthquakeNoticeEnabled) || other.earthquakeNoticeEnabled == earthquakeNoticeEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled,earthquakeNoticeEnabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled)';
+  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled, earthquakeNoticeEnabled: $earthquakeNoticeEnabled)';
 }
 
 
@@ -251,7 +253,7 @@ abstract mixin class _$GeneralNotificationSettingsCopyWith<$Res> implements $Gen
   factory _$GeneralNotificationSettingsCopyWith(_GeneralNotificationSettings value, $Res Function(_GeneralNotificationSettings) _then) = __$GeneralNotificationSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool vyse60Enabled
+ bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool vyse60Enabled, bool earthquakeNoticeEnabled
 });
 
 
@@ -268,7 +270,7 @@ class __$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,Object? earthquakeNoticeEnabled = null,}) {
   return _then(_GeneralNotificationSettings(
 notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
@@ -276,6 +278,7 @@ as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : train
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
 as bool,vyse60Enabled: null == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
+as bool,earthquakeNoticeEnabled: null == earthquakeNoticeEnabled ? _self.earthquakeNoticeEnabled : earthquakeNoticeEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
+++ b/app/lib/feature/notification/data/model/general_notification_settings.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GeneralNotificationSettings {
 
- bool get notificationEnabled; bool get tsunamiEnabled; bool get trainingEnabled; bool get nankaiExtraordinaryEnabled; bool get nankaiRegularEnabled; bool get hokkaido3renOffshoreEnabled;
+ bool get notificationEnabled; bool get tsunamiEnabled; bool get trainingEnabled; bool get nankaiExtraordinaryEnabled; bool get nankaiRegularEnabled; bool get vyse60Enabled;
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $GeneralNotificationSettingsCopyWith<GeneralNotificationSettings> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $GeneralNotificationSettingsCopyWith<$Res>  {
   factory $GeneralNotificationSettingsCopyWith(GeneralNotificationSettings value, $Res Function(GeneralNotificationSettings) _then) = _$GeneralNotificationSettingsCopyWithImpl;
 @useResult
 $Res call({
- bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
+ bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool vyse60Enabled
 });
 
 
@@ -62,14 +62,14 @@ class _$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,}) {
   return _then(_self.copyWith(
 notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
-as bool,hokkaido3renOffshoreEnabled: null == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
+as bool,vyse60Enabled: null == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -155,10 +155,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled);case _:
   return orElse();
 
 }
@@ -176,10 +176,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled)  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings():
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +196,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool notificationEnabled,  bool tsunamiEnabled,  bool trainingEnabled,  bool nankaiExtraordinaryEnabled,  bool nankaiRegularEnabled,  bool vyse60Enabled)?  $default,) {final _that = this;
 switch (_that) {
 case _GeneralNotificationSettings() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled);case _:
   return null;
 
 }
@@ -211,7 +211,7 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 
 
 class _GeneralNotificationSettings implements GeneralNotificationSettings {
-  const _GeneralNotificationSettings({required this.notificationEnabled, required this.tsunamiEnabled, required this.trainingEnabled, required this.nankaiExtraordinaryEnabled, required this.nankaiRegularEnabled, required this.hokkaido3renOffshoreEnabled});
+  const _GeneralNotificationSettings({required this.notificationEnabled, required this.tsunamiEnabled, required this.trainingEnabled, required this.nankaiExtraordinaryEnabled, required this.nankaiRegularEnabled, required this.vyse60Enabled});
   
 
 @override final  bool notificationEnabled;
@@ -219,7 +219,7 @@ class _GeneralNotificationSettings implements GeneralNotificationSettings {
 @override final  bool trainingEnabled;
 @override final  bool nankaiExtraordinaryEnabled;
 @override final  bool nankaiRegularEnabled;
-@override final  bool hokkaido3renOffshoreEnabled;
+@override final  bool vyse60Enabled;
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
@@ -231,16 +231,16 @@ _$GeneralNotificationSettingsCopyWith<_GeneralNotificationSettings> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GeneralNotificationSettings&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled);
 
 @override
 String toString() {
-  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'GeneralNotificationSettings(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled)';
 }
 
 
@@ -251,7 +251,7 @@ abstract mixin class _$GeneralNotificationSettingsCopyWith<$Res> implements $Gen
   factory _$GeneralNotificationSettingsCopyWith(_GeneralNotificationSettings value, $Res Function(_GeneralNotificationSettings) _then) = __$GeneralNotificationSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool hokkaido3renOffshoreEnabled
+ bool notificationEnabled, bool tsunamiEnabled, bool trainingEnabled, bool nankaiExtraordinaryEnabled, bool nankaiRegularEnabled, bool vyse60Enabled
 });
 
 
@@ -268,14 +268,14 @@ class __$GeneralNotificationSettingsCopyWithImpl<$Res>
 
 /// Create a copy of GeneralNotificationSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,}) {
   return _then(_GeneralNotificationSettings(
 notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
-as bool,hokkaido3renOffshoreEnabled: null == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
+as bool,vyse60Enabled: null == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
+++ b/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
@@ -34,7 +34,7 @@ class GeneralNotificationSettingsNotifier
     bool? trainingEnabled,
     bool? nankaiExtraordinaryEnabled,
     bool? nankaiRegularEnabled,
-    bool? hokkaido3renOffshoreEnabled,
+    bool? vyse60Enabled,
   }) async {
     final current = await future;
     final repo = await ref.read(pushNotificationRepositoryProvider.future);
@@ -42,23 +42,19 @@ class GeneralNotificationSettingsNotifier
     final result = await repo.patchNotificationSettings(
       deviceId: deviceId,
       settings: current.copyWith(
-        notificationEnabled:
-            notificationEnabled ?? current.notificationEnabled,
+        notificationEnabled: notificationEnabled ?? current.notificationEnabled,
         tsunamiEnabled: tsunamiEnabled ?? current.tsunamiEnabled,
         trainingEnabled: trainingEnabled ?? current.trainingEnabled,
         nankaiExtraordinaryEnabled:
             nankaiExtraordinaryEnabled ?? current.nankaiExtraordinaryEnabled,
         nankaiRegularEnabled:
             nankaiRegularEnabled ?? current.nankaiRegularEnabled,
-        hokkaido3renOffshoreEnabled:
-            hokkaido3renOffshoreEnabled ?? current.hokkaido3renOffshoreEnabled,
+        vyse60Enabled: vyse60Enabled ?? current.vyse60Enabled,
       ),
     );
-    state = AsyncData(
-      switch (result) {
-        Success(:final value) => value,
-        Failure(:final exception) => throw exception,
-      },
-    );
+    state = AsyncData(switch (result) {
+      Success(:final value) => value,
+      Failure(:final exception) => throw exception,
+    });
   }
 }

--- a/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
+++ b/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.dart
@@ -35,6 +35,7 @@ class GeneralNotificationSettingsNotifier
     bool? nankaiExtraordinaryEnabled,
     bool? nankaiRegularEnabled,
     bool? vyse60Enabled,
+    bool? earthquakeNoticeEnabled,
   }) async {
     final current = await future;
     final repo = await ref.read(pushNotificationRepositoryProvider.future);
@@ -50,6 +51,8 @@ class GeneralNotificationSettingsNotifier
         nankaiRegularEnabled:
             nankaiRegularEnabled ?? current.nankaiRegularEnabled,
         vyse60Enabled: vyse60Enabled ?? current.vyse60Enabled,
+        earthquakeNoticeEnabled:
+            earthquakeNoticeEnabled ?? current.earthquakeNoticeEnabled,
       ),
     );
     state = AsyncData(switch (result) {

--- a/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.g.dart
+++ b/app/lib/feature/notification/data/notifier/general_notification_settings_notifier.g.dart
@@ -43,7 +43,7 @@ final class GeneralNotificationSettingsNotifierProvider
 }
 
 String _$generalNotificationSettingsNotifierHash() =>
-    r'41f8811624256234e65ad6c39287d14ad13b1385';
+    r'7dd0f4cfd7ed13d7ff985104957932f67ea8877b';
 
 abstract class _$GeneralNotificationSettingsNotifier
     extends $AsyncNotifier<GeneralNotificationSettings> {

--- a/app/lib/feature/notification/data/repository/push_notification_repository.dart
+++ b/app/lib/feature/notification/data/repository/push_notification_repository.dart
@@ -36,6 +36,7 @@ class PushNotificationRepository {
         nankaiExtraordinaryEnabled: settings.nankaiExtraordinaryEnabled,
         nankaiRegularEnabled: settings.nankaiRegularEnabled,
         vyse60Enabled: settings.vyse60Enabled,
+        earthquakeNoticeEnabled: settings.earthquakeNoticeEnabled,
       ),
     );
     return response.data.toGeneralNotificationSettings;

--- a/app/lib/feature/notification/data/repository/push_notification_repository.dart
+++ b/app/lib/feature/notification/data/repository/push_notification_repository.dart
@@ -35,7 +35,7 @@ class PushNotificationRepository {
         trainingEnabled: settings.trainingEnabled,
         nankaiExtraordinaryEnabled: settings.nankaiExtraordinaryEnabled,
         nankaiRegularEnabled: settings.nankaiRegularEnabled,
-        hokkaido3renOffshoreEnabled: settings.hokkaido3renOffshoreEnabled,
+        vyse60Enabled: settings.vyse60Enabled,
       ),
     );
     return response.data.toGeneralNotificationSettings;

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -138,9 +138,7 @@ class _Body extends HookConsumerWidget {
       settings?.nankaiExtraordinaryEnabled ?? false,
     );
     final nankaiRegular = useState(settings?.nankaiRegularEnabled ?? false);
-    final hokkaido3ren = useState(
-      settings?.hokkaido3renOffshoreEnabled ?? false,
-    );
+    final vyse60 = useState(settings?.vyse60Enabled ?? false);
 
     useEffect(() {
       notificationEnabled.value = settings?.notificationEnabled ?? true;
@@ -148,7 +146,7 @@ class _Body extends HookConsumerWidget {
       training.value = settings?.trainingEnabled ?? false;
       nankaiExtraordinary.value = settings?.nankaiExtraordinaryEnabled ?? false;
       nankaiRegular.value = settings?.nankaiRegularEnabled ?? false;
-      hokkaido3ren.value = settings?.hokkaido3renOffshoreEnabled ?? false;
+      vyse60.value = settings?.vyse60Enabled ?? false;
       return null;
     }, [settings]);
 
@@ -267,7 +265,7 @@ class _Body extends HookConsumerWidget {
             trainingEnabled: training.value,
             nankaiExtraordinaryEnabled: nankaiExtraordinary.value,
             nankaiRegularEnabled: nankaiRegular.value,
-            hokkaido3renOffshoreEnabled: hokkaido3ren.value,
+            vyse60Enabled: vyse60.value,
           ),
         );
         if (!context.mounted) {

--- a/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
+++ b/app/lib/feature/settings/children/config/debug/device/debug_device_admin_page.dart
@@ -139,6 +139,9 @@ class _Body extends HookConsumerWidget {
     );
     final nankaiRegular = useState(settings?.nankaiRegularEnabled ?? false);
     final vyse60 = useState(settings?.vyse60Enabled ?? false);
+    final earthquakeNotice = useState(
+      settings?.earthquakeNoticeEnabled ?? false,
+    );
 
     useEffect(() {
       notificationEnabled.value = settings?.notificationEnabled ?? true;
@@ -147,6 +150,7 @@ class _Body extends HookConsumerWidget {
       nankaiExtraordinary.value = settings?.nankaiExtraordinaryEnabled ?? false;
       nankaiRegular.value = settings?.nankaiRegularEnabled ?? false;
       vyse60.value = settings?.vyse60Enabled ?? false;
+      earthquakeNotice.value = settings?.earthquakeNoticeEnabled ?? false;
       return null;
     }, [settings]);
 
@@ -266,6 +270,7 @@ class _Body extends HookConsumerWidget {
             nankaiExtraordinaryEnabled: nankaiExtraordinary.value,
             nankaiRegularEnabled: nankaiRegular.value,
             vyse60Enabled: vyse60.value,
+            earthquakeNoticeEnabled: earthquakeNotice.value,
           ),
         );
         if (!context.mounted) {

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_preset_notifier.g.dart
@@ -37,7 +37,7 @@ final class NotificationPresetNotifierProvider
 }
 
 String _$notificationPresetNotifierHash() =>
-    r'0a975d92f5c8bf5629e1140cf813081ad4bed805';
+    r'a719983a2c84c56b2ff28316b47cf7f1be82c503';
 
 abstract class _$NotificationPresetNotifier
     extends $AsyncNotifier<NotificationPreset> {

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -74,14 +74,14 @@ class _Body extends HookConsumerWidget {
       }
     });
 
-    ref.listen(
-      GeneralNotificationSettingsNotifier.updateSettingsMutation,
-      (_, next) async {
-        if (next is MutationError && context.mounted) {
-          await showErrorDialog(context, error: next.error);
-        }
-      },
-    );
+    ref.listen(GeneralNotificationSettingsNotifier.updateSettingsMutation, (
+      _,
+      next,
+    ) async {
+      if (next is MutationError && context.mounted) {
+        await showErrorDialog(context, error: next.error);
+      }
+    });
 
     return ListView(
       padding: const EdgeInsets.only(top: 16, bottom: 24),
@@ -90,14 +90,11 @@ class _Body extends HookConsumerWidget {
           value: notificationsEnabled,
           onChanged: (value) async {
             await GeneralNotificationSettingsNotifier.updateSettingsMutation
-                .run(
-                  ref,
-                  (tsx) async {
-                    await tsx
-                        .get(generalNotificationSettingsProvider.notifier)
-                        .updateSettings(notificationEnabled: value);
-                  },
-                );
+                .run(ref, (tsx) async {
+                  await tsx
+                      .get(generalNotificationSettingsProvider.notifier)
+                      .updateSettings(notificationEnabled: value);
+                });
           },
         ),
         if (notificationsEnabled) ...[
@@ -167,7 +164,9 @@ class _MasterNotificationControl extends StatelessWidget {
               vertical: spacing.md,
             ),
             decoration: BoxDecoration(
-              color: value ? colorTheme.surfaceContainerHighest : colorTheme.surfaceContainerHigh,
+              color: value
+                  ? colorTheme.surfaceContainerHighest
+                  : colorTheme.surfaceContainerHigh,
               borderRadius: BorderRadius.circular(shape.pill),
               border: Border.all(color: colorTheme.outlineVariant),
             ),
@@ -208,7 +207,9 @@ class _PresetSelectionMark extends StatelessWidget {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(
-          color: isSelected ? colorTheme.primary : designSystem.colorTheme.outline,
+          color: isSelected
+              ? colorTheme.primary
+              : designSystem.colorTheme.outline,
           width: isSelected ? 6 : 3,
         ),
       ),
@@ -232,19 +233,22 @@ class _CustomNotificationSettingsPage extends ConsumerWidget {
         .watch(earthquakeGlobalSettingsProvider)
         .value;
 
-    ref.listen(EewGlobalSettingsNotifier.updateSettingsMutation, (_, next) async {
+    ref.listen(EewGlobalSettingsNotifier.updateSettingsMutation, (
+      _,
+      next,
+    ) async {
       if (next is MutationError && context.mounted) {
         await showErrorDialog(context, error: next.error);
       }
     });
-    ref.listen(
-      EarthquakeGlobalSettingsNotifier.updateSettingsMutation,
-      (_, next) async {
-        if (next is MutationError && context.mounted) {
-          await showErrorDialog(context, error: next.error);
-        }
-      },
-    );
+    ref.listen(EarthquakeGlobalSettingsNotifier.updateSettingsMutation, (
+      _,
+      next,
+    ) async {
+      if (next is MutationError && context.mounted) {
+        await showErrorDialog(context, error: next.error);
+      }
+    });
 
     return Scaffold(
       appBar: AppBar(title: const Text('カスタム設定')),
@@ -263,14 +267,13 @@ class _CustomNotificationSettingsPage extends ConsumerWidget {
             estimatedIntensityEnabled:
                 earthquakeSettings?.estimatedIntensityEnabled ?? true,
             onEewForecastChanged: ({required value}) async {
-              await EewGlobalSettingsNotifier.updateSettingsMutation.run(
-                ref,
-                (tsx) async {
-                  await tsx
-                      .get(eewGlobalSettingsProvider.notifier)
-                      .updateSettings(enabled: value);
-                },
-              );
+              await EewGlobalSettingsNotifier.updateSettingsMutation.run(ref, (
+                tsx,
+              ) async {
+                await tsx
+                    .get(eewGlobalSettingsProvider.notifier)
+                    .updateSettings(enabled: value);
+              });
             },
             onEarthquakeChanged: ({required value}) async {
               await EarthquakeGlobalSettingsNotifier.updateSettingsMutation.run(
@@ -283,14 +286,13 @@ class _CustomNotificationSettingsPage extends ConsumerWidget {
               );
             },
             onLiveActivityChanged: ({required value}) async {
-              await EewGlobalSettingsNotifier.updateSettingsMutation.run(
-                ref,
-                (tsx) async {
-                  await tsx
-                      .get(eewGlobalSettingsProvider.notifier)
-                      .updateSettings(startLiveActivity: value);
-                },
-              );
+              await EewGlobalSettingsNotifier.updateSettingsMutation.run(ref, (
+                tsx,
+              ) async {
+                await tsx
+                    .get(eewGlobalSettingsProvider.notifier)
+                    .updateSettings(startLiveActivity: value);
+              });
             },
             onEstimatedIntensityChanged: ({required value}) async {
               await EarthquakeGlobalSettingsNotifier.updateSettingsMutation.run(
@@ -387,9 +389,7 @@ class _CustomSettingsSection extends StatelessWidget {
           const Divider(height: 1),
           LockedSettingTile(
             title: '通知音・割り込みレベル',
-            subtitle: isPro
-                ? '種類ごとに変更できます'
-                : '通知音・割り込みレベルの変更、続報通知の上書き設定ができます',
+            subtitle: isPro ? '種類ごとに変更できます' : '通知音・割り込みレベルの変更、続報通知の上書き設定ができます',
             locked: !isPro,
             onTap: isPro
                 ? () => Navigator.of(context).push<void>(
@@ -418,9 +418,9 @@ class _CustomSettingsSection extends StatelessWidget {
             subtitle: '100gal超えのレベル法, 1点検知の低精度の緊急地震速報(予報)',
             locked: !isPro,
             onTap: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('この機能は現在準備中です')),
-              );
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(const SnackBar(content: Text('この機能は現在準備中です')));
             },
           ),
         ],
@@ -527,7 +527,10 @@ class _EewWarningSettingsPage extends ConsumerWidget {
       }
     });
 
-    ref.listen(EewGlobalSettingsNotifier.updateSettingsMutation, (_, next) async {
+    ref.listen(EewGlobalSettingsNotifier.updateSettingsMutation, (
+      _,
+      next,
+    ) async {
       if (next is MutationError && context.mounted) {
         await showErrorDialog(context, error: next.error);
       }
@@ -567,14 +570,13 @@ class _EewWarningSettingsPage extends ConsumerWidget {
           _MasterNotificationControl(
             value: warningEnabled,
             onChanged: (value) async {
-              await EewGlobalSettingsNotifier.updateSettingsMutation.run(
-                ref,
-                (tsx) async {
-                  await tsx
-                      .get(eewGlobalSettingsProvider.notifier)
-                      .updateSettings(warningEnabled: value);
-                },
-              );
+              await EewGlobalSettingsNotifier.updateSettingsMutation.run(ref, (
+                tsx,
+              ) async {
+                await tsx
+                    .get(eewGlobalSettingsProvider.notifier)
+                    .updateSettings(warningEnabled: value);
+              });
             },
           ),
           const SettingsSectionHeader(text: '通知対象'),
@@ -687,10 +689,7 @@ class _TargetOptionTile extends StatelessWidget {
 }
 
 class _SlotListSection extends ConsumerWidget {
-  const _SlotListSection({
-    required this.isPro,
-    required this.maxRegions,
-  });
+  const _SlotListSection({required this.isPro, required this.maxRegions});
 
   final bool isPro;
   final int maxRegions;
@@ -702,7 +701,10 @@ class _SlotListSection extends ConsumerWidget {
 
     final slotsAsync = ref.watch(notificationSlotsProvider);
 
-    ref.listen(NotificationSlotsNotifier.putNationwideMutation, (_, next) async {
+    ref.listen(NotificationSlotsNotifier.putNationwideMutation, (
+      _,
+      next,
+    ) async {
       if (next is MutationError && context.mounted) {
         await showErrorDialog(context, error: next.error);
       }
@@ -711,8 +713,9 @@ class _SlotListSection extends ConsumerWidget {
     final slots = [...?slotsAsync.value]
       ..sort((a, b) => a.displayOrder.compareTo(b.displayOrder));
 
-    final hasNationwide = slots
-        .any((s) => s.slotType == NotificationSlotType.nationwide);
+    final hasNationwide = slots.any(
+      (s) => s.slotType == NotificationSlotType.nationwide,
+    );
     final regionSlotCount = slots
         .where((s) => s.slotType == NotificationSlotType.region)
         .length;
@@ -768,28 +771,22 @@ class _SlotListSection extends ConsumerWidget {
         ...tiles,
         if (!hasNationwide)
           Padding(
-            padding: EdgeInsets.fromLTRB(
-              spacing.lg,
-              spacing.sm,
-              spacing.lg,
-              0,
-            ),
+            padding: EdgeInsets.fromLTRB(spacing.lg, spacing.sm, spacing.lg, 0),
             child: FilledButton.tonalIcon(
               onPressed: () async {
-                await NotificationSlotsNotifier.putNationwideMutation.run(
-                  ref,
-                  (tsx) async {
-                    await tsx
-                        .get(notificationSlotsProvider.notifier)
-                        .putNationwide(
-                          eewEnabled: true,
-                          eewMinIntensity: defaultNotificationSlotMinIntensity,
-                          earthquakeEnabled: true,
-                          earthquakeMinIntensity:
-                              defaultNotificationSlotMinIntensity,
-                        );
-                  },
-                );
+                await NotificationSlotsNotifier.putNationwideMutation.run(ref, (
+                  tsx,
+                ) async {
+                  await tsx
+                      .get(notificationSlotsProvider.notifier)
+                      .putNationwide(
+                        eewEnabled: true,
+                        eewMinIntensity: defaultNotificationSlotMinIntensity,
+                        earthquakeEnabled: true,
+                        earthquakeMinIntensity:
+                            defaultNotificationSlotMinIntensity,
+                      );
+                });
               },
               icon: const Icon(Icons.public),
               label: const Text('全国を追加'),
@@ -937,21 +934,23 @@ class _GeneralNotificationSettingsSection extends ConsumerWidget {
         children: [
           InfoNotificationTile(
             title: '北海道・三陸沖後発地震注意情報',
-            subtitleText: '北海道の根室沖から東北地方の三陸沖の巨大地震の想定震源域やその周辺でMw7.0以上の地震が発生し、大規模地震の発生可能性が平常時より相対的に高まっている際に「北海道・三陸沖後発地震注意情報」を発表 ',
-            value: settings.hokkaido3renOffshoreEnabled,
+            subtitleText:
+                '北海道の根室沖から東北地方の三陸沖の巨大地震の想定震源域やその周辺でMw7.0以上の地震が発生し、大規模地震の発生可能性が平常時より相対的に高まっている際に「北海道・三陸沖後発地震注意情報」を発表 ',
+            value: settings.vyse60Enabled,
             onChanged: ({required value}) async {
               await GeneralNotificationSettingsNotifier.updateSettingsMutation
                   .run(ref, (tsx) async {
                     await tsx
                         .get(generalNotificationSettingsProvider.notifier)
-                        .updateSettings(hokkaido3renOffshoreEnabled: value);
+                        .updateSettings(vyse60Enabled: value);
                   });
             },
             bottomSheetTitle: '北海道・三陸沖後発地震注意情報',
             bottomSheetLinks: const [
               InfoLink(
                 title: '「北海道・三陸沖後発地震注意情報」について',
-                url: 'https://www.jma.go.jp/jma/kishou/know/jishin/nceq/info_guide.html',
+                url:
+                    'https://www.jma.go.jp/jma/kishou/know/jishin/nceq/info_guide.html',
               ),
               InfoLink(
                 title: '配信資料に関する仕様 No.40701 ～北海道・三陸沖後発地震注意情報～',
@@ -961,7 +960,8 @@ class _GeneralNotificationSettingsSection extends ConsumerWidget {
           ),
           InfoNotificationTile(
             title: '南海トラフ地震関連解説情報(定例外)',
-            subtitleText: '南海トラフ沿いで異常な現象が観測され、その現象が南海トラフ沿いの大規模な地震と関連するかどうか調査を開始・解説・終了した場合等に発表 ',
+            subtitleText:
+                '南海トラフ沿いで異常な現象が観測され、その現象が南海トラフ沿いの大規模な地震と関連するかどうか調査を開始・解説・終了した場合等に発表 ',
             value: settings.nankaiExtraordinaryEnabled,
             onChanged: ({required value}) async {
               await GeneralNotificationSettingsNotifier.updateSettingsMutation
@@ -975,11 +975,13 @@ class _GeneralNotificationSettingsSection extends ConsumerWidget {
             bottomSheetLinks: const [
               InfoLink(
                 title: '「南海トラフ地震に関連する情報」について',
-                url: 'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/info_criterion.html',
+                url:
+                    'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/info_criterion.html',
               ),
               InfoLink(
                 title: '「南海トラフ地震臨時情報」が発表されたときの防災対応',
-                url: 'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/bosai.html',
+                url:
+                    'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/bosai.html',
               ),
             ],
           ),
@@ -999,11 +1001,13 @@ class _GeneralNotificationSettingsSection extends ConsumerWidget {
             bottomSheetLinks: const [
               InfoLink(
                 title: '「南海トラフ地震に関連する情報」について',
-                url: 'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/info_criterion.html',
+                url:
+                    'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/info_criterion.html',
               ),
               InfoLink(
                 title: '南海トラフ沿いの地震に関する評価検討会とは',
-                url: 'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/assessment.html',
+                url:
+                    'https://www.jma.go.jp/jma/kishou/know/jishin/nteq/assessment.html',
               ),
             ],
           ),
@@ -1153,9 +1157,8 @@ class _AndroidNotificationSettingsTile extends StatelessWidget {
       subtitle: const Text('チャンネルごとに音・バイブなどをカスタマイズできます'),
       leading: const Icon(Icons.tune_outlined),
       trailing: const Icon(Icons.open_in_new),
-      onTap: () async => AppSettings.openAppSettings(
-        type: AppSettingsType.notification,
-      ),
+      onTap: () async =>
+          AppSettings.openAppSettings(type: AppSettingsType.notification),
     );
   }
 }

--- a/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/page/notification_settings_page.dart
@@ -1011,6 +1011,27 @@ class _GeneralNotificationSettingsSection extends ConsumerWidget {
               ),
             ],
           ),
+          InfoNotificationTile(
+            title: '地震・津波に関するお知らせ',
+            subtitleText:
+                '気象庁が発表する「地震・津波に関するお知らせ」(VZSE40)を通知します。試験・訓練配信のお知らせや、市町村の震度データの入電停止などの情報が含まれます。',
+            value: settings.earthquakeNoticeEnabled,
+            onChanged: ({required value}) async {
+              await GeneralNotificationSettingsNotifier.updateSettingsMutation
+                  .run(ref, (tsx) async {
+                    await tsx
+                        .get(generalNotificationSettingsProvider.notifier)
+                        .updateSettings(earthquakeNoticeEnabled: value);
+                  });
+            },
+            bottomSheetTitle: '地震・津波に関するお知らせ',
+            bottomSheetLinks: const [
+              InfoLink(
+                title: '「地震・津波に関するお知らせ」について',
+                url: 'https://www.data.jma.go.jp/suishin/shiyou/',
+              ),
+            ],
+          ),
           ListTile(
             enabled: false,
             title: const Text('津波通知'),

--- a/app/test/feature/notification/general_notification_settings_notifier_test.dart
+++ b/app/test/feature/notification/general_notification_settings_notifier_test.dart
@@ -17,7 +17,7 @@ const _initialSettings = GeneralNotificationSettings(
   trainingEnabled: false,
   nankaiExtraordinaryEnabled: false,
   nankaiRegularEnabled: false,
-  hokkaido3renOffshoreEnabled: false,
+  vyse60Enabled: false,
 );
 
 class _FakePushNotificationRepository extends PushNotificationRepository {

--- a/app/test/feature/notification/general_notification_settings_notifier_test.dart
+++ b/app/test/feature/notification/general_notification_settings_notifier_test.dart
@@ -18,12 +18,14 @@ const _initialSettings = GeneralNotificationSettings(
   nankaiExtraordinaryEnabled: false,
   nankaiRegularEnabled: false,
   vyse60Enabled: false,
+  earthquakeNoticeEnabled: false,
 );
 
 class _FakePushNotificationRepository extends PushNotificationRepository {
   _FakePushNotificationRepository() : super(api.ApiClient(Dio()));
 
   final patchedNotificationEnabled = <bool>[];
+  final patchedEarthquakeNoticeEnabled = <bool>[];
 
   @override
   Future<Result<GeneralNotificationSettings, Exception>>
@@ -40,6 +42,7 @@ class _FakePushNotificationRepository extends PushNotificationRepository {
     required GeneralNotificationSettings settings,
   }) async {
     patchedNotificationEnabled.add(settings.notificationEnabled);
+    patchedEarthquakeNoticeEnabled.add(settings.earthquakeNoticeEnabled);
     return Success(settings);
   }
 }
@@ -75,6 +78,34 @@ void main() {
     expect(
       container.read(generalNotificationSettingsProvider).value,
       _initialSettings.copyWith(notificationEnabled: true),
+    );
+  });
+
+  test('updateSettings(earthquakeNoticeEnabled: true) issues PATCH and '
+      'updates state', () async {
+    final repository = _FakePushNotificationRepository();
+    final container = ProviderContainer(
+      overrides: [
+        deviceProvisioningProvider.overrideWith(
+          _FakeDeviceProvisioningNotifier.new,
+        ),
+        pushNotificationRepositoryProvider.overrideWith(
+          (ref) async => repository,
+        ),
+        deviceIdProvider.overrideWith((ref) async => 'test-device'),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(generalNotificationSettingsProvider.future);
+    await container
+        .read(generalNotificationSettingsProvider.notifier)
+        .updateSettings(earthquakeNoticeEnabled: true);
+
+    expect(repository.patchedEarthquakeNoticeEnabled, [true]);
+    expect(
+      container.read(generalNotificationSettingsProvider).value,
+      _initialSettings.copyWith(earthquakeNoticeEnabled: true),
     );
   });
 }

--- a/app/test/feature/settings/features/notification_settings/notification_preset_applier_lifecycle_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_applier_lifecycle_test.dart
@@ -53,6 +53,7 @@ class _FakeGeneralNotificationSettingsNotifier
         nankaiExtraordinaryEnabled: false,
         nankaiRegularEnabled: false,
         vyse60Enabled: false,
+        earthquakeNoticeEnabled: false,
       );
 
   @override
@@ -63,6 +64,7 @@ class _FakeGeneralNotificationSettingsNotifier
     bool? nankaiExtraordinaryEnabled,
     bool? nankaiRegularEnabled,
     bool? vyse60Enabled,
+    bool? earthquakeNoticeEnabled,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 50));
   }

--- a/app/test/feature/settings/features/notification_settings/notification_preset_applier_lifecycle_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_applier_lifecycle_test.dart
@@ -52,7 +52,7 @@ class _FakeGeneralNotificationSettingsNotifier
         trainingEnabled: false,
         nankaiExtraordinaryEnabled: false,
         nankaiRegularEnabled: false,
-        hokkaido3renOffshoreEnabled: false,
+        vyse60Enabled: false,
       );
 
   @override
@@ -62,7 +62,7 @@ class _FakeGeneralNotificationSettingsNotifier
     bool? trainingEnabled,
     bool? nankaiExtraordinaryEnabled,
     bool? nankaiRegularEnabled,
-    bool? hokkaido3renOffshoreEnabled,
+    bool? vyse60Enabled,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 50));
   }
@@ -88,29 +88,31 @@ class _FakeDeviceProvisioningNotifier extends DeviceProvisioningNotifier {
 }
 
 void main() {
-  test('apply(recommended) survives autoDispose of the applier provider',
-      () async {
-    final presetNotifier = _FakeNotificationPresetNotifier();
-    final container = ProviderContainer(
-      overrides: [
-        deviceProvisioningProvider.overrideWith(
-          _FakeDeviceProvisioningNotifier.new,
-        ),
-        notificationSlotsProvider.overrideWith(
-          _SlowNotificationSlotsNotifier.new,
-        ),
-        generalNotificationSettingsProvider.overrideWith(
-          _FakeGeneralNotificationSettingsNotifier.new,
-        ),
-        notificationPresetProvider.overrideWith(() => presetNotifier),
-      ],
-    );
-    addTearDown(container.dispose);
+  test(
+    'apply(recommended) survives autoDispose of the applier provider',
+    () async {
+      final presetNotifier = _FakeNotificationPresetNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          deviceProvisioningProvider.overrideWith(
+            _FakeDeviceProvisioningNotifier.new,
+          ),
+          notificationSlotsProvider.overrideWith(
+            _SlowNotificationSlotsNotifier.new,
+          ),
+          generalNotificationSettingsProvider.overrideWith(
+            _FakeGeneralNotificationSettingsNotifier.new,
+          ),
+          notificationPresetProvider.overrideWith(() => presetNotifier),
+        ],
+      );
+      addTearDown(container.dispose);
 
-    // 実アプリと同じく ref.read で applier を取得して即 apply する
-    final applier = container.read(notificationPresetApplierProvider);
-    await applier.apply(NotificationPreset.recommended);
+      // 実アプリと同じく ref.read で applier を取得して即 apply する
+      final applier = container.read(notificationPresetApplierProvider);
+      await applier.apply(NotificationPreset.recommended);
 
-    expect(presetNotifier.selectedPresets, [NotificationPreset.recommended]);
-  });
+      expect(presetNotifier.selectedPresets, [NotificationPreset.recommended]);
+    },
+  );
 }

--- a/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
@@ -98,6 +98,7 @@ class _RecordingGeneralNotificationSettingsNotifier
         nankaiExtraordinaryEnabled: false,
         nankaiRegularEnabled: false,
         vyse60Enabled: false,
+        earthquakeNoticeEnabled: false,
       );
 
   @override
@@ -108,6 +109,7 @@ class _RecordingGeneralNotificationSettingsNotifier
     bool? nankaiExtraordinaryEnabled,
     bool? nankaiRegularEnabled,
     bool? vyse60Enabled,
+    bool? earthquakeNoticeEnabled,
   }) async {
     updateSettingsCalls.add(notificationEnabled);
   }

--- a/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
@@ -97,7 +97,7 @@ class _RecordingGeneralNotificationSettingsNotifier
         trainingEnabled: false,
         nankaiExtraordinaryEnabled: false,
         nankaiRegularEnabled: false,
-        hokkaido3renOffshoreEnabled: false,
+        vyse60Enabled: false,
       );
 
   @override
@@ -107,7 +107,7 @@ class _RecordingGeneralNotificationSettingsNotifier
     bool? trainingEnabled,
     bool? nankaiExtraordinaryEnabled,
     bool? nankaiRegularEnabled,
-    bool? hokkaido3renOffshoreEnabled,
+    bool? vyse60Enabled,
   }) async {
     updateSettingsCalls.add(notificationEnabled);
   }
@@ -143,9 +143,7 @@ ProviderContainer _container({
         _FakeDeviceProvisioningNotifier.new,
       ),
       notificationSlotsProvider.overrideWith(() => slotsNotifier),
-      generalNotificationSettingsProvider.overrideWith(
-        () => settingsNotifier,
-      ),
+      generalNotificationSettingsProvider.overrideWith(() => settingsNotifier),
       notificationPresetProvider.overrideWith(() => presetNotifier),
     ],
   );
@@ -153,32 +151,37 @@ ProviderContainer _container({
 
 void main() {
   group('NotificationPresetApplier', () {
-    test('recommended applies current location, enables notifications, selects preset',
-        () async {
-      final slotsNotifier = _RecordingNotificationSlotsNotifier();
-      final settingsNotifier = _RecordingGeneralNotificationSettingsNotifier();
-      final presetNotifier = _RecordingNotificationPresetNotifier();
-      final container = _container(
-        slotsNotifier: slotsNotifier,
-        settingsNotifier: settingsNotifier,
-        presetNotifier: presetNotifier,
-      );
-      addTearDown(container.dispose);
+    test(
+      'recommended applies current location, enables notifications, selects preset',
+      () async {
+        final slotsNotifier = _RecordingNotificationSlotsNotifier();
+        final settingsNotifier =
+            _RecordingGeneralNotificationSettingsNotifier();
+        final presetNotifier = _RecordingNotificationPresetNotifier();
+        final container = _container(
+          slotsNotifier: slotsNotifier,
+          settingsNotifier: settingsNotifier,
+          presetNotifier: presetNotifier,
+        );
+        addTearDown(container.dispose);
 
-      await container
-          .read(notificationPresetApplierProvider)
-          .apply(NotificationPreset.recommended);
+        await container
+            .read(notificationPresetApplierProvider)
+            .apply(NotificationPreset.recommended);
 
-      expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
-      final recommendedCall = slotsNotifier.putCurrentLocationCalls.first;
-      expect(recommendedCall.eewEnabled, isTrue);
-      expect(recommendedCall.eewMinIntensity, JmaIntensity.four);
-      expect(recommendedCall.earthquakeEnabled, isTrue);
-      expect(recommendedCall.earthquakeMinIntensity, JmaIntensity.one);
-      expect(slotsNotifier.putNationwideCalls, isEmpty);
-      expect(settingsNotifier.updateSettingsCalls, [true]);
-      expect(presetNotifier.selectedPresets, [NotificationPreset.recommended]);
-    });
+        expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
+        final recommendedCall = slotsNotifier.putCurrentLocationCalls.first;
+        expect(recommendedCall.eewEnabled, isTrue);
+        expect(recommendedCall.eewMinIntensity, JmaIntensity.four);
+        expect(recommendedCall.earthquakeEnabled, isTrue);
+        expect(recommendedCall.earthquakeMinIntensity, JmaIntensity.one);
+        expect(slotsNotifier.putNationwideCalls, isEmpty);
+        expect(settingsNotifier.updateSettingsCalls, [true]);
+        expect(presetNotifier.selectedPresets, [
+          NotificationPreset.recommended,
+        ]);
+      },
+    );
 
     test('all applies recommended settings plus nationwide', () async {
       final slotsNotifier = _RecordingNotificationSlotsNotifier();
@@ -196,7 +199,8 @@ void main() {
           .apply(NotificationPreset.all);
 
       expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
-      final allCurrentLocationCall = slotsNotifier.putCurrentLocationCalls.first;
+      final allCurrentLocationCall =
+          slotsNotifier.putCurrentLocationCalls.first;
       expect(allCurrentLocationCall.eewEnabled, isTrue);
       expect(allCurrentLocationCall.eewMinIntensity, JmaIntensity.four);
       expect(allCurrentLocationCall.earthquakeEnabled, isTrue);
@@ -204,7 +208,10 @@ void main() {
       expect(slotsNotifier.putNationwideCalls, hasLength(1));
       final nationwideCall = slotsNotifier.putNationwideCalls.first;
       expect(nationwideCall.eewEnabled, isTrue);
-      expect(nationwideCall.eewMinIntensity, defaultNotificationSlotMinIntensity);
+      expect(
+        nationwideCall.eewMinIntensity,
+        defaultNotificationSlotMinIntensity,
+      );
       expect(nationwideCall.earthquakeEnabled, isTrue);
       expect(
         nationwideCall.earthquakeMinIntensity,
@@ -235,31 +242,34 @@ void main() {
       expect(presetNotifier.selectedPresets, [NotificationPreset.none]);
     });
 
-    test('custom applies current location only without selecting preset',
-        () async {
-      final slotsNotifier = _RecordingNotificationSlotsNotifier();
-      final settingsNotifier = _RecordingGeneralNotificationSettingsNotifier();
-      final presetNotifier = _RecordingNotificationPresetNotifier();
-      final container = _container(
-        slotsNotifier: slotsNotifier,
-        settingsNotifier: settingsNotifier,
-        presetNotifier: presetNotifier,
-      );
-      addTearDown(container.dispose);
+    test(
+      'custom applies current location only without selecting preset',
+      () async {
+        final slotsNotifier = _RecordingNotificationSlotsNotifier();
+        final settingsNotifier =
+            _RecordingGeneralNotificationSettingsNotifier();
+        final presetNotifier = _RecordingNotificationPresetNotifier();
+        final container = _container(
+          slotsNotifier: slotsNotifier,
+          settingsNotifier: settingsNotifier,
+          presetNotifier: presetNotifier,
+        );
+        addTearDown(container.dispose);
 
-      await container
-          .read(notificationPresetApplierProvider)
-          .apply(NotificationPreset.custom);
+        await container
+            .read(notificationPresetApplierProvider)
+            .apply(NotificationPreset.custom);
 
-      expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
-      final customCall = slotsNotifier.putCurrentLocationCalls.first;
-      expect(customCall.eewEnabled, isTrue);
-      expect(customCall.eewMinIntensity, JmaIntensity.four);
-      expect(customCall.earthquakeEnabled, isTrue);
-      expect(customCall.earthquakeMinIntensity, JmaIntensity.one);
-      expect(slotsNotifier.putNationwideCalls, isEmpty);
-      expect(settingsNotifier.updateSettingsCalls, isEmpty);
-      expect(presetNotifier.selectedPresets, isEmpty);
-    });
+        expect(slotsNotifier.putCurrentLocationCalls, hasLength(1));
+        final customCall = slotsNotifier.putCurrentLocationCalls.first;
+        expect(customCall.eewEnabled, isTrue);
+        expect(customCall.eewMinIntensity, JmaIntensity.four);
+        expect(customCall.earthquakeEnabled, isTrue);
+        expect(customCall.earthquakeMinIntensity, JmaIntensity.one);
+        expect(slotsNotifier.putNationwideCalls, isEmpty);
+        expect(settingsNotifier.updateSettingsCalls, isEmpty);
+        expect(presetNotifier.selectedPresets, isEmpty);
+      },
+    );
   });
 }

--- a/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
@@ -118,7 +118,7 @@ class _FakeGeneralNotificationSettingsNotifier
         trainingEnabled: true,
         nankaiExtraordinaryEnabled: true,
         nankaiRegularEnabled: true,
-        hokkaido3renOffshoreEnabled: true,
+        vyse60Enabled: true,
       );
 }
 
@@ -204,9 +204,7 @@ class _TestApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = ThemeData.light().copyWith(
-      extensions: [
-        DesignSystemThemeExtension.light(),
-      ],
+      extensions: [DesignSystemThemeExtension.light()],
     );
     return MaterialApp(theme: theme, home: home);
   }

--- a/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_settings_page_eew_warning_test.dart
@@ -119,6 +119,7 @@ class _FakeGeneralNotificationSettingsNotifier
         nankaiExtraordinaryEnabled: true,
         nankaiRegularEnabled: true,
         vyse60Enabled: true,
+        earthquakeNoticeEnabled: true,
       );
 }
 

--- a/packages/eqmonitor_api/lib/src/clients/feed_api_client.dart
+++ b/packages/eqmonitor_api/lib/src/clients/feed_api_client.dart
@@ -18,10 +18,12 @@ part 'feed_api_client.g.dart';
 abstract class FeedApiClient {
   factory FeedApiClient(Dio dio, {String? baseUrl}) = _FeedApiClient;
 
-  /// Feed一覧（お知らせ・地震関連情報など）
+  /// Feed一覧（お知らせ・地震関連情報など）.
+  ///
+  /// [cursor] - カーソル情報, {type}:{id} を base64 エンコードしたもの.
   @GET(FeedApiClientUrls.getV2Feeds)
   Future<HttpResponse<FeedListResponse>> getV2Feeds({
-    @Query('after') String? after,
+    @Query('cursor') String? cursor,
     @Query('important') String? important,
     @Query('locale') String? locale = 'ja',
     @Query('limit') String? limit = '20',
@@ -42,13 +44,13 @@ abstract class FeedApiClient {
   });
 }
 
-
 abstract class FeedApiClientUrls {
-	/// /v2/feeds
-	static const getV2Feeds = "/v2/feeds";
-	/// /v2/feeds/source/{telegramHash}
-	static const getV2FeedsSourceTelegramHash = "/v2/feeds/source/{telegramHash}";
-	/// /v2/feeds/admin
-	static const postV2FeedsAdmin = "/v2/feeds/admin";
-}
+  /// /v2/feeds
+  static const getV2Feeds = "/v2/feeds";
 
+  /// /v2/feeds/source/{telegramHash}
+  static const getV2FeedsSourceTelegramHash = "/v2/feeds/source/{telegramHash}";
+
+  /// /v2/feeds/admin
+  static const postV2FeedsAdmin = "/v2/feeds/admin";
+}

--- a/packages/eqmonitor_api/lib/src/clients/feed_api_client.g.dart
+++ b/packages/eqmonitor_api/lib/src/clients/feed_api_client.g.dart
@@ -23,7 +23,7 @@ class _FeedApiClient implements FeedApiClient {
 
   @override
   Future<HttpResponse<FeedListResponse>> getV2Feeds({
-    String? after,
+    String? cursor,
     String? important,
     String? locale = 'ja',
     String? limit = '20',
@@ -31,7 +31,7 @@ class _FeedApiClient implements FeedApiClient {
   }) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{
-      r'after': after,
+      r'cursor': cursor,
       r'important': important,
       r'locale': locale,
       r'limit': limit,

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_request.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_request.dart
@@ -10,19 +10,21 @@ part 'notification_settings_request.g.dart';
 @Freezed()
 abstract class NotificationSettingsRequest with _$NotificationSettingsRequest {
   const factory NotificationSettingsRequest({
-    @JsonKey(includeIfNull: false,name: 'notification_enabled')
+    @JsonKey(includeIfNull: false, name: 'notification_enabled')
     bool? notificationEnabled,
-    @JsonKey(includeIfNull: false,name: 'tsunami_enabled')
+    @JsonKey(includeIfNull: false, name: 'tsunami_enabled')
     bool? tsunamiEnabled,
-    @JsonKey(includeIfNull: false,name: 'training_enabled')
+    @JsonKey(includeIfNull: false, name: 'training_enabled')
     bool? trainingEnabled,
-    @JsonKey(includeIfNull: false,name: 'nankai_extraordinary_enabled')
+    @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')
     bool? nankaiExtraordinaryEnabled,
-    @JsonKey(includeIfNull: false,name: 'nankai_regular_enabled')
+    @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')
     bool? nankaiRegularEnabled,
-    @JsonKey(includeIfNull: false,name: 'hokkaido3ren_offshore_enabled')
-    bool? hokkaido3renOffshoreEnabled,
+    @JsonKey(includeIfNull: false, name: 'vyse60_enabled') bool? vyse60Enabled,
+    @JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled')
+    bool? earthquakeNoticeEnabled,
   }) = _NotificationSettingsRequest;
-  
-  factory NotificationSettingsRequest.fromJson(Map<String, Object?> json) => _$NotificationSettingsRequestFromJson(json);
+
+  factory NotificationSettingsRequest.fromJson(Map<String, Object?> json) =>
+      _$NotificationSettingsRequestFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_request.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NotificationSettingsRequest {
 
-@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? get notificationEnabled;@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? get tsunamiEnabled;@JsonKey(includeIfNull: false, name: 'training_enabled') bool? get trainingEnabled;@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? get nankaiExtraordinaryEnabled;@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? get nankaiRegularEnabled;@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? get hokkaido3renOffshoreEnabled;
+@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? get notificationEnabled;@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? get tsunamiEnabled;@JsonKey(includeIfNull: false, name: 'training_enabled') bool? get trainingEnabled;@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? get nankaiExtraordinaryEnabled;@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? get nankaiRegularEnabled;@JsonKey(includeIfNull: false, name: 'vyse60_enabled') bool? get vyse60Enabled;@JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled') bool? get earthquakeNoticeEnabled;
 /// Create a copy of NotificationSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $NotificationSettingsRequestCopyWith<NotificationSettingsRequest> get copyWith =
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsRequest&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsRequest&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled)&&(identical(other.earthquakeNoticeEnabled, earthquakeNoticeEnabled) || other.earthquakeNoticeEnabled == earthquakeNoticeEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled,earthquakeNoticeEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsRequest(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsRequest(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled, earthquakeNoticeEnabled: $earthquakeNoticeEnabled)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $NotificationSettingsRequestCopyWith<$Res>  {
   factory $NotificationSettingsRequestCopyWith(NotificationSettingsRequest value, $Res Function(NotificationSettingsRequest) _then) = _$NotificationSettingsRequestCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? notificationEnabled,@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? hokkaido3renOffshoreEnabled
+@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? notificationEnabled,@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'vyse60_enabled') bool? vyse60Enabled,@JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled') bool? earthquakeNoticeEnabled
 });
 
 
@@ -65,14 +65,15 @@ class _$NotificationSettingsRequestCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = freezed,Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? hokkaido3renOffshoreEnabled = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = freezed,Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? vyse60Enabled = freezed,Object? earthquakeNoticeEnabled = freezed,}) {
   return _then(_self.copyWith(
 notificationEnabled: freezed == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,tsunamiEnabled: freezed == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,trainingEnabled: freezed == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiExtraordinaryEnabled: freezed == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiRegularEnabled: freezed == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
-as bool?,hokkaido3renOffshoreEnabled: freezed == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
+as bool?,vyse60Enabled: freezed == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
+as bool?,earthquakeNoticeEnabled: freezed == earthquakeNoticeEnabled ? _self.earthquakeNoticeEnabled : earthquakeNoticeEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,
   ));
 }
@@ -158,10 +159,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'vyse60_enabled')  bool? vyse60Enabled, @JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled')  bool? earthquakeNoticeEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NotificationSettingsRequest() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   return orElse();
 
 }
@@ -179,10 +180,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'vyse60_enabled')  bool? vyse60Enabled, @JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled')  bool? earthquakeNoticeEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsRequest():
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +200,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled')  bool? hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(includeIfNull: false, name: 'notification_enabled')  bool? notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled')  bool? tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled')  bool? trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled')  bool? nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled')  bool? nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'vyse60_enabled')  bool? vyse60Enabled, @JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled')  bool? earthquakeNoticeEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsRequest() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   return null;
 
 }
@@ -214,7 +215,7 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 @JsonSerializable()
 
 class _NotificationSettingsRequest implements NotificationSettingsRequest {
-  const _NotificationSettingsRequest({@JsonKey(includeIfNull: false, name: 'notification_enabled') this.notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled') this.tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled') this.trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') this.nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') this.nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') this.hokkaido3renOffshoreEnabled});
+  const _NotificationSettingsRequest({@JsonKey(includeIfNull: false, name: 'notification_enabled') this.notificationEnabled, @JsonKey(includeIfNull: false, name: 'tsunami_enabled') this.tsunamiEnabled, @JsonKey(includeIfNull: false, name: 'training_enabled') this.trainingEnabled, @JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') this.nankaiExtraordinaryEnabled, @JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') this.nankaiRegularEnabled, @JsonKey(includeIfNull: false, name: 'vyse60_enabled') this.vyse60Enabled, @JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled') this.earthquakeNoticeEnabled});
   factory _NotificationSettingsRequest.fromJson(Map<String, dynamic> json) => _$NotificationSettingsRequestFromJson(json);
 
 @override@JsonKey(includeIfNull: false, name: 'notification_enabled') final  bool? notificationEnabled;
@@ -222,7 +223,8 @@ class _NotificationSettingsRequest implements NotificationSettingsRequest {
 @override@JsonKey(includeIfNull: false, name: 'training_enabled') final  bool? trainingEnabled;
 @override@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') final  bool? nankaiExtraordinaryEnabled;
 @override@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') final  bool? nankaiRegularEnabled;
-@override@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') final  bool? hokkaido3renOffshoreEnabled;
+@override@JsonKey(includeIfNull: false, name: 'vyse60_enabled') final  bool? vyse60Enabled;
+@override@JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled') final  bool? earthquakeNoticeEnabled;
 
 /// Create a copy of NotificationSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -237,16 +239,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsRequest&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsRequest&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled)&&(identical(other.earthquakeNoticeEnabled, earthquakeNoticeEnabled) || other.earthquakeNoticeEnabled == earthquakeNoticeEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled,earthquakeNoticeEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsRequest(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsRequest(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled, earthquakeNoticeEnabled: $earthquakeNoticeEnabled)';
 }
 
 
@@ -257,7 +259,7 @@ abstract mixin class _$NotificationSettingsRequestCopyWith<$Res> implements $Not
   factory _$NotificationSettingsRequestCopyWith(_NotificationSettingsRequest value, $Res Function(_NotificationSettingsRequest) _then) = __$NotificationSettingsRequestCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? notificationEnabled,@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'hokkaido3ren_offshore_enabled') bool? hokkaido3renOffshoreEnabled
+@JsonKey(includeIfNull: false, name: 'notification_enabled') bool? notificationEnabled,@JsonKey(includeIfNull: false, name: 'tsunami_enabled') bool? tsunamiEnabled,@JsonKey(includeIfNull: false, name: 'training_enabled') bool? trainingEnabled,@JsonKey(includeIfNull: false, name: 'nankai_extraordinary_enabled') bool? nankaiExtraordinaryEnabled,@JsonKey(includeIfNull: false, name: 'nankai_regular_enabled') bool? nankaiRegularEnabled,@JsonKey(includeIfNull: false, name: 'vyse60_enabled') bool? vyse60Enabled,@JsonKey(includeIfNull: false, name: 'earthquake_notice_enabled') bool? earthquakeNoticeEnabled
 });
 
 
@@ -274,14 +276,15 @@ class __$NotificationSettingsRequestCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = freezed,Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? hokkaido3renOffshoreEnabled = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = freezed,Object? tsunamiEnabled = freezed,Object? trainingEnabled = freezed,Object? nankaiExtraordinaryEnabled = freezed,Object? nankaiRegularEnabled = freezed,Object? vyse60Enabled = freezed,Object? earthquakeNoticeEnabled = freezed,}) {
   return _then(_NotificationSettingsRequest(
 notificationEnabled: freezed == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,tsunamiEnabled: freezed == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,trainingEnabled: freezed == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiExtraordinaryEnabled: freezed == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,nankaiRegularEnabled: freezed == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
-as bool?,hokkaido3renOffshoreEnabled: freezed == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
+as bool?,vyse60Enabled: freezed == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
+as bool?,earthquakeNoticeEnabled: freezed == earthquakeNoticeEnabled ? _self.earthquakeNoticeEnabled : earthquakeNoticeEnabled // ignore: cast_nullable_to_non_nullable
 as bool?,
   ));
 }

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_request.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_request.g.dart
@@ -29,8 +29,9 @@ _NotificationSettingsRequest _$NotificationSettingsRequestFromJson(
         'nankai_regular_enabled',
         (v) => v as bool?,
       ),
-      hokkaido3renOffshoreEnabled: $checkedConvert(
-        'hokkaido3ren_offshore_enabled',
+      vyse60Enabled: $checkedConvert('vyse60_enabled', (v) => v as bool?),
+      earthquakeNoticeEnabled: $checkedConvert(
+        'earthquake_notice_enabled',
         (v) => v as bool?,
       ),
     );
@@ -42,7 +43,8 @@ _NotificationSettingsRequest _$NotificationSettingsRequestFromJson(
     'trainingEnabled': 'training_enabled',
     'nankaiExtraordinaryEnabled': 'nankai_extraordinary_enabled',
     'nankaiRegularEnabled': 'nankai_regular_enabled',
-    'hokkaido3renOffshoreEnabled': 'hokkaido3ren_offshore_enabled',
+    'vyse60Enabled': 'vyse60_enabled',
+    'earthquakeNoticeEnabled': 'earthquake_notice_enabled',
   },
 );
 
@@ -54,5 +56,6 @@ Map<String, dynamic> _$NotificationSettingsRequestToJson(
   'training_enabled': ?instance.trainingEnabled,
   'nankai_extraordinary_enabled': ?instance.nankaiExtraordinaryEnabled,
   'nankai_regular_enabled': ?instance.nankaiRegularEnabled,
-  'hokkaido3ren_offshore_enabled': ?instance.hokkaido3renOffshoreEnabled,
+  'vyse60_enabled': ?instance.vyse60Enabled,
+  'earthquake_notice_enabled': ?instance.earthquakeNoticeEnabled,
 };

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_response.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_response.dart
@@ -8,21 +8,20 @@ part 'notification_settings_response.freezed.dart';
 part 'notification_settings_response.g.dart';
 
 @Freezed()
-abstract class NotificationSettingsResponse with _$NotificationSettingsResponse {
+abstract class NotificationSettingsResponse
+    with _$NotificationSettingsResponse {
   const factory NotificationSettingsResponse({
-    @JsonKey(name: 'notification_enabled')
-    required bool notificationEnabled,
-    @JsonKey(name: 'tsunami_enabled')
-    required bool tsunamiEnabled,
-    @JsonKey(name: 'training_enabled')
-    required bool trainingEnabled,
+    @JsonKey(name: 'notification_enabled') required bool notificationEnabled,
+    @JsonKey(name: 'tsunami_enabled') required bool tsunamiEnabled,
+    @JsonKey(name: 'training_enabled') required bool trainingEnabled,
     @JsonKey(name: 'nankai_extraordinary_enabled')
     required bool nankaiExtraordinaryEnabled,
-    @JsonKey(name: 'nankai_regular_enabled')
-    required bool nankaiRegularEnabled,
-    @JsonKey(name: 'hokkaido3ren_offshore_enabled')
-    required bool hokkaido3renOffshoreEnabled,
+    @JsonKey(name: 'nankai_regular_enabled') required bool nankaiRegularEnabled,
+    @JsonKey(name: 'vyse60_enabled') required bool vyse60Enabled,
+    @JsonKey(name: 'earthquake_notice_enabled')
+    required bool earthquakeNoticeEnabled,
   }) = _NotificationSettingsResponse;
-  
-  factory NotificationSettingsResponse.fromJson(Map<String, Object?> json) => _$NotificationSettingsResponseFromJson(json);
+
+  factory NotificationSettingsResponse.fromJson(Map<String, Object?> json) =>
+      _$NotificationSettingsResponseFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_response.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NotificationSettingsResponse {
 
-@JsonKey(name: 'notification_enabled') bool get notificationEnabled;@JsonKey(name: 'tsunami_enabled') bool get tsunamiEnabled;@JsonKey(name: 'training_enabled') bool get trainingEnabled;@JsonKey(name: 'nankai_extraordinary_enabled') bool get nankaiExtraordinaryEnabled;@JsonKey(name: 'nankai_regular_enabled') bool get nankaiRegularEnabled;@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool get hokkaido3renOffshoreEnabled;
+@JsonKey(name: 'notification_enabled') bool get notificationEnabled;@JsonKey(name: 'tsunami_enabled') bool get tsunamiEnabled;@JsonKey(name: 'training_enabled') bool get trainingEnabled;@JsonKey(name: 'nankai_extraordinary_enabled') bool get nankaiExtraordinaryEnabled;@JsonKey(name: 'nankai_regular_enabled') bool get nankaiRegularEnabled;@JsonKey(name: 'vyse60_enabled') bool get vyse60Enabled;@JsonKey(name: 'earthquake_notice_enabled') bool get earthquakeNoticeEnabled;
 /// Create a copy of NotificationSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $NotificationSettingsResponseCopyWith<NotificationSettingsResponse> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsResponse&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationSettingsResponse&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled)&&(identical(other.earthquakeNoticeEnabled, earthquakeNoticeEnabled) || other.earthquakeNoticeEnabled == earthquakeNoticeEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled,earthquakeNoticeEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsResponse(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsResponse(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled, earthquakeNoticeEnabled: $earthquakeNoticeEnabled)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $NotificationSettingsResponseCopyWith<$Res>  {
   factory $NotificationSettingsResponseCopyWith(NotificationSettingsResponse value, $Res Function(NotificationSettingsResponse) _then) = _$NotificationSettingsResponseCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'notification_enabled') bool notificationEnabled,@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool hokkaido3renOffshoreEnabled
+@JsonKey(name: 'notification_enabled') bool notificationEnabled,@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'vyse60_enabled') bool vyse60Enabled,@JsonKey(name: 'earthquake_notice_enabled') bool earthquakeNoticeEnabled
 });
 
 
@@ -65,14 +65,15 @@ class _$NotificationSettingsResponseCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,Object? earthquakeNoticeEnabled = null,}) {
   return _then(_self.copyWith(
 notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
-as bool,hokkaido3renOffshoreEnabled: null == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
+as bool,vyse60Enabled: null == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
+as bool,earthquakeNoticeEnabled: null == earthquakeNoticeEnabled ? _self.earthquakeNoticeEnabled : earthquakeNoticeEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -158,10 +159,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'vyse60_enabled')  bool vyse60Enabled, @JsonKey(name: 'earthquake_notice_enabled')  bool earthquakeNoticeEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NotificationSettingsResponse() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   return orElse();
 
 }
@@ -179,10 +180,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'vyse60_enabled')  bool vyse60Enabled, @JsonKey(name: 'earthquake_notice_enabled')  bool earthquakeNoticeEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsResponse():
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +200,10 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled')  bool hokkaido3renOffshoreEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'notification_enabled')  bool notificationEnabled, @JsonKey(name: 'tsunami_enabled')  bool tsunamiEnabled, @JsonKey(name: 'training_enabled')  bool trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled')  bool nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled')  bool nankaiRegularEnabled, @JsonKey(name: 'vyse60_enabled')  bool vyse60Enabled, @JsonKey(name: 'earthquake_notice_enabled')  bool earthquakeNoticeEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _NotificationSettingsResponse() when $default != null:
-return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.hokkaido3renOffshoreEnabled);case _:
+return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEnabled,_that.nankaiExtraordinaryEnabled,_that.nankaiRegularEnabled,_that.vyse60Enabled,_that.earthquakeNoticeEnabled);case _:
   return null;
 
 }
@@ -214,7 +215,7 @@ return $default(_that.notificationEnabled,_that.tsunamiEnabled,_that.trainingEna
 @JsonSerializable()
 
 class _NotificationSettingsResponse implements NotificationSettingsResponse {
-  const _NotificationSettingsResponse({@JsonKey(name: 'notification_enabled') required this.notificationEnabled, @JsonKey(name: 'tsunami_enabled') required this.tsunamiEnabled, @JsonKey(name: 'training_enabled') required this.trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled') required this.nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled') required this.nankaiRegularEnabled, @JsonKey(name: 'hokkaido3ren_offshore_enabled') required this.hokkaido3renOffshoreEnabled});
+  const _NotificationSettingsResponse({@JsonKey(name: 'notification_enabled') required this.notificationEnabled, @JsonKey(name: 'tsunami_enabled') required this.tsunamiEnabled, @JsonKey(name: 'training_enabled') required this.trainingEnabled, @JsonKey(name: 'nankai_extraordinary_enabled') required this.nankaiExtraordinaryEnabled, @JsonKey(name: 'nankai_regular_enabled') required this.nankaiRegularEnabled, @JsonKey(name: 'vyse60_enabled') required this.vyse60Enabled, @JsonKey(name: 'earthquake_notice_enabled') required this.earthquakeNoticeEnabled});
   factory _NotificationSettingsResponse.fromJson(Map<String, dynamic> json) => _$NotificationSettingsResponseFromJson(json);
 
 @override@JsonKey(name: 'notification_enabled') final  bool notificationEnabled;
@@ -222,7 +223,8 @@ class _NotificationSettingsResponse implements NotificationSettingsResponse {
 @override@JsonKey(name: 'training_enabled') final  bool trainingEnabled;
 @override@JsonKey(name: 'nankai_extraordinary_enabled') final  bool nankaiExtraordinaryEnabled;
 @override@JsonKey(name: 'nankai_regular_enabled') final  bool nankaiRegularEnabled;
-@override@JsonKey(name: 'hokkaido3ren_offshore_enabled') final  bool hokkaido3renOffshoreEnabled;
+@override@JsonKey(name: 'vyse60_enabled') final  bool vyse60Enabled;
+@override@JsonKey(name: 'earthquake_notice_enabled') final  bool earthquakeNoticeEnabled;
 
 /// Create a copy of NotificationSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -237,16 +239,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsResponse&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.hokkaido3renOffshoreEnabled, hokkaido3renOffshoreEnabled) || other.hokkaido3renOffshoreEnabled == hokkaido3renOffshoreEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationSettingsResponse&&(identical(other.notificationEnabled, notificationEnabled) || other.notificationEnabled == notificationEnabled)&&(identical(other.tsunamiEnabled, tsunamiEnabled) || other.tsunamiEnabled == tsunamiEnabled)&&(identical(other.trainingEnabled, trainingEnabled) || other.trainingEnabled == trainingEnabled)&&(identical(other.nankaiExtraordinaryEnabled, nankaiExtraordinaryEnabled) || other.nankaiExtraordinaryEnabled == nankaiExtraordinaryEnabled)&&(identical(other.nankaiRegularEnabled, nankaiRegularEnabled) || other.nankaiRegularEnabled == nankaiRegularEnabled)&&(identical(other.vyse60Enabled, vyse60Enabled) || other.vyse60Enabled == vyse60Enabled)&&(identical(other.earthquakeNoticeEnabled, earthquakeNoticeEnabled) || other.earthquakeNoticeEnabled == earthquakeNoticeEnabled));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,hokkaido3renOffshoreEnabled);
+int get hashCode => Object.hash(runtimeType,notificationEnabled,tsunamiEnabled,trainingEnabled,nankaiExtraordinaryEnabled,nankaiRegularEnabled,vyse60Enabled,earthquakeNoticeEnabled);
 
 @override
 String toString() {
-  return 'NotificationSettingsResponse(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, hokkaido3renOffshoreEnabled: $hokkaido3renOffshoreEnabled)';
+  return 'NotificationSettingsResponse(notificationEnabled: $notificationEnabled, tsunamiEnabled: $tsunamiEnabled, trainingEnabled: $trainingEnabled, nankaiExtraordinaryEnabled: $nankaiExtraordinaryEnabled, nankaiRegularEnabled: $nankaiRegularEnabled, vyse60Enabled: $vyse60Enabled, earthquakeNoticeEnabled: $earthquakeNoticeEnabled)';
 }
 
 
@@ -257,7 +259,7 @@ abstract mixin class _$NotificationSettingsResponseCopyWith<$Res> implements $No
   factory _$NotificationSettingsResponseCopyWith(_NotificationSettingsResponse value, $Res Function(_NotificationSettingsResponse) _then) = __$NotificationSettingsResponseCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'notification_enabled') bool notificationEnabled,@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'hokkaido3ren_offshore_enabled') bool hokkaido3renOffshoreEnabled
+@JsonKey(name: 'notification_enabled') bool notificationEnabled,@JsonKey(name: 'tsunami_enabled') bool tsunamiEnabled,@JsonKey(name: 'training_enabled') bool trainingEnabled,@JsonKey(name: 'nankai_extraordinary_enabled') bool nankaiExtraordinaryEnabled,@JsonKey(name: 'nankai_regular_enabled') bool nankaiRegularEnabled,@JsonKey(name: 'vyse60_enabled') bool vyse60Enabled,@JsonKey(name: 'earthquake_notice_enabled') bool earthquakeNoticeEnabled
 });
 
 
@@ -274,14 +276,15 @@ class __$NotificationSettingsResponseCopyWithImpl<$Res>
 
 /// Create a copy of NotificationSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? hokkaido3renOffshoreEnabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? notificationEnabled = null,Object? tsunamiEnabled = null,Object? trainingEnabled = null,Object? nankaiExtraordinaryEnabled = null,Object? nankaiRegularEnabled = null,Object? vyse60Enabled = null,Object? earthquakeNoticeEnabled = null,}) {
   return _then(_NotificationSettingsResponse(
 notificationEnabled: null == notificationEnabled ? _self.notificationEnabled : notificationEnabled // ignore: cast_nullable_to_non_nullable
 as bool,tsunamiEnabled: null == tsunamiEnabled ? _self.tsunamiEnabled : tsunamiEnabled // ignore: cast_nullable_to_non_nullable
 as bool,trainingEnabled: null == trainingEnabled ? _self.trainingEnabled : trainingEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiExtraordinaryEnabled: null == nankaiExtraordinaryEnabled ? _self.nankaiExtraordinaryEnabled : nankaiExtraordinaryEnabled // ignore: cast_nullable_to_non_nullable
 as bool,nankaiRegularEnabled: null == nankaiRegularEnabled ? _self.nankaiRegularEnabled : nankaiRegularEnabled // ignore: cast_nullable_to_non_nullable
-as bool,hokkaido3renOffshoreEnabled: null == hokkaido3renOffshoreEnabled ? _self.hokkaido3renOffshoreEnabled : hokkaido3renOffshoreEnabled // ignore: cast_nullable_to_non_nullable
+as bool,vyse60Enabled: null == vyse60Enabled ? _self.vyse60Enabled : vyse60Enabled // ignore: cast_nullable_to_non_nullable
+as bool,earthquakeNoticeEnabled: null == earthquakeNoticeEnabled ? _self.earthquakeNoticeEnabled : earthquakeNoticeEnabled // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/packages/eqmonitor_api/lib/src/models/notification_settings_response.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/notification_settings_response.g.dart
@@ -29,8 +29,9 @@ _NotificationSettingsResponse _$NotificationSettingsResponseFromJson(
         'nankai_regular_enabled',
         (v) => v as bool,
       ),
-      hokkaido3renOffshoreEnabled: $checkedConvert(
-        'hokkaido3ren_offshore_enabled',
+      vyse60Enabled: $checkedConvert('vyse60_enabled', (v) => v as bool),
+      earthquakeNoticeEnabled: $checkedConvert(
+        'earthquake_notice_enabled',
         (v) => v as bool,
       ),
     );
@@ -42,7 +43,8 @@ _NotificationSettingsResponse _$NotificationSettingsResponseFromJson(
     'trainingEnabled': 'training_enabled',
     'nankaiExtraordinaryEnabled': 'nankai_extraordinary_enabled',
     'nankaiRegularEnabled': 'nankai_regular_enabled',
-    'hokkaido3renOffshoreEnabled': 'hokkaido3ren_offshore_enabled',
+    'vyse60Enabled': 'vyse60_enabled',
+    'earthquakeNoticeEnabled': 'earthquake_notice_enabled',
   },
 );
 
@@ -54,5 +56,6 @@ Map<String, dynamic> _$NotificationSettingsResponseToJson(
   'training_enabled': instance.trainingEnabled,
   'nankai_extraordinary_enabled': instance.nankaiExtraordinaryEnabled,
   'nankai_regular_enabled': instance.nankaiRegularEnabled,
-  'hokkaido3ren_offshore_enabled': instance.hokkaido3renOffshoreEnabled,
+  'vyse60_enabled': instance.vyse60Enabled,
+  'earthquake_notice_enabled': instance.earthquakeNoticeEnabled,
 };

--- a/packages/eqmonitor_api/lib/src/models/shindo_db_station.dart
+++ b/packages/eqmonitor_api/lib/src/models/shindo_db_station.dart
@@ -14,7 +14,9 @@ abstract class ShindoDbStation with _$ShindoDbStation {
     required String name,
     required num latitude,
     required num longitude,
+    @JsonKey(includeIfNull: true, name: 'city_code') required String? cityCode,
   }) = _ShindoDbStation;
-  
-  factory ShindoDbStation.fromJson(Map<String, Object?> json) => _$ShindoDbStationFromJson(json);
+
+  factory ShindoDbStation.fromJson(Map<String, Object?> json) =>
+      _$ShindoDbStationFromJson(json);
 }

--- a/packages/eqmonitor_api/lib/src/models/shindo_db_station.freezed.dart
+++ b/packages/eqmonitor_api/lib/src/models/shindo_db_station.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ShindoDbStation {
 
- String get code; String get name; num get latitude; num get longitude;
+ String get code; String get name; num get latitude; num get longitude;@JsonKey(includeIfNull: true, name: 'city_code') String? get cityCode;
 /// Create a copy of ShindoDbStation
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ShindoDbStationCopyWith<ShindoDbStation> get copyWith => _$ShindoDbStationCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ShindoDbStation&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ShindoDbStation&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,code,name,latitude,longitude);
+int get hashCode => Object.hash(runtimeType,code,name,latitude,longitude,cityCode);
 
 @override
 String toString() {
-  return 'ShindoDbStation(code: $code, name: $name, latitude: $latitude, longitude: $longitude)';
+  return 'ShindoDbStation(code: $code, name: $name, latitude: $latitude, longitude: $longitude, cityCode: $cityCode)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ShindoDbStationCopyWith<$Res>  {
   factory $ShindoDbStationCopyWith(ShindoDbStation value, $Res Function(ShindoDbStation) _then) = _$ShindoDbStationCopyWithImpl;
 @useResult
 $Res call({
- String code, String name, num latitude, num longitude
+ String code, String name, num latitude, num longitude,@JsonKey(includeIfNull: true, name: 'city_code') String? cityCode
 });
 
 
@@ -65,13 +65,14 @@ class _$ShindoDbStationCopyWithImpl<$Res>
 
 /// Create a copy of ShindoDbStation
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? code = null,Object? name = null,Object? latitude = null,Object? longitude = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? code = null,Object? name = null,Object? latitude = null,Object? longitude = null,Object? cityCode = freezed,}) {
   return _then(_self.copyWith(
 code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
 as num,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
-as num,
+as num,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -156,10 +157,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String code,  String name,  num latitude,  num longitude)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String code,  String name,  num latitude,  num longitude, @JsonKey(includeIfNull: true, name: 'city_code')  String? cityCode)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ShindoDbStation() when $default != null:
-return $default(_that.code,_that.name,_that.latitude,_that.longitude);case _:
+return $default(_that.code,_that.name,_that.latitude,_that.longitude,_that.cityCode);case _:
   return orElse();
 
 }
@@ -177,10 +178,10 @@ return $default(_that.code,_that.name,_that.latitude,_that.longitude);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String code,  String name,  num latitude,  num longitude)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String code,  String name,  num latitude,  num longitude, @JsonKey(includeIfNull: true, name: 'city_code')  String? cityCode)  $default,) {final _that = this;
 switch (_that) {
 case _ShindoDbStation():
-return $default(_that.code,_that.name,_that.latitude,_that.longitude);case _:
+return $default(_that.code,_that.name,_that.latitude,_that.longitude,_that.cityCode);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -197,10 +198,10 @@ return $default(_that.code,_that.name,_that.latitude,_that.longitude);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String code,  String name,  num latitude,  num longitude)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String code,  String name,  num latitude,  num longitude, @JsonKey(includeIfNull: true, name: 'city_code')  String? cityCode)?  $default,) {final _that = this;
 switch (_that) {
 case _ShindoDbStation() when $default != null:
-return $default(_that.code,_that.name,_that.latitude,_that.longitude);case _:
+return $default(_that.code,_that.name,_that.latitude,_that.longitude,_that.cityCode);case _:
   return null;
 
 }
@@ -212,13 +213,14 @@ return $default(_that.code,_that.name,_that.latitude,_that.longitude);case _:
 @JsonSerializable()
 
 class _ShindoDbStation implements ShindoDbStation {
-  const _ShindoDbStation({required this.code, required this.name, required this.latitude, required this.longitude});
+  const _ShindoDbStation({required this.code, required this.name, required this.latitude, required this.longitude, @JsonKey(includeIfNull: true, name: 'city_code') required this.cityCode});
   factory _ShindoDbStation.fromJson(Map<String, dynamic> json) => _$ShindoDbStationFromJson(json);
 
 @override final  String code;
 @override final  String name;
 @override final  num latitude;
 @override final  num longitude;
+@override@JsonKey(includeIfNull: true, name: 'city_code') final  String? cityCode;
 
 /// Create a copy of ShindoDbStation
 /// with the given fields replaced by the non-null parameter values.
@@ -233,16 +235,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ShindoDbStation&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ShindoDbStation&&(identical(other.code, code) || other.code == code)&&(identical(other.name, name) || other.name == name)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.cityCode, cityCode) || other.cityCode == cityCode));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,code,name,latitude,longitude);
+int get hashCode => Object.hash(runtimeType,code,name,latitude,longitude,cityCode);
 
 @override
 String toString() {
-  return 'ShindoDbStation(code: $code, name: $name, latitude: $latitude, longitude: $longitude)';
+  return 'ShindoDbStation(code: $code, name: $name, latitude: $latitude, longitude: $longitude, cityCode: $cityCode)';
 }
 
 
@@ -253,7 +255,7 @@ abstract mixin class _$ShindoDbStationCopyWith<$Res> implements $ShindoDbStation
   factory _$ShindoDbStationCopyWith(_ShindoDbStation value, $Res Function(_ShindoDbStation) _then) = __$ShindoDbStationCopyWithImpl;
 @override @useResult
 $Res call({
- String code, String name, num latitude, num longitude
+ String code, String name, num latitude, num longitude,@JsonKey(includeIfNull: true, name: 'city_code') String? cityCode
 });
 
 
@@ -270,13 +272,14 @@ class __$ShindoDbStationCopyWithImpl<$Res>
 
 /// Create a copy of ShindoDbStation
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? code = null,Object? name = null,Object? latitude = null,Object? longitude = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? code = null,Object? name = null,Object? latitude = null,Object? longitude = null,Object? cityCode = freezed,}) {
   return _then(_ShindoDbStation(
 code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
 as num,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
-as num,
+as num,cityCode: freezed == cityCode ? _self.cityCode : cityCode // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/packages/eqmonitor_api/lib/src/models/shindo_db_station.g.dart
+++ b/packages/eqmonitor_api/lib/src/models/shindo_db_station.g.dart
@@ -15,9 +15,10 @@ _ShindoDbStation _$ShindoDbStationFromJson(Map<String, dynamic> json) =>
         name: $checkedConvert('name', (v) => v as String),
         latitude: $checkedConvert('latitude', (v) => v as num),
         longitude: $checkedConvert('longitude', (v) => v as num),
+        cityCode: $checkedConvert('city_code', (v) => v as String?),
       );
       return val;
-    });
+    }, fieldKeyMap: const {'cityCode': 'city_code'});
 
 Map<String, dynamic> _$ShindoDbStationToJson(_ShindoDbStation instance) =>
     <String, dynamic>{
@@ -25,4 +26,5 @@ Map<String, dynamic> _$ShindoDbStationToJson(_ShindoDbStation instance) =>
       'name': instance.name,
       'latitude': instance.latitude,
       'longitude': instance.longitude,
+      'city_code': instance.cityCode,
     };


### PR DESCRIPTION
## 概要

backend の通知設定API (`/v2/device/me/settings/notification`) スキーマ変更にアプリを追従させます。

| コミット | 内容 |
|---|---|
| `ade6026d` | backend サブモジュールを最新 main (`b2a27809`) に更新 |
| `0d2c6a80` | `hokkaido3ren_offshore_enabled` → `vyse60_enabled` リネーム追従 + OpenAPI からAPIクライアント再生成 |
| `67ee862a` | VZSE40「地震・津波に関するお知らせ」の通知設定 (`earthquake_notice_enabled`) をモデル→Notifier→Repository→設定画面UIに配線 |

## 背景（調査結果）

backend 側で直近に以下の変更が入ったが、アプリが未追従だった:

- **`vyse60_enabled` へのリネーム** (backend `6bef0421`): アプリの生成済み `NotificationSettingsResponse` は旧フィールド `hokkaido3ren_offshore_enabled` を**非nullable必須**でパースするため、backend デプロイ後は通知設定 GET がパースエラーになる（**クラッシュ級の不具合リスク**）→ 本PRで解消
- **`earthquake_notice_enabled` の新規追加** (backend `a5c9d039`, デフォルトOFF=オプトイン): アプリから設定不可だった → 設定画面の一般通知セクションに「地震・津波に関するお知らせ」トグルを追加（既存の北海道・三陸沖タイルと同一パターン）

## テスト

- app: `flutter test test/feature/notification/ test/feature/settings/features/notification_settings/` **42件成功**（新規: `updateSettings(earthquakeNoticeEnabled:)` が PATCH を発行し state 更新されることの TDD テスト）
- `packages/eqmonitor_api`: `dart analyze` クリーン
- app の `dart analyze` はローカル環境の analysis server ハング問題（別途調査中）により未実施 → **CI での確認をお願いします**
- 既知: `packages/eqmonitor_api` に **pre-existing の契約テスト失敗17件**（EEW/津波/changelog系、develop時点から存在、本PRとは無関係と検証済み）

## ⚠️ リリースゲート（重要）

`earthquake_notice_enabled` は Response で必須フィールドとして生成されるため、**backend `b2a27809` 以降が本番デプロイされる前にこのアプリバージョンが配布されると**、通知設定 GET がパース失敗し一般通知セクションが無限ローディングになります（クラッシュはしない）。リリース時は backend が先行デプロイ済みであることを確認してください。

## フォローアップ候補（本PR対象外）

1. `_GeneralNotificationSettingsSection` が `AsyncError` と `AsyncLoading` を区別せず無限スピナーになる問題の改善（エラー表示+リトライ導線）
2. pre-existing 契約テスト失敗17件の Issue 化と修正
3. backend 側 contract-fixtures に device settings 系エンドポイントが無く、契約ドリフトをCIで検知できない（今回の不整合もCIをすり抜けた）→ backend リポジトリでの fixture 追加
4. VZSE40 タイルの詳細リンクは汎用の「配信資料に関する仕様」ページ（固有仕様PDFが特定できなかったため）。固有資料の公開が確認できたらURL更新
5. 調査で検出した状態管理/UXの改善候補: 通知プリセットの自動サイレント変更（OS権限OFFで設定画面を開くだけでサーバー設定が「通知しない」に書き換わる副作用）、スロット更新の stale-read 競合、`invalidateSelf()` による冗長GET

🤖 Generated with [Claude Code](https://claude.com/claude-code)
