### PR TITLE
Fix Shindo DB map rendering bounds

### DIFF
--- a/app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart
+++ b/app/lib/feature/earthquake_history/data/repository/earthquake_history_repository.dart
@@ -395,7 +395,17 @@ class EarthquakeHistoryRepository {
     final unresolvedAccum =
         <ShindoDbIntensityClass, List<ShindoDbStationNode>>{};
 
+    final uniqueStationRecords = <String, EarthquakeCatalogStationRecord>{};
     for (final record in catalog.stationRecords) {
+      final current = uniqueStationRecords[record.stationCode];
+      if (current == null ||
+          record.intensityClass.orderIndex >
+              current.intensityClass.orderIndex) {
+        uniqueStationRecords[record.stationCode] = record;
+      }
+    }
+
+    for (final record in uniqueStationRecords.values) {
       final item = stationByCode[record.stationCode];
       final cityCode = item?.cityCode;
       final cityEntry = cityCode != null ? cityIndex[cityCode] : null;
@@ -471,7 +481,7 @@ class EarthquakeHistoryRepository {
     return ShindoDbIntensityTree(
       tree: tree,
       unresolvedStations: unresolvedStations,
-      totalStationCount: catalog.stationRecords.length,
+      totalStationCount: uniqueStationRecords.length,
     );
   }
 

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
@@ -47,7 +47,10 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
       unawaited(
         enqueue(() async {
           try {
-            final geoJson = _buildGeoJson(tree, colorModel);
+            final geoJson = buildShindoDbStationGeoJson(
+              tree: tree,
+              colorModel: colorModel,
+            );
 
             if (disposed) {
               return;
@@ -165,59 +168,99 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
 
     return const SizedBox.shrink();
   }
+}
 
-  static String _buildGeoJson(
-    ShindoDbIntensityTree tree,
-    IntensityColors colorModel,
-  ) {
+const shindoDbStationGeoJsonFeatureLimit = 5000;
+
+String buildShindoDbStationGeoJson({
+  required ShindoDbIntensityTree tree,
+  required IntensityColors colorModel,
+}) {
+  final builder = ShindoDbStationGeoJsonBuilder(colorModel: colorModel);
+  return builder.build(tree: tree);
+}
+
+class ShindoDbStationGeoJsonBuilder {
+  const ShindoDbStationGeoJsonBuilder({required this.colorModel});
+
+  final IntensityColors colorModel;
+
+  String build({required ShindoDbIntensityTree tree}) {
     final features = <Map<String, dynamic>>[];
-
-    void addStation(ShindoDbStationNode station, ShindoDbIntensityClass cls) {
-      final loc = station.location;
-      if (loc == null) {
-        return;
-      }
-      final colorJma = cls.colorJmaIntensity;
-      final color = colorJma != null
-          ? colorModel.fromJmaIntensity(colorJma).background.toHexStringRGB()
-          : '#9e9e9e';
-      final props = <String, dynamic>{
-        'color': color,
-        'name': station.name,
-        'sortKey': cls.orderIndex,
-      };
-      final exactJma = cls.exactJmaIntensity;
-      if (exactJma != null) {
-        props['iconId'] = 'JmaIntensity.small.${exactJma.name}';
-      }
-      features.add({
-        'type': 'Feature',
-        'geometry': {
-          'type': 'Point',
-          'coordinates': [loc.lon, loc.lat],
-        },
-        'properties': props,
-      });
-    }
+    final addedStationCodes = <String>{};
 
     for (final entry in tree.tree.entries) {
-      final cls = entry.key;
       for (final pref in entry.value) {
         for (final cityNode in pref.cities) {
           for (final station in cityNode.stations) {
-            addStation(station, cls);
+            addStation(
+              features: features,
+              addedStationCodes: addedStationCodes,
+              station: station,
+              cls: entry.key,
+            );
+            if (features.length >= shindoDbStationGeoJsonFeatureLimit) {
+              return encodeFeatures(features);
+            }
           }
         }
       }
     }
 
     for (final entry in tree.unresolvedStations.entries) {
-      final cls = entry.key;
       for (final station in entry.value) {
-        addStation(station, cls);
+        addStation(
+          features: features,
+          addedStationCodes: addedStationCodes,
+          station: station,
+          cls: entry.key,
+        );
+        if (features.length >= shindoDbStationGeoJsonFeatureLimit) {
+          return encodeFeatures(features);
+        }
       }
     }
 
+    return encodeFeatures(features);
+  }
+
+  String encodeFeatures(List<Map<String, dynamic>> features) {
     return jsonEncode({'type': 'FeatureCollection', 'features': features});
+  }
+
+  void addStation({
+    required List<Map<String, dynamic>> features,
+    required Set<String> addedStationCodes,
+    required ShindoDbStationNode station,
+    required ShindoDbIntensityClass cls,
+  }) {
+    final loc = station.location;
+    if (loc == null ||
+        features.length >= shindoDbStationGeoJsonFeatureLimit ||
+        !addedStationCodes.add(station.record.stationCode)) {
+      return;
+    }
+
+    final colorJma = cls.colorJmaIntensity;
+    final color = colorJma != null
+        ? colorModel.fromJmaIntensity(colorJma).background.toHexStringRGB()
+        : '#9e9e9e';
+    final props = <String, dynamic>{
+      'color': color,
+      'name': station.name,
+      'sortKey': cls.orderIndex,
+    };
+    final exactJma = cls.exactJmaIntensity;
+    if (exactJma != null) {
+      props['iconId'] = 'JmaIntensity.small.${exactJma.name}';
+    }
+    features.add({
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [loc.lon, loc.lat],
+      },
+      'properties': props,
+    });
   }
 }

--- a/app/test/feature/earthquake_history/data/shindo_db_intensity_tree_test.dart
+++ b/app/test/feature/earthquake_history/data/shindo_db_intensity_tree_test.dart
@@ -155,6 +155,42 @@ void main() {
       expect(result.totalStationCount, 3);
     });
 
+    test('同一観測点コードは最大階級の1件に集約されること', () {
+      final repo = _makeRepository(
+        earthquakeParameter: _makeEarthquakeParameter([
+          _prefecture([
+            _region('010100', [_city('01100')]),
+          ]),
+        ]),
+        shindoDbStations: _makeShindoDbStations([
+          ShindoDbStationItem(
+            code: 'ST001',
+            name: '札幌観測点',
+            location: const LatLng(43.0, 141.0),
+            cityCode: '01100',
+          ),
+        ]),
+      );
+
+      final result = repo.buildShindoDbIntensityTree(
+        catalog: _makeCatalog([
+          _makeRecord('ST001', ShindoDbIntensityClass.three),
+          _makeRecord('ST001', ShindoDbIntensityClass.fiveLower),
+          _makeRecord('ST001', ShindoDbIntensityClass.four),
+        ]),
+      );
+
+      expect(result.totalStationCount, 1);
+      expect(result.tree.keys, contains(ShindoDbIntensityClass.fiveLower));
+      expect(result.tree.keys, isNot(contains(ShindoDbIntensityClass.three)));
+      expect(result.tree.keys, isNot(contains(ShindoDbIntensityClass.four)));
+      final nodes = result.tree[ShindoDbIntensityClass.fiveLower] ?? [];
+      expect(
+        nodes.single.cities.single.stations.single.record.stationCode,
+        'ST001',
+      );
+    });
+
     test('cityCode が null の観測点は unresolvedStations に入ること', () {
       // 53999 相当 (cityCode: null) → unresolvedStations[class] に入り name が解決される
       final repo = _makeRepository(

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_test.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/core/theme/model/app_theme.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_catalog.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart';
+import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lat_lng/lat_lng.dart';
+
+void main() {
+  group('buildShindoDbStationGeoJson', () {
+    test('同一観測点コードは1件に集約される', () {
+      final geoJson = buildShindoDbStationGeoJson(
+        tree: _tree([
+          _station('ST001'),
+          _station('ST001'),
+          _station('ST002'),
+        ]),
+        colorModel: _colorModel,
+      );
+
+      final features = _features(geoJson);
+
+      expect(features, hasLength(2));
+      expect(features.map((feature) => feature['properties']['name']), [
+        'ST001',
+        'ST002',
+      ]);
+    });
+
+    test('GeoJSON 生成件数は上限値で打ち切られる', () {
+      final geoJson = buildShindoDbStationGeoJson(
+        tree: _tree([
+          for (var i = 0; i < shindoDbStationGeoJsonFeatureLimit + 1; i++)
+            _station('ST${i.toString().padLeft(5, '0')}'),
+        ]),
+        colorModel: _colorModel,
+      );
+
+      expect(
+        _features(geoJson),
+        hasLength(shindoDbStationGeoJsonFeatureLimit),
+      );
+    });
+  });
+}
+
+final _colorModel = switch (AppTheme.eqmonitorDefault().light) {
+  final light? => light.intensity,
+  null => throw StateError('EQMonitor default light theme is missing'),
+};
+
+List<Map<String, dynamic>> _features(String geoJson) {
+  final decoded = jsonDecode(geoJson) as Map<String, dynamic>;
+  return (decoded['features'] as List<dynamic>).cast<Map<String, dynamic>>();
+}
+
+ShindoDbIntensityTree _tree(List<ShindoDbStationNode> stations) =>
+    ShindoDbIntensityTree(
+      tree: {
+        ShindoDbIntensityClass.three: [
+          ShindoDbPrefectureNode(
+            prefecture: EarthquakeParameterPrefectureItem(
+              code: '01',
+              name: const LocalizedName(ja: 'テスト都道府県'),
+              regions: const [],
+            ),
+            cities: [
+              ShindoDbCityNode(
+                city: EarthquakeParameterCityItem(
+                  code: '01100',
+                  name: const LocalizedName(ja: 'テスト市区町村'),
+                  kana: null,
+                  stations: const [],
+                ),
+                region: EarthquakeParameterRegionItem(
+                  code: '010100',
+                  name: const LocalizedName(ja: 'テスト地域'),
+                  kana: null,
+                  cities: const [],
+                ),
+                stations: stations,
+              ),
+            ],
+          ),
+        ],
+      },
+      unresolvedStations: const {},
+      totalStationCount: stations.length,
+    );
+
+ShindoDbStationNode _station(String code) => ShindoDbStationNode(
+  record: EarthquakeCatalogStationRecord(
+    stationCode: code,
+    intensityClass: ShindoDbIntensityClass.three,
+    instrumentalIntensity: null,
+    observedAt: null,
+    maxAcceleration: null,
+    maxAccelTime: null,
+    periods: null,
+    observationCount: null,
+  ),
+  name: code,
+  location: const LatLng(43.06, 141.35),
+);


### PR DESCRIPTION
### Motivation
- Prevent client-side CPU/memory exhaustion and UI hangs by eliminating the unbounded path that builds and encodes all REST-provided Shindo DB station records into a single GeoJSON document.
- Ensure the app is robust against malicious or compromised catalog responses that repeat station records and inflate rendered payloads.

### Description
- Deduplicate catalog station records in the repository (`buildShindoDbIntensityTree`) by `stationCode`, keeping the record with the highest intensity for each code and using the deduplicated count for `totalStationCount`.
- Replace the previous unbounded GeoJSON builder with `ShindoDbStationGeoJsonBuilder` and `buildShindoDbStationGeoJson`, which deduplicates located station codes, caps output at `shindoDbStationGeoJsonFeatureLimit = 5000` features, and stops traversal early to avoid building oversized payloads.
- Update the station map layer to use the new bounded GeoJSON builder before adding the `GeoJsonSource` to MapLibre.
- Add regression unit tests covering repository deduplication and station GeoJSON deduplication/limit behavior (new/modified tests: `app/test/feature/earthquake_history/data/shindo_db_intensity_tree_test.dart` and `app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_test.dart`).

### Testing
- Ran `git --no-pager diff --check`, which passed with no whitespace errors.
- Attempted to run formatter and unit tests via `mise exec -- dart format ... && mise exec -- flutter test ...`, but the `mise` toolchain installation failed in this environment due to network/tunnel errors and missing plugin dependencies, so the added tests were not executed here.
- New automated tests were added to assert deduplication and feature-limit semantics in `app/test/feature/earthquake_history/data/shindo_db_intensity_tree_test.dart` and `app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_test.dart`, but their execution is pending in CI or a developer environment where `mise`/`flutter` are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550566dc3c832aa04370a1d5945374)