### PR TITLE
Enforce build-number-only forced updates

### DIFF
--- a/app/lib/feature/start/ui/component/forced_update_dialog.dart
+++ b/app/lib/feature/start/ui/component/forced_update_dialog.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/feature/start/data/notifier/start_notifier.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 import 'package:flutter/foundation.dart';
@@ -20,6 +21,48 @@ class ForcedUpdateWrapper extends ConsumerStatefulWidget {
   @override
   ConsumerState<ForcedUpdateWrapper> createState() =>
       _ForcedUpdateWrapperState();
+}
+
+class ForcedUpdateRequirementMatcher {
+  const ForcedUpdateRequirementMatcher({required this.packageInfo});
+
+  final PackageInfo packageInfo;
+
+  bool isUpdateRequired(api.RequiredVersion requiredVersion) {
+    final versionUpdateRequired = isVersionUpdateRequired(requiredVersion);
+    final buildUpdateRequired = isBuildNumberUpdateRequired(requiredVersion);
+    return versionUpdateRequired || buildUpdateRequired;
+  }
+
+  bool isVersionUpdateRequired(api.RequiredVersion requiredVersion) {
+    final requiredVersionString = requiredVersion.version;
+    if (requiredVersionString == null) {
+      return false;
+    }
+
+    Version current;
+    Version required;
+    try {
+      current = Version.parse(packageInfo.version);
+      required = Version.parse(requiredVersionString);
+    } on FormatException {
+      return false;
+    }
+    return current < required;
+  }
+
+  bool isBuildNumberUpdateRequired(api.RequiredVersion requiredVersion) {
+    final requiredBuildNumber = requiredVersion.buildNumber;
+    if (requiredBuildNumber == null) {
+      return false;
+    }
+
+    final currentBuildNumber = int.tryParse(packageInfo.buildNumber);
+    if (currentBuildNumber == null) {
+      return false;
+    }
+    return currentBuildNumber < requiredBuildNumber;
+  }
 }
 
 class _ForcedUpdateWrapperState extends ConsumerState<ForcedUpdateWrapper> {
@@ -61,26 +104,11 @@ class _ForcedUpdateWrapperState extends ConsumerState<ForcedUpdateWrapper> {
       return;
     }
 
-    final info = await PackageInfo.fromPlatform();
-    Version current;
-    try {
-      current = Version.parse(info.version);
-    } on FormatException {
-      return;
-    }
+    final info = ref.read(packageInfoProvider);
+    final matcher = ForcedUpdateRequirementMatcher(packageInfo: info);
 
     for (final req in requiredVersions) {
-      final versionStr = req.version;
-      if (versionStr == null) {
-        continue;
-      }
-      Version required;
-      try {
-        required = Version.parse(versionStr);
-      } on FormatException {
-        continue;
-      }
-      if (current < required) {
+      if (matcher.isUpdateRequired(req)) {
         if (!mounted) {
           return;
         }

--- a/app/test/feature/start/ui/component/forced_update_dialog_test.dart
+++ b/app/test/feature/start/ui/component/forced_update_dialog_test.dart
@@ -1,0 +1,34 @@
+import 'package:eqmonitor/feature/start/ui/component/forced_update_dialog.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  const packageInfo = PackageInfo(
+    appName: 'EQMonitor',
+    packageName: 'net.yumnumm.eqmonitor',
+    version: '3.0.0',
+    buildNumber: '100',
+  );
+  const matcher = ForcedUpdateRequirementMatcher(packageInfo: packageInfo);
+
+  group('ForcedUpdateRequirementMatcher', () {
+    test('requires updates for build-number-only rules', () {
+      const requiredVersion = api.RequiredVersion(buildNumber: 101);
+
+      expect(matcher.isUpdateRequired(requiredVersion), isTrue);
+    });
+
+    test('does not require updates for satisfied build-number-only rules', () {
+      const requiredVersion = api.RequiredVersion(buildNumber: 100);
+
+      expect(matcher.isUpdateRequired(requiredVersion), isFalse);
+    });
+
+    test('keeps requiring updates for semantic version rules', () {
+      const requiredVersion = api.RequiredVersion(version: '3.1.0');
+
+      expect(matcher.isUpdateRequired(requiredVersion), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- The API now allows `RequiredVersion` entries that omit `version` and specify `build_number`, but the client previously skipped rules with a null `version`, making build-number-only forced updates ineffective.
- The change ensures emergency rollouts that rely on build-number comparisons are enforced so vulnerable builds can be retired.

### Description
- Add `ForcedUpdateRequirementMatcher` to centralize logic that checks both semantic `version` and `build_number` requirements against the current `PackageInfo`.
- Replace `PackageInfo.fromPlatform()` usage with the bootstrapped `packageInfoProvider` so the already-initialized package info is reused during forced-update checks.
- Update the forced-update loop to evaluate every `RequiredVersion` with the matcher instead of skipping entries that have `version == null`.
- Add unit tests `app/test/feature/start/ui/component/forced_update_dialog_test.dart` that cover build-number-only rules (requires update / satisfied) and a semantic-version rule.

### Testing
- Ran `git --no-pager diff --check` which produced no check failures (succeeded).
- Added a focused unit test file for `ForcedUpdateRequirementMatcher`, but running `flutter test` was blocked because the environment tooling (`mise` / Flutter) could not be installed due to outbound download failures, so the tests were not executed here (blocked).
- `dart`/`flutter` formatting and test runs were attempted via `mise exec --`, but were also blocked by the same tooling installation issues (failed to install required tools).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550566e808832a97c06a4e46450d36)