### PR TITLE
feat: 地震履歴詳細画面のデータソースラベルに電文コメントを表示

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/earthquake.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake.dart
@@ -3,6 +3,7 @@ import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_catal
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
 import 'package:eqmonitor/feature/parameter/data/model/parameter.dart';
@@ -22,6 +23,9 @@ abstract class Earthquake with _$Earthquake {
     required DateTime? arrivalTime,
     required List<EarthquakeDataSource> dataSources,
     required List<EarthquakeTelegramType> telegramTypes,
+
+    /// 電文コメント（固定付加文・自由付加文）
+    @Default([]) List<EarthquakeTelegramComment> telegramComments,
     required EarthquakeHypocenter? hypocenter,
     required EarthquakeIntensity? intensity,
 
@@ -50,6 +54,7 @@ extension EarthquakeApiExtension on api.Earthquake {
         .map((e) => e.telegram.type.toEarthquakeTelegramTypeOrNull)
         .whereType<EarthquakeTelegramType>()
         .toList(),
+    telegramComments: extractTelegramComments(telegrams),
     hypocenter: hypocenter?.toEarthquakeHypocenter,
     estimatedIntensityTileUrl: estimatedIntensityTile,
     catalog: catalog?.toEarthquakeCatalog,

--- a/app/lib/feature/earthquake_history/data/model/earthquake.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake.freezed.dart
@@ -15,7 +15,8 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Earthquake {
 
- String get eventId; TelegramStatus get status; DateTime? get originTime; OriginTimePrecision get originTimePrecision; DateTime? get arrivalTime; List<EarthquakeDataSource> get dataSources; List<EarthquakeTelegramType> get telegramTypes; EarthquakeHypocenter? get hypocenter; EarthquakeIntensity? get intensity;/// 推計震度PMTilesのフルURL
+ String get eventId; TelegramStatus get status; DateTime? get originTime; OriginTimePrecision get originTimePrecision; DateTime? get arrivalTime; List<EarthquakeDataSource> get dataSources; List<EarthquakeTelegramType> get telegramTypes;/// 電文コメント（固定付加文・自由付加文）
+ List<EarthquakeTelegramComment> get telegramComments; EarthquakeHypocenter? get hypocenter; EarthquakeIntensity? get intensity;/// 推計震度PMTilesのフルURL
  String? get estimatedIntensityTileUrl;@JsonKey(includeFromJson: false, includeToJson: false) EarthquakeCatalog? get catalog;
 /// Create a copy of Earthquake
 /// with the given fields replaced by the non-null parameter values.
@@ -29,16 +30,16 @@ $EarthquakeCopyWith<Earthquake> get copyWith => _$EarthquakeCopyWithImpl<Earthqu
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Earthquake&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.status, status) || other.status == status)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.originTimePrecision, originTimePrecision) || other.originTimePrecision == originTimePrecision)&&(identical(other.arrivalTime, arrivalTime) || other.arrivalTime == arrivalTime)&&const DeepCollectionEquality().equals(other.dataSources, dataSources)&&const DeepCollectionEquality().equals(other.telegramTypes, telegramTypes)&&(identical(other.hypocenter, hypocenter) || other.hypocenter == hypocenter)&&(identical(other.intensity, intensity) || other.intensity == intensity)&&(identical(other.estimatedIntensityTileUrl, estimatedIntensityTileUrl) || other.estimatedIntensityTileUrl == estimatedIntensityTileUrl)&&(identical(other.catalog, catalog) || other.catalog == catalog));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Earthquake&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.status, status) || other.status == status)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.originTimePrecision, originTimePrecision) || other.originTimePrecision == originTimePrecision)&&(identical(other.arrivalTime, arrivalTime) || other.arrivalTime == arrivalTime)&&const DeepCollectionEquality().equals(other.dataSources, dataSources)&&const DeepCollectionEquality().equals(other.telegramTypes, telegramTypes)&&const DeepCollectionEquality().equals(other.telegramComments, telegramComments)&&(identical(other.hypocenter, hypocenter) || other.hypocenter == hypocenter)&&(identical(other.intensity, intensity) || other.intensity == intensity)&&(identical(other.estimatedIntensityTileUrl, estimatedIntensityTileUrl) || other.estimatedIntensityTileUrl == estimatedIntensityTileUrl)&&(identical(other.catalog, catalog) || other.catalog == catalog));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,eventId,status,originTime,originTimePrecision,arrivalTime,const DeepCollectionEquality().hash(dataSources),const DeepCollectionEquality().hash(telegramTypes),hypocenter,intensity,estimatedIntensityTileUrl,catalog);
+int get hashCode => Object.hash(runtimeType,eventId,status,originTime,originTimePrecision,arrivalTime,const DeepCollectionEquality().hash(dataSources),const DeepCollectionEquality().hash(telegramTypes),const DeepCollectionEquality().hash(telegramComments),hypocenter,intensity,estimatedIntensityTileUrl,catalog);
 
 @override
 String toString() {
-  return 'Earthquake(eventId: $eventId, status: $status, originTime: $originTime, originTimePrecision: $originTimePrecision, arrivalTime: $arrivalTime, dataSources: $dataSources, telegramTypes: $telegramTypes, hypocenter: $hypocenter, intensity: $intensity, estimatedIntensityTileUrl: $estimatedIntensityTileUrl, catalog: $catalog)';
+  return 'Earthquake(eventId: $eventId, status: $status, originTime: $originTime, originTimePrecision: $originTimePrecision, arrivalTime: $arrivalTime, dataSources: $dataSources, telegramTypes: $telegramTypes, telegramComments: $telegramComments, hypocenter: $hypocenter, intensity: $intensity, estimatedIntensityTileUrl: $estimatedIntensityTileUrl, catalog: $catalog)';
 }
 
 
@@ -49,7 +50,7 @@ abstract mixin class $EarthquakeCopyWith<$Res>  {
   factory $EarthquakeCopyWith(Earthquake value, $Res Function(Earthquake) _then) = _$EarthquakeCopyWithImpl;
 @useResult
 $Res call({
- String eventId, TelegramStatus status, DateTime? originTime, OriginTimePrecision originTimePrecision, DateTime? arrivalTime, List<EarthquakeDataSource> dataSources, List<EarthquakeTelegramType> telegramTypes, EarthquakeHypocenter? hypocenter, EarthquakeIntensity? intensity, String? estimatedIntensityTileUrl,@JsonKey(includeFromJson: false, includeToJson: false) EarthquakeCatalog? catalog
+ String eventId, TelegramStatus status, DateTime? originTime, OriginTimePrecision originTimePrecision, DateTime? arrivalTime, List<EarthquakeDataSource> dataSources, List<EarthquakeTelegramType> telegramTypes, List<EarthquakeTelegramComment> telegramComments, EarthquakeHypocenter? hypocenter, EarthquakeIntensity? intensity, String? estimatedIntensityTileUrl,@JsonKey(includeFromJson: false, includeToJson: false) EarthquakeCatalog? catalog
 });
 
 
@@ -66,7 +67,7 @@ class _$EarthquakeCopyWithImpl<$Res>
 
 /// Create a copy of Earthquake
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? eventId = null,Object? status = null,Object? originTime = freezed,Object? originTimePrecision = null,Object? arrivalTime = freezed,Object? dataSources = null,Object? telegramTypes = null,Object? hypocenter = freezed,Object? intensity = freezed,Object? estimatedIntensityTileUrl = freezed,Object? catalog = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? eventId = null,Object? status = null,Object? originTime = freezed,Object? originTimePrecision = null,Object? arrivalTime = freezed,Object? dataSources = null,Object? telegramTypes = null,Object? telegramComments = null,Object? hypocenter = freezed,Object? intensity = freezed,Object? estimatedIntensityTileUrl = freezed,Object? catalog = freezed,}) {
   return _then(_self.copyWith(
 eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
@@ -75,7 +76,8 @@ as DateTime?,originTimePrecision: null == originTimePrecision ? _self.originTime
 as OriginTimePrecision,arrivalTime: freezed == arrivalTime ? _self.arrivalTime : arrivalTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,dataSources: null == dataSources ? _self.dataSources : dataSources // ignore: cast_nullable_to_non_nullable
 as List<EarthquakeDataSource>,telegramTypes: null == telegramTypes ? _self.telegramTypes : telegramTypes // ignore: cast_nullable_to_non_nullable
-as List<EarthquakeTelegramType>,hypocenter: freezed == hypocenter ? _self.hypocenter : hypocenter // ignore: cast_nullable_to_non_nullable
+as List<EarthquakeTelegramType>,telegramComments: null == telegramComments ? _self.telegramComments : telegramComments // ignore: cast_nullable_to_non_nullable
+as List<EarthquakeTelegramComment>,hypocenter: freezed == hypocenter ? _self.hypocenter : hypocenter // ignore: cast_nullable_to_non_nullable
 as EarthquakeHypocenter?,intensity: freezed == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
 as EarthquakeIntensity?,estimatedIntensityTileUrl: freezed == estimatedIntensityTileUrl ? _self.estimatedIntensityTileUrl : estimatedIntensityTileUrl // ignore: cast_nullable_to_non_nullable
 as String?,catalog: freezed == catalog ? _self.catalog : catalog // ignore: cast_nullable_to_non_nullable
@@ -200,10 +202,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String eventId,  TelegramStatus status,  DateTime? originTime,  OriginTimePrecision originTimePrecision,  DateTime? arrivalTime,  List<EarthquakeDataSource> dataSources,  List<EarthquakeTelegramType> telegramTypes,  EarthquakeHypocenter? hypocenter,  EarthquakeIntensity? intensity,  String? estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false)  EarthquakeCatalog? catalog)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String eventId,  TelegramStatus status,  DateTime? originTime,  OriginTimePrecision originTimePrecision,  DateTime? arrivalTime,  List<EarthquakeDataSource> dataSources,  List<EarthquakeTelegramType> telegramTypes,  List<EarthquakeTelegramComment> telegramComments,  EarthquakeHypocenter? hypocenter,  EarthquakeIntensity? intensity,  String? estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false)  EarthquakeCatalog? catalog)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Earthquake() when $default != null:
-return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrecision,_that.arrivalTime,_that.dataSources,_that.telegramTypes,_that.hypocenter,_that.intensity,_that.estimatedIntensityTileUrl,_that.catalog);case _:
+return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrecision,_that.arrivalTime,_that.dataSources,_that.telegramTypes,_that.telegramComments,_that.hypocenter,_that.intensity,_that.estimatedIntensityTileUrl,_that.catalog);case _:
   return orElse();
 
 }
