### PR TITLE
Restore /v2/device App Check auth-failure responses

### DIFF
--- a/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Client.swift
+++ b/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Client.swift
@@ -1099,7 +1099,7 @@ public struct Client: APIProtocol {
             }
         )
     }
-    /// デバイスを登録してJWTを返す。X-Firebase-AppCheck または X-Challenge-Code/X-Challenge-Response ヘッダーが存在する場合はそれぞれ検証を試みるが、検証失敗時も registrationType=null として登録を続行する。
+    /// デバイスを登録してJWTを返す。X-Firebase-AppCheck または X-Challenge-Code/X-Challenge-Response が必要。
     ///
     /// - Remark: HTTP `POST /v2/device`.
     /// - Remark: Generated from `#/paths//v2/device/post(postV2Device)`.
@@ -1156,6 +1156,12 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .created(.init(body: body))
+                case 400:
+                    return .badRequest(.init())
+                case 401:
+                    return .unauthorized(.init())
+                case 403:
+                    return .forbidden(.init())
                 case 500:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.postV2Device.Output.InternalServerError.Body

--- a/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Types.swift
+++ b/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Types.swift
@@ -15310,6 +15310,111 @@ public enum Operations {
                     }
                 }
             }
+            public struct BadRequest: Sendable, Hashable {
+                /// Creates a new `BadRequest`.
+                public init() {}
+            }
+            /// リクエスト不正
+            ///
+            /// - Remark: Generated from `#/paths//v2/device/post(postV2Device)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.postV2Device.Output.BadRequest)
+            /// リクエスト不正
+            ///
+            /// - Remark: Generated from `#/paths//v2/device/post(postV2Device)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            public static var badRequest: Self {
+                .badRequest(.init())
+            }
+            /// The associated value of the enum case if `self` is `.badRequest`.
+            ///
+            /// - Throws: An error if `self` is not `.badRequest`.
+            /// - SeeAlso: `.badRequest`.
+            public var badRequest: Operations.postV2Device.Output.BadRequest {
+                get throws {
+                    switch self {
+                    case let .badRequest(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "badRequest",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Unauthorized: Sendable, Hashable {
+                /// Creates a new `Unauthorized`.
+                public init() {}
+            }
+            /// AppCheck 認証失敗
+            ///
+            /// - Remark: Generated from `#/paths//v2/device/post(postV2Device)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.postV2Device.Output.Unauthorized)
+            /// AppCheck 認証失敗
+            ///
+            /// - Remark: Generated from `#/paths//v2/device/post(postV2Device)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            public static var unauthorized: Self {
+                .unauthorized(.init())
+            }
+            /// The associated value of the enum case if `self` is `.unauthorized`.
+            ///
+            /// - Throws: An error if `self` is not `.unauthorized`.
+            /// - SeeAlso: `.unauthorized`.
+            public var unauthorized: Operations.postV2Device.Output.Unauthorized {
+                get throws {
+                    switch self {
+                    case let .unauthorized(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unauthorized",
+                            response: self
+                        )
+                    }
+                }
+            }
+            public struct Forbidden: Sendable, Hashable {
+                /// Creates a new `Forbidden`.
+                public init() {}
+            }
+            /// チャレンジ不一致・期限切れ・使用済み
+            ///
+            /// - Remark: Generated from `#/paths//v2/device/post(postV2Device)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.postV2Device.Output.Forbidden)
+            /// チャレンジ不一致・期限切れ・使用済み
+            ///
+            /// - Remark: Generated from `#/paths//v2/device/post(postV2Device)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            public static var forbidden: Self {
+                .forbidden(.init())
+            }
+            /// The associated value of the enum case if `self` is `.forbidden`.
+            ///
+            /// - Throws: An error if `self` is not `.forbidden`.
+            /// - SeeAlso: `.forbidden`.
+            public var forbidden: Operations.postV2Device.Output.Forbidden {
+                get throws {
+                    switch self {
+                    case let .forbidden(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "forbidden",
+                            response: self
+                        )
+                    }
+                }
+            }
             public struct InternalServerError: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/v2/device/POST/responses/500/content`.
                 @frozen public enum Body: Sendable, Hashable {

--- a/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/openapi.json
+++ b/app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/openapi.json
@@ -651,7 +651,7 @@
         "tags": [
           "Device"
         ],
-        "description": "デバイスを登録してJWTを返す。X-Firebase-AppCheck または X-Challenge-Code/X-Challenge-Response ヘッダーが存在する場合はそれぞれ検証を試みるが、検証失敗時も registrationType=null として登録を続行する。",
+        "description": "デバイスを登録してJWTを返す。X-Firebase-AppCheck または X-Challenge-Code/X-Challenge-Response が必要。",
         "responses": {
           "201": {
             "description": "デバイスID と デバイストークン",
@@ -662,6 +662,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "リクエスト不正"
+          },
+          "401": {
+            "description": "AppCheck 認証失敗"
+          },
+          "403": {
+            "description": "チャレンジ不一致・期限切れ・使用済み"
           },
           "500": {
             "description": "サーバーエラー",


### PR DESCRIPTION
### Motivation
- Prevent a regression where device registration was documented/generated as permissive and allowed creation of `deviceToken` without requiring App Check or challenge validation, which undermines the abuse-control boundary. 
- Ensure the OpenAPI contract and generated Swift client/types accurately model `400`/`401`/`403` failures so callers and consumers cannot assume unconditional registration success.

### Description
- Restore the `/v2/device` operation in `app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/openapi.json` to require App Check/challenge and reintroduce `400`, `401`, and `403` responses. 
- Update the generated Swift client at `app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Client.swift` to deserialize and return `400`, `401`, and `403` cases instead of treating them as undocumented. 
- Update generated types at `app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/GeneratedSources/Types.swift` to include `badRequest`, `unauthorized`, and `forbidden` cases for `postV2Device` outputs. 
- Commit message: `Fix: デバイス登録の認証失敗レスポンスを復元` (files modified: the three files above).

### Testing
- Ran `python3 -m json.tool app/ios/Packages/EQMonitorAPI/Sources/EQMonitorAPI/openapi.json` to validate JSON syntax (succeeded). 
- Executed a Python validation snippet that asserts the `/v2/device` description no longer contains the permissive wording and that `400`/`401`/`403` are present in `openapi.json`, and that the corresponding `Client.swift` and `Types.swift` contain the new response handling and enum cases (succeeded).
- Attempted `swift test` in `app/ios/Packages/EQMonitorAPI`, but it was blocked because SwiftPM dependency fetches from GitHub failed with network/proxy errors (`CONNECT tunnel failed, response 403`), so Swift unit tests could not run to completion. 
- `git push` was attempted but no remote push destination is configured, so the branch was committed locally but not pushed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ec2e7780832a8ddb6046ae5516dc)