### PR TITLE
fix: developのリリースビルド失敗を修正（残存していたclient引数を削除）

### DIFF
--- a/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
+++ b/app/lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart
@@ -176,7 +176,6 @@ class EarthquakeHistoryDataSource
         longitudeLte: parameter.longitudeLte,
         sortBy: parameter.sortBy,
         sortOrder: parameter.sortOrder,
-        client: client,
       ),
       EarthquakeHistoryParameterRegion(:final String regionCode) =>
         _repository.searchByRegion(

--- a/app/test/feature/earthquake_history/data/earthquake_history_config_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_history_config_test.dart
@@ -40,35 +40,16 @@ void main() {
       );
       expect(roundTrip(original), original);
     });
-
-    test(
-      '不明な enum 値 (fillMode) は @JsonKey の unknownEnumValue で auto に fallback',
-      () {
-        const defaults = EarthquakeHistoryConfig(
-          list: EarthquakeHistoryListConfig(),
-        );
-        final json =
-            jsonDecode(jsonEncode(defaults.toJson())) as Map<String, dynamic>;
-        (json['detail'] as Map<String, dynamic>)['fill_mode'] = 'unknownValue';
-      },
-    );
-
-    test('旧 matchIcon 値は unknownEnumValue で auto にマッピングされる', () {
-      const defaults = EarthquakeHistoryConfig(
-        list: EarthquakeHistoryListConfig(),
-      );
-      final json =
-          jsonDecode(jsonEncode(defaults.toJson())) as Map<String, dynamic>;
-      (json['detail'] as Map<String, dynamic>)['fill_mode'] = 'matchIcon';
-    });
   });
 
   group('RegionSearchType enum', () {
-    test('prefecture / city の 2 値', () {
-      expect(RegionSearchType.values.length, 2);
+    test('prefecture / region / city / station の 4 値', () {
+      expect(RegionSearchType.values.length, 4);
       expect(RegionSearchType.values, [
         RegionSearchType.prefecture,
+        RegionSearchType.region,
         RegionSearchType.city,
+        RegionSearchType.station,
       ]);
     });
   });

--- a/app/test/feature/earthquake_history/ui/components/depth_text_test.dart
+++ b/app/test/feature/earthquake_history/ui/components/depth_text_test.dart
@@ -10,9 +10,7 @@ void main() {
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: Scaffold(
-          body: DepthText(depth: depth),
-        ),
+        home: Scaffold(body: DepthText(depth: depth)),
       ),
     );
   }
@@ -20,35 +18,30 @@ void main() {
   testWidgets('shallow: "深さ" + "ごく浅い"', (tester) async {
     await pumpDepthText(tester, depth: const EarthquakeDepth.shallow());
 
-    expect(find.text('深さ'), findsOneWidget);
-    expect(find.text('ごく浅い'), findsOneWidget);
+    expect(find.text('深さごく浅い'), findsOneWidget);
   });
 
   testWidgets('value: "深さ" + "<値>km"', (tester) async {
     await pumpDepthText(tester, depth: const EarthquakeDepth.value(value: 30));
 
-    expect(find.text('深さ'), findsOneWidget);
-    expect(find.text('30km'), findsOneWidget);
+    expect(find.text('深さ30km'), findsOneWidget);
   });
 
   testWidgets('over700km: "深さ" + "700km以上"', (tester) async {
     await pumpDepthText(tester, depth: const EarthquakeDepth.over700km());
 
-    expect(find.text('深さ'), findsOneWidget);
-    expect(find.text('700km以上'), findsOneWidget);
+    expect(find.text('深さ700km以上'), findsOneWidget);
   });
 
   testWidgets('unknown: "深さ" + "調査中"', (tester) async {
     await pumpDepthText(tester, depth: const EarthquakeDepth.unknown());
 
-    expect(find.text('深さ'), findsOneWidget);
-    expect(find.text('調査中'), findsOneWidget);
+    expect(find.text('深さ調査中'), findsOneWidget);
   });
 
   testWidgets('null: "深さ" + "調査中"', (tester) async {
     await pumpDepthText(tester, depth: null);
 
-    expect(find.text('深さ'), findsOneWidget);
-    expect(find.text('調査中'), findsOneWidget);
+    expect(find.text('深さ調査中'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 概要

deploy-app (build #871, `develop`@3b96621) が以下のコンパイルエラーで失敗していたため修正します。

```
lib/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart:179:17: Error: The getter 'client' isn't defined for the type 'EarthquakeHistoryDataSource'.
```

## 原因

0cb902164（cache-first リフレッシュの revert）で `_fetch` の `client` パラメータは削除されたものの、`fetchEarthquakeList` 呼び出し側に `client: client,` 引数が残存していたため。

## 修正内容

- **earthquake_history_data_source.dart**: 残存していた `client: client,` 引数を削除（repository 側は `client` 未指定時に既定クライアントを使用するため挙動変更なし）

あわせて、直近マージされた PR 同士のセマンティック競合により develop 上で既に落ちていたテスト 8 件を現状の実装に追従させました:

- **earthquake_history_config_test.dart**
  - `RegionSearchType` は現在 4 値（prefecture/region/city/station）のため期待値を更新
  - 削除済みの `detail.fill_mode` 設定を参照していたテスト 2 件を削除（アサーションも失われており、対象機能自体が存在しない）
- **depth_text_test.dart**: `DepthText` が単一の `Text.rich` になったため、期待文字列を結合形（例: `深さごく浅い`）に修正

## 確認

- `flutter test test/feature/earthquake_history` → 177 件すべてパス
- `dart analyze`（lib/test の earthquake_history 配下）→ No issues found
- `dart format` 適用済み

マージ後、`develop` への push で deploy-app が自動トリガーされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)