@@ -221,10 +223,10 @@ return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrec
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String eventId,  TelegramStatus status,  DateTime? originTime,  OriginTimePrecision originTimePrecision,  DateTime? arrivalTime,  List<EarthquakeDataSource> dataSources,  List<EarthquakeTelegramType> telegramTypes,  EarthquakeHypocenter? hypocenter,  EarthquakeIntensity? intensity,  String? estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false)  EarthquakeCatalog? catalog)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String eventId,  TelegramStatus status,  DateTime? originTime,  OriginTimePrecision originTimePrecision,  DateTime? arrivalTime,  List<EarthquakeDataSource> dataSources,  List<EarthquakeTelegramType> telegramTypes,  List<EarthquakeTelegramComment> telegramComments,  EarthquakeHypocenter? hypocenter,  EarthquakeIntensity? intensity,  String? estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false)  EarthquakeCatalog? catalog)  $default,) {final _that = this;
 switch (_that) {
 case _Earthquake():
-return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrecision,_that.arrivalTime,_that.dataSources,_that.telegramTypes,_that.hypocenter,_that.intensity,_that.estimatedIntensityTileUrl,_that.catalog);case _:
+return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrecision,_that.arrivalTime,_that.dataSources,_that.telegramTypes,_that.telegramComments,_that.hypocenter,_that.intensity,_that.estimatedIntensityTileUrl,_that.catalog);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -241,10 +243,10 @@ return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrec
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String eventId,  TelegramStatus status,  DateTime? originTime,  OriginTimePrecision originTimePrecision,  DateTime? arrivalTime,  List<EarthquakeDataSource> dataSources,  List<EarthquakeTelegramType> telegramTypes,  EarthquakeHypocenter? hypocenter,  EarthquakeIntensity? intensity,  String? estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false)  EarthquakeCatalog? catalog)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String eventId,  TelegramStatus status,  DateTime? originTime,  OriginTimePrecision originTimePrecision,  DateTime? arrivalTime,  List<EarthquakeDataSource> dataSources,  List<EarthquakeTelegramType> telegramTypes,  List<EarthquakeTelegramComment> telegramComments,  EarthquakeHypocenter? hypocenter,  EarthquakeIntensity? intensity,  String? estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false)  EarthquakeCatalog? catalog)?  $default,) {final _that = this;
 switch (_that) {
 case _Earthquake() when $default != null:
-return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrecision,_that.arrivalTime,_that.dataSources,_that.telegramTypes,_that.hypocenter,_that.intensity,_that.estimatedIntensityTileUrl,_that.catalog);case _:
+return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrecision,_that.arrivalTime,_that.dataSources,_that.telegramTypes,_that.telegramComments,_that.hypocenter,_that.intensity,_that.estimatedIntensityTileUrl,_that.catalog);case _:
   return null;
 
 }
@@ -256,7 +258,7 @@ return $default(_that.eventId,_that.status,_that.originTime,_that.originTimePrec
 @JsonSerializable()
 
 class _Earthquake implements Earthquake {
-  const _Earthquake({required this.eventId, required this.status, required this.originTime, required this.originTimePrecision, required this.arrivalTime, required final  List<EarthquakeDataSource> dataSources, required final  List<EarthquakeTelegramType> telegramTypes, required this.hypocenter, required this.intensity, required this.estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false) this.catalog}): _dataSources = dataSources,_telegramTypes = telegramTypes;
+  const _Earthquake({required this.eventId, required this.status, required this.originTime, required this.originTimePrecision, required this.arrivalTime, required final  List<EarthquakeDataSource> dataSources, required final  List<EarthquakeTelegramType> telegramTypes, final  List<EarthquakeTelegramComment> telegramComments = const [], required this.hypocenter, required this.intensity, required this.estimatedIntensityTileUrl, @JsonKey(includeFromJson: false, includeToJson: false) this.catalog}): _dataSources = dataSources,_telegramTypes = telegramTypes,_telegramComments = telegramComments;
   factory _Earthquake.fromJson(Map<String, dynamic> json) => _$EarthquakeFromJson(json);
 
 @override final  String eventId;
@@ -278,6 +280,15 @@ class _Earthquake implements Earthquake {
   return EqualUnmodifiableListView(_telegramTypes);
 }
 
+/// 電文コメント（固定付加文・自由付加文）
+ final  List<EarthquakeTelegramComment> _telegramComments;
+/// 電文コメント（固定付加文・自由付加文）
+@override@JsonKey() List<EarthquakeTelegramComment> get telegramComments {
+  if (_telegramComments is EqualUnmodifiableListView) return _telegramComments;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_telegramComments);
+}
+
 @override final  EarthquakeHypocenter? hypocenter;
 @override final  EarthquakeIntensity? intensity;
 /// 推計震度PMTilesのフルURL
@@ -297,16 +308,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Earthquake&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.status, status) || other.status == status)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.originTimePrecision, originTimePrecision) || other.originTimePrecision == originTimePrecision)&&(identical(other.arrivalTime, arrivalTime) || other.arrivalTime == arrivalTime)&&const DeepCollectionEquality().equals(other._dataSources, _dataSources)&&const DeepCollectionEquality().equals(other._telegramTypes, _telegramTypes)&&(identical(other.hypocenter, hypocenter) || other.hypocenter == hypocenter)&&(identical(other.intensity, intensity) || other.intensity == intensity)&&(identical(other.estimatedIntensityTileUrl, estimatedIntensityTileUrl) || other.estimatedIntensityTileUrl == estimatedIntensityTileUrl)&&(identical(other.catalog, catalog) || other.catalog == catalog));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Earthquake&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.status, status) || other.status == status)&&(identical(other.originTime, originTime) || other.originTime == originTime)&&(identical(other.originTimePrecision, originTimePrecision) || other.originTimePrecision == originTimePrecision)&&(identical(other.arrivalTime, arrivalTime) || other.arrivalTime == arrivalTime)&&const DeepCollectionEquality().equals(other._dataSources, _dataSources)&&const DeepCollectionEquality().equals(other._telegramTypes, _telegramTypes)&&const DeepCollectionEquality().equals(other._telegramComments, _telegramComments)&&(identical(other.hypocenter, hypocenter) || other.hypocenter == hypocenter)&&(identical(other.intensity, intensity) || other.intensity == intensity)&&(identical(other.estimatedIntensityTileUrl, estimatedIntensityTileUrl) || other.estimatedIntensityTileUrl == estimatedIntensityTileUrl)&&(identical(other.catalog, catalog) || other.catalog == catalog));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,eventId,status,originTime,originTimePrecision,arrivalTime,const DeepCollectionEquality().hash(_dataSources),const DeepCollectionEquality().hash(_telegramTypes),hypocenter,intensity,estimatedIntensityTileUrl,catalog);
+int get hashCode => Object.hash(runtimeType,eventId,status,originTime,originTimePrecision,arrivalTime,const DeepCollectionEquality().hash(_dataSources),const DeepCollectionEquality().hash(_telegramTypes),const DeepCollectionEquality().hash(_telegramComments),hypocenter,intensity,estimatedIntensityTileUrl,catalog);
 
 @override
 String toString() {
-  return 'Earthquake(eventId: $eventId, status: $status, originTime: $originTime, originTimePrecision: $originTimePrecision, arrivalTime: $arrivalTime, dataSources: $dataSources, telegramTypes: $telegramTypes, hypocenter: $hypocenter, intensity: $intensity, estimatedIntensityTileUrl: $estimatedIntensityTileUrl, catalog: $catalog)';
+  return 'Earthquake(eventId: $eventId, status: $status, originTime: $originTime, originTimePrecision: $originTimePrecision, arrivalTime: $arrivalTime, dataSources: $dataSources, telegramTypes: $telegramTypes, telegramComments: $telegramComments, hypocenter: $hypocenter, intensity: $intensity, estimatedIntensityTileUrl: $estimatedIntensityTileUrl, catalog: $catalog)';
 }
 
 
