### PR TITLE
fix: 指定地域(都道府県/市区町村)選択時の例外を修正

### DIFF
--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart
@@ -132,7 +132,7 @@ class EarthquakeHistoryNotifier extends _$EarthquakeHistoryNotifier {
           sortOrder: parameter.sortOrder,
         ),
       EarthquakeHistoryParameterCity(:final String cityCode) =>
-        repository.searchByRegion(
+        repository.searchByCity(
           code: cityCode,
           limit: limit,
           cursor: cursor,

--- a/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
+++ b/app/lib/feature/home/ui/component/sheet/home_earthquake_history_sheet.dart
@@ -2,7 +2,9 @@ import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter_x.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/region_name_resolver.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_not_found.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
@@ -30,15 +32,12 @@ class HomeEarthquakeHistorySheet extends HookConsumerWidget {
     return homeAsync.when(
       data: (home) {
         final scope = home.common.earthquakeHistoryScope;
-        // TODO: 地域名を取得する
-        final locationName = switch (paramAsync.value) {
-          EarthquakeHistoryParameterAll() || null => null,
-          EarthquakeHistoryParameterRegion(:final regionCode) => regionCode,
-          EarthquakeHistoryParameterPrefecture(:final prefectureCode) =>
-            prefectureCode,
-          EarthquakeHistoryParameterCity(:final cityCode) => cityCode,
-          EarthquakeHistoryParameterStation(:final stationCode) => stationCode,
-        };
+        // 地域コードから名称を解決する。解決できない場合はコードをそのまま表示。
+        final selection = paramAsync.value?.regionSelection;
+        final locationName = selection != null
+            ? ref.watch(regionNameProvider(selection.$1, selection.$2)).value ??
+                  selection.$2
+            : null;
 
         Future<void> openRegionPicker() async {
           final result = await HomeDesignatedRegionPickerPage.show(

--- a/app/lib/feature/home/ui/page/home_designated_region_picker_page.dart
+++ b/app/lib/feature/home/ui/page/home_designated_region_picker_page.dart
@@ -1,6 +1,7 @@
 import 'package:eqmonitor/core/component/selector/city_selector.dart';
 import 'package:eqmonitor/core/component/selector/prefecture_selector.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/region_name_resolver.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/region_picker_map_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -47,14 +48,17 @@ class HomeDesignatedRegionPickerPage extends HookConsumerWidget {
         prefectureCode,
       _ => null,
     });
-    // TODO: 地域名を取得する
-    final selectedName = useState<String?>(switch (initialParameter) {
-      EarthquakeHistoryParameterCity(:final cityCode) => cityCode,
-      EarthquakeHistoryParameterRegion(:final regionCode) => regionCode,
-      EarthquakeHistoryParameterPrefecture(:final prefectureCode) =>
-        prefectureCode,
-      _ => null,
-    });
+    // ユーザー操作で明示的に設定された地域名。未設定時は [resolvedName] で補完する。
+    final selectedName = useState<String?>(null);
+    // selectedCode/selectedType からパラメータ木を辿って地域名を解決する。
+    // (初期パラメータ復元時など selectedName が未設定のケースを補完する)
+    final resolvedName =
+        (selectedCode.value != null && selectedCode.value!.isNotEmpty)
+        ? ref
+              .watch(regionNameProvider(selectedType.value, selectedCode.value!))
+              .value
+        : null;
+    final displayName = selectedName.value ?? resolvedName;
 
     Future<void> openMap() async {
       final result = await RegionPickerMapPage.show(
@@ -72,23 +76,46 @@ class HomeDesignatedRegionPickerPage extends HookConsumerWidget {
     final canApply =
         selectedCode.value != null && selectedCode.value!.isNotEmpty;
 
+    /// 選択中の種別([selectedType])とコードから対応する
+    /// [EarthquakeHistoryParameter] を生成する。
+    EarthquakeHistoryParameter buildParameter() {
+      final code =
+          selectedCode.value ??
+          () {
+            throw Exception('code is null');
+          }();
+      return switch (selectedType.value) {
+        RegionSearchType.prefecture => EarthquakeHistoryParameter.prefecture(
+          sortBy: .eventId,
+          sortOrder: .desc,
+          prefectureCode: code,
+        ),
+        RegionSearchType.city => EarthquakeHistoryParameter.city(
+          sortBy: .eventId,
+          sortOrder: .desc,
+          cityCode: code,
+        ),
+        RegionSearchType.region => EarthquakeHistoryParameter.region(
+          sortBy: .eventId,
+          sortOrder: .desc,
+          regionCode: code,
+        ),
+        RegionSearchType.station => EarthquakeHistoryParameter.station(
+          sortBy: .eventId,
+          sortOrder: .desc,
+          stationCode: code,
+        ),
+      };
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('指定地域を選択'),
         actions: [
           if (canApply)
             TextButton(
-              onPressed: () => Navigator.of(context).pop(
-                EarthquakeHistoryParameter.city(
-                  sortBy: .eventId,
-                  sortOrder: .desc,
-                  cityCode:
-                      selectedCode.value ??
-                      () {
-                        throw Exception('city code is null');
-                      }(),
-                ),
-              ),
+              onPressed: () =>
+                  Navigator.of(context).pop(buildParameter()),
               child: const Text('決定'),
             ),
         ],
@@ -164,11 +191,11 @@ class HomeDesignatedRegionPickerPage extends HookConsumerWidget {
               label: const Text('地図から選択'),
             ),
             const SizedBox(height: 16),
-            if (selectedName.value != null && selectedName.value!.isNotEmpty)
+            if (displayName != null && displayName.isNotEmpty)
               Card(
                 child: ListTile(
                   leading: const Icon(Icons.place_outlined),
-                  title: Text(selectedName.value!),
+                  title: Text(displayName),
                   subtitle: Text(
                     selectedType.value == RegionSearchType.prefecture
                         ? '都道府県'
@@ -187,21 +214,12 @@ class HomeDesignatedRegionPickerPage extends HookConsumerWidget {
             const SizedBox(height: 24),
             FilledButton(
               onPressed: canApply
-                  ? () => Navigator.of(context).pop(
-                      EarthquakeHistoryParameter.city(
-                        sortBy: .eventId,
-                        sortOrder: .desc,
-                        cityCode:
-                            selectedCode.value ??
-                            () {
-                              throw Exception('city code is null');
-                            }(),
-                      ),
-                    )
+                  ? () => Navigator.of(context).pop(buildParameter())
                   : null,
               child: const Text('この地域を設定する'),
             ),
-            if (initialParameter is EarthquakeHistoryParameterCity) ...[
+            if (initialParameter is EarthquakeHistoryParameterCity ||
+                initialParameter is EarthquakeHistoryParameterPrefecture) ...[
               const SizedBox(height: 8),
               OutlinedButton(
                 onPressed: () => Navigator.of(context).pop(

--- a/app/test/feature/earthquake_history/earthquake_history_notifier_fetch_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_notifier_fetch_test.dart
@@ -1,0 +1,305 @@
+import 'package:core/core.dart';
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart' as app;
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_search_response.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_metadata.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:eqmonitor/feature/parameter/data/model/shindo_db/shindo_db_stations_parameter.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// [EarthquakeHistoryNotifier] の地域種別ごとのルーティングを検証する。
+///
+/// DataSource 側 (`earthquake_history_data_source_fetch_test.dart`) には
+/// 同等のテストが存在していたが、Notifier 側には無かったため
+/// `City` が `searchByRegion` に誤ルーティングされる不具合
+/// (Exception: Region not found) を長期間見逃していた。
+/// 本テストはその回帰防止を目的とする。
+void main() {
+  Future<_SpyEarthquakeHistoryRepository> readWith(
+    EarthquakeHistoryParameter parameter,
+  ) async {
+    final repository = _SpyEarthquakeHistoryRepository();
+    final container = ProviderContainer(
+      overrides: [
+        earthquakeHistoryRepositoryProvider.overrideWith(
+          (ref) async => repository,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(earthquakeHistoryProvider(parameter).future);
+    return repository;
+  }
+
+  // 回帰テスト本命: City は searchByCity に流れ、searchByRegion は呼ばれない。
+  test(
+    'EarthquakeHistoryParameterCity calls searchByCity, not searchByRegion',
+    () async {
+      final repository = await readWith(
+        const EarthquakeHistoryParameter.city(
+          sortBy: EarthquakeSortBy.eventId,
+          sortOrder: SortOrder.desc,
+          cityCode: '4720100',
+        ),
+      );
+
+      expect(
+        repository.searchByCityCodes,
+        equals(['4720100']),
+        reason: 'searchByCity should be called with the city code',
+      );
+      expect(
+        repository.searchByRegionCodes,
+        isEmpty,
+        reason: 'searchByRegion must NOT be called for City parameter',
+      );
+    },
+  );
+
+  test('EarthquakeHistoryParameterPrefecture calls searchByPrefecture', () async {
+    final repository = await readWith(
+      const EarthquakeHistoryParameter.prefecture(
+        sortBy: EarthquakeSortBy.eventId,
+        sortOrder: SortOrder.desc,
+        prefectureCode: '14',
+      ),
+    );
+
+    expect(repository.searchByPrefectureCodes, equals(['14']));
+    expect(repository.searchByRegionCodes, isEmpty);
+    expect(repository.searchByCityCodes, isEmpty);
+  });
+
+  test('EarthquakeHistoryParameterRegion calls searchByRegion', () async {
+    final repository = await readWith(
+      const EarthquakeHistoryParameter.region(
+        sortBy: EarthquakeSortBy.eventId,
+        sortOrder: SortOrder.desc,
+        regionCode: '250',
+      ),
+    );
+
+    expect(repository.searchByRegionCodes, equals(['250']));
+    expect(repository.searchByCityCodes, isEmpty);
+  });
+
+  test('EarthquakeHistoryParameterStation calls searchByStation', () async {
+    final repository = await readWith(
+      const EarthquakeHistoryParameter.station(
+        sortBy: EarthquakeSortBy.eventId,
+        sortOrder: SortOrder.desc,
+        stationCode: '4720100',
+      ),
+    );
+
+    expect(repository.searchByStationCodes, equals(['4720100']));
+    expect(repository.searchByRegionCodes, isEmpty);
+    expect(repository.searchByCityCodes, isEmpty);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Spy – EarthquakeHistoryRepository の search メソッド呼び出しを記録する。
+// ---------------------------------------------------------------------------
+
+final class _SpyEarthquakeHistoryRepository
+    extends EarthquakeHistoryRepository {
+  _SpyEarthquakeHistoryRepository()
+    : super(
+        earthquake: api.ApiClient(Dio()).earthquake,
+        earthquakeParameter: _earthquakeParameter,
+        shindoDbStations: _shindoDbStations,
+      );
+
+  final searchByRegionCodes = <String>[];
+  final searchByPrefectureCodes = <String>[];
+  final searchByCityCodes = <String>[];
+  final searchByStationCodes = <String>[];
+
+  @override
+  Future<PaginatedResponse<EarthquakePartialRegion>> searchByRegion({
+    required String code,
+    int? limit,
+    String? cursor,
+    double? magnitudeGte,
+    double? magnitudeLte,
+    int? depthGte,
+    int? depthLte,
+    JmaIntensity? intensityGte,
+    JmaIntensity? intensityLte,
+    List<app.TelegramStatus>? statuses,
+    List<int>? epicenterCodes,
+    EarthquakeType? earthquakeType,
+    Date? originTimeGte,
+    Date? originTimeLte,
+    JmaLpgmIntensity? maxLpgmIntensityGte,
+    JmaLpgmIntensity? maxLpgmIntensityLte,
+    EarthquakeSortBy? sortBy,
+    SortOrder? sortOrder,
+  }) async {
+    searchByRegionCodes.add(code);
+    return PaginatedResponse(
+      items: [
+        EarthquakePartialRegion(
+          regionIntensity: JmaIntensity.three,
+          earthquake: _makeEarthquake('event-region'),
+        ),
+      ],
+      nextToken: null,
+    );
+  }
+
+  @override
+  Future<PaginatedResponse<EarthquakePartialPrefecture>> searchByPrefecture({
+    required String code,
+    int? limit,
+    String? cursor,
+    double? magnitudeGte,
+    double? magnitudeLte,
+    int? depthGte,
+    int? depthLte,
+    JmaIntensity? intensityGte,
+    JmaIntensity? intensityLte,
+    List<app.TelegramStatus>? statuses,
+    List<int>? epicenterCodes,
+    EarthquakeType? earthquakeType,
+    Date? originTimeGte,
+    Date? originTimeLte,
+    JmaLpgmIntensity? maxLpgmIntensityGte,
+    JmaLpgmIntensity? maxLpgmIntensityLte,
+    EarthquakeSortBy? sortBy,
+    SortOrder? sortOrder,
+  }) async {
+    searchByPrefectureCodes.add(code);
+    return PaginatedResponse(
+      items: [
+        EarthquakePartialPrefecture(
+          prefectureIntensity: JmaIntensity.three,
+          earthquake: _makeEarthquake('event-prefecture'),
+        ),
+      ],
+      nextToken: null,
+    );
+  }
+
+  @override
+  Future<PaginatedResponse<EarthquakePartialRegion>> searchByCity({
+    required String code,
+    int? limit,
+    String? cursor,
+    double? magnitudeGte,
+    double? magnitudeLte,
+    int? depthGte,
+    int? depthLte,
+    JmaIntensity? intensityGte,
+    JmaIntensity? intensityLte,
+    List<app.TelegramStatus>? statuses,
+    List<int>? epicenterCodes,
+    EarthquakeType? earthquakeType,
+    Date? originTimeGte,
+    Date? originTimeLte,
+    JmaLpgmIntensity? maxLpgmIntensityGte,
+    JmaLpgmIntensity? maxLpgmIntensityLte,
+    EarthquakeSortBy? sortBy,
+    SortOrder? sortOrder,
+  }) async {
+    searchByCityCodes.add(code);
+    return PaginatedResponse(
+      items: [
+        EarthquakePartialRegion(
+          regionIntensity: JmaIntensity.three,
+          earthquake: _makeEarthquake('event-city'),
+        ),
+      ],
+      nextToken: null,
+    );
+  }
+
+  @override
+  Future<PaginatedResponse<EarthquakePartialStation>> searchByStation({
+    required String code,
+    int? limit,
+    String? cursor,
+    double? magnitudeGte,
+    double? magnitudeLte,
+    int? depthGte,
+    int? depthLte,
+    JmaIntensity? intensityGte,
+    JmaIntensity? intensityLte,
+    List<app.TelegramStatus>? statuses,
+    List<int>? epicenterCodes,
+    EarthquakeType? earthquakeType,
+    Date? originTimeGte,
+    Date? originTimeLte,
+    JmaLpgmIntensity? maxLpgmIntensityGte,
+    JmaLpgmIntensity? maxLpgmIntensityLte,
+    EarthquakeSortBy? sortBy,
+    SortOrder? sortOrder,
+  }) async {
+    searchByStationCodes.add(code);
+    return PaginatedResponse(
+      items: [
+        EarthquakePartialStation(
+          stationIntensity: JmaIntensity.three,
+          earthquake: _makeEarthquake('event-station'),
+        ),
+      ],
+      nextToken: null,
+    );
+  }
+}
+
+const _parameterMetadata = ParameterMetadata(
+  type: ParameterType.jmaCodeTable,
+  schemaVersion: 1,
+  sourceVersion: 'test',
+  sourceUpdatedAt: null,
+  sourceUrls: [],
+  sha256: 'test',
+);
+
+const _earthquakeParameter = EarthquakeParameter(
+  metadata: _parameterMetadata,
+  prefectures: [],
+);
+
+const _shindoDbStations = ShindoDbStationsParameter(
+  metadata: ParameterMetadata(
+    type: ParameterType.shindoDbStations,
+    schemaVersion: 1,
+    sourceVersion: 'test',
+    sourceUpdatedAt: null,
+    sourceUrls: [],
+    sha256: 'test',
+  ),
+  stations: [],
+);
+
+EarthquakePartialNormal _makeEarthquake(String eventId) =>
+    EarthquakePartialNormal(
+      eventId: eventId,
+      status: app.TelegramStatus.normal,
+      originTime: null,
+      originTimePrecision: OriginTimePrecision.second,
+      arrivalTime: null,
+      dataSources: [EarthquakeDataSource.jmaDisasterInformationXml],
+      hypocenter: null,
+      intensity: null,
+      earthquakeType: EarthquakeType.normal,
+      telegramTypes: const [],
+      estimatedIntensityTileUrl: null,
+    );

--- a/app/test/feature/home/ui/home_designated_region_picker_page_test.dart
+++ b/app/test/feature/home/ui/home_designated_region_picker_page_test.dart
@@ -1,0 +1,92 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:eqmonitor/feature/home/ui/page/home_designated_region_picker_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 「指定地域を選択」ページが、選択中の種別に応じた
+/// [EarthquakeHistoryParameter] を返すことを検証する。
+///
+/// 以前は種別に関わらず常に `.city()` を生成していたため、
+/// 都道府県コード (2桁) が cityCode として保存され
+/// `Exception: Region not found` の原因となっていた。
+void main() {
+  Future<EarthquakeHistoryParameter?> pickWith(
+    WidgetTester tester,
+    EarthquakeHistoryParameter initialParameter,
+  ) async {
+    EarthquakeHistoryParameter? result;
+    var picked = false;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () async {
+                    result = await HomeDesignatedRegionPickerPage.show(
+                      context,
+                      initialParameter: initialParameter,
+                    );
+                    picked = true;
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    // 画面遷移アニメーション完了(無限スピナーがあるため pumpAndSettle は使わない)
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    await tester.tap(find.text('決定'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(picked, isTrue, reason: 'ページが結果を返して閉じるべき');
+    return result;
+  }
+
+  testWidgets('都道府県を初期選択して決定すると Prefecture パラメータを返す', (tester) async {
+    final result = await pickWith(
+      tester,
+      const EarthquakeHistoryParameter.prefecture(
+        sortBy: EarthquakeSortBy.eventId,
+        sortOrder: SortOrder.desc,
+        prefectureCode: '14',
+      ),
+    );
+
+    expect(result, isA<EarthquakeHistoryParameterPrefecture>());
+    expect(
+      (result as EarthquakeHistoryParameterPrefecture).prefectureCode,
+      equals('14'),
+    );
+  });
+
+  testWidgets('市区町村を初期選択して決定すると City パラメータを返す', (tester) async {
+    final result = await pickWith(
+      tester,
+      const EarthquakeHistoryParameter.city(
+        sortBy: EarthquakeSortBy.eventId,
+        sortOrder: SortOrder.desc,
+        cityCode: '1410000',
+      ),
+    );
+
+    expect(result, isA<EarthquakeHistoryParameterCity>());
+    expect(
+      (result as EarthquakeHistoryParameterCity).cityCode,
+      equals('1410000'),
+    );
+  });
+}


### PR DESCRIPTION
## 概要

「指定地域を選択」で都道府県・市区町村を指定すると `Exception: Region not found: 14` が発生し地震履歴が表示されない不具合を修正します。

## 原因

2つの独立したバグが合流していました。

### 🔴 バグ1: ピッカーが常に `.city()` を返す
`home_designated_region_picker_page.dart` の決定/設定ボタンが、選択種別 (`selectedType`) を無視して常に `EarthquakeHistoryParameter.city()` を生成していた。都道府県選択時は 2桁の都道府県コード（例: `14` = 神奈川）が `cityCode` として保存・永続化されていた。

### 🔴 バグ2: Notifier が City を `searchByRegion` に誤ルーティング
`earthquake_history_notifier.dart` が `EarthquakeHistoryParameterCity` を `searchByCity` ではなく `searchByRegion` に流していた。`searchByRegion` は3桁の細分化地域コードを検索するため一致せず `throw Exception('Region not found: $code')`。

> DataSource 側 (`earthquake_history_data_source.dart`) は元々 `searchByCity` を使っており、Notifier だけが不整合だった。

### 合流フロー
都道府県 `14` を選択 → バグ1で `.city(cityCode: "14")` を保存 → ホーム地震履歴シート（Notifier 使用）がバグ2で `searchByRegion("14")` → `Region not found: 14`。

## 修正内容

- **バグ1**: 選択種別に応じて `prefecture` / `city`（`region` / `station` も網羅）のパラメータを出し分ける `buildParameter()` に置き換え。都道府県指定時も「設定を解除する」を表示。
- **バグ2**: `EarthquakeHistoryParameterCity` を `searchByCity` にルーティング（DataSource と整合）。
- **軽微**: 地域名がコード文字列のまま表示されていた TODO を `regionName` リゾルバで解決（ピッカー / ホームシートの2箇所）。

## テスト

- `earthquake_history_notifier_fetch_test.dart`（新規）: Notifier の種別ごとのルーティングを検証。**City → searchByCity（searchByRegion を呼ばない）** の回帰テストを含む。従来 DataSource 側にのみ存在し Notifier 側に無かったギャップを解消。
- `home_designated_region_picker_page_test.dart`（新規）: 都道府県選択で `Prefecture` パラメータ、市区町村選択で `City` パラメータを返すことを検証。
- `flutter test` 6件パス。`dart analyze` クリーン（既存の無関係な警告のみ）。

## 影響範囲

- 都道府県指定 → `searchByPrefecture`、市区町村指定 → `searchByCity` で正常取得。ホーム / 履歴一覧の両方で一致。
- フィルタチップ経由の region / station 指定は元々 Notifier のルーティングが正しく、影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)