### PR TITLE
fix: 震度データベース観測点をSymbolレイヤー単独描画に変更し全階級のアイコンを追加

### DIFF
--- a/app/lib/feature/earthquake_history/data/provider/shindo_db_intensity_icon_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/shindo_db_intensity_icon_provider.dart
@@ -1,0 +1,52 @@
+import 'dart:typed_data';
+
+import 'package:eqmonitor/core/theme/build_theme.dart';
+import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
+import 'package:eqmonitor/core/theme/theme_provider.dart';
+import 'package:eqmonitor/core/util/widget_to_image.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'shindo_db_intensity_icon_provider.g.dart';
+
+/// 震度データベース固有の震度階級 (旧階級 5/6・歴史的階級) の地図用アイコン
+///
+/// 現行の JMA 震度と一致する階級は intensityIconProvider の画像を流用するため、
+/// ここでは [ShindoDbIntensityClass.exactJmaIntensity] を持たない階級のみ描画する。
+@Riverpod(keepAlive: true)
+Future<Map<ShindoDbIntensityClass, Uint8List>> shindoDbIntensityIcon(
+  Ref ref,
+) async {
+  final colorSet = ref.watch(activeColorSetProvider);
+  final brightness = ref.watch(brightnessProvider);
+
+  final result = <ShindoDbIntensityClass, Uint8List>{};
+  final futures = <Future<void>>[];
+  for (final cls in ShindoDbIntensityClass.values.where(
+    (cls) => cls.exactJmaIntensity == null,
+  )) {
+    futures.add(() async {
+      final bytes = await renderWidgetToImageBytes(
+        logicalSize: const Size(50, 50),
+        widget: Theme(
+          data: buildTheme(colorSet: colorSet, brightness: brightness),
+          child: ShindoDbIntensityClassMapIcon(intensityClass: cls),
+        ),
+      );
+      if (bytes == null) {
+        throw Exception('Failed to render ShindoDbIntensityClassMapIcon');
+      }
+      result[cls] = bytes;
+    }());
+  }
+  await futures.wait;
+  return result;
+}
+
+extension ShindoDbIntensityIconEx on Map<ShindoDbIntensityClass, Uint8List> {
+  Map<String, Uint8List> get toMapStyleImages => {
+    for (final entry in entries) entry.key.mapIconId: entry.value,
+  };
+}