@@ -317,7 +328,7 @@ abstract mixin class _$EarthquakeCopyWith<$Res> implements $EarthquakeCopyWith<$
   factory _$EarthquakeCopyWith(_Earthquake value, $Res Function(_Earthquake) _then) = __$EarthquakeCopyWithImpl;
 @override @useResult
 $Res call({
- String eventId, TelegramStatus status, DateTime? originTime, OriginTimePrecision originTimePrecision, DateTime? arrivalTime, List<EarthquakeDataSource> dataSources, List<EarthquakeTelegramType> telegramTypes, EarthquakeHypocenter? hypocenter, EarthquakeIntensity? intensity, String? estimatedIntensityTileUrl,@JsonKey(includeFromJson: false, includeToJson: false) EarthquakeCatalog? catalog
+ String eventId, TelegramStatus status, DateTime? originTime, OriginTimePrecision originTimePrecision, DateTime? arrivalTime, List<EarthquakeDataSource> dataSources, List<EarthquakeTelegramType> telegramTypes, List<EarthquakeTelegramComment> telegramComments, EarthquakeHypocenter? hypocenter, EarthquakeIntensity? intensity, String? estimatedIntensityTileUrl,@JsonKey(includeFromJson: false, includeToJson: false) EarthquakeCatalog? catalog
 });
 
 
