### PR TITLE
Limit earthquake catalog conversion size to mitigate OOM/hang risk

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/earthquake_catalog.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_catalog.dart
@@ -4,6 +4,16 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'earthquake_catalog.freezed.dart';
 
+const earthquakeCatalogMaxHypocenterCount = 16;
+const earthquakeCatalogMaxStationRecordCount = 2048;
+const earthquakeCatalogMaxMagnitudeCount = 8;
+const earthquakeCatalogMaxTextLength = 128;
+
+String truncateEarthquakeCatalogText(String value) =>
+    value.length <= earthquakeCatalogMaxTextLength
+        ? value
+        : value.substring(0, earthquakeCatalogMaxTextLength);
+
 /// 震度データベース (i####.zip カタログ) 由来の詳細情報
 @freezed
 abstract class EarthquakeCatalog with _$EarthquakeCatalog {
@@ -103,9 +113,11 @@ String formatCatalogPeriodValue(api.CatalogPeriodValue value) {
 extension EarthquakeCatalogApiExtension on api.Catalog {
   EarthquakeCatalog get toEarthquakeCatalog => EarthquakeCatalog(
     hypocenters: hypocenters
+        .take(earthquakeCatalogMaxHypocenterCount)
         .map((e) => e._toEarthquakeCatalogHypocenter)
         .toList(),
     stationRecords: stationRecords
+        .take(earthquakeCatalogMaxStationRecordCount)
         .map((e) => e._toEarthquakeCatalogStationRecord)
         .toList(),
     damageScaleLabel: damageScale?._label,
@@ -118,7 +130,7 @@ extension on api.CatalogHypocenter {
   EarthquakeCatalogHypocenter get _toEarthquakeCatalogHypocenter =>
       EarthquakeCatalogHypocenter(
         seq: seq,
-        epicenterName: epicenterName,
+        epicenterName: truncateEarthquakeCatalogText(epicenterName),
         stationCount: stationCount,
         recordTypeLabel: recordType._label,
         originTime: originTime,
@@ -132,6 +144,7 @@ extension on api.CatalogHypocenter {
         determinationFlagLabel: determinationFlag?._label,
         evaluationLabel: evaluation?._label,
         magnitudes: magnitudes
+            .take(earthquakeCatalogMaxMagnitudeCount)
             .map(
               (m) => EarthquakeCatalogMagnitude(
                 typeLabel: m.type._label,
@@ -145,7 +158,7 @@ extension on api.CatalogHypocenter {
 extension on api.CatalogStationRecord {
   EarthquakeCatalogStationRecord get _toEarthquakeCatalogStationRecord =>
       EarthquakeCatalogStationRecord(
-        stationCode: stationCode,
+        stationCode: truncateEarthquakeCatalogText(stationCode),
         intensityClass: intensity.classValue.toShindoDbIntensityClass,
         instrumentalIntensity: intensity.instrumental?.toDouble(),
         observedAt: observedAt,

--- a/app/test/feature/earthquake_history/data/earthquake_catalog_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_catalog_test.dart
@@ -88,5 +88,62 @@ void main() {
       expect(result.tsunamiScaleLabel, startsWith('1:'));
       expect(result.linkMatchConfidence, 0.98);
     });
+
+    test('過大なカタログ配列と文字列は表示用モデル化時に制限されること', () {
+      final longText = List.filled(
+        earthquakeCatalogMaxTextLength + 1,
+        'A',
+      ).join();
+      final catalog = api.Catalog(
+        hypocenters: List.generate(
+          earthquakeCatalogMaxHypocenterCount + 1,
+          (index) => api.CatalogHypocenter(
+            seq: index,
+            recordType: api.CatalogHypocenterRecordType.a,
+            magnitudes: List.generate(
+              earthquakeCatalogMaxMagnitudeCount + 1,
+              (magnitudeIndex) => api.CatalogHypocenterMagnitude(
+                type: api.CatalogMagnitudeType.upperD,
+                value: magnitudeIndex,
+              ),
+            ),
+            epicenterName: longText,
+            stationCount: 1,
+          ),
+        ),
+        stationRecords: List.generate(
+          earthquakeCatalogMaxStationRecordCount + 1,
+          (index) => api.CatalogStationRecord(
+            stationCode: longText,
+            intensity: const api.CatalogStationIntensity(
+              classValue: api.CatalogIntensityClass.value1,
+            ),
+          ),
+        ),
+      );
+
+      final result = catalog.toEarthquakeCatalog;
+
+      expect(
+        result.hypocenters,
+        hasLength(earthquakeCatalogMaxHypocenterCount),
+      );
+      expect(
+        result.stationRecords,
+        hasLength(earthquakeCatalogMaxStationRecordCount),
+      );
+      expect(
+        result.hypocenters.first.magnitudes,
+        hasLength(earthquakeCatalogMaxMagnitudeCount),
+      );
+      expect(
+        result.hypocenters.first.epicenterName.length,
+        earthquakeCatalogMaxTextLength,
+      );
+      expect(
+        result.stationRecords.first.stationCode.length,
+        earthquakeCatalogMaxTextLength,
+      );
+    });
   });
 }


### PR DESCRIPTION
### Motivation

- The earthquake detail flow eagerly converts and renders every catalog hypocenter and station record from API responses, which can allow a malicious or corrupted large `station_records` array to cause excessive allocations, UI stalls, or out-of-memory crashes.
- The change aims to limit client-side work at conversion time to preserve availability and avoid unbounded memory growth while keeping normal data unaffected.

### Description

- Added size and text limits and a truncation helper: `earthquakeCatalogMaxHypocenterCount`, `earthquakeCatalogMaxStationRecordCount`, `earthquakeCatalogMaxMagnitudeCount`, `earthquakeCatalogMaxTextLength`, and `truncateEarthquakeCatalogText` in `app/lib/feature/earthquake_history/data/model/earthquake_catalog.dart`.
- Applied these limits during API→app-model conversion by capping `hypocenters`, `stationRecords`, and `magnitudes` with `.take(...)` and truncating display strings like `epicenterName` and `stationCode` before building domain models.
- Kept other conversion behavior intact (types, numeric conversions, optional fields) and confined changes to the display/model mapping layer to minimize behavioral risk.
- Added a regression test `test('過大なカタログ配列と文字列は表示用モデル化時に制限されること', ...)` in `app/test/feature/earthquake_history/data/earthquake_catalog_test.dart` that verifies arrays and long text are constrained by the new limits.

### Testing

- A regression unit test was added to assert limits in `app/test/feature/earthquake_history/data/earthquake_catalog_test.dart` and the repository diff passed `git --no-pager diff --check` in this environment.
- Attempted to run the Flutter/Dart test runner with `mise exec -- flutter test app/test/feature/earthquake_history/data/earthquake_catalog_test.dart`, but execution was blocked because the environment failed to install required toolchain components (network/tool resolution errors), so the test could not be executed here.
- No other automated test failures were observed in this environment after the change (tooling prevented full test execution).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550566b0f8832aa9b10fa961707900)