### PR TITLE
fix: eqmonitor_apiのcontract drift/fixture不整合17件を解消

### DIFF
--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew.json
@@ -15,10 +15,8 @@
       "origin_time": "2023-11-14T22:08:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "311",
-          "name": "茨城県北部"
-        },
+        "code": "311",
+        "name": "茨城県北部",
         "coordinates": {
           "latitude": 36.7,
           "longitude": 140.7
@@ -33,10 +31,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "2200",
-              "name": "茨城北部"
-            },
+            "code": "2200",
+            "name": "茨城北部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -49,10 +45,8 @@
             }
           },
           {
-            "value": {
-              "code": "2300",
-              "name": "茨城南部"
-            },
+            "code": "2300",
+            "name": "茨城南部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew__multiple-events.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew__multiple-events.json
@@ -15,10 +15,8 @@
       "origin_time": "2023-11-14T22:03:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "311",
-          "name": "茨城県北部"
-        },
+        "code": "311",
+        "name": "茨城県北部",
         "coordinates": {
           "latitude": 36.7,
           "longitude": 140.7
@@ -33,10 +31,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "2200",
-              "name": "茨城北部"
-            },
+            "code": "2200",
+            "name": "茨城北部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -49,10 +45,8 @@
             }
           },
           {
-            "value": {
-              "code": "2300",
-              "name": "茨城南部"
-            },
+            "code": "2300",
+            "name": "茨城南部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -90,10 +84,8 @@
       "origin_time": "2023-11-14T20:13:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "424",
-          "name": "福島県沖"
-        },
+        "code": "424",
+        "name": "福島県沖",
         "coordinates": {
           "latitude": 37.2,
           "longitude": 141.2
@@ -108,10 +100,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "3410",
-              "name": "浜通り"
-            },
+            "code": "3410",
+            "name": "浜通り",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -124,10 +114,8 @@
             }
           },
           {
-            "value": {
-              "code": "3420",
-              "name": "中通り"
-            },
+            "code": "3420",
+            "name": "中通り",
             "is_plum": false,
             "is_warning": false,
             "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew__warning.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew__warning.json
@@ -15,10 +15,8 @@
       "origin_time": "2023-11-14T22:03:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "531",
-          "name": "石川県能登地方"
-        },
+        "code": "531",
+        "name": "石川県能登地方",
         "coordinates": {
           "latitude": 37.5,
           "longitude": 137.2
@@ -33,10 +31,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "5310",
-              "name": "能登"
-            },
+            "code": "5310",
+            "name": "能登",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -48,10 +44,8 @@
             }
           },
           {
-            "value": {
-              "code": "5320",
-              "name": "加賀"
-            },
+            "code": "5320",
+            "name": "加賀",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -64,10 +58,8 @@
             }
           },
           {
-            "value": {
-              "code": "5110",
-              "name": "富山"
-            },
+            "code": "5110",
+            "name": "富山",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -80,10 +72,8 @@
             }
           },
           {
-            "value": {
-              "code": "5210",
-              "name": "福井"
-            },
+            "code": "5210",
+            "name": "福井",
             "is_plum": false,
             "is_warning": false,
             "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId.json
@@ -15,10 +15,8 @@
       "origin_time": "2023-11-14T22:06:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "311",
-          "name": "茨城県北部"
-        },
+        "code": "311",
+        "name": "茨城県北部",
         "coordinates": {
           "latitude": 36.7,
           "longitude": 140.7
@@ -33,10 +31,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "2200",
-              "name": "茨城北部"
-            },
+            "code": "2200",
+            "name": "茨城北部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -74,10 +70,8 @@
       "origin_time": "2023-11-14T22:06:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "311",