@@ -334,7 +345,7 @@ class __$EarthquakeCopyWithImpl<$Res>
 
 /// Create a copy of Earthquake
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? status = null,Object? originTime = freezed,Object? originTimePrecision = null,Object? arrivalTime = freezed,Object? dataSources = null,Object? telegramTypes = null,Object? hypocenter = freezed,Object? intensity = freezed,Object? estimatedIntensityTileUrl = freezed,Object? catalog = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? status = null,Object? originTime = freezed,Object? originTimePrecision = null,Object? arrivalTime = freezed,Object? dataSources = null,Object? telegramTypes = null,Object? telegramComments = null,Object? hypocenter = freezed,Object? intensity = freezed,Object? estimatedIntensityTileUrl = freezed,Object? catalog = freezed,}) {
   return _then(_Earthquake(
 eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
@@ -343,7 +354,8 @@ as DateTime?,originTimePrecision: null == originTimePrecision ? _self.originTime
 as OriginTimePrecision,arrivalTime: freezed == arrivalTime ? _self.arrivalTime : arrivalTime // ignore: cast_nullable_to_non_nullable
 as DateTime?,dataSources: null == dataSources ? _self._dataSources : dataSources // ignore: cast_nullable_to_non_nullable
 as List<EarthquakeDataSource>,telegramTypes: null == telegramTypes ? _self._telegramTypes : telegramTypes // ignore: cast_nullable_to_non_nullable
-as List<EarthquakeTelegramType>,hypocenter: freezed == hypocenter ? _self.hypocenter : hypocenter // ignore: cast_nullable_to_non_nullable
+as List<EarthquakeTelegramType>,telegramComments: null == telegramComments ? _self._telegramComments : telegramComments // ignore: cast_nullable_to_non_nullable
+as List<EarthquakeTelegramComment>,hypocenter: freezed == hypocenter ? _self.hypocenter : hypocenter // ignore: cast_nullable_to_non_nullable
 as EarthquakeHypocenter?,intensity: freezed == intensity ? _self.intensity : intensity // ignore: cast_nullable_to_non_nullable
 as EarthquakeIntensity?,estimatedIntensityTileUrl: freezed == estimatedIntensityTileUrl ? _self.estimatedIntensityTileUrl : estimatedIntensityTileUrl // ignore: cast_nullable_to_non_nullable
 as String?,catalog: freezed == catalog ? _self.catalog : catalog // ignore: cast_nullable_to_non_nullable

--- a/app/lib/feature/earthquake_history/data/model/earthquake.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake.g.dart
@@ -42,6 +42,18 @@ _Earthquake _$EarthquakeFromJson(Map<String, dynamic> json) => $checkedCreate(
             .map((e) => $enumDecode(_$EarthquakeTelegramTypeEnumMap, e))
             .toList(),
       ),
+      telegramComments: $checkedConvert(
+        'telegram_comments',
+        (v) =>
+            (v as List<dynamic>?)
+                ?.map(
+                  (e) => EarthquakeTelegramComment.fromJson(
+                    e as Map<String, dynamic>,
+                  ),
+                )
+                .toList() ??
+            const [],
+      ),
       hypocenter: $checkedConvert(
         'hypocenter',
         (v) => v == null
@@ -68,6 +80,7 @@ _Earthquake _$EarthquakeFromJson(Map<String, dynamic> json) => $checkedCreate(
     'arrivalTime': 'arrival_time',
     'dataSources': 'data_sources',
     'telegramTypes': 'telegram_types',
+    'telegramComments': 'telegram_comments',
     'estimatedIntensityTileUrl': 'estimated_intensity_tile_url',
   },
 );
@@ -86,6 +99,7 @@ Map<String, dynamic> _$EarthquakeToJson(_Earthquake instance) =>
       'telegram_types': instance.telegramTypes
           .map((e) => _$EarthquakeTelegramTypeEnumMap[e]!)
           .toList(),
+      'telegram_comments': instance.telegramComments,
       'hypocenter': instance.hypocenter,
       'intensity': instance.intensity,
       'estimated_intensity_tile_url': instance.estimatedIntensityTileUrl,

--- a/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart
@@ -1,5 +1,6 @@
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:extensions/extensions.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'earthquake_telegram_comment.freezed.dart';
@@ -45,3 +46,55 @@ List<EarthquakeTelegramComment> extractTelegramComments(
     })
     .nonNulls
     .toList();
+
+/// 詳細画面に表示するコメント行を選択する
+///
+/// - VXSE53 があれば最新（reportedAt基準）の53をベースに採用、
+///   なければ最新の51と52を結合
+/// - VXSE61 / VXSE62 のコメントは追加で表示（タイプごとに最新）
+/// - 各電文から固定付加文（additional）→自由付加文（free）の順に収集し、
+///   半角化のうえ同一文言は重複除去する
+List<String> selectTelegramCommentLines(
+  List<EarthquakeTelegramComment> comments,
+) {
+  EarthquakeTelegramComment? latestOf(EarthquakeTelegramType type) {
+    EarthquakeTelegramComment? latest;
+    for (final comment in comments) {
+      if (comment.type != type) {
+        continue;
+      }
+      if (latest == null || comment.reportedAt.isAfter(latest.reportedAt)) {
+        latest = comment;
+      }
+    }
+    return latest;
+  }
+
+  final vxse53 = latestOf(EarthquakeTelegramType.vxse53);
+  final base = vxse53 != null
+      ? [vxse53]
+      : [
+          latestOf(EarthquakeTelegramType.vxse51),
+          latestOf(EarthquakeTelegramType.vxse52),
+        ].nonNulls.toList();
+
+  final selected = [
+    ...base,
+    latestOf(EarthquakeTelegramType.vxse61),
+    latestOf(EarthquakeTelegramType.vxse62),
+  ].nonNulls;
+
+  final lines = <String>[];
+  for (final comment in selected) {
+    for (final text in [comment.additional, comment.free]) {
+      if (text == null || text.isEmpty) {
+        continue;
+      }
+      final line = text.toHalfWidth;
+      if (!lines.contains(line)) {
+        lines.add(line);
+      }
+    }
+  }
+  return lines;
+}

--- a/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart
@@ -1,0 +1,47 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'earthquake_telegram_comment.freezed.dart';
+part 'earthquake_telegram_comment.g.dart';
+
+/// 電文に付随するコメント（固定付加文・自由付加文）
+@freezed
+abstract class EarthquakeTelegramComment with _$EarthquakeTelegramComment {
+  const factory EarthquakeTelegramComment({
+    required EarthquakeTelegramType type,
+    required DateTime reportedAt,
+
+    /// 固定付加文
+    required String? additional,
+
+    /// 自由付加文
+    required String? free,
+  }) = _EarthquakeTelegramComment;
+
+  factory EarthquakeTelegramComment.fromJson(Map<String, dynamic> json) =>
+      _$EarthquakeTelegramCommentFromJson(json);
+}
+
+/// APIの電文リストからコメント（固定付加文・自由付加文）を持つ電文を抽出する
+List<EarthquakeTelegramComment> extractTelegramComments(
+  List<api.EarthquakeTelegram> telegrams,
+) => telegrams
+    .map((e) {
+      final type = e.telegram.type.toEarthquakeTelegramTypeOrNull;
+      final comments = e.comments;
+      if (type == null || comments == null) {
+        return null;
+      }
+      if (comments.additional == null && comments.free == null) {
+        return null;
+      }
+      return EarthquakeTelegramComment(
+        type: type,
+        reportedAt: e.telegram.reportedAt,
+        additional: comments.additional,
+        free: comments.free,
+      );
+    })
+    .nonNulls
+    .toList();

--- a/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.freezed.dart
@@ -1,0 +1,290 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'earthquake_telegram_comment.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EarthquakeTelegramComment {
+
+ EarthquakeTelegramType get type; DateTime get reportedAt;/// 固定付加文
+ String? get additional;/// 自由付加文
+ String? get free;
+/// Create a copy of EarthquakeTelegramComment
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EarthquakeTelegramCommentCopyWith<EarthquakeTelegramComment> get copyWith => _$EarthquakeTelegramCommentCopyWithImpl<EarthquakeTelegramComment>(this as EarthquakeTelegramComment, _$identity);
+
+  /// Serializes this EarthquakeTelegramComment to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EarthquakeTelegramComment&&(identical(other.type, type) || other.type == type)&&(identical(other.reportedAt, reportedAt) || other.reportedAt == reportedAt)&&(identical(other.additional, additional) || other.additional == additional)&&(identical(other.free, free) || other.free == free));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,reportedAt,additional,free);
+
+@override
+String toString() {
+  return 'EarthquakeTelegramComment(type: $type, reportedAt: $reportedAt, additional: $additional, free: $free)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EarthquakeTelegramCommentCopyWith<$Res>  {
+  factory $EarthquakeTelegramCommentCopyWith(EarthquakeTelegramComment value, $Res Function(EarthquakeTelegramComment) _then) = _$EarthquakeTelegramCommentCopyWithImpl;
+@useResult
+$Res call({
+ EarthquakeTelegramType type, DateTime reportedAt, String? additional, String? free
+});
+
+
+
+
+}
+/// @nodoc
+class _$EarthquakeTelegramCommentCopyWithImpl<$Res>
+    implements $EarthquakeTelegramCommentCopyWith<$Res> {
+  _$EarthquakeTelegramCommentCopyWithImpl(this._self, this._then);
+
+  final EarthquakeTelegramComment _self;
+  final $Res Function(EarthquakeTelegramComment) _then;
+
+/// Create a copy of EarthquakeTelegramComment
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? reportedAt = null,Object? additional = freezed,Object? free = freezed,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as EarthquakeTelegramType,reportedAt: null == reportedAt ? _self.reportedAt : reportedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,additional: freezed == additional ? _self.additional : additional // ignore: cast_nullable_to_non_nullable
+as String?,free: freezed == free ? _self.free : free // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EarthquakeTelegramComment].
+extension EarthquakeTelegramCommentPatterns on EarthquakeTelegramComment {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EarthquakeTelegramComment value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EarthquakeTelegramComment() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EarthquakeTelegramComment value)  $default,){
+final _that = this;
+switch (_that) {
+case _EarthquakeTelegramComment():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EarthquakeTelegramComment value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EarthquakeTelegramComment() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( EarthquakeTelegramType type,  DateTime reportedAt,  String? additional,  String? free)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EarthquakeTelegramComment() when $default != null:
+return $default(_that.type,_that.reportedAt,_that.additional,_that.free);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( EarthquakeTelegramType type,  DateTime reportedAt,  String? additional,  String? free)  $default,) {final _that = this;
+switch (_that) {
+case _EarthquakeTelegramComment():
+return $default(_that.type,_that.reportedAt,_that.additional,_that.free);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( EarthquakeTelegramType type,  DateTime reportedAt,  String? additional,  String? free)?  $default,) {final _that = this;
+switch (_that) {
+case _EarthquakeTelegramComment() when $default != null:
+return $default(_that.type,_that.reportedAt,_that.additional,_that.free);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _EarthquakeTelegramComment implements EarthquakeTelegramComment {
+  const _EarthquakeTelegramComment({required this.type, required this.reportedAt, required this.additional, required this.free});
+  factory _EarthquakeTelegramComment.fromJson(Map<String, dynamic> json) => _$EarthquakeTelegramCommentFromJson(json);
+
+@override final  EarthquakeTelegramType type;
+@override final  DateTime reportedAt;
+/// 固定付加文
+@override final  String? additional;
+/// 自由付加文
+@override final  String? free;
+
+/// Create a copy of EarthquakeTelegramComment
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EarthquakeTelegramCommentCopyWith<_EarthquakeTelegramComment> get copyWith => __$EarthquakeTelegramCommentCopyWithImpl<_EarthquakeTelegramComment>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EarthquakeTelegramCommentToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EarthquakeTelegramComment&&(identical(other.type, type) || other.type == type)&&(identical(other.reportedAt, reportedAt) || other.reportedAt == reportedAt)&&(identical(other.additional, additional) || other.additional == additional)&&(identical(other.free, free) || other.free == free));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,reportedAt,additional,free);
+
+@override
+String toString() {
+  return 'EarthquakeTelegramComment(type: $type, reportedAt: $reportedAt, additional: $additional, free: $free)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EarthquakeTelegramCommentCopyWith<$Res> implements $EarthquakeTelegramCommentCopyWith<$Res> {
+  factory _$EarthquakeTelegramCommentCopyWith(_EarthquakeTelegramComment value, $Res Function(_EarthquakeTelegramComment) _then) = __$EarthquakeTelegramCommentCopyWithImpl;
+@override @useResult
+$Res call({
+ EarthquakeTelegramType type, DateTime reportedAt, String? additional, String? free
+});
+
+
+
+
+}
+/// @nodoc
+class __$EarthquakeTelegramCommentCopyWithImpl<$Res>
+    implements _$EarthquakeTelegramCommentCopyWith<$Res> {
+  __$EarthquakeTelegramCommentCopyWithImpl(this._self, this._then);
+
+  final _EarthquakeTelegramComment _self;
+  final $Res Function(_EarthquakeTelegramComment) _then;
+
+/// Create a copy of EarthquakeTelegramComment
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? reportedAt = null,Object? additional = freezed,Object? free = freezed,}) {
+  return _then(_EarthquakeTelegramComment(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as EarthquakeTelegramType,reportedAt: null == reportedAt ? _self.reportedAt : reportedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,additional: freezed == additional ? _self.additional : additional // ignore: cast_nullable_to_non_nullable
+as String?,free: freezed == free ? _self.free : free // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'earthquake_telegram_comment.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EarthquakeTelegramComment _$EarthquakeTelegramCommentFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate(
+  '_EarthquakeTelegramComment',
+  json,
+  ($checkedConvert) {
+    final val = _EarthquakeTelegramComment(
+      type: $checkedConvert(
+        'type',
+        (v) => $enumDecode(_$EarthquakeTelegramTypeEnumMap, v),
+      ),
+      reportedAt: $checkedConvert(
+        'reported_at',
+        (v) => DateTime.parse(v as String),
+      ),
+      additional: $checkedConvert('additional', (v) => v as String?),
+      free: $checkedConvert('free', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'reportedAt': 'reported_at'},
+);
+
+Map<String, dynamic> _$EarthquakeTelegramCommentToJson(
+  _EarthquakeTelegramComment instance,
+) => <String, dynamic>{
+  'type': _$EarthquakeTelegramTypeEnumMap[instance.type]!,
+  'reported_at': instance.reportedAt.toIso8601String(),
+  'additional': instance.additional,
+  'free': instance.free,
+};
+
+const _$EarthquakeTelegramTypeEnumMap = {
+  EarthquakeTelegramType.vxse51: 'vxse51',
+  EarthquakeTelegramType.vxse52: 'vxse52',
+  EarthquakeTelegramType.vxse53: 'vxse53',
+  EarthquakeTelegramType.vxse61: 'vxse61',
+  EarthquakeTelegramType.vxse62: 'vxse62',
+  EarthquakeTelegramType.vxse45Forecast: 'vxse45Forecast',
+  EarthquakeTelegramType.vxse45Warning: 'vxse45Warning',
+};

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -8,6 +8,7 @@ import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/intensity_display_mode.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/estimated_intensity_notice_notifier.dart';
@@ -121,6 +122,9 @@ class _LoadedContent extends HookConsumerWidget {
     ];
 
     final designSystem = context.designSystem;
+    final telegramCommentLines = selectTelegramCommentLines(
+      earthquake.telegramComments,
+    );
 
     return Scaffold(
       body: Stack(
@@ -245,12 +249,24 @@ class _LoadedContent extends HookConsumerWidget {
                         horizontal: 4,
                         vertical: 2,
                       ),
-                      child: Text(
-                        'データソース: ${earthquake.dataSources.map((e) => switch (e) {
-                          .jmaDisasterInformationXml => "気象庁災害情報XML",
-                          .jmaIntensityDatabase => "気象庁震度データベース",
-                        }).join(', ')}',
-                        style: Theme.of(context).textTheme.bodySmall,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          for (final line in telegramCommentLines)
+                            Text(
+                              line,
+                              style: Theme.of(context).textTheme.bodySmall,
+                              textAlign: TextAlign.end,
+                            ),
+                          Text(
+                            'データソース: ${earthquake.dataSources.map((e) => switch (e) {
+                              .jmaDisasterInformationXml => "気象庁災害情報XML",
+                              .jmaIntensityDatabase => "気象庁震度データベース",
+                            }).join(', ')}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
                       ),
                     ),
                   ),

--- a/app/test/feature/earthquake_history/earthquake_model_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_model_test.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Earthquake.telegramComments', () {
+    Earthquake buildEarthquake() => Earthquake(
+      eventId: '20260713120000',
+      status: TelegramStatus.normal,
+      originTime: DateTime(2026, 7, 13, 12),
+      originTimePrecision: OriginTimePrecision.second,
+      arrivalTime: null,
+      dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+      telegramTypes: const [EarthquakeTelegramType.vxse53],
+      telegramComments: [
+        EarthquakeTelegramComment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          additional: 'この地震による津波の心配はありません。',
+          free: null,
+        ),
+      ],
+      hypocenter: null,
+      intensity: null,
+      estimatedIntensityTileUrl: null,
+    );
+
+    test('JSON往復でtelegramCommentsが保持される', () {
+      final earthquake = buildEarthquake();
+      final json =
+          jsonDecode(jsonEncode(earthquake.toJson())) as Map<String, dynamic>;
+      expect(Earthquake.fromJson(json), earthquake);
+    });
+
+    test('telegramCommentsキーがない旧キャッシュJSONは空リストになる', () {
+      final earthquake = buildEarthquake();
+      final json =
+          jsonDecode(jsonEncode(earthquake.toJson())) as Map<String, dynamic>
+            ..remove('telegram_comments');
+      expect(Earthquake.fromJson(json).telegramComments, isEmpty);
+    });
+  });
+}

