### PR TITLE
Bound seismicity cumulative binning to prevent unbounded daily expansion

### DIFF
--- a/app/lib/feature/seismicity/data/logic/seismicity_cumulative_binning.dart
+++ b/app/lib/feature/seismicity/data/logic/seismicity_cumulative_binning.dart
@@ -8,6 +8,8 @@ import 'package:eqmonitor/feature/seismicity/data/model/seismicity_event.dart';
 class SeismicityCumulativeBinning {
   const SeismicityCumulativeBinning();
 
+  static const maxDailyBinCount = 3660;
+
   List<SeismicityDailyBin> bin(List<SeismicityEvent> events) {
     if (events.isEmpty) {
       return const [];
@@ -26,6 +28,24 @@ class SeismicityCumulativeBinning {
     final sortedDays = countsByDay.keys.toList()..sort();
     final firstDay = sortedDays.first;
     final lastDay = sortedDays.last;
+
+    final inclusiveDayCount = lastDay.difference(firstDay).inDays + 1;
+    if (inclusiveDayCount > maxDailyBinCount) {
+      final bins = <SeismicityDailyBin>[];
+      var cumulative = 0;
+      for (final day in sortedDays) {
+        final count = countsByDay[day] ?? 0;
+        cumulative += count;
+        bins.add(
+          SeismicityDailyBin(
+            date: day,
+            count: count,
+            cumulativeCount: cumulative,
+          ),
+        );
+      }
+      return bins;
+    }
 
     final bins = <SeismicityDailyBin>[];
     var cumulative = 0;

--- a/app/test/feature/seismicity/data/logic/seismicity_cumulative_binning_test.dart
+++ b/app/test/feature/seismicity/data/logic/seismicity_cumulative_binning_test.dart
@@ -35,6 +35,24 @@ void main() {
     expect(bins[2].cumulativeCount, 3);
   });
 
+  test('過大な日付範囲はイベント発生日のみをビンにして過剰な生成を避ける', () {
+    const binning = SeismicityCumulativeBinning();
+    final events = [
+      _event(DateTime.utc(1)),
+      _event(DateTime.utc(9999, 12, 31)),
+    ];
+
+    final bins = binning.bin(events);
+
+    expect(bins.length, 2);
+    expect(bins[0].date, DateTime.utc(1));
+    expect(bins[0].count, 1);
+    expect(bins[0].cumulativeCount, 1);
+    expect(bins[1].date, DateTime.utc(9999, 12, 31));
+    expect(bins[1].count, 1);
+    expect(bins[1].cumulativeCount, 2);
+  });
+
   test('空リストは空を返す', () {
     const binning = SeismicityCumulativeBinning();
     expect(binning.bin(const []), isEmpty);


### PR DESCRIPTION
### Motivation
- The cumulative/histogram chart expanded one bin per calendar day between the earliest and latest selected event with no cap, allowing a sparse remote dataset with extreme dates to allocate millions of bins and crash the app.

### Description
- Add a configurable cap `maxDailyBinCount = 3660` to the cumulative binning helper to limit inclusive-day expansion to a reasonable span (~10 years). 
- When the inclusive day span exceeds the cap, fall back to emitting bins only for the actual event days (sorted event days) while preserving correct cumulative counts, avoiding per-day allocation for every intervening empty day.
- Preserve the original per-day contiguous binning behavior for reasonable spans below the cap.
- Add a regression unit test `過大な日付範囲はイベント発生日のみをビンにして過剰な生成を避ける` in `app/test/feature/seismicity/data/logic/seismicity_cumulative_binning_test.dart` that verifies two events with extreme dates produce only two bins with correct cumulative counts.

### Testing
- Added a unit test covering the extreme sparse-dates case and existing tests remain in the same test file; the new test is at `app/test/feature/seismicity/data/logic/seismicity_cumulative_binning_test.dart`.
- Attempts to run `dart format` and `flutter test` in this environment via the project toolchain were blocked because required tools could not be installed due to external download/network failures, so runtime execution of the test suite could not be completed here.
- Static/diff edits were validated in-repo and the change is limited to `app/lib/feature/seismicity/data/logic/seismicity_cumulative_binning.dart` and the test file noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550566da60832a8c4d479c030437f5)