--- a/app/lib/feature/earthquake_history/data/provider/shindo_db_intensity_icon_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/shindo_db_intensity_icon_provider.g.dart
@@ -1,0 +1,67 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'shindo_db_intensity_icon_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 震度データベース固有の震度階級 (旧階級 5/6・歴史的階級) の地図用アイコン
+///
+/// 現行の JMA 震度と一致する階級は intensityIconProvider の画像を流用するため、
+/// ここでは [ShindoDbIntensityClass.exactJmaIntensity] を持たない階級のみ描画する。
+
+@ProviderFor(shindoDbIntensityIcon)
+final shindoDbIntensityIconProvider = ShindoDbIntensityIconProvider._();
+
+/// 震度データベース固有の震度階級 (旧階級 5/6・歴史的階級) の地図用アイコン
+///
+/// 現行の JMA 震度と一致する階級は intensityIconProvider の画像を流用するため、
+/// ここでは [ShindoDbIntensityClass.exactJmaIntensity] を持たない階級のみ描画する。
+
+final class ShindoDbIntensityIconProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<Map<ShindoDbIntensityClass, Uint8List>>,
+          Map<ShindoDbIntensityClass, Uint8List>,
+          FutureOr<Map<ShindoDbIntensityClass, Uint8List>>
+        >
+    with
+        $FutureModifier<Map<ShindoDbIntensityClass, Uint8List>>,
+        $FutureProvider<Map<ShindoDbIntensityClass, Uint8List>> {
+  /// 震度データベース固有の震度階級 (旧階級 5/6・歴史的階級) の地図用アイコン
+  ///
+  /// 現行の JMA 震度と一致する階級は intensityIconProvider の画像を流用するため、
+  /// ここでは [ShindoDbIntensityClass.exactJmaIntensity] を持たない階級のみ描画する。
+  ShindoDbIntensityIconProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'shindoDbIntensityIconProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$shindoDbIntensityIconHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<Map<ShindoDbIntensityClass, Uint8List>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<Map<ShindoDbIntensityClass, Uint8List>> create(Ref ref) {
+    return shindoDbIntensityIcon(ref);
+  }
+}
+
+String _$shindoDbIntensityIconHash() =>
+    r'b0f1ed3844f4a80635728c6a5c04c25c3076eea0';

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart
@@ -91,7 +91,7 @@ class _MapContent extends HookConsumerWidget {
   final bool showingDb;
 
   static const _stationLayerId = 'eq-history-station-intensity-circle';
-  static const _dbStationLayerId = 'eq-history-shindo-db-station-circle';
+  static const _dbStationLayerId = 'eq-history-shindo-db-station-icon';
   static const _regionSourceLayerId = 'areaForecastLocalE';
   static const _citySourceLayerId = 'areaInformationCityQuake';
 

--- a/app/lib/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart
+++ b/app/lib/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart
@@ -6,6 +6,85 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intens
 import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
 import 'package:flutter/material.dart';
 
+extension ShindoDbIntensityClassMapIconId on ShindoDbIntensityClass {
+  /// 地図スタイルに登録された観測点アイコン画像の ID
+  ///
+  /// 現行の JMA 震度と一致する階級は [JmaIntensityIcon] 由来の画像を流用し、
+  /// 旧階級 (5/6) と歴史的階級は [ShindoDbIntensityClassMapIcon] 由来の
+  /// 専用画像を参照する。
+  String get mapIconId {
+    final exact = exactJmaIntensity;
+    return exact != null
+        ? 'JmaIntensity.${IntensityIconType.small.name}.${exact.name}'
+        : 'ShindoDbIntensityClass.${IntensityIconType.small.name}.$name';
+  }
+}
+
+/// 震度データベースの震度階級の地図用円形アイコン
+///
+/// 現行の JMA 震度と一致する階級は [JmaIntensityIcon] をそのまま利用し、
+/// 旧階級 (5/6) と歴史的階級はラベルテキスト入りの円を描画する。
+class ShindoDbIntensityClassMapIcon extends StatelessWidget {
+  const ShindoDbIntensityClassMapIcon({
+    required this.intensityClass,
+    this.size = 50,
+    super.key,
+  });
+
+  final ShindoDbIntensityClass intensityClass;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final exact = intensityClass.exactJmaIntensity;
+    if (exact != null) {
+      return JmaIntensityIcon(
+        intensity: exact,
+        type: IntensityIconType.small,
+        size: size,
+      );
+    }
+
+    final colorTheme = context.designSystem.colorTheme;
+    final colorJma = intensityClass.colorJmaIntensity;
+    final entry = colorJma != null
+        ? colorTheme.intensity.fromJmaIntensity(colorJma)
+        : null;
+    final fg = entry?.resolvedForeground ?? colorTheme.onSurface;
+    final bg = entry?.background ?? colorTheme.surfaceContainerHighest;
+    final borderColor = Color.lerp(bg, fg, 0.3) ?? fg;
+    return SizedBox(
+      height: size,
+      width: size,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: bg,
+          border: Border.all(color: borderColor, width: 5),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(2),
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                intensityClass.label,
+                style: TextStyle(
+                  color: fg,
+                  fontSize: 100,
+                  fontWeight: FontWeight.bold,
+                  fontFamily: FontFamily.googleSansCode,
+                  fontFamilyFallback: const [FontFamily.notoSansJP],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class ShindoDbIntensityClassIcon extends StatelessWidget {
   const ShindoDbIntensityClassIcon({
     required this.intensityClass,

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
@@ -3,12 +3,11 @@ import 'dart:convert';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
-import 'package:eqmonitor/core/theme/model/intensity_colors.dart';
-import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
-import 'package:eqmonitor/core/util/converter/color_converter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/shindo_db_intensity_icon_provider.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart';
 import 'package:eqmonitor/feature/map/features/icon/data/provider/intensity_icon_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -26,28 +25,26 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
   final EarthquakeHistoryMapLayerParameter parameter;
 
   static const _sourceId = 'eq-history-shindo-db-station';
-  static const _circleLayerId = 'eq-history-shindo-db-station-circle';
   static const _iconLayerId = 'eq-history-shindo-db-station-icon';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final styleController = MapController.maybeOf(context)?.style;
-    final colorModel = ref.watch(activeColorSetProvider).intensity;
     final iconData = ref.watch(intensityIconProvider).value;
+    final dbIconData = ref.watch(shindoDbIntensityIconProvider).value;
     final enqueue = useMapOperationQueue();
 
     useEffect(() {
-      if (styleController == null) {
+      if (styleController == null || iconData == null || dbIconData == null) {
         return null;
       }
 
       var disposed = false;
-      var iconLayerAdded = false;
 
       unawaited(
         enqueue(() async {
           try {
-            final geoJson = _buildGeoJson(tree, colorModel);
+            final geoJson = _buildGeoJson(tree);
 
             if (disposed) {
               return;
@@ -59,78 +56,38 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
             if (disposed) {
               return;
             }
-            final cachedBytes = iconData?.toMapStyleImages;
-            if (cachedBytes != null) {
-              await styleController.addImages(cachedBytes);
-            }
+            await styleController.addImages({
+              ...iconData.toMapStyleImages,
+              ...dbIconData.toMapStyleImages,
+            });
 
             if (disposed) {
               return;
             }
             await styleController.addLayer(
-              CircleStyleLayer(
-                id: _circleLayerId,
+              SymbolStyleLayer(
+                id: _iconLayerId,
                 sourceId: _sourceId,
                 minZoom: parameter.stationMinZoom,
-                layout: const {
-                  'circle-sort-key': ['get', 'sortKey'],
-                },
-                paint: {
-                  'circle-radius': [
+                layout: {
+                  'icon-image': ['get', 'iconId'],
+                  'icon-allow-overlap': true,
+                  'icon-ignore-placement': true,
+                  'symbol-sort-key': ['get', 'sortKey'],
+                  'icon-size': [
                     'interpolate',
                     ['linear'],
                     ['zoom'],
-                    4,
-                    parameter.stationCircleRadiusMin,
-                    10,
-                    parameter.stationCircleRadiusMax,
-                  ],
-                  'circle-color': ['get', 'color'],
-                  'circle-stroke-color': '#ffffff',
-                  'circle-stroke-width': [
-                    'interpolate',
-                    ['linear'],
-                    ['zoom'],
-                    4,
-                    0.3,
-                    10,
-                    1.5,
+                    3,
+                    parameter.stationIconSizeMin,
+                    7,
+                    parameter.stationIconSizeMid,
+                    20,
+                    parameter.stationIconSizeMax,
                   ],
                 },
               ),
             );
-
-            if (disposed) {
-              return;
-            }
-            if (iconData != null) {
-              await styleController.addLayer(
-                SymbolStyleLayer(
-                  id: _iconLayerId,
-                  sourceId: _sourceId,
-                  minZoom: parameter.stationMinZoom,
-                  filter: const ['has', 'iconId'],
-                  layout: {
-                    'icon-image': ['get', 'iconId'],
-                    'icon-allow-overlap': true,
-                    'icon-ignore-placement': true,
-                    'symbol-sort-key': ['get', 'sortKey'],
-                    'icon-size': [
-                      'interpolate',
-                      ['linear'],
-                      ['zoom'],
-                      3,
-                      parameter.stationIconSizeMin,
-                      7,
-                      parameter.stationIconSizeMid,
-                      20,
-                      parameter.stationIconSizeMax,
-                    ],
-                  },
-                ),
-              );
-              iconLayerAdded = true;
-            }
           } on Exception catch (e) {
             talker.log(e);
           }
@@ -141,15 +98,8 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
         disposed = true;
         unawaited(
           enqueue(() async {
-            if (iconLayerAdded) {
-              try {
-                await styleController.removeLayer(_iconLayerId);
-              } on Exception catch (e) {
-                talker.log(e);
-              }
-            }
             try {
-              await styleController.removeLayer(_circleLayerId);
+              await styleController.removeLayer(_iconLayerId);
             } on Exception catch (e) {
               talker.log(e);
             }
@@ -161,15 +111,12 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
           }),
         );
       };
-    }, [styleController, tree, colorModel, parameter, iconData]);
+    }, [styleController, tree, parameter, iconData, dbIconData]);
 
     return const SizedBox.shrink();
   }
 
-  static String _buildGeoJson(
-    ShindoDbIntensityTree tree,
-    IntensityColors colorModel,
-  ) {
+  static String _buildGeoJson(ShindoDbIntensityTree tree) {
     final features = <Map<String, dynamic>>[];
 
     void addStation(ShindoDbStationNode station, ShindoDbIntensityClass cls) {
@@ -177,26 +124,18 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
       if (loc == null) {
         return;
       }
-      final colorJma = cls.colorJmaIntensity;
-      final color = colorJma != null
-          ? colorModel.fromJmaIntensity(colorJma).background.toHexStringRGB()
-          : '#9e9e9e';
-      final props = <String, dynamic>{
-        'color': color,
-        'name': station.name,
-        'sortKey': cls.orderIndex,
-      };
-      final exactJma = cls.exactJmaIntensity;
-      if (exactJma != null) {
-        props['iconId'] = 'JmaIntensity.small.${exactJma.name}';
-      }
       features.add({
         'type': 'Feature',
         'geometry': {
           'type': 'Point',
           'coordinates': [loc.lon, loc.lat],
         },
-        'properties': props,
+        'properties': {
+          'name': station.name,
+          'iconId': cls.mapIconId,
+          // 高震度が上に描画されるようソートキーに使用
+          'sortKey': cls.orderIndex,
+        },
       });
     }
 

--- a/app/test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart
+++ b/app/test/feature/earthquake_history/ui/shindo_db_intensity_class_map_icon_test.dart
@@ -1,0 +1,96 @@
+import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/shindo_db_intensity_class_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> pumpIcon(
+    WidgetTester tester,
+    ShindoDbIntensityClass intensityClass,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.light().copyWith(
+          extensions: <ThemeExtension<dynamic>>[
+            DesignSystemThemeExtension.light(),
+          ],
+        ),
+        home: Scaffold(
+          body: Center(
+            child: ShindoDbIntensityClassMapIcon(
+              intensityClass: intensityClass,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('ShindoDbIntensityClassMapIcon', () {
+    testWidgets('全階級が例外なく描画できること', (tester) async {
+      for (final cls in ShindoDbIntensityClass.values) {
+        await pumpIcon(tester, cls);
+        expect(tester.takeException(), isNull, reason: '$cls');
+      }
+    });
+
+    testWidgets('現行のJMA震度と一致する階級は JmaIntensityIcon を流用すること', (tester) async {
+      for (final cls in ShindoDbIntensityClass.values.where(
+        (c) => c.exactJmaIntensity != null,
+      )) {
+        await pumpIcon(tester, cls);
+        expect(find.byType(JmaIntensityIcon), findsOneWidget, reason: '$cls');
+      }
+    });
+
+    testWidgets('旧階級・歴史的階級はラベルテキストを描画すること', (tester) async {
+      for (final cls in ShindoDbIntensityClass.values.where(
+        (c) => c.exactJmaIntensity == null,
+      )) {
+        await pumpIcon(tester, cls);
+        expect(find.byType(JmaIntensityIcon), findsNothing, reason: '$cls');
+        expect(find.text(cls.label), findsOneWidget, reason: '$cls');
+      }
+    });
+  });
+
+  group('mapIconId', () {
+    test('全階級がアイコンIDを持つこと', () {
+      for (final cls in ShindoDbIntensityClass.values) {
+        expect(cls.mapIconId, isNotEmpty, reason: '$cls');
+      }
+    });
+
+    test('現行のJMA震度と一致する階級は JmaIntensity のアイコンIDを返すこと', () {
+      expect(ShindoDbIntensityClass.four.mapIconId, 'JmaIntensity.small.four');
+      expect(
+        ShindoDbIntensityClass.fiveLower.mapIconId,
+        'JmaIntensity.small.fiveLower',
+      );
+      expect(
+        ShindoDbIntensityClass.seven.mapIconId,
+        'JmaIntensity.small.seven',
+      );
+    });
+
+    test('旧階級・歴史的階級は専用のアイコンIDを返すこと', () {
+      expect(
+        ShindoDbIntensityClass.five.mapIconId,
+        'ShindoDbIntensityClass.small.five',
+      );
+      expect(
+        ShindoDbIntensityClass.six.mapIconId,
+        'ShindoDbIntensityClass.small.six',
+      );
+      expect(
+        ShindoDbIntensityClass.unknownFelt.mapIconId,
+        'ShindoDbIntensityClass.small.unknownFelt',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

地震履歴詳細画面（震度データベース表示）で観測点マークが2種類（数字入りバッジ / 無地の丸ドット）混在していた問題の修正です。

旧観測網の地震（例: 1923年関東大震災）では、細分化前の旧震度階級 5/6 や歴史的階級に対応する地図アイコンが存在せず、Circleレイヤーのフォールバック（無地の丸）で描画されていました。震度4以下はアイコン表示のため、高震度の観測点ほど目立たないという逆転が起きていました。

## 変更内容

- **Symbolレイヤー単独描画**: 観測点レイヤーの Circle+Symbol 2レイヤー構成を廃止し、Symbolレイヤーのみで描画
- **震度DB固有階級のアイコン追加**: 現行のJMA震度アイコンを流用できない9階級に専用アイコンを追加
  - 旧階級: 震度5・震度6（5弱/6弱の色 + ラベル）
  - 歴史的階級: 震度不明(9)・顕著(R)・やや顕著(M)・小局発(S)・局発(L)・有感(F)・付近有感(X)（グレー地 + ラベル）
- `ShindoDbIntensityClassMapIcon` ウィジェット + `shindoDbIntensityIconProvider` を新設（テーマ・明暗に追従）
- アイコンIDの決定を `ShindoDbIntensityClass.mapIconId` 拡張に一元化
- 観測点タップ判定のレイヤーIDをSymbolレイヤーIDに更新

## テスト

- 新規: `shindo_db_intensity_class_map_icon_test.dart`（全18階級の描画・アイコンID対応）
- `test/feature/earthquake_history` 配下で新規失敗なし（既存失敗8件は develop でも失敗することを確認済み）
- `dart analyze` 新規指摘なし / `dart format` 適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