--- a/app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart
@@ -1,0 +1,87 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+
+api.EarthquakeTelegram _telegram({
+  required api.TelegramType type,
+  required DateTime reportedAt,
+  api.TelegramComments? comments,
+}) => api.EarthquakeTelegram(
+  telegram: api.Telegram(
+    id: '${type.name}-${reportedAt.toIso8601String()}',
+    eventId: '20260713120000',
+    type: type,
+    title: 'タイトル',
+    status: api.TelegramStatus.normal,
+    infoType: api.InfoType.publication,
+    editorialOffice: '気象庁本庁',
+    publishingOffice: const ['気象庁'],
+    pressedAt: reportedAt,
+    reportedAt: reportedAt,
+    infoKind: '地震情報',
+    infoKindVersion: '1.0',
+    hash: 'hash',
+    createdAt: reportedAt,
+  ),
+  comments: comments,
+);
+
+void main() {
+  group('extractTelegramComments', () {
+    test('コメント付きの対象電文を変換する', () {
+      final reportedAt = DateTime(2026, 7, 13, 12);
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse53,
+          reportedAt: reportedAt,
+          comments: const api.TelegramComments(
+            additional: 'この地震による津波の心配はありません。',
+            free: '自由付加文です。',
+          ),
+        ),
+      ]);
+
+      expect(result, [
+        EarthquakeTelegramComment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: reportedAt,
+          additional: 'この地震による津波の心配はありません。',
+          free: '自由付加文です。',
+        ),
+      ]);
+    });
+
+    test('commentsがnullの電文は除外する', () {
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12),
+        ),
+      ]);
+      expect(result, isEmpty);
+    });
+
+    test('additionalもfreeもnullの電文は除外する', () {
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          comments: const api.TelegramComments(text: '主文のみ'),
+        ),
+      ]);
+      expect(result, isEmpty);
+    });
+
+    test('対象外タイプ（VXSE45等）は除外する', () {
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse45,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          comments: const api.TelegramComments(additional: '固定付加文'),
+        ),
+      ]);
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart
+++ b/app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart
@@ -84,4 +84,114 @@ void main() {
       expect(result, isEmpty);
     });
   });
+
+  group('selectTelegramCommentLines', () {
+    EarthquakeTelegramComment comment({
+      required EarthquakeTelegramType type,
+      required DateTime reportedAt,
+      String? additional,
+      String? free,
+    }) => EarthquakeTelegramComment(
+      type: type,
+      reportedAt: reportedAt,
+      additional: additional,
+      free: free,
+    );
+
+    test('VXSE53があれば53のコメントを採用し51/52は無視する', () {
+      final lines = selectTelegramCommentLines([
+        comment(
+          type: EarthquakeTelegramType.vxse51,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          additional: '速報の付加文',
+        ),
+        comment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12, 10),
+          additional: 'この地震による津波の心配はありません。',
+        ),
+      ]);
+      expect(lines, ['この地震による津波の心配はありません。']);
+    });
+
+    test('VXSE53が複数あればreportedAtが最新のものを採用する', () {
+      final lines = selectTelegramCommentLines([
+        comment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12, 20),
+          additional: '最新の付加文',
+        ),
+        comment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12, 10),
+          additional: '古い付加文',
+        ),
+      ]);
+      expect(lines, ['最新の付加文']);
+    });
+
+    test('VXSE53がなければ51と52のコメントを結合する', () {
+      final lines = selectTelegramCommentLines([
+        comment(
+          type: EarthquakeTelegramType.vxse51,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          additional: '今後の情報に注意してください。',
+        ),
+        comment(
+          type: EarthquakeTelegramType.vxse52,
+          reportedAt: DateTime(2026, 7, 13, 12, 5),
+          additional: 'この地震による津波の心配はありません。',
+        ),
+      ]);
+      expect(lines, ['今後の情報に注意してください。', 'この地震による津波の心配はありません。']);
+    });
+
+    test('VXSE6xのコメントは53に追加して表示する', () {
+      final lines = selectTelegramCommentLines([
+        comment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12, 10),
+          additional: 'この地震による津波の心配はありません。',
+        ),
+        comment(
+          type: EarthquakeTelegramType.vxse61,
+          reportedAt: DateTime(2026, 7, 13, 13),
+          free: '地震活動に関するお知らせ。',
+        ),
+      ]);
+      expect(lines, ['この地震による津波の心配はありません。', '地震活動に関するお知らせ。']);
+    });
+
+    test('additionalとfreeの両方があればその順で表示し、同一文言は重複除去する', () {
+      final lines = selectTelegramCommentLines([
+        comment(
+          type: EarthquakeTelegramType.vxse51,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          additional: 'この地震による津波の心配はありません。',
+          free: '自由付加文です。',
+        ),
+        comment(
+          type: EarthquakeTelegramType.vxse52,
+          reportedAt: DateTime(2026, 7, 13, 12, 5),
+          additional: 'この地震による津波の心配はありません。',
+        ),
+      ]);
+      expect(lines, ['この地震による津波の心配はありません。', '自由付加文です。']);
+    });
+
+    test('全角英数は半角に変換される', () {
+      final lines = selectTelegramCommentLines([
+        comment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12, 10),
+          free: '地震の規模はＭ７．０です。',
+        ),
+      ]);
+      expect(lines, ['地震の規模はM7.0です。']);
+    });
+
+    test('空入力なら空リストを返す', () {
+      expect(selectTelegramCommentLines([]), isEmpty);
+    });
+  });
 }

