### PR TITLE
ci: Flutter品質ゲートのpath filter漏れを塞ぎmelos実行を再現可能にする

### DIFF
--- a/.github/workflows/wc-changes.yaml
+++ b/.github/workflows/wc-changes.yaml
@@ -40,10 +40,15 @@ jobs:
             flutter:
               - 'app/**'
               - 'packages/**'
+              - 'tools/**'
+              - 'pubspec.yaml'
               - 'pubspec.lock'
               - 'mise.lock'
+              - 'analysis_options.yaml'
               - '.github/workflows/flutter.yaml'
               - '.github/workflows/wc-check-dart-*.yaml'
+              - '.github/workflows/pr-flutter-check.yaml'
+              - '.github/workflows/wc-changes.yaml'
             terraform:
               - 'terraform/**'
               - '.github/workflows/terraform.yaml'

--- a/docs/superpowers/specs/2026-05-30-spec1-contract-drift-findings.md
+++ b/docs/superpowers/specs/2026-05-30-spec1-contract-drift-findings.md
@@ -50,3 +50,21 @@ named fixtures、または未検証エンドポイント（start/changelog/param
    それらが信頼できる drift オラクルになり、本テストでも gate に昇格できる。
 3. `required_versions` / `parameters/:type` は実スキーマと突き合わせて、stub・openapi の
    どちらが古いかを確定する。
+
+## 運用ノート（#1497 時点で追記）
+
+- **Owner:** YumNumm
+- **β 前の扱い:** waiver。quarantine による影響は fixture の厳密性検証のみに限定され、
+  アプリのランタイム挙動（実際の backend レスポンスの解釈）には影響しない。
+  β 配布のブロッカーとはしない。
+- **追跡ガード:** `packages/eqmonitor_api/test/contract_drift_test.dart` に
+  `_quarantine` セットの件数・全要素を固定検証するテスト
+  （`quarantine セットが記録済みの内容から変化していない`）を追加した。
+  新規に quarantine を追加/削除する場合は、このテストの `expectedQuarantine` と
+  本 doc（上表・件数）を必ず同時に更新すること。無自覚な quarantine の追加を
+  テスト失敗として顕在化させるためのガードであり、本表の記載件数（12件）は
+  導入時点のスナップショットである。コード側の `_quarantine` は現在 18 件
+  （telegram named fixtures の追加分などを含む）まで増えており、本表は
+  未更新分の drift を含む可能性がある。β リリース前レビュー時に、コードの
+  `_quarantine` の全要素を棚卸しし、本表を実態に同期させること。
+- **レビュー期限:** β リリース前（次回 backend stub fixture 更新のタイミングに合わせる）。

