### PR TITLE
Restrict Chuck network inspector to debug builds

### DIFF
--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -12,6 +12,7 @@ import 'package:eqmonitor/core/provider/interceptor/device_id_interceptor.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:talker_dio_logger/talker_dio_logger_interceptor.dart';
 import 'package:talker_dio_logger/talker_dio_logger_settings.dart';
@@ -43,8 +44,10 @@ Future<Dio> dio(Ref ref) async {
   dio.interceptors.add(deviceIdInterceptor);
   dio.interceptors.add(deviceAuthTokenInterceptor);
 
-  final chuck = ref.watch(chuckProvider);
-  dio.interceptors.add(chuck.dioInterceptor);
+  if (kDebugMode) {
+    final chuck = ref.watch(chuckProvider);
+    dio.interceptors.add(chuck.dioInterceptor);
+  }
 
   // ETag/304 透過キャッシュ。onResponse は登録順に実行されるため
   // TalkerDioLogger より前に置く。304 ヒット時は handler.resolve で

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -67,11 +67,12 @@ class _DebugWidget extends ConsumerWidget {
                   .read(debugProvider.notifier)
                   .save(isEnabled: !isDebugEnabled),
             ),
-            ListTile(
-              title: const Text('Chuck'),
-              leading: const Icon(Icons.list),
-              onTap: () async => ref.read(chuckProvider).showInspector(),
-            ),
+            if (kDebugMode)
+              ListTile(
+                title: const Text('Chuck'),
+                leading: const Icon(Icons.list),
+                onTap: () async => ref.read(chuckProvider).showInspector(),
+              ),
             ListTile(
               title: const Text('Flavor'),
               leading: const Icon(Icons.flag),


### PR DESCRIPTION
### Motivation
- Prevent production builds from capturing requests/responses (including App Check and device bearer tokens) via the Chuck network inspector by ensuring the inspector and its Dio interceptor are only active in debug builds.

### Description
- Gate Chuck interceptor registration behind `kDebugMode` so the `Chuck.dioInterceptor` is only added when `kDebugMode` is true in `app/lib/core/provider/dio_provider.dart`.
- Hide the Chuck inspector UI by showing the Chuck `ListTile` only when `kDebugMode` is true in `app/lib/feature/settings/children/config/debug/debug_page.dart`.

### Testing
- Ran a source-level Python validator that checks for `kDebugMode` gating of the Chuck interceptor and Chuck tile, which passed.
- Ran `git --no-pager diff --check`, which passed with no whitespace errors.
- Attempted to run `dart format` via the project toolchain, but the `mise` tool installation failed due to network/tool resolution errors (format step not completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550566c168832aab366f11c1ebaf3e)