### PR TITLE
Fix stale DB source selection in earthquake details

### DIFF
--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -75,7 +75,8 @@ class _LoadedContent extends HookConsumerWidget {
     final hasEstimated = earthquake.estimatedIntensityTileUrl != null;
     final hasLpgm = earthquake.intensity?.maxLpgmIntensity != null;
 
-    final hasCatalog = earthquake.catalog != null;
+    final catalog = earthquake.catalog;
+    final hasCatalog = catalog != null;
     final hasXml = earthquake.dataSources.contains(
       EarthquakeDataSource.jmaDisasterInformationXml,
     );
@@ -87,7 +88,12 @@ class _LoadedContent extends HookConsumerWidget {
           ? EarthquakeDataSource.jmaIntensityDatabase
           : EarthquakeDataSource.jmaDisasterInformationXml,
     );
-    final showingDb = source.value == EarthquakeDataSource.jmaIntensityDatabase;
+    final effectiveSource =
+        source.value == EarthquakeDataSource.jmaIntensityDatabase && hasCatalog
+        ? EarthquakeDataSource.jmaIntensityDatabase
+        : EarthquakeDataSource.jmaDisasterInformationXml;
+    final showingDb =
+        effectiveSource == EarthquakeDataSource.jmaIntensityDatabase;
 
     final displayMode = useState(
       hasEstimated ? IntensityDisplayMode.estimated : IntensityDisplayMode.jma,
@@ -158,7 +164,7 @@ class _LoadedContent extends HookConsumerWidget {
                                     label: '震度データベース',
                                   ),
                                 ],
-                                selected: source.value,
+                                selected: effectiveSource,
                                 onSelected: (v) => source.value = v,
                               ),
                         ),
@@ -171,12 +177,12 @@ class _LoadedContent extends HookConsumerWidget {
                           ),
                         ],
                       ),
-                      if (showingDb) ...[
+                      if (showingDb && catalog != null) ...[
                         ShindoDbHypocenterInformationCard(
-                          catalog: earthquake.catalog!,
+                          catalog: catalog,
                           originTime: earthquake.originTime,
                         ),
-                        ShindoDbEventNotes(catalog: earthquake.catalog!),
+                        ShindoDbEventNotes(catalog: catalog),
                       ] else
                         EarthquakeHypocenterInformationCard(item: earthquake),
                       CurrentLocationIntensityCard(item: earthquake),
@@ -186,7 +192,7 @@ class _LoadedContent extends HookConsumerWidget {
                         onDisplayModeChanged: (mode) =>
                             displayMode.value = mode,
                         availableModes: availableModes,
-                        source: source.value,
+                        source: effectiveSource,
                         showDatabaseBadge: isDbOnly,
                       ),
                       if (earthquake.originTime != null &&

--- a/app/test/feature/earthquake_history/ui/earthquake_details_source_toggle_widget_test.dart
+++ b/app/test/feature/earthquake_history/ui/earthquake_details_source_toggle_widget_test.dart
@@ -26,7 +26,8 @@ class _SourceToggleHarness extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final hasCatalog = earthquake.catalog != null;
+    final catalog = earthquake.catalog;
+    final hasCatalog = catalog != null;
     final hasXml = earthquake.dataSources.contains(
       EarthquakeDataSource.jmaDisasterInformationXml,
     );
@@ -38,7 +39,12 @@ class _SourceToggleHarness extends HookConsumerWidget {
           ? EarthquakeDataSource.jmaIntensityDatabase
           : EarthquakeDataSource.jmaDisasterInformationXml,
     );
-    final showingDb = source.value == EarthquakeDataSource.jmaIntensityDatabase;
+    final effectiveSource =
+        source.value == EarthquakeDataSource.jmaIntensityDatabase && hasCatalog
+        ? EarthquakeDataSource.jmaIntensityDatabase
+        : EarthquakeDataSource.jmaDisasterInformationXml;
+    final showingDb =
+        effectiveSource == EarthquakeDataSource.jmaIntensityDatabase;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -55,12 +61,12 @@ class _SourceToggleHarness extends HookConsumerWidget {
                 label: '震度データベース',
               ),
             ],
-            selected: source.value,
+            selected: effectiveSource,
             onSelected: (v) => source.value = v,
           ),
-        if (showingDb)
+        if (showingDb && catalog != null)
           ShindoDbHypocenterInformationCard(
-            catalog: earthquake.catalog!,
+            catalog: catalog,
             originTime: earthquake.originTime,
           )
         else
@@ -70,7 +76,7 @@ class _SourceToggleHarness extends HookConsumerWidget {
           displayMode: IntensityDisplayMode.jma,
           onDisplayModeChanged: (_) {},
           availableModes: const [IntensityDisplayMode.jma],
-          source: source.value,
+          source: effectiveSource,
           showDatabaseBadge: isDbOnly,
         ),
       ],
@@ -207,6 +213,28 @@ void main() {
 
     // 震度カードのタイトルが表示される
     expect(find.text('各地の震度'), findsOneWidget);
+  });
+
+  testWidgets('DB選択後にcatalogなしへ更新されてもXML表示へ戻る', (tester) async {
+    await pumpHarness(
+      tester,
+      earthquake: bothSourcesEarthquake,
+      withDbOverride: true,
+    );
+
+    await tester.tap(find.text('防災情報XML'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('震度データベース'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ShindoDbHypocenterInformationCard), findsOneWidget);
+
+    await pumpHarness(tester, earthquake: xmlOnlyEarthquake);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(EarthquakeHypocenterInformationCard), findsOneWidget);
+    expect(find.byType(ShindoDbHypocenterInformationCard), findsNothing);
   });
 
   testWidgets('(b) XML のみ → トグル非表示・XML カード表示', (tester) async {


### PR DESCRIPTION
### Motivation
- Prevent a client-side crash where a persistent UI source selection (`useState`) can remain set to the DB source after a refreshed `Earthquake` no longer contains a `catalog`, which leads to `catalog!` force-unwraps and runtime exceptions.
- Make the details UI resilient to background revalidation/refresh of earthquake data so pages remain available even when upstream responses drop the DB catalog.

### Description
- Introduced a local `catalog` variable and `hasCatalog` check and computed an `effectiveSource` that falls back to `jmaDisasterInformationXml` when `catalog` is absent to avoid stale DB rendering.
- Replaced usages of the raw `source.value` with `effectiveSource` for the segmented control and `EarthquakeIntensityCard` so UI and downstream components use a catalog-aware source.
- Removed unsafe `earthquake.catalog!` force-unwraps and guarded the DB-only rendering branch with `catalog != null`, passing the non-null `catalog` variable to DB widgets instead of force-unwrapping.
- Updated the source-toggle test harness and added a new widget test that exercises selecting DB and then re-rendering with an earthquake lacking `catalog` to cover the regression.

### Testing
- Added a widget test `DB選択後にcatalogなしへ更新されてもXML表示へ戻る` in `app/test/feature/earthquake_history/ui/earthquake_details_source_toggle_widget_test.dart` that verifies selecting DB then refreshing to a catalog-less earthquake returns to XML rendering and does not throw.
- Attempted to run `flutter test` on the modified test, but execution was blocked by the environment/toolchain resolution (tool downloads/network) so the test could not be executed in this CI/container; the test file is included in the PR for CI to run in a proper Flutter environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5505681808832ab4e3909299f6d4aa)