### PR TITLE
fix: Android βビルドでIS_BETA_TESTINGを有効化

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -502,7 +502,8 @@ jobs:
             --dart-define-from-file=../environment/.env.prod \
             --dart-define COMMIT_INFORMATION="$COMMIT_INFORMATION" \
             --dart-define BUILD_TIMESTAMP="$BUILD_TIMESTAMP" \
-            --dart-define BUILD_COMMIT_MESSAGE="$BUILD_COMMIT_MESSAGE"
+            --dart-define BUILD_COMMIT_MESSAGE="$BUILD_COMMIT_MESSAGE" \
+            --dart-define IS_BETA_TESTING="true"
 
       - name: Copy AAB to expected location
         run: |


### PR DESCRIPTION
## 概要

Android の配布用 AAB ビルド(`build-android` job)に `--dart-define IS_BETA_TESTING="true"` を追加します(iOS 側 L152 と同形式)。これにより Android βビルドでも `BuildConfig.isBetaTesting == true` となり、β警告・同意画面・β用デバッグ導線が有効になります。

Closes #1488

## 変更内容

- `.github/workflows/deploy-app.yaml`: Android `flutter build appbundle` コマンドへ dart-define を1行追加(最小差分。iOS との共通化は行わず YAGNI)

## 検証

- `actionlint` クリーン、pre-commit hooks (gitleaks/zizmor/pinact) 通過
- AAB 実ビルドは環境依存のため未実施(静的検証のみ)

## 配布後の手動確認チェックリスト

- [ ] Android 配布 artifact の初回起動で `/beta-warning` に到達する
- [ ] β同意後に通常画面へ進める

🤖 Generated with [Claude Code](https://claude.com/claude-code)