### PR TITLE
Treat Dart Errors as corrupt-cache failures in CachedNotifier

### DIFF
--- a/app/lib/core/provider/cached_notifier.dart
+++ b/app/lib/core/provider/cached_notifier.dart
@@ -37,7 +37,7 @@ mixin CachedNotifier<T> on $AsyncNotifier<T> {
       );
       unawaited(Future.microtask(() => _revalidateInBackground(gen, cached)));
       return cached;
-    } on Exception catch (e) {
+    } on Object catch (e) {
       if (isCacheMiss(e)) {
         return fetch(await ref.read(apiClientProvider.future));
       }
@@ -59,7 +59,7 @@ mixin CachedNotifier<T> on $AsyncNotifier<T> {
       if (ref.mounted && gen == _generation) {
         state = AsyncData(fresh);
       }
-    } on Exception catch (e, st) {
+    } on Object catch (e, st) {
       if (ref.mounted && gen == _generation) {
         state = AsyncError<T>(e, st).copyWithPrevious(state);
       }

--- a/app/lib/feature/parameter/data/notifier/parameter_set_notifier.dart
+++ b/app/lib/feature/parameter/data/notifier/parameter_set_notifier.dart
@@ -23,7 +23,7 @@ class ParameterSetNotifier extends _$ParameterSetNotifier
           .read(startupProfilerProvider)
           .measure('parameter_load', sw.elapsedMicroseconds);
       return result;
-    } on Exception catch (e, st) {
+    } on Object catch (e, st) {
       talker.warning(
         '[Parameter] API/キャッシュからの読み込みに失敗したため、同梱パラメータを使用します。',
         e,

--- a/app/test/core/provider/cached_notifier_test.dart
+++ b/app/test/core/provider/cached_notifier_test.dart
@@ -228,6 +228,19 @@ void main() {
       expect(result, 'recovered');
     });
 
+    test('ArgumentError from cache triggers force-fresh path', () async {
+      _cacheError = ArgumentError.value(
+        'UNKNOWN',
+        'metadata.type',
+        'Unknown union discriminator',
+      );
+      _freshValue = 'recovered-from-argument-error';
+
+      final result = await container.read(_testProvider.future);
+
+      expect(result, 'recovered-from-argument-error');
+    });
+
     test('force-fresh network error propagates', () async {
       _cacheError = const FormatException('corrupt');
       _networkError = Exception('network down');


### PR DESCRIPTION
### Motivation
- A previous change narrowed cache-read error handling to `Exception`, which lets Dart `Error` subclasses (e.g. `ArgumentError`) escape the corrupt-cache recovery path and cause persistent failures for safety-critical cached data. 
- HTTP 200 responses are persisted before model parsing completes, so a malformed but cacheable response can poison the cache and must be recoverable by client-side logic. 
- Parameter loading is safety-critical and must fall back to bundled assets when cached/API parsing fails for any `Object` type, not only `Exception`.

### Description
- Broadened cached-path error handling from `on Exception` to `on Object` in `cachedBuild()` so non-`Exception` parse failures trigger the force-fresh recovery; updated `app/lib/core/provider/cached_notifier.dart`. 
- Broadened background revalidation catch to `on Object` so non-`Exception` failures preserve stale cached value as an `AsyncError` instead of escaping the microtask; updated `app/lib/core/provider/cached_notifier.dart`. 
- Broadened the parameter notifier fallback to catch `on Object` so bundled-asset fallback runs on `Error`-type parse failures; updated `app/lib/feature/parameter/data/notifier/parameter_set_notifier.dart`. 
- Added a regression unit test to ensure an `ArgumentError` thrown while parsing cached data triggers the force-fresh recovery; updated `app/test/core/provider/cached_notifier_test.dart`.

### Testing
- Ran `git --no-pager diff --check` which produced no diff-check failures. 
- Added a unit test entry in `app/test/core/provider/cached_notifier_test.dart` to cover `ArgumentError` recovery, but running `mise exec -- flutter test` was blocked by tool installation/network failures in the environment so tests were not executed here. 
- Changes were committed locally as described and are ready for CI/maintainer test runs where `flutter test` can be executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ca1ff84c832aa426d8509eed9eb2)