### PR TITLE
Do not stop background location when notification slots are unresolved

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.dart
@@ -131,7 +131,7 @@ class ShakeDetectionSettingsNotifier extends _$ShakeDetectionSettingsNotifier {
     );
     state = AsyncData(nextState);
     if (removesCurrentLocation && !value.any((e) => e.isCurrentLocation)) {
-      final slots = ref.read(notificationSlotsProvider).value ?? [];
+      final slots = ref.read(notificationSlotsProvider).value;
       const lifecycle = BackgroundLocationMonitoringLifecycle();
       await lifecycle.stopIfUnused(
         slots: slots,

--- a/app/test/feature/location/background_location_service_error_test.dart
+++ b/app/test/feature/location/background_location_service_error_test.dart
@@ -112,6 +112,23 @@ void main() {
   });
 
   test(
+    'BackgroundLocationMonitoringPolicy keeps monitoring when slots unknown',
+    () {
+      const policy = BackgroundLocationMonitoringPolicy();
+      const models = _TestModels();
+
+      final shouldStop = policy.shouldStop(
+        slots: null,
+        shakeDetectionState: models.shakeDetectionState(
+          hasCurrentLocation: false,
+        ),
+      );
+
+      expect(shouldStop, isFalse);
+    },
+  );
+
+  test(
     'BackgroundLocationMonitoringPolicy keeps monitoring with current location',
     () {
       const policy = BackgroundLocationMonitoringPolicy();


### PR DESCRIPTION
### Motivation
- Prevent premature stopping of the OS background location monitor when `notificationSlotsProvider` is not yet loaded, since collapsing unknown slot state to an empty list bypasses the lifecycle policy that treats `null` as unknown.

### Description
- Change `shake_detection_settings_notifier.dart` to preserve unresolved `notificationSlotsProvider` state by removing the `?? []` coalescing so `null` is passed through to `BackgroundLocationMonitoringLifecycle.stopIfUnused` (file: `app/lib/feature/settings/features/notification_settings/data/notifier/shake_detection_settings_notifier.dart`).
- Add a unit test asserting the lifecycle policy keeps monitoring when slots are unknown by testing `BackgroundLocationMonitoringPolicy.shouldStop(slots: null, ...)` (file: `app/test/feature/location/background_location_service_error_test.dart`).

### Testing
- Added unit test `BackgroundLocationMonitoringPolicy keeps monitoring when slots unknown` to `app/test/feature/location/background_location_service_error_test.dart` (test added but not executed in this environment).
- Attempts to run `flutter test` for the modified test via the project tooling timed out/failed due to tool resolution/network issues in the environment, and `dart format` via `mise` was also blocked by tool installation, so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5505671c04832a9aebe697970c7cf6)