### PR TITLE
fix: 震度塗り潰しレイヤーで同一地域が複数レベルに重複描画される問題を修正

### DIFF
--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_fill_layer.dart
@@ -416,19 +416,42 @@ class EarthquakeHistoryFillLayerBuilder {
     EarthquakeIntensity intensity,
     JmaIntensity intensityLevel,
   ) {
-    final codes = <String>[];
     final nodes = intensity.intensityTree[intensityLevel];
     if (nodes == null) {
-      return codes;
+      return [];
     }
+    // 複数レベルの観測点を持つ市区町村は各レベルのバケツに重複して現れる。
+    // 半透明 fill が重なって混色しないよう、最大レベルにのみ含める。
+    final maxLevels = _cityMaxJmaLevels(intensity);
+    final codes = <String>{};
     for (final region in nodes) {
       for (final city in region.cities) {
-        if (city.maxIntensity != null) {
+        if (city.maxIntensity != null &&
+            maxLevels[city.city.code] == intensityLevel) {
           codes.add(city.city.code);
         }
       }
     }
-    return codes;
+    return codes.toList();
+  }
+
+  /// 市区町村コード → 全レベル横断での最大震度レベル
+  Map<String, JmaIntensity> _cityMaxJmaLevels(EarthquakeIntensity intensity) {
+    final maxLevels = <String, JmaIntensity>{};
+    for (final entry in intensity.intensityTree.entries) {
+      for (final region in entry.value) {
+        for (final city in region.cities) {
+          if (city.maxIntensity == null) {
+            continue;
+          }
+          final current = maxLevels[city.city.code];
+          if (current == null || entry.key.orderIndex > current.orderIndex) {
+            maxLevels[city.city.code] = entry.key;
+          }
+        }
+      }
+    }
+    return maxLevels;
   }
 
   List<JmaLpgmIntensity> sortedLpgmLevels(EarthquakeIntensity intensity) {
@@ -455,35 +478,81 @@ class EarthquakeHistoryFillLayerBuilder {
     EarthquakeIntensity intensity,
     JmaLpgmIntensity intensityLevel,
   ) {
-    final codes = <String>[];
     final nodes = intensity.lpgmIntensityTree[intensityLevel];
     if (nodes == null) {
-      return codes;
+      return [];
     }
+    // 複数階級に跨る細分区域は最大階級にのみ含める (jmaCityCodes と同様)。
+    final maxLevels = _regionMaxLpgmLevels(intensity);
+    final codes = <String>{};
     for (final region in nodes) {
-      if (region.maxLpgmIntensity == intensityLevel) {
+      if (region.maxLpgmIntensity != null &&
+          maxLevels[region.region.code] == intensityLevel) {
         codes.add(region.region.code);
       }
     }
-    return codes;
+    return codes.toList();
+  }
+
+  /// 細分区域コード → 全階級横断での最大長周期地震動階級
+  Map<String, JmaLpgmIntensity> _regionMaxLpgmLevels(
+    EarthquakeIntensity intensity,
+  ) {
+    final maxLevels = <String, JmaLpgmIntensity>{};
+    for (final entry in intensity.lpgmIntensityTree.entries) {
+      for (final region in entry.value) {
+        if (region.maxLpgmIntensity == null) {
+          continue;
+        }
+        final current = maxLevels[region.region.code];
+        if (current == null || entry.key.orderIndex > current.orderIndex) {
+          maxLevels[region.region.code] = entry.key;
+        }
+      }
+    }
+    return maxLevels;
   }
 
   List<String> lpgmCityCodes(
     EarthquakeIntensity intensity,
     JmaLpgmIntensity intensityLevel,
   ) {
-    final codes = <String>[];
     final nodes = intensity.lpgmIntensityTree[intensityLevel];
     if (nodes == null) {
-      return codes;
+      return [];
     }
+    // 複数階級に跨る市区町村は最大階級にのみ含める (jmaCityCodes と同様)。
+    final maxLevels = _cityMaxLpgmLevels(intensity);
+    final codes = <String>{};
     for (final region in nodes) {
       for (final city in region.cities) {
-        if (city.maxLpgmIntensity != null) {
+        if (city.maxLpgmIntensity != null &&
+            maxLevels[city.city.code] == intensityLevel) {
           codes.add(city.city.code);
         }
       }
     }
-    return codes;
+    return codes.toList();
+  }
+
+  /// 市区町村コード → 全階級横断での最大長周期地震動階級
+  Map<String, JmaLpgmIntensity> _cityMaxLpgmLevels(
+    EarthquakeIntensity intensity,
+  ) {
+    final maxLevels = <String, JmaLpgmIntensity>{};
+    for (final entry in intensity.lpgmIntensityTree.entries) {
+      for (final region in entry.value) {
+        for (final city in region.cities) {
+          if (city.maxLpgmIntensity == null) {
+            continue;
+          }
+          final current = maxLevels[city.city.code];
+          if (current == null || entry.key.orderIndex > current.orderIndex) {
+            maxLevels[city.city.code] = entry.key;
+          }
+        }
+      }
+    }
+    return maxLevels;
   }
 }

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_fill_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_fill_layer.dart
@@ -60,51 +60,20 @@ class EarthquakeHistoryShindoDbFillLayer extends HookConsumerWidget {
       unawaited(
         enqueue(() async {
           try {
-            // region ごとの最大階級を事前計算
-            final regionMaxClass = <String, ShindoDbIntensityClass>{};
-            for (final entry in tree.tree.entries) {
-              final cls = entry.key;
-              for (final pref in entry.value) {
-                for (final cityNode in pref.cities) {
-                  final regionCode = cityNode.region.code;
-                  final current = regionMaxClass[regionCode];
-                  if (current == null || cls.orderIndex > current.orderIndex) {
-                    regionMaxClass[regionCode] = cls;
-                  }
-                }
-              }
-            }
-
-            // orderIndex 昇順(低震度→高震度)で追加し、高震度レイヤーが上に来るようにする
-            final sortedClasses =
-                tree.tree.keys
-                    .where((cls) => cls.colorJmaIntensity != null)
-                    .toList()
-                  ..sort((a, b) => a.orderIndex.compareTo(b.orderIndex));
-
-            for (final cls in sortedClasses) {
+            final fillCodes = computeShindoDbFillCodes(tree);
+            for (final entry in fillCodes.entries) {
               if (disposed) {
                 return;
               }
+              final cls = entry.key;
               final color = colorModel
                   .fromJmaIntensity(cls.colorJmaIntensity!)
                   .background
                   .toHexStringRGB();
               final idPrefix = 'eq-history-shindo-db-${cls.name}';
 
-              final cityCodes = <String>[];
-              final regionCodesForClass = <String>[];
-              final prefNodes = tree.tree[cls] ?? [];
-              for (final pref in prefNodes) {
-                for (final cityNode in pref.cities) {
-                  cityCodes.add(cityNode.city.code);
-                  final regionCode = cityNode.region.code;
-                  if (regionMaxClass[regionCode] == cls &&
-                      !regionCodesForClass.contains(regionCode)) {
-                    regionCodesForClass.add(regionCode);
-                  }
-                }
-              }
+              final cityCodes = entry.value.cityCodes;
+              final regionCodesForClass = entry.value.regionCodes;
 
               // region レイヤー (auto モード相当: ズームで city に切り替わる)
               final mode = EarthquakeHistoryMapLayerMode.auto;
@@ -161,4 +130,65 @@ class EarthquakeHistoryShindoDbFillLayer extends HookConsumerWidget {
 
     return const SizedBox.shrink();
   }
+}
+
+/// 階級ごとの塗り潰し対象コード (orderIndex 昇順 = 低階級→高階級)。
+/// 低階級から順にレイヤー追加することで高階級レイヤーが上に来る。
+Map<
+  ShindoDbIntensityClass,
+  ({List<String> regionCodes, List<String> cityCodes})
+>
+computeShindoDbFillCodes(ShindoDbIntensityTree tree) {
+  // region / city ごとの最大階級を事前計算。
+  // 複数階級に観測点が跨る場合は最大階級にのみ含め、
+  // 半透明 fill の重なりによる混色を防ぐ。
+  final regionMaxClass = <String, ShindoDbIntensityClass>{};
+  final cityMaxClass = <String, ShindoDbIntensityClass>{};
+  for (final entry in tree.tree.entries) {
+    final cls = entry.key;
+    for (final pref in entry.value) {
+      for (final cityNode in pref.cities) {
+        final regionCode = cityNode.region.code;
+        final currentRegion = regionMaxClass[regionCode];
+        if (currentRegion == null ||
+            cls.orderIndex > currentRegion.orderIndex) {
+          regionMaxClass[regionCode] = cls;
+        }
+        final cityCode = cityNode.city.code;
+        final currentCity = cityMaxClass[cityCode];
+        if (currentCity == null || cls.orderIndex > currentCity.orderIndex) {
+          cityMaxClass[cityCode] = cls;
+        }
+      }
+    }
+  }
+
+  final sortedClasses =
+      tree.tree.keys.where((cls) => cls.colorJmaIntensity != null).toList()
+        ..sort((a, b) => a.orderIndex.compareTo(b.orderIndex));
+
+  final result =
+      <
+        ShindoDbIntensityClass,
+        ({List<String> regionCodes, List<String> cityCodes})
+      >{};
+  for (final cls in sortedClasses) {
+    final cityCodes = <String>[];
+    final regionCodes = <String>[];
+    for (final pref in tree.tree[cls] ?? <ShindoDbPrefectureNode>[]) {
+      for (final cityNode in pref.cities) {
+        final cityCode = cityNode.city.code;
+        if (cityMaxClass[cityCode] == cls && !cityCodes.contains(cityCode)) {
+          cityCodes.add(cityCode);
+        }
+        final regionCode = cityNode.region.code;
+        if (regionMaxClass[regionCode] == cls &&
+            !regionCodes.contains(regionCode)) {
+          regionCodes.add(regionCode);
+        }
+      }
+    }
+    result[cls] = (regionCodes: regionCodes, cityCodes: cityCodes);
+  }
+  return result;
 }

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_fill_layer_builder_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_fill_layer_builder_test.dart
@@ -23,17 +23,14 @@ void main() {
 
   group('regionCodeFilter', () {
     test('areaForecastLocalE の code フィールドで in フィルタを生成する', () {
-      expect(
-        builder.regionCodeFilter(['001', '002', '003']),
+      expect(builder.regionCodeFilter(['001', '002', '003']), [
+        'in',
+        ['get', 'code'],
         [
-          'in',
-          ['get', 'code'],
-          [
-            'literal',
-            ['001', '002', '003'],
-          ],
+          'literal',
+          ['001', '002', '003'],
         ],
-      );
+      ]);
     });
 
     test('空リストでもフィルタ構造は変わらない', () {
@@ -48,17 +45,14 @@ void main() {
 
   group('cityCodeFilter', () {
     test('areaInformationCityQuake の regioncode フィールドで in フィルタを生成する', () {
-      expect(
-        builder.cityCodeFilter(['1010001', '1310000']),
+      expect(builder.cityCodeFilter(['1010001', '1310000']), [
+        'in',
+        ['get', 'regioncode'],
         [
-          'in',
-          ['get', 'regioncode'],
-          [
-            'literal',
-            ['1010001', '1310000'],
-          ],
+          'literal',
+          ['1010001', '1310000'],
         ],
-      );
+      ]);
     });
 
     test('regionCodeFilter と異なるフィールド名を使う', () {
@@ -434,6 +428,55 @@ void main() {
       expect(jma.every((l) => !l.id.contains('lpgm')), isTrue);
     });
   });
+
+  // ──────────────────────────────────────────────
+  // 複数震度レベルに跨る市区町村・細分区域の重複排除
+  // (重複すると半透明 fill が重なり、意図しない混色になる)
+  // ──────────────────────────────────────────────
+
+  group('jmaCityCodes の重複排除', () {
+    final testData = _FillLayerTestData();
+
+    test('複数レベルに登場する市区町村は最大レベルにのみ含まれる', () {
+      final intensity = testData.cityInMultipleLevelsIntensity();
+      expect(builder.jmaCityCodes(intensity, JmaIntensity.four), ['2110001']);
+      expect(builder.jmaCityCodes(intensity, JmaIntensity.three), ['2110002']);
+    });
+
+    test('buildJmaLayers の city filter に同一市区町村が複数レイヤーで現れない', () {
+      final layers = builder.buildJmaLayers(
+        intensity: testData.cityInMultipleLevelsIntensity(),
+        colorModel: colorModel,
+        mode: EarthquakeHistoryMapLayerMode.city,
+        parameter: parameter,
+      );
+      final codes = layers
+          .whereType<FillStyleLayer>()
+          .expand((l) => ((l.filter![2] as List<Object>)[1] as List<String>))
+          .toList();
+      expect(codes.toSet(), hasLength(codes.length), reason: '市区町村コードの重複なし');
+    });
+  });
+
+  group('lpgmCityCodes / lpgmRegionCodes の重複排除', () {
+    final testData = _FillLayerTestData();
+
+    test('複数階級に登場する市区町村は最大階級にのみ含まれる', () {
+      final intensity = testData.lpgmMultiLevelIntensity();
+      expect(builder.lpgmCityCodes(intensity, JmaLpgmIntensity.two), [
+        '2110001',
+      ]);
+      expect(builder.lpgmCityCodes(intensity, JmaLpgmIntensity.one), [
+        '2210001',
+      ]);
+    });
+
+    test('複数階級に登場する細分区域は最大階級にのみ含まれる', () {
+      final intensity = testData.lpgmMultiLevelIntensity();
+      expect(builder.lpgmRegionCodes(intensity, JmaLpgmIntensity.two), ['210']);
+      expect(builder.lpgmRegionCodes(intensity, JmaLpgmIntensity.one), ['220']);
+    });
+  });
 }
 
 // ──────────────────────────────────────────────
@@ -546,6 +589,107 @@ class _FillLayerTestData {
           ),
         ],
       },
+    );
+  }
+
+  /// 市区町村 2110001 が震度 3・4 の両バケツに登場するデータ
+  /// (震度3の観測点と震度4の観測点を両方持つ市区町村を再現)
+  EarthquakeIntensity cityInMultipleLevelsIntensity() {
+    return EarthquakeIntensity(
+      maxIntensity: JmaIntensity.four,
+      maxLpgmIntensity: null,
+      regions: const {},
+      intensityTree: {
+        JmaIntensity.three: [
+          PrefectureIntensityNode(
+            prefecture: _prefecture('21'),
+            cities: [
+              CityIntensityNode(
+                city: _city('2110001'),
+                maxIntensity: JmaIntensity.three,
+                stations: const [],
+              ),
+              CityIntensityNode(
+                city: _city('2110002'),
+                maxIntensity: JmaIntensity.three,
+                stations: const [],
+              ),
+            ],
+          ),
+        ],
+        JmaIntensity.four: [
+          PrefectureIntensityNode(
+            prefecture: _prefecture('21'),
+            cities: [
+              CityIntensityNode(
+                city: _city('2110001'),
+                maxIntensity: JmaIntensity.four,
+                stations: const [],
+              ),
+            ],
+          ),
+        ],
+      },
+      lpgmIntensityTree: const {},
+    );
+  }
+
+  /// 細分区域 210 (市区町村 2110001) が階級 1・2 の両バケツに、
+  /// 細分区域 220 (市区町村 2210001) が階級 1 のみに登場するデータ
+  EarthquakeIntensity lpgmMultiLevelIntensity() {
+    return EarthquakeIntensity(
+      maxIntensity: JmaIntensity.four,
+      maxLpgmIntensity: JmaLpgmIntensity.two,
+      regions: const {},
+      intensityTree: const {},
+      lpgmIntensityTree: {
+        JmaLpgmIntensity.one: [
+          PrefectureLpgmIntensityNode(
+            region: _regionItem(_regionCode),
+            maxLpgmIntensity: JmaLpgmIntensity.one,
+            cities: [
+              CityLpgmIntensityNode(
+                city: _city('2110001'),
+                maxLpgmIntensity: JmaLpgmIntensity.one,
+                stations: const [],
+              ),
+            ],
+          ),
+          PrefectureLpgmIntensityNode(
+            region: _regionItem(_regionCode2),
+            maxLpgmIntensity: JmaLpgmIntensity.one,
+            cities: [
+              CityLpgmIntensityNode(
+                city: _city('2210001'),
+                maxLpgmIntensity: JmaLpgmIntensity.one,
+                stations: const [],
+              ),
+            ],
+          ),
+        ],
+        JmaLpgmIntensity.two: [
+          PrefectureLpgmIntensityNode(
+            region: _regionItem(_regionCode),
+            maxLpgmIntensity: JmaLpgmIntensity.two,
+            cities: [
+              CityLpgmIntensityNode(
+                city: _city('2110001'),
+                maxLpgmIntensity: JmaLpgmIntensity.two,
+                stations: const [],
+              ),
+            ],
+          ),
+        ],
+      },
+    );
+  }
+
+  EarthquakeParameterRegionItem _regionItem(String code) {
+    return EarthquakeParameterRegionItem(
+      code: code,
+      name: const LocalizedName(ja: 'テスト地域'),
+      kana: null,
+      cities: const [],
     );
   }
 

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_fill_layer_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_fill_layer_test.dart
@@ -1,0 +1,114 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_fill_layer.dart';
+import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('computeShindoDbFillCodes', () {
+    test('複数階級に登場する市区町村は最大階級にのみ含まれる', () {
+      // 市区町村 01100 は階級 3・4 の両方に観測点を持つ
+      final tree = _tree({
+        ShindoDbIntensityClass.four: [
+          _prefNode([_cityNode('01100', '010100')]),
+        ],
+        ShindoDbIntensityClass.three: [
+          _prefNode([
+            _cityNode('01100', '010100'),
+            _cityNode('01200', '010200'),
+          ]),
+        ],
+      });
+
+      final codes = computeShindoDbFillCodes(tree);
+
+      expect(codes[ShindoDbIntensityClass.four]?.cityCodes, ['01100']);
+      expect(codes[ShindoDbIntensityClass.three]?.cityCodes, ['01200']);
+    });
+
+    test('複数階級に登場する細分区域は最大階級にのみ含まれる', () {
+      final tree = _tree({
+        ShindoDbIntensityClass.four: [
+          _prefNode([_cityNode('01100', '010100')]),
+        ],
+        ShindoDbIntensityClass.three: [
+          _prefNode([
+            _cityNode('01200', '010100'),
+            _cityNode('01300', '010200'),
+          ]),
+        ],
+      });
+
+      final codes = computeShindoDbFillCodes(tree);
+
+      expect(codes[ShindoDbIntensityClass.four]?.regionCodes, ['010100']);
+      expect(codes[ShindoDbIntensityClass.three]?.regionCodes, ['010200']);
+    });
+
+    test('低階級→高階級の順で返す (高階級レイヤーが上に描画される)', () {
+      final tree = _tree({
+        ShindoDbIntensityClass.four: [
+          _prefNode([_cityNode('01100', '010100')]),
+        ],
+        ShindoDbIntensityClass.one: [
+          _prefNode([_cityNode('01200', '010200')]),
+        ],
+      });
+
+      expect(computeShindoDbFillCodes(tree).keys.toList(), [
+        ShindoDbIntensityClass.one,
+        ShindoDbIntensityClass.four,
+      ]);
+    });
+
+    test('色を持たない歴史的階級は含まない', () {
+      final tree = _tree({
+        ShindoDbIntensityClass.unknownFelt: [
+          _prefNode([_cityNode('01100', '010100')]),
+        ],
+        ShindoDbIntensityClass.two: [
+          _prefNode([_cityNode('01200', '010200')]),
+        ],
+      });
+
+      expect(computeShindoDbFillCodes(tree).keys.toList(), [
+        ShindoDbIntensityClass.two,
+      ]);
+    });
+  });
+}
+
+ShindoDbIntensityTree _tree(
+  Map<ShindoDbIntensityClass, List<ShindoDbPrefectureNode>> tree,
+) => ShindoDbIntensityTree(
+  tree: tree,
+  unresolvedStations: const {},
+  totalStationCount: 0,
+);
+
+ShindoDbPrefectureNode _prefNode(List<ShindoDbCityNode> cities) =>
+    ShindoDbPrefectureNode(
+      prefecture: EarthquakeParameterPrefectureItem(
+        code: '01',
+        name: const LocalizedName(ja: 'テスト都道府県'),
+        regions: const [],
+      ),
+      cities: cities,
+    );
+
+ShindoDbCityNode _cityNode(String cityCode, String regionCode) =>
+    ShindoDbCityNode(
+      city: EarthquakeParameterCityItem(
+        code: cityCode,
+        name: const LocalizedName(ja: 'テスト市区町村'),
+        kana: null,
+        stations: const [],
+      ),
+      region: EarthquakeParameterRegionItem(
+        code: regionCode,
+        name: const LocalizedName(ja: 'テスト地域'),
+        kana: null,
+        cities: const [],
+      ),
+      stations: const [],
+    );


### PR DESCRIPTION
## 問題

地震履歴詳細の地図で、塗り潰し色が震度スケールの色数（最大震度4なら4色）を明らかに超えて表示される。

## 原因

`intensityTree` は観測点の震度ごとにバケツ分けされるため、複数の震度レベルの観測点を持つ市区町村は複数のバケツに登場する。塗り潰しレイヤー生成時にレベル横断の重複排除がなく、同一ポリゴンに半透明 fill（opacity 0.6）が複数枚重なり、混色で震度スケールに存在しない色が生まれていた。

## 修正内容

類似箇所を調査し、同じ構造の問題を全て修正:

| 箇所 | 対象 | 修正 |
|---|---|---|
| `jmaCityCodes` | JMA震度・市区町村 | 全レベル横断の最大震度レイヤーにのみ含める（今回の主原因） |
| `lpgmCityCodes` | 長周期地震動・市区町村 | 同上 |
| `lpgmRegionCodes` | 長周期地震動・細分区域 | 同上（LPGMツリーは細分区域も複数階級に跨り得る） |
| 震度DB表示 city fill | 震度DB・市区町村 | 階級横断の最大値判定を追加（region 側は対策済みで city 側だけ漏れていた）。コード算出を `computeShindoDbFillCodes` に抽出しテスト可能に |

調査済みで問題なし: EEWレイヤー（`groupListsBy` で最大値集約済み）、震度履歴の match 式レイヤー（1レイヤーで塗り分け）、観測点サークルレイヤー。

## テスト

- TDD で再現テストを追加（重複データで失敗することを確認してから修正）
- `flutter test test/feature/earthquake_history/ui/layer/` : 46件全て成功
- 全体スイート: 修正前後で失敗数は同一の35件（クリーンな HEAD でも失敗する既存の問題であることを stash して確認済み）、回帰なし
- `dart analyze lib/feature/earthquake_history test/feature/earthquake_history` : No issues found

実機での見た目の確認は未実施です（塗り重なりの解消は要目視確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)