### PR TITLE
Fix: do not silently serve stale cache for default earthquake-history refresh

### DIFF
--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:eqmonitor/core/api/cache_only_api_client_provider.dart';
-import 'package:eqmonitor/core/paging/cache_first_refresh.dart';
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/realtime/model/realtime_event.dart';
@@ -13,7 +11,6 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_
 import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
-import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:paging_view/paging_view.dart';
@@ -38,12 +35,9 @@ Future<EarthquakeHistoryDataSource> earthquakeHistoryDataSource(
   final repository = await ref.watch(
     earthquakeHistoryRepositoryProvider.future,
   );
-  final cacheOnly = await ref.watch(cacheOnlyApiClientProvider.future);
-
   final dataSource = EarthquakeHistoryDataSource(
     repository: repository,
     parameter: parameter,
-    cacheOnlyClient: cacheOnly,
     onRefreshStarted: () =>
         ref.invalidate(earthquakeHistoryDetailsProvider, asReload: true),
   );
@@ -84,11 +78,9 @@ class EarthquakeHistoryDataSource
   EarthquakeHistoryDataSource({
     required EarthquakeHistoryRepository repository,
     required EarthquakeHistoryParameter parameter,
-    required api.ApiClient cacheOnlyClient,
     VoidCallback? onRefreshStarted,
   }) : _repository = repository,
-       _parameter = parameter,
-       _cacheOnlyClient = cacheOnlyClient {
+       _parameter = parameter {
     onLoadStarted = (action) {
       if (action is Refresh) {
         onRefreshStarted?.call();
@@ -98,14 +90,10 @@ class EarthquakeHistoryDataSource
 
   final EarthquakeHistoryRepository _repository;
   final EarthquakeHistoryParameter _parameter;
-  final api.ApiClient _cacheOnlyClient;
 
   final ValueNotifier<bool> isRevalidating = ValueNotifier(false);
-  bool _disposed = false;
-
   @override
   void dispose() {
-    _disposed = true;
     isRevalidating.dispose();
     super.dispose();
   }
@@ -123,21 +111,10 @@ class EarthquakeHistoryDataSource
   Future<LoadResult<String?, EarthquakePartial>> load(
     LoadAction<String?> action,
   ) async => switch (action) {
-    Refresh() when isDefaultAllParameter(_parameter) =>
-      await cacheFirstRefresh<EarthquakePartial>(
-        fetchPage: ({required cacheOnly}) async {
-          final page = await _fetch(
-            limit: 10,
-            cursor: null,
-            client: cacheOnly ? _cacheOnlyClient : null,
-          );
-          return PageData(data: page.items, appendKey: page.nextToken);
-        },
-        upsert: upsertItems,
-        isActive: () => !_disposed,
-        isRevalidating: isRevalidating,
-        onRevalidateError: (e, st) => talker.error(e, st),
-      ),
+    Refresh() when isDefaultAllParameter(_parameter) => await _load(
+      limit: 10,
+      cursor: null,
+    ),
     Refresh() => await _load(
       limit: _parameter is EarthquakeHistoryParameterAll ? 10 : 50,
       cursor: null,
@@ -171,7 +148,6 @@ class EarthquakeHistoryDataSource
   Future<PaginatedResponse<EarthquakePartial>> _fetch({
     required int limit,
     required String? cursor,
-    api.ApiClient? client,
   }) async {
     final parameter = _parameter;
 

--- a/app/test/feature/earthquake_history/earthquake_history_data_source_fetch_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_data_source_fetch_test.dart
@@ -36,7 +36,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -76,7 +75,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -111,7 +109,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -139,7 +136,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -167,7 +163,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -178,6 +173,27 @@ void main() {
         repository.searchByStationCalls.first['statuses'],
         equals([app.TelegramStatus.training]),
       );
+    },
+  );
+
+  test(
+    'default All refresh returns Failure when network fetch fails',
+    () async {
+      final repository = _SpyEarthquakeHistoryRepository(throwOnFetch: true);
+      const parameter = EarthquakeHistoryParameter.all(
+        sortBy: EarthquakeSortBy.eventId,
+        sortOrder: SortOrder.desc,
+      );
+      final dataSource = EarthquakeHistoryDataSource(
+        repository: repository,
+        parameter: parameter,
+      );
+      addTearDown(dataSource.dispose);
+
+      final result = await dataSource.load(const Refresh());
+
+      expect(result, isA<Failure<String?, EarthquakePartial>>());
+      expect(repository.fetchEarthquakeListCalls, hasLength(1));
     },
   );
 }
@@ -230,12 +246,14 @@ EarthquakePartialNormal _makeEarthquake(String eventId) =>
 
 final class _SpyEarthquakeHistoryRepository
     extends EarthquakeHistoryRepository {
-  _SpyEarthquakeHistoryRepository()
+  _SpyEarthquakeHistoryRepository({this.throwOnFetch = false})
     : super(
         earthquake: api.ApiClient(Dio()).earthquake,
         earthquakeParameter: _earthquakeParameter,
         shindoDbStations: _shindoDbStations,
       );
+
+  final bool throwOnFetch;
 
   final fetchEarthquakeListCalls = <Map<String, Object?>>[];
   final searchByRegionCalls = <Map<String, Object?>>[];
@@ -281,6 +299,9 @@ final class _SpyEarthquakeHistoryRepository
       'longitudeGte': longitudeGte,
       'longitudeLte': longitudeLte,
     });
+    if (throwOnFetch) {
+      throw Exception('network failure');
+    }
     return PaginatedResponse(
       items: [_makeEarthquake('event-1')],
       nextToken: null,

--- a/app/test/feature/earthquake_history/earthquake_history_upsert_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_history_upsert_test.dart
@@ -37,7 +37,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -68,7 +67,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -98,7 +96,6 @@ void main() {
       final dataSource = EarthquakeHistoryDataSource(
         repository: repository,
         parameter: parameter,
-        cacheOnlyClient: api.ApiClient(Dio()),
       );
       addTearDown(dataSource.dispose);
 
@@ -126,7 +123,6 @@ void main() {
     final dataSource = EarthquakeHistoryDataSource(
       repository: repository,
       parameter: parameter,
-      cacheOnlyClient: api.ApiClient(Dio()),
     );
     addTearDown(dataSource.dispose);
 


### PR DESCRIPTION
### Motivation
- Prevent a stale-cache integrity issue where the default `EarthquakeHistoryParameter.all` refresh used `cacheFirstRefresh`, immediately returning cached `Success` and only logging background revalidation failures, which could present obsolete earthquake data as a normal successful load. 
- Restore safety-oriented behavior so a refresh for the default parameter surface network failures as `Failure` instead of masking them. 
- Simplify the data-source wiring by removing the cache-only client dependency for the default refresh path.

### Description
- Replace the `Refresh()` branch that invoked `cacheFirstRefresh` (for `isDefaultAllParameter`) with a synchronous `_load(limit: 10, cursor: null)` call so the refresh awaits the network fetch. 
- Remove the `cacheOnly` API client dependency and `_cacheOnlyClient` constructor parameter/field and the provider usage that previously injected it. 
- Add a regression unit test `default All refresh returns Failure when network fetch fails` and extend the test spy (`_SpyEarthquakeHistoryRepository`) with a `throwOnFetch` flag to simulate a failing network fetch. 
- Update existing earthquake-history tests to use the simplified `EarthquakeHistoryDataSource` constructor (removed `cacheOnlyClient` usages).

### Testing
- Ran `git --no-pager diff --check` and verified diffs apply cleanly. 
- Added a regression test but attempted `flutter test` / `dart format` could not be executed in this environment because the toolchain installation failed (`dart`/`flutter` not available and `mise` downloads failed), so the test was not run here. 
- No other automated test runs completed in this environment; the change is covered by the new unit test which should be run in CI with a proper Flutter/Dart toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55011f181c832aa739f36684504fb1)