### PR TITLE
Separate GeoJSON Dio to prevent device ID leakage

### DIFF
--- a/app/lib/feature/seismicity/data/provider/seismicity_repository_provider.dart
+++ b/app/lib/feature/seismicity/data/provider/seismicity_repository_provider.dart
@@ -1,11 +1,25 @@
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/provider/dio_base_options.dart';
 import 'package:eqmonitor/core/provider/dio_provider.dart';
 import 'package:eqmonitor/feature/seismicity/data/repository/seismicity_repository.dart';
+import 'package:riverpod/riverpod.dart' as riverpod;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'seismicity_repository_provider.g.dart';
 
+final seismicityGeoJsonDioProvider = riverpod.Provider<Dio>((ref) {
+  final dio = Dio(buildApiBaseOptions(baseUrl: ''));
+  dio.options.connectTimeout = const Duration(milliseconds: 10000);
+  dio.options.sendTimeout = const Duration(milliseconds: 10000);
+  return dio;
+});
+
 @Riverpod(keepAlive: true)
 Future<SeismicityRepository> seismicityRepository(Ref ref) async {
-  final dio = await ref.watch(dioProvider.future);
-  return SeismicityRepository(dio: dio);
+  final manifestDio = await ref.watch(dioProvider.future);
+  final geoJsonDio = ref.watch(seismicityGeoJsonDioProvider);
+  return SeismicityRepository(
+    manifestDio: manifestDio,
+    geoJsonDio: geoJsonDio,
+  );
 }

--- a/app/lib/feature/seismicity/data/repository/seismicity_repository.dart
+++ b/app/lib/feature/seismicity/data/repository/seismicity_repository.dart
@@ -11,10 +11,11 @@ import 'package:eqmonitor/feature/seismicity/data/model/seismicity_span.dart';
 /// このリポジトリが返す [SeismicityDataset.events] が唯一の分析用データソース。
 class SeismicityRepository {
   SeismicityRepository({
-    required Dio dio,
+    required Dio manifestDio,
+    required Dio geoJsonDio,
     SeismicityLocalCacheDataSource? cache,
-  }) : _manifestDataSource = SeismicityManifestDataSource(dio),
-       _geoJsonDataSource = SeismicityGeoJsonDataSource(dio),
+  }) : _manifestDataSource = SeismicityManifestDataSource(manifestDio),
+       _geoJsonDataSource = SeismicityGeoJsonDataSource(geoJsonDio),
        _cache = cache ?? SeismicityLocalCacheDataSource();
 
   final SeismicityManifestDataSource _manifestDataSource;

--- a/app/test/feature/seismicity/data/notifier/seismicity_dataset_notifier_test.dart
+++ b/app/test/feature/seismicity/data/notifier/seismicity_dataset_notifier_test.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:eqmonitor/core/provider/dio_provider.dart';
 import 'package:eqmonitor/feature/seismicity/data/model/seismicity_span.dart';
 import 'package:eqmonitor/feature/seismicity/data/notifier/seismicity_dataset_notifier.dart';
