### PR TITLE
Fix WebSocket heartbeat pongを接続層で返す

### DIFF
--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/api/api_client_provider.dart';
 import 'package:eqmonitor/core/provider/app_lifecycle.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart';
+import 'package:eqmonitor_websocket/eqmonitor_websocket.dart';
 import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:web_socket/web_socket.dart';
@@ -40,9 +41,16 @@ class EqmonitorWsEventStream extends _$EqmonitorWsEventStream {
 
     try {
       final websocket = await ref.watch(eqmonitorWebSocketProvider.future);
+      const heartbeatResponder = WsHeartbeatResponder();
       _retryCount = 0;
 
       await for (final event in websocket.events) {
+        if (event case TextDataReceived(:final text)) {
+          final response = heartbeatResponder.buildResponse(text);
+          if (response != null) {
+            websocket.sendText(response);
+          }
+        }
         yield event;
         if (event case CloseReceived(:final code, :final reason)) {
           talker.warning(
@@ -55,10 +63,7 @@ class EqmonitorWsEventStream extends _$EqmonitorWsEventStream {
       talker.error('EQMonitor WebSocket: connection failed', e);
     }
 
-    final delaySeconds = math.min(
-      math.pow(2, _retryCount).toInt(),
-      60,
-    );
+    final delaySeconds = math.min(math.pow(2, _retryCount).toInt(), 60);
     _retryCount++;
     talker.info(
       'EQMonitor WebSocket: reconnecting in ${delaySeconds}s '

--- a/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart
+++ b/app/lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_payload_stream.dart';
 import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart';
 import 'package:eqmonitor/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_state.dart';
@@ -11,7 +9,7 @@ part 'eqmonitor_ws_status_notifier.g.dart';
 /// WebSocket の接続状態・ping 情報を保持する keepAlive Notifier。
 ///
 /// phase は [eqmonitorWebSocketProvider] の AsyncValue から導出する。
-/// [WsPingMessage] 受信時に pong を返送し、サーバーの ping 送出間隔を [EqMonitorWsStatusState.pingRtt] に記録する。
+/// [WsPingMessage] 受信時に最終 ping 時刻とサーバーの ping 送出間隔を [EqMonitorWsStatusState.pingRtt] に記録する。
 /// なお pingRtt はネットワーク RTT ではなくサーバーからの ping 受信間隔である点に注意。
 @Riverpod(keepAlive: true)
 class EqMonitorWsStatus extends _$EqMonitorWsStatus {
@@ -29,9 +27,7 @@ class EqMonitorWsStatus extends _$EqMonitorWsStatus {
 
     ref.listen(eqmonitorWebSocketTicketProvider, (_, next) {
       next.whenData(
-        (ticket) => state = state.copyWith(
-          currentUrl: _maskTicket(ticket.url),
-        ),
+        (ticket) => state = state.copyWith(currentUrl: _maskTicket(ticket.url)),
       );
     });
 
@@ -68,12 +64,6 @@ class EqMonitorWsStatus extends _$EqMonitorWsStatus {
       lastPingAt: now,
       pingRtt: prev != null ? now.difference(prev) : state.pingRtt,
     );
-
-    final ws = switch (ref.read(eqmonitorWebSocketProvider)) {
-      AsyncData(:final value) => value,
-      _ => null,
-    };
-    ws?.sendText(jsonEncode(const WsPongMessage().toJson()));
   }
 
   static String _maskTicket(String url) {

--- a/packages/eqmonitor_websocket/lib/eqmonitor_websocket.dart
+++ b/packages/eqmonitor_websocket/lib/eqmonitor_websocket.dart
@@ -1,5 +1,6 @@
 export 'src/realtime_event_envelope.dart';
 export 'src/ws_estimated_intensity_payload.dart';
+export 'src/ws_heartbeat_responder.dart';
 export 'src/ws_message.dart';
 export 'src/ws_pong_message.dart';
 export 'src/ws_realtime_operation.dart';

--- a/packages/eqmonitor_websocket/lib/src/ws_heartbeat_responder.dart
+++ b/packages/eqmonitor_websocket/lib/src/ws_heartbeat_responder.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+
+import 'package:eqmonitor_websocket/src/ws_pong_message.dart';
+
+class WsHeartbeatResponder {
+  const WsHeartbeatResponder();
+
+  String? buildResponse(String text) {
+    try {
+      final json = jsonDecode(text);
+      if (json is! Map<String, dynamic>) {
+        return null;
+      }
+      if (json['type'] != 'ping') {
+        return null;
+      }
+      return jsonEncode(const WsPongMessage().toJson());
+    } on FormatException {
+      return null;
+    }
+  }
+}

--- a/packages/eqmonitor_websocket/test/ws_heartbeat_responder_test.dart
+++ b/packages/eqmonitor_websocket/test/ws_heartbeat_responder_test.dart
@@ -1,0 +1,20 @@
+import 'package:eqmonitor_websocket/eqmonitor_websocket.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WsHeartbeatResponder', () {
+    const responder = WsHeartbeatResponder();
+
+    test('application-level ping に pong JSON を返すこと', () {
+      expect(responder.buildResponse('{"type":"ping"}'), '{"type":"pong"}');
+    });
+
+    test('ping 以外のメッセージには応答しないこと', () {
+      expect(responder.buildResponse('{"type":"ready"}'), isNull);
+    });
+
+    test('不正な JSON には応答しないこと', () {
+      expect(responder.buildResponse('not-json'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- WebSocket の application-level `ping` に接続層で即時 `pong` を返すように変更
- ステータス Notifier は ping 時刻と間隔の記録だけに整理
- heartbeat 応答の単体テストを `eqmonitor_websocket` に追加

## Root Cause
サーバーは WebSocket protocol pong ではなく JSON メッセージ `{"type":"pong"}` を要求しているが、アプリ側の pong 送信がステータス監視側の副作用に寄っており、接続処理の責務として保証されていなかった。

## Validation
- `mise exec -- dart test packages/eqmonitor_websocket/test/ws_heartbeat_responder_test.dart`
- `mise exec -- dart analyze packages/eqmonitor_websocket`
- `mise exec -- flutter analyze lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_provider.dart lib/core/realtime/data_source/eqmonitor/eqmonitor_ws_status_notifier.dart`

## Note
`mise exec -- dart test packages/eqmonitor_websocket/test` は既存 fixture の `datasource` / `datasources` 不整合で2件失敗しています。今回追加した heartbeat テストは通過しています。