--- a/docs/superpowers/plans/2026-07-13-earthquake-detail-telegram-comments.md
+++ b/docs/superpowers/plans/2026-07-13-earthquake-detail-telegram-comments.md
@@ -1,0 +1,628 @@
+# 地震履歴詳細画面: 電文コメント表示 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 地震履歴詳細画面の地図右下「データソース: …」ラベル内に、電文の固定付加文・自由付加文を表示する。
+
+**Architecture:** 詳細APIレスポンスに既に含まれる電文コメントを、`toEarthquake` 変換時に新ドメインモデル `EarthquakeTelegramComment` として保持する。表示対象の選択（VXSE53優先、なければ51+52、6xは追加）は純粋関数で実装し単体テストする。UIは既存ラベルカードの `Text` を `Column` 化してコメント行を追加するだけ。追加API呼び出しなし。
+
+**Tech Stack:** Flutter / Dart 3.11, Riverpod, freezed + json_serializable（`build_runner` でコード生成、生成ファイルはコミット対象）
+
+**Spec:** `docs/superpowers/specs/2026-07-13-earthquake-detail-telegram-comments-design.md`
+
+## Global Constraints
+
+- `dart analyze` 警告ゼロ（CI必須）。`dart format` 済みであること。
+- 生成ファイル（`*.freezed.dart`, `*.g.dart`)はコミットする。
+- クロスパッケージ依存は package import（相対import禁止）。
+- 作業ディレクトリ: リポジトリルート（`app/` はFlutterアプリ）。
+- **注意（既知の問題）**: `dart analyze` は app/ でプラグイン起因でハングすることがある。必ず `timeout 300` を付けて実行する。
+- コミットメッセージは日本語・Conventional Commits（例: `feat: ...`）。
+
+---
+
+### Task 1: `EarthquakeTelegramComment` モデルと抽出関数
+
+**Files:**
+- Create: `app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart`
+- Create: `app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart`
+- 生成される: 同ディレクトリの `earthquake_telegram_comment.freezed.dart` / `.g.dart`
+
+**Interfaces:**
+- Consumes: `api.EarthquakeTelegram`（`package:eqmonitor_api` — `telegram: Telegram`, `comments: TelegramComments?`）、`EarthquakeTelegramType` と拡張 `toEarthquakeTelegramTypeOrNull`（`app/lib/feature/earthquake_history/data/model/earthquake_telegram_type.dart`）
+- Produces:
+  - `class EarthquakeTelegramComment { EarthquakeTelegramType type; DateTime reportedAt; String? additional; String? free; }`（freezed / JSON対応）
+  - `List<EarthquakeTelegramComment> extractTelegramComments(List<api.EarthquakeTelegram> telegrams)`
+
+- [ ] **Step 1: モデルファイルを作成（抽出関数はまだ書かない）**
+
+`app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart`:
+
+```dart
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'earthquake_telegram_comment.freezed.dart';
+part 'earthquake_telegram_comment.g.dart';
+
+/// 電文に付随するコメント（固定付加文・自由付加文）
+@freezed
+abstract class EarthquakeTelegramComment with _$EarthquakeTelegramComment {
+  const factory EarthquakeTelegramComment({
+    required EarthquakeTelegramType type,
+    required DateTime reportedAt,
+
+    /// 固定付加文
+    required String? additional,
+
+    /// 自由付加文
+    required String? free,
+  }) = _EarthquakeTelegramComment;
+
+  factory EarthquakeTelegramComment.fromJson(Map<String, dynamic> json) =>
+      _$EarthquakeTelegramCommentFromJson(json);
+}
+```
+
+（`api` importはこの時点では未使用warningになるため、Step 3の抽出関数追加まで import 行を入れず、Step 5で追加してもよい。シンプルにするなら Step 5 実装時にまとめて import を整える。）
+
+- [ ] **Step 2: コード生成を実行**
+
+Run: `cd app && dart run build_runner build --delete-conflicting-outputs`
+Expected: `Succeeded after ...` で `earthquake_telegram_comment.freezed.dart` / `.g.dart` が生成される
+
+- [ ] **Step 3: 抽出関数の失敗するテストを書く**
+
+`app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart`:
+
+```dart
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+
+api.EarthquakeTelegram _telegram({
+  required api.TelegramType type,
+  required DateTime reportedAt,
+  api.TelegramComments? comments,
+}) => api.EarthquakeTelegram(
+  telegram: api.Telegram(
+    id: '${type.name}-${reportedAt.toIso8601String()}',
+    eventId: '20260713120000',
+    type: type,
+    title: 'タイトル',
+    status: api.TelegramStatus.normal,
+    infoType: api.InfoType.publication,
+    editorialOffice: '気象庁本庁',
+    publishingOffice: const ['気象庁'],
+    pressedAt: reportedAt,
+    reportedAt: reportedAt,
+    infoKind: '地震情報',
+    infoKindVersion: '1.0',
+    hash: 'hash',
+    createdAt: reportedAt,
+  ),
+  comments: comments,
+);
+
+void main() {
+  group('extractTelegramComments', () {
+    test('コメント付きの対象電文を変換する', () {
+      final reportedAt = DateTime(2026, 7, 13, 12);
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse53,
+          reportedAt: reportedAt,
+          comments: const api.TelegramComments(
+            additional: 'この地震による津波の心配はありません。',
+            free: '自由付加文です。',
+          ),
+        ),
+      ]);
+
+      expect(result, [
+        EarthquakeTelegramComment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: reportedAt,
+          additional: 'この地震による津波の心配はありません。',
+          free: '自由付加文です。',
+        ),
+      ]);
+    });
+
+    test('commentsがnullの電文は除外する', () {
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12),
+        ),
+      ]);
+      expect(result, isEmpty);
+    });
+
+    test('additionalもfreeもnullの電文は除外する', () {
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          comments: const api.TelegramComments(text: '主文のみ'),
+        ),
+      ]);
+      expect(result, isEmpty);
+    });
+
+    test('対象外タイプ（VXSE45等）は除外する', () {
+      final result = extractTelegramComments([
+        _telegram(
+          type: api.TelegramType.vxse45,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          comments: const api.TelegramComments(additional: '固定付加文'),
+        ),
+      ]);
+      expect(result, isEmpty);
+    });
+  });
+}
+```
+
+- [ ] **Step 4: テストが失敗することを確認**
+
+Run: `cd app && flutter test test/feature/earthquake_history/earthquake_telegram_comment_test.dart`
+Expected: コンパイルエラー `The function 'extractTelegramComments' isn't defined` で FAIL
+
+- [ ] **Step 5: 抽出関数を実装**
+
+`earthquake_telegram_comment.dart` の末尾に追加（`api` importが有効になる）:
+
+```dart
+/// APIの電文リストからコメント（固定付加文・自由付加文）を持つ電文を抽出する
+List<EarthquakeTelegramComment> extractTelegramComments(
+  List<api.EarthquakeTelegram> telegrams,
+) => telegrams
+    .map((e) {
+      final type = e.telegram.type.toEarthquakeTelegramTypeOrNull;
+      final comments = e.comments;
+      if (type == null || comments == null) {
+        return null;
+      }
+      if (comments.additional == null && comments.free == null) {
+        return null;
+      }
+      return EarthquakeTelegramComment(
+        type: type,
+        reportedAt: e.telegram.reportedAt,
+        additional: comments.additional,
+        free: comments.free,
+      );
+    })
+    .nonNulls
+    .toList();
+```
+
+- [ ] **Step 6: テストが通ることを確認**
+
+Run: `cd app && flutter test test/feature/earthquake_history/earthquake_telegram_comment_test.dart`
+Expected: `All tests passed!`（4件）
+
+- [ ] **Step 7: フォーマット・コミット**
+
+```bash
+cd app && dart format lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart test/feature/earthquake_history/earthquake_telegram_comment_test.dart
+git add app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.freezed.dart app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.g.dart app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart
+git commit -m "feat: 電文コメントのドメインモデルと抽出関数を追加"
+```
+
+---
+
+### Task 2: 表示コメント選択ロジック `selectTelegramCommentLines`
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart`（Task 1で作成したファイルの末尾に関数追加）
+- Modify: `app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart`（groupを追加）
+
+**Interfaces:**
+- Consumes: `EarthquakeTelegramComment`（Task 1）、`String.toHalfWidth`（`package:extensions/extensions.dart`、全角ASCII→半角変換）
+- Produces: `List<String> selectTelegramCommentLines(List<EarthquakeTelegramComment> comments)` — 1要素=表示1行。空リスト=表示なし。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`earthquake_telegram_comment_test.dart` の `main()` 内に group を追加:
+
+```dart
+group('selectTelegramCommentLines', () {
+  EarthquakeTelegramComment comment({
+    required EarthquakeTelegramType type,
+    required DateTime reportedAt,
+    String? additional,
+    String? free,
+  }) => EarthquakeTelegramComment(
+    type: type,
+    reportedAt: reportedAt,
+    additional: additional,
+    free: free,
+  );
+
+  test('VXSE53があれば53のコメントを採用し51/52は無視する', () {
+    final lines = selectTelegramCommentLines([
+      comment(
+        type: EarthquakeTelegramType.vxse51,
+        reportedAt: DateTime(2026, 7, 13, 12),
+        additional: '速報の付加文',
+      ),
+      comment(
+        type: EarthquakeTelegramType.vxse53,
+        reportedAt: DateTime(2026, 7, 13, 12, 10),
+        additional: 'この地震による津波の心配はありません。',
+      ),
+    ]);
+    expect(lines, ['この地震による津波の心配はありません。']);
+  });
+
+  test('VXSE53が複数あればreportedAtが最新のものを採用する', () {
+    final lines = selectTelegramCommentLines([
+      comment(
+        type: EarthquakeTelegramType.vxse53,
+        reportedAt: DateTime(2026, 7, 13, 12, 20),
+        additional: '最新の付加文',
+      ),
+      comment(
+        type: EarthquakeTelegramType.vxse53,
+        reportedAt: DateTime(2026, 7, 13, 12, 10),
+        additional: '古い付加文',
+      ),
+    ]);
+    expect(lines, ['最新の付加文']);
+  });
+
+  test('VXSE53がなければ51と52のコメントを結合する', () {
+    final lines = selectTelegramCommentLines([
+      comment(
+        type: EarthquakeTelegramType.vxse51,
+        reportedAt: DateTime(2026, 7, 13, 12),
+        additional: '今後の情報に注意してください。',
+      ),
+      comment(
+        type: EarthquakeTelegramType.vxse52,
+        reportedAt: DateTime(2026, 7, 13, 12, 5),
+        additional: 'この地震による津波の心配はありません。',
+      ),
+    ]);
+    expect(lines, [
+      '今後の情報に注意してください。',
+      'この地震による津波の心配はありません。',
+    ]);
+  });
+
+  test('VXSE6xのコメントは53に追加して表示する', () {
+    final lines = selectTelegramCommentLines([
+      comment(
+        type: EarthquakeTelegramType.vxse53,
+        reportedAt: DateTime(2026, 7, 13, 12, 10),
+        additional: 'この地震による津波の心配はありません。',
+      ),
+      comment(
+        type: EarthquakeTelegramType.vxse61,
+        reportedAt: DateTime(2026, 7, 13, 13),
+        free: '地震活動に関するお知らせ。',
+      ),
+    ]);
+    expect(lines, [
+      'この地震による津波の心配はありません。',
+      '地震活動に関するお知らせ。',
+    ]);
+  });
+
+  test('additionalとfreeの両方があればその順で表示し、同一文言は重複除去する', () {
+    final lines = selectTelegramCommentLines([
+      comment(
+        type: EarthquakeTelegramType.vxse51,
+        reportedAt: DateTime(2026, 7, 13, 12),
+        additional: 'この地震による津波の心配はありません。',
+        free: '自由付加文です。',
+      ),
+      comment(
+        type: EarthquakeTelegramType.vxse52,
+        reportedAt: DateTime(2026, 7, 13, 12, 5),
+        additional: 'この地震による津波の心配はありません。',
+      ),
+    ]);
+    expect(lines, [
+      'この地震による津波の心配はありません。',
+      '自由付加文です。',
+    ]);
+  });
+
+  test('全角英数は半角に変換される', () {
+    final lines = selectTelegramCommentLines([
+      comment(
+        type: EarthquakeTelegramType.vxse53,
+        reportedAt: DateTime(2026, 7, 13, 12, 10),
+        free: '地震の規模はＭ７．０です。',
+      ),
+    ]);
+    expect(lines, ['地震の規模はM7.0です。']);
+  });
+
+  test('空入力なら空リストを返す', () {
+    expect(selectTelegramCommentLines([]), isEmpty);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd app && flutter test test/feature/earthquake_history/earthquake_telegram_comment_test.dart`
+Expected: コンパイルエラー `The function 'selectTelegramCommentLines' isn't defined` で FAIL
+
+- [ ] **Step 3: 選択ロジックを実装**
+
+`earthquake_telegram_comment.dart` に import を追加:
+
+```dart
+import 'package:extensions/extensions.dart';
+```
+
+末尾に関数を追加:
+
+```dart
+/// 詳細画面に表示するコメント行を選択する
+///
+/// - VXSE53 があれば最新（reportedAt基準）の53をベースに採用、
+///   なければ最新の51と52を結合
+/// - VXSE61 / VXSE62 のコメントは追加で表示（タイプごとに最新）
+/// - 各電文から固定付加文（additional）→自由付加文（free）の順に収集し、
+///   半角化のうえ同一文言は重複除去する
+List<String> selectTelegramCommentLines(
+  List<EarthquakeTelegramComment> comments,
+) {
+  EarthquakeTelegramComment? latestOf(EarthquakeTelegramType type) {
+    EarthquakeTelegramComment? latest;
+    for (final comment in comments) {
+      if (comment.type != type) {
+        continue;
+      }
+      if (latest == null || comment.reportedAt.isAfter(latest.reportedAt)) {
+        latest = comment;
+      }
+    }
+    return latest;
+  }
+
+  final vxse53 = latestOf(EarthquakeTelegramType.vxse53);
+  final base = vxse53 != null
+      ? [vxse53]
+      : [
+          latestOf(EarthquakeTelegramType.vxse51),
+          latestOf(EarthquakeTelegramType.vxse52),
+        ].nonNulls.toList();
+
+  final selected = [
+    ...base,
+    latestOf(EarthquakeTelegramType.vxse61),
+    latestOf(EarthquakeTelegramType.vxse62),
+  ].nonNulls;
+
+  final lines = <String>[];
+  for (final comment in selected) {
+    for (final text in [comment.additional, comment.free]) {
+      if (text == null || text.isEmpty) {
+        continue;
+      }
+      final line = text.toHalfWidth;
+      if (!lines.contains(line)) {
+        lines.add(line);
+      }
+    }
+  }
+  return lines;
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd app && flutter test test/feature/earthquake_history/earthquake_telegram_comment_test.dart`
+Expected: `All tests passed!`（Task 1の4件 + 7件 = 11件）
+
+- [ ] **Step 5: フォーマット・コミット**
+
+```bash
+cd app && dart format lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart test/feature/earthquake_history/earthquake_telegram_comment_test.dart
+git add app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart app/test/feature/earthquake_history/earthquake_telegram_comment_test.dart
+git commit -m "feat: 電文コメントの表示選択ロジックを追加"
+```
+
+---
+
+### Task 3: ドメイン `Earthquake` にコメントを保持
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/data/model/earthquake.dart`
+- Create: `app/test/feature/earthquake_history/earthquake_model_test.dart`
+- 再生成される: `earthquake.freezed.dart` / `earthquake.g.dart`
+
+**Interfaces:**
+- Consumes: `EarthquakeTelegramComment` / `extractTelegramComments`（Task 1）
+- Produces: `Earthquake.telegramComments`（`List<EarthquakeTelegramComment>`、デフォルト空リスト）。`toEarthquake` がAPIレスポンスから自動で詰める。
+
+- [ ] **Step 1: 後方互換の失敗するテストを書く**
+
+`app/test/feature/earthquake_history/earthquake_model_test.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Earthquake.telegramComments', () {
+    Earthquake buildEarthquake() => Earthquake(
+      eventId: '20260713120000',
+      status: TelegramStatus.normal,
+      originTime: DateTime(2026, 7, 13, 12),
+      originTimePrecision: OriginTimePrecision.second,
+      arrivalTime: null,
+      dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+      telegramTypes: const [EarthquakeTelegramType.vxse53],
+      telegramComments: [
+        EarthquakeTelegramComment(
+          type: EarthquakeTelegramType.vxse53,
+          reportedAt: DateTime(2026, 7, 13, 12),
+          additional: 'この地震による津波の心配はありません。',
+          free: null,
+        ),
+      ],
+      hypocenter: null,
+      intensity: null,
+      estimatedIntensityTileUrl: null,
+    );
+
+    test('JSON往復でtelegramCommentsが保持される', () {
+      final earthquake = buildEarthquake();
+      final json =
+          jsonDecode(jsonEncode(earthquake.toJson())) as Map<String, dynamic>;
+      expect(Earthquake.fromJson(json), earthquake);
+    });
+
+    test('telegramCommentsキーがない旧キャッシュJSONは空リストになる', () {
+      final earthquake = buildEarthquake();
+      final json =
+          jsonDecode(jsonEncode(earthquake.toJson())) as Map<String, dynamic>
+            ..remove('telegramComments');
+      expect(Earthquake.fromJson(json).telegramComments, isEmpty);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd app && flutter test test/feature/earthquake_history/earthquake_model_test.dart`
+Expected: コンパイルエラー `No named parameter with the name 'telegramComments'` で FAIL
+
+- [ ] **Step 3: `Earthquake` にフィールドを追加し `toEarthquake` を拡張**
+
+`app/lib/feature/earthquake_history/data/model/earthquake.dart` に import を追加:
+
+```dart
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
+```
+
+factory の `telegramTypes` の直後にフィールドを追加:
+
+```dart
+    required List<EarthquakeTelegramType> telegramTypes,
+
+    /// 電文コメント（固定付加文・自由付加文）
+    @Default([]) List<EarthquakeTelegramComment> telegramComments,
+```
+
+`toEarthquake` の `telegramTypes: ...` の直後に追加:
+
+```dart
+    telegramComments: extractTelegramComments(telegrams),
+```
+
+- [ ] **Step 4: コード生成を実行**
+
+Run: `cd app && dart run build_runner build --delete-conflicting-outputs`
+Expected: `Succeeded after ...` で `earthquake.freezed.dart` / `earthquake.g.dart` が更新される
+
+- [ ] **Step 5: テストが通ることを確認**
+
+Run: `cd app && flutter test test/feature/earthquake_history/`
+Expected: `All tests passed!`（Task 1〜2の11件 + 2件）
+
+- [ ] **Step 6: フォーマット・コミット**
+
+```bash
+cd app && dart format lib/feature/earthquake_history/data/model/earthquake.dart test/feature/earthquake_history/earthquake_model_test.dart
+git add app/lib/feature/earthquake_history/data/model/earthquake.dart app/lib/feature/earthquake_history/data/model/earthquake.freezed.dart app/lib/feature/earthquake_history/data/model/earthquake.g.dart app/test/feature/earthquake_history/earthquake_model_test.dart
+git commit -m "feat: ドメインEarthquakeに電文コメントを保持"
+```
+
+---
+
+### Task 4: 詳細画面のデータソースラベルにコメントを表示
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart`（`_LoadedContent.build` とデータソースラベル部、現227-260行付近）
+
+**Interfaces:**
+- Consumes: `Earthquake.telegramComments`（Task 3）、`selectTelegramCommentLines`（Task 2）
+- Produces: UIのみ（他タスクからの依存なし）
+
+- [ ] **Step 1: import と表示行の算出を追加**
+
+import 追加（アルファベット順の位置に）:
+
+```dart
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_comment.dart';
+```
+
+`_LoadedContent.build` 内の `final designSystem = context.designSystem;` の直後に追加:
+
+```dart
+    final telegramCommentLines = selectTelegramCommentLines(
+      earthquake.telegramComments,
+    );
+```
+
+- [ ] **Step 2: ラベルカード内を Column 化してコメント行を追加**
+
+データソースラベルの `BackdropFilter` 内 `Padding` の child を、既存の単一 `Text` から以下に置き換える:
+
+```dart
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          for (final line in telegramCommentLines)
+                            Text(
+                              line,
+                              style: Theme.of(context).textTheme.bodySmall,
+                              textAlign: TextAlign.end,
+                            ),
+                          Text(
+                            'データソース: ${earthquake.dataSources.map((e) => switch (e) {
+                              .jmaDisasterInformationXml => "気象庁災害情報XML",
+                              .jmaIntensityDatabase => "気象庁震度データベース",
+                            }).join(', ')}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+```
+
+（「データソース: …」の `Text` は既存のまま、`Column` の最後の子に移動するだけ。`telegramCommentLines` が空なら従来と同一表示。）
+
+- [ ] **Step 3: 静的解析**
+
+Run: `cd app && timeout 300 dart analyze .`
+Expected: `No issues found!`（ハングしたらtimeoutで打ち切り、`dart analyze lib/feature/earthquake_history` で再試行）
+
+- [ ] **Step 4: アプリ全体のテストを実行**
+
+Run: `cd app && flutter test`
+Expected: 既存テスト含め `All tests passed!`
+
+- [ ] **Step 5: フォーマット・コミット**
+
+```bash
+cd app && dart format lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+git add app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+git commit -m "feat: 地震履歴詳細画面のデータソースラベルに電文コメントを表示"
+```
+
+---
+
+## 完了後
+
+- superpowers:verification-before-completion → superpowers:finishing-a-development-branch に従う。
+- PRを作る場合: base `develop`、`gh pr create --repo YumNumm/EQMonitor --base develop`（CLAUDE.md 厳守）。

--- a/docs/superpowers/specs/2026-07-13-earthquake-detail-telegram-comments-design.md
+++ b/docs/superpowers/specs/2026-07-13-earthquake-detail-telegram-comments-design.md
@@ -1,0 +1,94 @@
+# 地震履歴詳細画面: 電文コメント表示 — 設計
+
+日付: 2026-07-13
+ステータス: 承認済み
+
+## 目的
+
+地震履歴詳細画面の地図右下にある「データソース: …」ラベル内に、電文のコメント（固定付加文・自由付加文）を表示する。例:「この地震による津波の心配はありません」。
+
+## 背景
+
+- 詳細API（`getV2EarthquakeEventId`）のレスポンス `api.Earthquake.telegrams` には各電文の `comments`（`TelegramComments`: `text` / `free` / `warning` / `forecast` / `additional`）が既に含まれている。
+- しかし `toEarthquake` 変換（`app/lib/feature/earthquake_history/data/model/earthquake.dart`）では電文タイプのみ抽出し、コメントは破棄している。
+- したがって追加のAPI呼び出しは不要で、モデル変換の拡張のみで実現できる。
+
+## 要件（確定事項）
+
+- 表示するコメント種別: **固定付加文（`additional`）+ 自由付加文（`free`）**。`text` / `warning` / `forecast` は対象外。
+- 対象電文の選択: **VXSE53 があれば53を採用。なければ VXSE51 + VXSE52。VXSE6x（61/62）のコメントは追加で表示**。
+- 表示位置: 地図右下の既存データソースラベル（ぼかし背景カード）内、「データソース: …」行の上。
+
+## データフロー
+
+```
+getV2EarthquakeEventId → api.Earthquake.telegrams[].comments
+  → toEarthquake でコメント抽出（新規）
+  → ドメイン Earthquake.telegramComments（新フィールド）
+  → 表示コメント選択ロジック（純粋関数）
+  → 地図右下データソースラベル内に表示
+```
+
+## コンポーネント
+
+### 1. 新モデル `EarthquakeTelegramComment`
+
+freezed モデル。配置: `app/lib/feature/earthquake_history/data/model/earthquake_telegram_comment.dart`
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `type` | `EarthquakeTelegramType` | 電文タイプ（vxse51/52/53/61/62） |
+| `reportedAt` | `DateTime` | 「最新の電文」判定用 |
+| `additional` | `String?` | 固定付加文 |
+| `free` | `String?` | 自由付加文 |
+
+JSONシリアライズ対応（ドメイン `Earthquake` がキャッシュされるため）。
+
+### 2. ドメイン `Earthquake` の拡張
+
+`@Default([]) List<EarthquakeTelegramComment> telegramComments` を追加。`@Default([])` により、キーを持たないキャッシュ済みJSONもそのままデシリアライズできる（後方互換）。
+
+### 3. `toEarthquake` の拡張
+
+`api.Earthquake.telegrams` から以下の条件を満たす電文を `EarthquakeTelegramComment` に変換して詰める:
+
+- 電文タイプが VXSE51/52/53/61/62（`toEarthquakeTelegramTypeOrNull` が非null）
+- `comments` が非null かつ `additional` または `free` の少なくとも一方が非null
+
+### 4. 表示コメント選択ロジック
+
+純粋関数（単体テスト対象）。入力 `List<EarthquakeTelegramComment>` → 出力 `List<String>`（1要素=1行）。
+
+1. **ベース電文の決定**: VXSE53 があれば最新（`reportedAt` 基準）の53。なければ最新の51と最新の52（存在するもののみ、両方あれば結合）。
+2. **6x系の追加**: VXSE61 / VXSE62 のコメントを追加（タイプごとに最新のもの）。
+3. **文言の収集**: 各電文から `additional` → `free` の順で非null・非空のものを収集し、`toHalfWidth` を適用。
+4. **重複除去**: 同一文言は出現順を保って1つに（例: 51と52が同一の津波コメントを持つ場合）。
+
+### 5. UI変更
+
+`app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart` のデータソースラベル（現227-260行付近）:
+
+- カード内の `Text` を `Column` 化し、選択されたコメント行を「データソース: …」行の上に追加。
+- スタイルは既存と同じ `bodySmall`。
+- コメントが空の場合は現状と完全に同一の表示（カードの見た目・レイアウトに変化なし）。
+
+## エッジケース
+
+| ケース | 挙動 |
+|---|---|
+| 震度DBのみのイベント（電文なし） | `telegramComments` 空 → 従来表示 |
+| 全電文の `additional`・`free` が null | 同上 |
+| 旧キャッシュJSON（新フィールドなし） | `@Default([])` により空 → 従来表示 |
+| 51と52が同一コメント | 重複除去で1行 |
+
+## テスト・検証
+
+- 選択ロジックの単体テスト: 53優先 / 51+52フォールバック / 6x追加 / 重複除去 / 空入力。
+- `melos run generate` でコード生成（生成ファイルはコミット対象）。
+- `dart analyze` 警告ゼロ、`melos run test` パス。
+
+## 対象外（YAGNI）
+
+- 電文一覧画面の変更（既に `EarthquakeTelegramTile` でコメント表示済み）。
+- 震度データベース側のイベントノート（`ShindoDbEventNotes`）への変更。
+- `text` / `warning` / `forecast` コメントの表示。


### PR DESCRIPTION
## 概要

地震履歴詳細画面の地図右下「データソース: …」ラベル内に、電文のコメント（固定付加文・自由付加文）を表示します。例:「この地震による津波の心配はありません。」

詳細API（`getV2EarthquakeEventId`）のレスポンスに既に含まれている電文コメントを活用するため、**追加のAPI呼び出しはありません**。

## 変更内容

- **新モデル `EarthquakeTelegramComment`**（freezed）と、APIレスポンスの電文リストからコメントを抽出する `extractTelegramComments` を追加
- **表示行選択ロジック `selectTelegramCommentLines`**: VXSE53があれば最新の53を採用、なければ51+52を結合。VXSE61/62のコメントはタイプごとに最新を追加表示。additional→freeの順で収集し、半角化・重複除去
- **ドメイン `Earthquake` に `telegramComments` フィールドを追加**（`@Default([])` によりキャッシュ済み旧JSONと後方互換）し、`toEarthquake` で自動的に抽出
- **詳細画面UI**: データソースラベルのカード内をColumn化し、コメント行を「データソース: …」行の上に表示。コメントが空の場合は従来と同一の表示

## テスト

- 新規テスト13件（抽出フィルタ4件・選択ロジック7件・JSON往復/後方互換2件）すべてパス
- `test/feature/earthquake_history/` 全体: +151 -8（失敗8件は本ブランチと無関係な既存の失敗で、ベースラインから変化なし）
- `dart analyze lib/feature/earthquake_history` クリーン

## 設計ドキュメント

- スペック: `docs/superpowers/specs/2026-07-13-earthquake-detail-telegram-comments-design.md`
- 実装計画: `docs/superpowers/plans/2026-07-13-earthquake-detail-telegram-comments.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)