### PR TITLE
Fix current-location notification region persistence

### DIFF
--- a/app/lib/feature/location/data/background_location_service.dart
+++ b/app/lib/feature/location/data/background_location_service.dart
@@ -129,10 +129,13 @@ Future<void> _applyLocation(Ref ref, double latitude, double longitude) async {
     try {
       didUpdateEew = await retry.run(
         action: () async {
-          await ref
+          return ref
               .read(notificationSlotsProvider.notifier)
-              .updateCurrentLocationRegion(regionCode: code, regionName: name);
-          return true;
+              .updateCurrentLocationRegion(
+                regionCode: code,
+                regionName: name,
+                cityCode: earthquakeResolution?.cityCode,
+              );
         },
       );
     } on Object catch (e, st) {

--- a/app/lib/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/notifier/notification_slots_notifier.dart
@@ -175,23 +175,18 @@ class NotificationSlotsNotifier extends _$NotificationSlotsNotifier {
   Future<bool> updateCurrentLocationRegion({
     required int regionCode,
     String? regionName,
+    String? cityCode,
   }) async {
     final current = await future;
     final existing = current
         .where((s) => s.slotType == .currentLocation)
         .firstOrNull;
-    if (existing == null || existing.regionId == regionCode) {
+    if (existing == null ||
+        (existing.regionId == regionCode && existing.cityCode == cityCode)) {
       return false;
     }
     final repo = await ref.read(notificationSlotRepositoryProvider.future);
-    await repo.putCurrentLocation(
-      eewEnabled: existing.eewEnabled,
-      eewMinIntensity: existing.eewMinIntensity,
-      eewOverrides: existing.eewOverrides,
-      earthquakeEnabled: existing.earthquakeEnabled,
-      earthquakeMinIntensity: existing.earthquakeMinIntensity,
-      earthquakeOverrides: existing.earthquakeOverrides,
-    );
+    await repo.putDeviceLocation(regionId: regionCode, cityCode: cityCode);
     ref.invalidateSelf();
     return true;
   }

--- a/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
+++ b/app/lib/feature/settings/features/notification_settings/data/repository/notification_slot_repository.dart
@@ -66,6 +66,18 @@ class NotificationSlotRepository {
     await _api.device.deleteV2DeviceMeSettingsSlotsCurrentLocation();
   }
 
+  Future<void> putDeviceLocation({
+    required int regionId,
+    String? cityCode,
+  }) async {
+    await _api.device.putV2DeviceMeLocation(
+      body: api.DeviceLocationRequest(
+        regionId: regionId.toString(),
+        cityCode: cityCode,
+      ),
+    );
+  }
+
   Future<NotificationSlot> putNationwide({
     bool? eewEnabled,
     JmaIntensity? eewMinIntensity,

--- a/app/test/feature/location/background_location_update_notifier_test.dart
+++ b/app/test/feature/location/background_location_update_notifier_test.dart
@@ -34,6 +34,37 @@ class _FakeNotificationSlotsNotifier extends NotificationSlotsNotifier {
   Future<List<NotificationSlot>> build() async => _slots;
 }
 
+final class _FakeDeviceLocationApiAdapter implements HttpClientAdapter {
+  final putDeviceLocationCalls = <api.DeviceLocationRequest>[];
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.path.endsWith('/device/me/location') &&
+        options.method == 'PUT') {
+      final request = api.DeviceLocationRequest.fromJson(
+        Map<String, Object?>.from(options.data as Map<String, dynamic>),
+      );
+      putDeviceLocationCalls.add(request);
+      return _jsonResponse(
+        jsonEncode({
+          'region_id': request.regionId,
+          'city_code': request.cityCode,
+          'tsunami_forecast_region_code': null,
+        }),
+      );
+    }
+
+    throw UnimplementedError('Unhandled: ${options.method} ${options.path}');
+  }
+}
+
 /// `ShakeDetectionSettingsNotifier` が読む `apiClientProvider` を差し替える
 /// HTTP アダプタ。揺れ検知設定の GET / PUT とサブ地域マスター GET を模倣する。
 final class _FakeShakeApiAdapter implements HttpClientAdapter {
@@ -154,14 +185,21 @@ ProviderContainer _createShakeContainer(_FakeShakeApiAdapter adapter) {
   );
 }
 
-ProviderContainer _createSlotsContainer(List<NotificationSlot> slots) =>
-    ProviderContainer(
-      overrides: [
-        notificationSlotsProvider.overrideWith(
-          () => _FakeNotificationSlotsNotifier(slots),
-        ),
-      ],
-    );
+ProviderContainer _createSlotsContainer(
+  List<NotificationSlot> slots, {
+  required _FakeDeviceLocationApiAdapter adapter,
+}) {
+  final dio = Dio(BaseOptions(baseUrl: 'https://example.com'))
+    ..httpClientAdapter = adapter;
+  return ProviderContainer(
+    overrides: [
+      apiClientProvider.overrideWith((ref) async => api.ApiClient(dio)),
+      notificationSlotsProvider.overrideWith(
+        () => _FakeNotificationSlotsNotifier(slots),
+      ),
+    ],
+  );
+}
 
 NotificationSlot _currentLocationSlot({required int? regionId}) =>
     NotificationSlot(
@@ -448,9 +486,11 @@ void main() {
   // ==========================================================================
   group('NotificationSlotsNotifier.updateCurrentLocationRegion', () {
     test('現在地スロットの regionCode が変化した場合に true を返す', () async {
-      final container = _createSlotsContainer([
-        _currentLocationSlot(regionId: 9011),
-      ]);
+      final adapter = _FakeDeviceLocationApiAdapter();
+      final container = _createSlotsContainer(
+        [_currentLocationSlot(regionId: 9011)],
+        adapter: adapter,
+      );
       addTeardownToContainer(container);
 
       await container.read(notificationSlotsProvider.future);
@@ -460,12 +500,16 @@ void main() {
           .updateCurrentLocationRegion(regionCode: 9012, regionName: '多摩東部');
 
       expect(result, isTrue);
+      expect(adapter.putDeviceLocationCalls, hasLength(1));
+      expect(adapter.putDeviceLocationCalls.single.regionId, '9012');
     });
 
     test('現在地スロットの regionCode が同一なら false を返す', () async {
-      final container = _createSlotsContainer([
-        _currentLocationSlot(regionId: 9011),
-      ]);
+      final adapter = _FakeDeviceLocationApiAdapter();
+      final container = _createSlotsContainer(
+        [_currentLocationSlot(regionId: 9011)],
+        adapter: adapter,
+      );
       addTeardownToContainer(container);
 
       await container.read(notificationSlotsProvider.future);
@@ -475,11 +519,16 @@ void main() {
           .updateCurrentLocationRegion(regionCode: 9011, regionName: '東京地方');
 
       expect(result, isFalse);
+      expect(adapter.putDeviceLocationCalls, isEmpty);
     });
 
     test('現在地スロットがない場合は false を返す', () async {
       // 地域スロットのみ存在し、現在地スロットは無い。
-      final container = _createSlotsContainer([_regionSlot(regionId: 9999)]);
+      final adapter = _FakeDeviceLocationApiAdapter();
+      final container = _createSlotsContainer(
+        [_regionSlot(regionId: 9999)],
+        adapter: adapter,
+      );
       addTeardownToContainer(container);
 
       await container.read(notificationSlotsProvider.future);
@@ -489,6 +538,7 @@ void main() {
           .updateCurrentLocationRegion(regionCode: 9012, regionName: '多摩東部');
 
       expect(result, isFalse);
+      expect(adapter.putDeviceLocationCalls, isEmpty);
     });
   });
 }


### PR DESCRIPTION
### Motivation
- Background location updates resolved the user's EEW region and city but only invalidated cached notification-slot state instead of persisting the device current-location to the backend, which can cause alerts to be targeted to stale or null areas.
- The background update path also discarded the notifier's boolean result and did not forward the resolved earthquake `cityCode`, preventing correct no-op detection and debug visibility.

### Description
- Added `putDeviceLocation` to `NotificationSlotRepository` which calls the generated `putV2DeviceMeLocation` API with an `DeviceLocationRequest` carrying `region_id` and optional `city_code`.
- Updated `NotificationSlotsNotifier.updateCurrentLocationRegion` to accept an optional `cityCode`, to treat a change as region OR city change, and to call `putDeviceLocation` (instead of only invalidating cached slot state) before calling `ref.invalidateSelf()`.
- Changed the background service in `background_location_service.dart` to pass the resolved earthquake `cityCode` into `updateCurrentLocationRegion` and to preserve/return the notifier result from the retry so the caller can reflect real success/failure.
- Extended unit tests with a `_FakeDeviceLocationApiAdapter` and `ProviderContainer` overrides to assert that location updates trigger the new device-location API when appropriate and that unchanged/missing current-location slots do not call the API.

### Testing
- Ran `git --no-pager diff --check` to validate diffs and there were no check failures.
- Attempted to run `dart format` and `flutter test` via `mise exec`, but tool installation failed in this environment (network/download failures), so the `flutter test` run could not complete here; the test file was updated to exercise the new behavior and should be executed in CI or a local environment with `mise`/Flutter available.
- The repository changes are limited to the notifier, repository, background service, and tests and are designed to preserve existing behavior while adding persistence of current-location data to the backend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550566c918832a8cafc0d439d592a8)