--- a/packages/eqmonitor_api/test/contract_drift_test.dart
+++ b/packages/eqmonitor_api/test/contract_drift_test.dart
@@ -59,6 +59,14 @@ final _parsers = <String, Object? Function(Map<String, Object?>)>{
 ///
 /// 境界は「default/named」ではなく「現在判明している乖離」。stub fixture を修正したら
 /// ここから外して gate に昇格する。
+///
+/// - Owner: YumNumm
+/// - β 前の扱い: waiver（影響は fixture 厳密性のみで、ランタイム挙動に影響なし）。
+///   β リリース前に findings doc を再レビューし、stub fixture 側の修正が終わったエントリは
+///   gate に昇格させること。
+/// - このセットを追加/削除する場合は、下部の
+///   `quarantine セットが記録済みの内容から変化していない` テストの期待値も更新し、
+///   findings doc に追記すること（新規追加が無自覚に紛れ込むことを防ぐガード）。
 const _quarantine = <String>{
   'get__v1_changelog.json',
   'get__v1_changelog__with-entries.json',
@@ -89,6 +97,48 @@ void main() {
       indexFile.existsSync(),
       isTrue,
       reason: 'index.json が無い。generate.dart で fixtures をコピーしたか確認',
+    );
+  });
+
+  test('quarantine セットが記録済みの内容から変化していない', () {
+    // 新規 quarantine の追加/削除が無自覚に紛れ込むことを防ぐガード。
+    // _quarantine を変更する場合は、この期待値と
+    // docs/superpowers/specs/2026-05-30-spec1-contract-drift-findings.md
+    // の両方を合わせて更新すること（owner: YumNumm）。
+    const expectedQuarantine = <String>{
+      'get__v1_changelog.json',
+      'get__v1_changelog__with-entries.json',
+      'get__v1_start.json',
+      'get__v1_start__force-update.json',
+      'get__v1_start__maintenance.json',
+      'get__v2_earthquake_eventId__canceled.json',
+      'get__v2_parameters_type.json',
+      'get__v2_parameters_manifest__with-parameters.json',
+      'get__v2_telegram_id.json',
+      'get__v2_telegram_id__vtse41.json',
+      'get__v2_telegram_id__vtse51.json',
+      'get__v2_telegram_id__vtse52.json',
+      'get__v2_telegram_id__vtse56.json',
+      'get__v2_telegram_id__vxse51.json',
+      'get__v2_telegram_id__vxse56.json',
+      'get__v2_telegram_id__vzse40.json',
+      'get__v2_telegram_id__with-comments.json',
+      'get__v2_tsunami_tsunamiId__with-telegrams.json',
+    };
+
+    expect(
+      _quarantine.length,
+      expectedQuarantine.length,
+      reason:
+          '_quarantine の件数が変化した（${_quarantine.length} 件）。'
+          '意図した変更であれば expectedQuarantine と findings doc を更新すること。',
+    );
+    expect(
+      _quarantine,
+      equals(expectedQuarantine),
+      reason:
+          '_quarantine の内容が記録済みの期待値と一致しない。'
+          '意図した変更であれば expectedQuarantine と findings doc を更新すること。',
     );
   });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,11 +25,14 @@ melos:
   scripts:
     analyze:
       run: |
-        melos exec -c 1 -- \
+        dart run melos exec -c 1 -- \
           dart analyze . --fatal-infos
       description: |
         Run `dart analyze` in all packages.
         - Note: you can also rely on your IDEs Dart Analysis / Issues window.
+        - Uses `dart run melos exec` (not a bare `melos` call) so this script
+          works whether melos is globally activated or not (e.g. via
+          `dart run melos run analyze` without `dart pub global activate melos`).
     generate:
       run: melos run generate:dart && melos run generate:flutter
       description: Build all generated files for Dart & Flutter packages in this project.


### PR DESCRIPTION
## 概要

β前監査で見つかったPR CIの品質ゲート漏れへの対応(#1497)。

- `.github/workflows/wc-changes.yaml`: flutter path filterに `analysis_options.yaml` / root `pubspec.yaml` / `tools/**` / `pr-flutter-check.yaml` / `wc-changes.yaml` 自体を追加。これらのみを変更したPRでもanalyze/testが発火するようになります
- root `pubspec.yaml` の `analyze` スクリプトを `dart run melos exec` 形式に修正し、melosのグローバルactivate無しでも `dart run melos run analyze` が動くように(CLAUDE.md記載の `melos run analyze` とも両立)
- `contract_drift_test.dart` にquarantineセットの内容(件数+全要素)を固定するガードテストを追加。新規quarantineの黙った追加はテスト失敗として顕在化します
- findings doc に owner(YumNumm)・β前waiver・コード側18件と旧table 12件の乖離の明示を追記

Closes #1497

## 判断メモ

- deploy-app.yaml への preflight job 追加は「不要」の決定に従い実施していません
- `pr-flutter-check.yaml` の status-check の skip=pass 挙動は、filter拡張後は「Flutter無関係PRはスキップでよい」という意図通りの挙動のため変更していません
- 他のmelosスクリプト(`test` 等)にも同種の潜在問題がありますが、CIは `melos exec` を直接呼ぶため影響なし。最小差分の原則で `analyze` のみ修正

## 検証

- ガードテスト: TDDで要素1件削除→RED(`Expected: <18> Actual: <17>`)→復元→GREEN確認
- contract drift suite: 56 passed / 17 skipped / 13 failed — **この13件はdevelop(base)時点から存在する実driftで本PRとは無関係**。別PR(準備中)で解消します
- actionlint / zizmor / pinact クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)