-          "name": "茨城県北部"
-        },
+        "code": "311",
+        "name": "茨城県北部",
         "coordinates": {
           "latitude": 36.7,
           "longitude": 140.7
@@ -92,10 +86,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "2200",
-              "name": "茨城北部"
-            },
+            "code": "2200",
+            "name": "茨城北部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -108,10 +100,8 @@
             }
           },
           {
-            "value": {
-              "code": "2300",
-              "name": "茨城南部"
-            },
+            "code": "2300",
+            "name": "茨城南部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -149,10 +139,8 @@
       "origin_time": "2023-11-14T22:06:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "311",
-          "name": "茨城県北部"
-        },
+        "code": "311",
+        "name": "茨城県北部",
         "coordinates": {
           "latitude": 36.7,
           "longitude": 140.7
@@ -167,10 +155,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "2200",
-              "name": "茨城北部"
-            },
+            "code": "2200",
+            "name": "茨城北部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -183,10 +169,8 @@
             }
           },
           {
-            "value": {
-              "code": "2300",
-              "name": "茨城南部"
-            },
+            "code": "2300",
+            "name": "茨城南部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId__warning-sequence.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId__warning-sequence.json
@@ -15,10 +15,8 @@
       "origin_time": "2023-11-14T21:58:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "531",
-          "name": "石川県能登地方"
-        },
+        "code": "531",
+        "name": "石川県能登地方",
         "coordinates": {
           "latitude": 37.5,
           "longitude": 137.2
@@ -33,10 +31,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "5310",
-              "name": "能登"
-            },
+            "code": "5310",
+            "name": "能登",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -74,10 +70,8 @@
       "origin_time": "2023-11-14T21:58:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "531",