+import 'package:eqmonitor/feature/seismicity/data/provider/seismicity_repository_provider.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:riverpod/riverpod.dart';
@@ -90,6 +91,10 @@ void main() {
       overrides: [
         dioProvider.overrideWith((ref) async {
           return Dio(BaseOptions(baseUrl: 'https://example.com'))
+            ..httpClientAdapter = _SuccessAdapter();
+        }),
+        seismicityGeoJsonDioProvider.overrideWith((ref) {
+          return Dio(BaseOptions(baseUrl: ''))
             ..httpClientAdapter = _SuccessAdapter();
         }),
       ],

--- a/app/test/feature/seismicity/data/repository/seismicity_repository_test.dart
+++ b/app/test/feature/seismicity/data/repository/seismicity_repository_test.dart
@@ -63,6 +63,20 @@ class _SuccessAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
+class _RecordingSuccessAdapter extends _SuccessAdapter {
+  final requests = <RequestOptions>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    return super.fetch(options, requestStream, cancelFuture);
+  }
+}
+
 class _FailingAdapter implements HttpClientAdapter {
   @override
   Future<ResponseBody> fetch(
@@ -97,7 +111,11 @@ void main() {
     final cache = SeismicityLocalCacheDataSource(
       directoryProvider: () async => tempDir,
     );
-    final repository = SeismicityRepository(dio: dio, cache: cache);
+    final repository = SeismicityRepository(
+      manifestDio: dio,
+      geoJsonDio: dio,
+      cache: cache,
+    );
 
     final dataset = await repository.fetch(span: SeismicitySpan.p1m);
 
@@ -110,6 +128,38 @@ void main() {
     expect(cached!.events.single.eventId, 'eq-1');
   });
 
+  test('GeoJSON 取得には manifest 用 Dio の端末IDヘッダーを引き継がない', () async {
+    final manifestDio = Dio(BaseOptions(baseUrl: 'https://example.com'))
+      ..httpClientAdapter = _SuccessAdapter()
+      ..interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            options.headers['x-eqmonitor-device-id'] = 'device-id';
+            handler.next(options);
+          },
+        ),
+      );
+    final geoJsonAdapter = _RecordingSuccessAdapter();
+    final geoJsonDio = Dio(BaseOptions(baseUrl: ''))
+      ..httpClientAdapter = geoJsonAdapter;
+    final cache = SeismicityLocalCacheDataSource(
+      directoryProvider: () async => tempDir,
+    );
+    final repository = SeismicityRepository(
+      manifestDio: manifestDio,
+      geoJsonDio: geoJsonDio,
+      cache: cache,
+    );
+
+    await repository.fetch(span: SeismicitySpan.p1m);
+
+    expect(geoJsonAdapter.requests, hasLength(1));
+    expect(
+      geoJsonAdapter.requests.single.headers,
+      isNot(contains('x-eqmonitor-device-id')),
+    );
+  });
+
   test('取得失敗時はローカルキャッシュへフォールバックする', () async {
     final workingDio = Dio(BaseOptions(baseUrl: 'https://example.com'))
       ..httpClientAdapter = _SuccessAdapter();
@@ -118,13 +168,18 @@ void main() {
     );
     // 事前に一度成功させてキャッシュへ書き込んでおく
     await SeismicityRepository(
-      dio: workingDio,
+      manifestDio: workingDio,
+      geoJsonDio: workingDio,
       cache: cache,
     ).fetch(span: SeismicitySpan.p1m);
 
     final failingDio = Dio(BaseOptions(baseUrl: 'https://example.com'))
       ..httpClientAdapter = _FailingAdapter();
-    final repository = SeismicityRepository(dio: failingDio, cache: cache);
+    final repository = SeismicityRepository(
+      manifestDio: failingDio,
+      geoJsonDio: failingDio,
+      cache: cache,
+    );
 
     final dataset = await repository.fetch(span: SeismicitySpan.p1m);
 
@@ -138,7 +193,11 @@ void main() {
     final cache = SeismicityLocalCacheDataSource(
       directoryProvider: () async => tempDir,
     );
-    final repository = SeismicityRepository(dio: failingDio, cache: cache);
+    final repository = SeismicityRepository(
+      manifestDio: failingDio,
+      geoJsonDio: failingDio,
+      cache: cache,
+    );
 
     expect(
       () => repository.fetch(span: SeismicitySpan.p1m),


### PR DESCRIPTION
### Motivation
- The seismicity UI started using the global Dio which unconditionally attaches a stable `x-eqmonitor-device-id` header, and the manifest-driven GeoJSON fetch can follow arbitrary absolute URLs; this creates a risk of disclosing the device identifier to third-party hosts when the page is opened. 

### Description
- Introduce a dedicated provider `seismicityGeoJsonDioProvider` that constructs an unauthenticated `Dio` for GeoJSON downloads with safe defaults and no global interceptors. 
- Change `seismicityRepository` provider to supply separate `manifestDio` (the existing app API `dioProvider`) and `geoJsonDio` to the repository. 
- Update `SeismicityRepository` constructor to accept `manifestDio` and `geoJsonDio` and wire them into `SeismicityManifestDataSource` and `SeismicityGeoJsonDataSource` respectively. 
- Add/adjust tests to cover the new wiring and verify GeoJSON requests do not inherit `x-eqmonitor-device-id`, and update notifier test overrides to inject the new GeoJSON Dio. 

### Testing
- Ran `git --no-pager diff --check` which passed with no whitespace/errors. 
- Added unit tests exercising `SeismicityRepository` (including a test asserting GeoJSON requests do not include `x-eqmonitor-device-id`) and updated notifier tests, but full `flutter test` execution via `mise exec -- flutter test ...` was blocked by the environment tooling/installation step and timed out. 
- Changes were committed locally (`Fix seismicityのGeoJSON取得から端末IDを分離`) but `git push` was not performed because no remote push destination is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5505668d0c832abdfd62ae6069abe5)