-          "name": "石川県能登地方"
-        },
+        "code": "531",
+        "name": "石川県能登地方",
         "coordinates": {
           "latitude": 37.5,
           "longitude": 137.2
@@ -92,10 +86,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "5310",
-              "name": "能登"
-            },
+            "code": "5310",
+            "name": "能登",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -107,10 +99,8 @@
             }
           },
           {
-            "value": {
-              "code": "5320",
-              "name": "加賀"
-            },
+            "code": "5320",
+            "name": "加賀",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -123,10 +113,8 @@
             }
           },
           {
-            "value": {
-              "code": "5110",
-              "name": "富山"
-            },
+            "code": "5110",
+            "name": "富山",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -139,10 +127,8 @@
             }
           },
           {
-            "value": {
-              "code": "5210",
-              "name": "福井"
-            },
+            "code": "5210",
+            "name": "福井",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -180,10 +166,8 @@
       "origin_time": "2023-11-14T21:58:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "531",
-          "name": "石川県能登地方"
-        },
+        "code": "531",
+        "name": "石川県能登地方",
         "coordinates": {
           "latitude": 37.5,
           "longitude": 137.2
@@ -198,10 +182,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "5310",
-              "name": "能登"
-            },
+            "code": "5310",
+            "name": "能登",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -213,10 +195,8 @@
             }
           },
           {
-            "value": {
-              "code": "5320",
-              "name": "加賀"
-            },
+            "code": "5320",
+            "name": "加賀",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -229,10 +209,8 @@
             }
           },
           {
-            "value": {
-              "code": "5110",
-              "name": "富山"
-            },
+            "code": "5110",
+            "name": "富山",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -245,10 +223,8 @@
             }
           },
           {
-            "value": {
-              "code": "5210",
-              "name": "福井"
-            },
+            "code": "5210",
+            "name": "福井",
             "is_plum": false,
             "is_warning": false,
             "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId_serialNo.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId_serialNo.json
@@ -13,10 +13,8 @@
   "origin_time": "2023-11-14T22:08:20.000Z",
   "arrival_time": null,
   "hypocenter": {
-    "value": {
-      "code": "311",
-      "name": "茨城県北部"
-    },
+    "code": "311",
+    "name": "茨城県北部",
     "coordinates": {
       "latitude": 36.7,
       "longitude": 140.7
@@ -31,10 +29,8 @@
     },
     "regions": [
       {
-        "value": {
-          "code": "2200",
-          "name": "茨城北部"
-        },
+        "code": "2200",
+        "name": "茨城北部",
         "is_plum": false,
         "is_warning": false,
         "intensity": {
@@ -47,10 +43,8 @@
         }
       },
       {
-        "value": {
-          "code": "2300",
-          "name": "茨城南部"
-        },
+        "code": "2300",
+        "name": "茨城南部",
         "is_plum": false,
         "is_warning": false,
         "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId_serialNo__plum.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId_serialNo__plum.json
@@ -13,10 +13,8 @@
   "origin_time": "2023-11-14T22:10:20.000Z",
   "arrival_time": null,
   "hypocenter": {
-    "value": {
-      "code": "999",
-      "name": "不明"
-    },
+    "code": "999",
+    "name": "不明",
     "magnitude": null,
     "depth": null
   },
@@ -27,10 +25,8 @@
     },
     "regions": [
       {
-        "value": {
-          "code": "2200",
-          "name": "茨城北部"
-        },
+        "code": "2200",
+        "name": "茨城北部",
         "is_plum": true,
         "is_warning": false,
         "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId_serialNo__warning.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_eventId_serialNo__warning.json
@@ -13,10 +13,8 @@
   "origin_time": "2023-11-14T22:03:20.000Z",
   "arrival_time": null,
   "hypocenter": {
-    "value": {
-      "code": "531",
-      "name": "石川県能登地方"
-    },
+    "code": "531",
+    "name": "石川県能登地方",
     "coordinates": {
       "latitude": 37.5,
       "longitude": 137.2
@@ -31,10 +29,8 @@
     },
     "regions": [
       {
-        "value": {
-          "code": "5310",
-          "name": "能登"
-        },
+        "code": "5310",
+        "name": "能登",
         "is_plum": false,
         "is_warning": true,
         "intensity": {
@@ -46,10 +42,8 @@
         }
       },
       {
-        "value": {
-          "code": "5320",
-          "name": "加賀"
-        },
+        "code": "5320",
+        "name": "加賀",
         "is_plum": false,
         "is_warning": true,
         "intensity": {
@@ -62,10 +56,8 @@
         }
       },
       {
-        "value": {
-          "code": "5110",
-          "name": "富山"
-        },
+        "code": "5110",
+        "name": "富山",
         "is_plum": false,
         "is_warning": false,
         "intensity": {
@@ -78,10 +70,8 @@
         }
       },
       {
-        "value": {
-          "code": "5210",
-          "name": "福井"
-        },
+        "code": "5210",
+        "name": "福井",
         "is_plum": false,
         "is_warning": false,
         "intensity": {
@@ -106,49 +96,37 @@
   "warning": {
     "zones": [
       {
-        "value": {
-          "code": "1",
-          "name": "北陸"
-        },
+        "code": "1",
+        "name": "北陸",
         "had_warning": false
       }
     ],
     "prefectures": [
       {
-        "value": {
-          "code": "17",
-          "name": "石川県"
-        },
+        "code": "17",
+        "name": "石川県",
         "had_warning": false
       },
       {
-        "value": {
-          "code": "16",
-          "name": "富山県"
-        },
+        "code": "16",
+        "name": "富山県",
         "had_warning": false
       },
       {
-        "value": {
-          "code": "18",
-          "name": "福井県"
-        },
+        "code": "18",
+        "name": "福井県",
         "had_warning": false
       }
     ],
     "regions": [
       {
-        "value": {
-          "code": "5310",
-          "name": "能登"
-        },
+        "code": "5310",
+        "name": "能登",
         "had_warning": false
       },
       {
-        "value": {
-          "code": "5320",
-          "name": "加賀"
-        },
+        "code": "5320",
+        "name": "加賀",
         "had_warning": false
       }
     ]

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_latest__active-forecast.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_latest__active-forecast.json
@@ -15,10 +15,8 @@
       "origin_time": "2023-11-14T22:10:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "311",
-          "name": "茨城県北部"
-        },
+        "code": "311",
+        "name": "茨城県北部",
         "coordinates": {
           "latitude": 36.7,
           "longitude": 140.7
@@ -33,10 +31,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "2200",
-              "name": "茨城北部"
-            },
+            "code": "2200",
+            "name": "茨城北部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -49,10 +45,8 @@
             }
           },
           {
-            "value": {
-              "code": "2300",
-              "name": "茨城南部"
-            },
+            "code": "2300",
+            "name": "茨城南部",
             "is_plum": false,
             "is_warning": false,
             "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_latest__active-warning.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_eew_latest__active-warning.json
@@ -15,10 +15,8 @@
       "origin_time": "2023-11-14T22:11:20.000Z",
       "arrival_time": null,
       "hypocenter": {
-        "value": {
-          "code": "531",
-          "name": "石川県能登地方"
-        },
+        "code": "531",
+        "name": "石川県能登地方",
         "coordinates": {
           "latitude": 37.5,
           "longitude": 137.2
@@ -33,10 +31,8 @@
         },
         "regions": [
           {
-            "value": {
-              "code": "5310",
-              "name": "能登"
-            },
+            "code": "5310",
+            "name": "能登",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -48,10 +44,8 @@
             }
           },
           {
-            "value": {
-              "code": "5320",
-              "name": "加賀"
-            },
+            "code": "5320",
+            "name": "加賀",
             "is_plum": false,
             "is_warning": true,
             "intensity": {
@@ -64,10 +58,8 @@
             }
           },
           {
-            "value": {
-              "code": "5110",
-              "name": "富山"
-            },
+            "code": "5110",
+            "name": "富山",
             "is_plum": false,
             "is_warning": false,
             "intensity": {
@@ -80,10 +72,8 @@
             }
           },
           {
-            "value": {
-              "code": "5210",
-              "name": "福井"
-            },
+            "code": "5210",
+            "name": "福井",
             "is_plum": false,
             "is_warning": false,
             "intensity": {

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id.json
@@ -17,7 +17,48 @@
     "info_kind_version": "1.0_0",
     "hash": "stub-hash-vxse53",
     "created_at": "2025-12-15T12:03:05.000Z",
-    "body": null
+    "body": {
+      "type": "EARTHQUAKE",
+      "earthquake": {
+        "eventId": "20251215120000",
+        "status": "NORMAL",
+        "magnitude": "4.5",
+        "maxIntensity": "4",
+        "depth": 10,
+        "latitude": "36.7",
+        "longitude": "140.7",
+        "epicenterCode": 311,
+        "epicenterName": "茨城県北部",
+        "originTime": "2025-12-15T12:00:00.000Z",
+        "originTimePrecision": "SECOND",
+        "datasource": "JMA_DISASTER_INFORMATION_XML"
+      },
+      "intensityRegions": [
+        {
+          "eventId": "20251215120000",
+          "code": "2200",
+          "name": "茨城北部",
+          "intensity": "4",
+          "datasource": "JMA_DISASTER_INFORMATION_XML"
+        },
+        {
+          "eventId": "20251215120000",
+          "code": "2300",
+          "name": "茨城南部",
+          "intensity": "3",
+          "datasource": "JMA_DISASTER_INFORMATION_XML"
+        }
+      ],
+      "intensityPrefectures": [
+        {
+          "eventId": "20251215120000",
+          "code": "8",
+          "name": "茨城県",
+          "intensity": "4",
+          "datasource": "JMA_DISASTER_INFORMATION_XML"
+        }
+      ]
+    }
   },
   "comments": null
 }

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id__vxse51.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id__vxse51.json
@@ -17,7 +17,32 @@
     "info_kind_version": "1.0_0",
     "hash": "stub-hash-vxse51",
     "created_at": "2025-12-15T12:01:05.000Z",
-    "body": null
+    "body": {
+      "type": "EARTHQUAKE",
+      "earthquake": {
+        "eventId": "20251215120000",
+        "status": "NORMAL",
+        "maxIntensity": "4"
+      },
+      "intensityRegions": [
+        {
+          "eventId": "20251215120000",
+          "code": "2200",
+          "name": "茨城北部",
+          "intensity": "4",
+          "datasource": "JMA_DISASTER_INFORMATION_XML"
+        }
+      ],
+      "intensityPrefectures": [
+        {
+          "eventId": "20251215120000",
+          "code": "8",
+          "name": "茨城県",
+          "intensity": "4",
+          "datasource": "JMA_DISASTER_INFORMATION_XML"
+        }
+      ]
+    }
   },
   "comments": null
 }

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id__vxse53-cancel.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id__vxse53-cancel.json
@@ -1,0 +1,28 @@
+{
+  "telegram": {
+    "id": "stub-telegram-vxse53-cancel",
+    "event_id": "20251215120000",
+    "serial_no": 2,
+    "type": "VXSE53",
+    "title": "震源・震度情報",
+    "status": "NORMAL",
+    "info_type": "CANCELLATION",
+    "editorial_office": "気象庁",
+    "publishing_office": [
+      "気象庁"
+    ],
+    "pressed_at": "2025-12-15T12:05:00.000Z",
+    "reported_at": "2025-12-15T12:05:02.000Z",
+    "info_kind": "震源・震度に関する情報",
+    "info_kind_version": "1.0_0",
+    "hash": "stub-hash-vxse53-cancel",
+    "created_at": "2025-12-15T12:05:05.000Z",
+    "body": {
+      "type": "EARTHQUAKE",
+      "earthquake": {
+        "eventId": "20251215120000"
+      }
+    }
+  },
+  "comments": null
+}

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id__vxse56.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_telegram_id__vxse56.json
@@ -4,7 +4,7 @@
     "event_id": "20240101161000",
     "serial_no": 1,
     "type": "VXSE56",
-    "title": "長周期地震動に関する観測情報",
+    "title": "地震の活動状況等に関する情報",
     "status": "NORMAL",
     "info_type": "PUBLICATION",
     "editorial_office": "気象庁",
@@ -13,14 +13,17 @@
     ],
     "pressed_at": "2024-01-01T07:15:00.000Z",
     "reported_at": "2024-01-01T07:15:02.000Z",
-    "info_kind": "長周期地震動に関する観測情報",
+    "info_kind": "地震の活動状況等に関する情報",
     "info_kind_version": "1.0_0",
     "hash": "stub-hash-vxse56",
     "created_at": "2024-01-01T07:15:05.000Z",
-    "body": null
+    "body": {
+      "type": "EARTHQUAKE_EXPLANATION",
+      "text": "この地震の活動状況等に関する情報の本文です。"
+    }
   },
   "comments": {
-    "free_form_comment": "長周期地震動階級3以上を観測した地域があります。",
+    "free": "長周期地震動階級3以上を観測した地域があります。",
     "warning": null
   }
 }

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_tsunami__active-warning.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_tsunami__active-warning.json
@@ -33,8 +33,11 @@
       ],
       "latest_telegrams": [
         {
+          "id": "stub-telegram-vtse41",
           "type": "VTSE41",
           "title": "大津波警報・津波警報・津波注意報",
+          "editorial_office": "気象庁本庁",
+          "publishing_office": ["気象庁"],
           "pressed_at": "2011-03-11T05:49:00.000Z",
           "reported_at": "2011-03-11T05:49:02.000Z",
           "info_kind": "津波警報・注意報・予報a",

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_tsunami_byeventid_eventId__active-warning.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_tsunami_byeventid_eventId__active-warning.json
@@ -31,8 +31,11 @@
   ],
   "latest_telegrams": [
     {
+      "id": "stub-telegram-vtse41",
       "type": "VTSE41",
       "title": "大津波警報・津波警報・津波注意報",
+      "editorial_office": "気象庁本庁",
+      "publishing_office": ["気象庁"],
       "pressed_at": "2011-03-11T05:49:00.000Z",
       "reported_at": "2011-03-11T05:49:02.000Z",
       "info_kind": "津波警報・注意報・予報a",

--- a/packages/eqmonitor_api/test/fixtures/contract/get__v2_tsunami_tsunamiId__active-warning.json
+++ b/packages/eqmonitor_api/test/fixtures/contract/get__v2_tsunami_tsunamiId__active-warning.json
@@ -31,8 +31,11 @@
   ],
   "latest_telegrams": [
     {
+      "id": "stub-telegram-vtse41",
       "type": "VTSE41",
       "title": "大津波警報・津波警報・津波注意報",
+      "editorial_office": "気象庁本庁",
+      "publishing_office": ["気象庁"],
       "pressed_at": "2011-03-11T05:49:00.000Z",
       "reported_at": "2011-03-11T05:49:02.000Z",
       "info_kind": "津波警報・注意報・予報a",

--- a/packages/eqmonitor_api/test/verify_body_parse_test.dart
+++ b/packages/eqmonitor_api/test/verify_body_parse_test.dart
@@ -47,15 +47,19 @@ void main() {
       expect(eq.earthquake?.magnitude, isNull);
     });
 
-    test('VXSE56 body: EARTHQUAKE type', () {
+    test('VXSE56 body: EARTHQUAKE_EXPLANATION type', () {
       final file = File(
         'test/fixtures/contract/get__v2_telegram_id__vxse56.json',
       );
       final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
       final result = TelegramDetailResponse.fromJson(json);
+      // VXSE56(地震の活動状況等に関する情報)は backend の
+      // dmdata-db-writer/src/telegram/transformer.ts の
+      // transformEarthquakeExplanation() で処理され、
+      // body.type は "EARTHQUAKE" ではなく "EARTHQUAKE_EXPLANATION" になる。
       expect(
         result.telegram.body,
-        isA<TelegramBodyUnionEarthquakeTelegramBody>(),
+        isA<TelegramBodyUnionEarthquakeExplanationTelegramBody>(),
       );
     });
   });


### PR DESCRIPTION
## 概要

β前監査(#1497関連)で発覚した `packages/eqmonitor_api` のテスト失敗17件(quarantine外)を実解消します。quarantineへの追加による回避はしていません。

- **contract_drift_test 13件**: 全てfixture側の不備。EEW系10件はfixtureの `code`/`name` が旧形式の `value` ラップになっていた(backendの `CodeName` スキーマはフラット)。津波系3件は `latest_telegrams` に必須フィールド(`id`/`editorial_office`/`publishing_office`)が欠落
- **verify_body_parse_test 4件**: 3件はfixtureの `body: null`(backendスキーマ上bodyは非null必須union)や欠落fixtureの補完。1件(VXSE56)は**テスト自体の誤り**で、backendのtransformerはVXSE56に常に `EARTHQUAKE_EXPLANATION` bodyを生成するため期待型を修正(fixtureのtype/title不整合も解消)

**Dartモデル・生成コードは無変更**(全件でbackendスキーマとDartモデルは一致しており、ランタイムのパースクラッシュリスクは無いと確認)。各件の判定根拠(backend valibotスキーマ/transformerのfile:line)はレビューで独立検証済みです。

## テスト

- `dart test`(eqmonitor_apiパッケージ全体): **79 passed / 18 skipped(既存quarantine/no-mappingのみ)/ 0 failed**(修正前: 17 failed)
- `dart analyze` クリーン
- quarantineセット・backendサブモジュールは未変更

## フォローアップ候補(スコープ外)

- 今回修正した `get__v2_telegram_id*.json` 3件はcontract_drift側では引き続きquarantine登録されている(セットは意図的に未変更)。fixtureが正しくなったため、quarantine解除を#1497のガードテスト(PR #1506)マージ後に検討可能
- 津波fixtureの `earthquakes[].hypocenter` に同種のvalueラップが残存(Dartモデル側がoptionalのため現状無害)。fixture全体のtype/title整合の監査も推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)