### PR TITLE
fix: MapLibreのAndroidクラスをR8削除から保護

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -72,6 +72,10 @@ android {
             signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
             multiDexEnabled = true
             resValue("string", "app_name", "EQMonitor")
         }

--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+# MapLibre classes are resolved by jnigen at runtime, so R8 cannot discover
+# every usage from the Android bytecode call graph.
+-keep class org.maplibre.android.** { *; }

--- a/docs/knowledge/20260716_maplibre_android_jnigen_proguard.md
+++ b/docs/knowledge/20260716_maplibre_android_jnigen_proguard.md
@@ -1,0 +1,44 @@
+# MapLibre Android / jnigen の ProGuard 設定
+
+## 症状
+
+Android の release ビルドで、MapLibre のクラスに対する
+`ClassNotFoundException` が実行時に発生することがある。
+
+例:
+
+```text
+java.lang.ClassNotFoundException: Didn't find class
+"org/maplibre/android/style/expressions/Expression$Converter"
+```
+
+## 原因
+
+`maplibre_android` は jnigen から Java クラスを文字列で解決する。
+R8 は Dart/JNI 側の参照を Android バイトコードの到達可能性解析で検出できず、
+release の minify 時に必要なクラスを削除する場合がある。
+
+MapLibre のパッケージを個別に keep すると、jnigen の生成対象が増えた際に
+再び漏れる可能性がある。EQMonitor では次の規則で MapLibre Android SDK 全体を保持する。
+
+```proguard
+-keep class org.maplibre.android.** { *; }
+```
+
+release 全体の minify と resource shrinking は無効化しない。
+
+## 検証
+
+Flutter / Dart コマンドは `mise exec --` 経由で実行する。
+
+```bash
+cd app
+mise exec -- flutter build apk \
+  --release \
+  --dart-define-from-file=../environment/.env.prod
+cd ..
+tool/verify_maplibre_android_classes.sh \
+  app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+検証スクリプトが対象クラスを検出して終了コード `0` を返すことを確認する。

--- a/docs/superpowers/plans/2026-07-16-maplibre-android-proguard.md
+++ b/docs/superpowers/plans/2026-07-16-maplibre-android-proguard.md
@@ -1,0 +1,185 @@
+# MapLibre Android ProGuard Protection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep every `org.maplibre.android` class and member in minified Android release builds so jnigen can resolve `Expression$Converter` at runtime.
+
+**Architecture:** Add an app-owned ProGuard file to the release build type instead of changing the pinned MapLibre fork. Verify the built artifact itself with `apkanalyzer`, because a source-level rule assertion cannot prove that R8 retained the class.
+
+**Tech Stack:** Flutter 3.44, Android Gradle Plugin, R8/ProGuard, MapLibre Native Android 13.0.2, jnigen, `apkanalyzer`, POSIX shell
+
+## Global Constraints
+
+- Run Flutter and Dart commands through `mise exec --`.
+- Keep release minification and resource shrinking enabled.
+- Keep all classes and members below `org.maplibre.android`.
+- Do not change the pinned MapLibre fork commit or Dart map implementation.
+- Record the Android release/jnigen operational finding in `docs/knowledge/`.
+
+---
+
+### Task 1: Artifact-level regression check
+
+**Files:**
+- Create: `tool/verify_maplibre_android_classes.sh`
+
+**Interfaces:**
+- Consumes: release APK path as the only positional argument and `apkanalyzer` from `PATH`.
+- Produces: exit code 0 only when `org.maplibre.android.style.expressions.Expression$Converter` exists in the APK DEX.
+
+- [ ] **Step 1: Add the artifact verifier before changing R8 configuration**
+
+```sh
+#!/bin/sh
+set -eu
+
+apk_path=${1:?Usage: verify_maplibre_android_classes.sh <apk-path>}
+class_name='org.maplibre.android.style.expressions.Expression$Converter'
+
+if ! command -v apkanalyzer >/dev/null 2>&1; then
+  echo 'apkanalyzer is required' >&2
+  exit 2
+fi
+
+if apkanalyzer dex packages --defined-only "$apk_path" | grep -Fq "$class_name"; then
+  echo "Verified $class_name in $apk_path"
+  exit 0
+fi
+
+echo "Missing $class_name in $apk_path" >&2
+exit 1
+```
+
+- [ ] **Step 2: Resolve dependencies and create a baseline release APK**
+
+Run from `app/`:
+
+```bash
+cp ../environment/.env.example ../environment/.env.prod
+mise exec -- flutter pub get --enforce-lockfile
+mise exec -- flutter build apk --release --no-pub --dart-define-from-file=../environment/.env.prod
+```
+
+Expected: `build/app/outputs/flutter-apk/app-release.apk` is created.
+
+- [ ] **Step 3: Verify the regression check fails for the expected reason**
+
+Run from the repository root:
+
+```bash
+tool/verify_maplibre_android_classes.sh app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+Expected: exit 1 with `Missing org.maplibre.android.style.expressions.Expression$Converter`.
+
+- [ ] **Step 4: Record the baseline APK size**
+
+```bash
+stat -f '%z' app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+Expected: one integer byte count, retained for comparison in the PR body.
+
+### Task 2: Release R8 protection
+
+**Files:**
+- Create: `app/android/app/proguard-rules.pro`
+- Modify: `app/android/app/build.gradle.kts`
+
+**Interfaces:**
+- Consumes: Android release build type and R8 rule syntax.
+- Produces: release builds that retain all MapLibre Android classes and members while keeping minification enabled.
+
+- [ ] **Step 1: Add the app-owned MapLibre keep rule**
+
+```proguard
+# MapLibre classes are resolved by jnigen at runtime, so R8 cannot discover
+# every usage from the Android bytecode call graph.
+-keep class org.maplibre.android.** { *; }
+```
+
+- [ ] **Step 2: Load the rule from the release build type**
+
+Add to `getByName("release")` in `app/android/app/build.gradle.kts`:
+
+```kotlin
+proguardFiles(
+    getDefaultProguardFile("proguard-android-optimize.txt"),
+    "proguard-rules.pro",
+)
+```
+
+Keep `isMinifyEnabled = true` and `isShrinkResources = true` unchanged.
+
+- [ ] **Step 3: Rebuild the release APK from clean Android outputs**
+
+Run from `app/`:
+
+```bash
+rm -rf build/app/outputs/flutter-apk android/app/build/outputs
+mise exec -- flutter build apk --release --no-pub --dart-define-from-file=../environment/.env.prod
+```
+
+Expected: exit 0 and a new `build/app/outputs/flutter-apk/app-release.apk`.
+
+- [ ] **Step 4: Verify the artifact-level check passes**
+
+```bash
+tool/verify_maplibre_android_classes.sh app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+Expected: exit 0 with `Verified org.maplibre.android.style.expressions.Expression$Converter`.
+
+- [ ] **Step 5: Record and compare the protected APK size**
+
+```bash
+stat -f '%z' app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+Expected: one integer byte count; calculate its byte and percentage difference from Task 1.
+
+### Task 3: Knowledge record and repository checks
+
+**Files:**
+- Create: `docs/knowledge/20260716_maplibre_android_jnigen_proguard.md`
+
+**Interfaces:**
+- Consumes: confirmed root cause, keep rule, build command, and artifact check.
+- Produces: a durable operational reference for future MapLibre/jnigen upgrades.
+
+- [ ] **Step 1: Document the failure mode and exact verification commands**
+
+The document must state:
+
+```markdown
+- Symptom: release-only `ClassNotFoundException` for a MapLibre class.
+- Cause: jnigen string/JNI references are invisible to R8 reachability analysis.
+- Rule: `-keep class org.maplibre.android.** { *; }`.
+- Verification: build a release APK and run `tool/verify_maplibre_android_classes.sh` against it.
+```
+
+- [ ] **Step 2: Run formatting/static checks relevant to the changed files**
+
+```bash
+git --no-pager diff --check origin/develop...HEAD
+mise exec -- flutter analyze app
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Commit the focused implementation**
+
+```bash
+git add tool/verify_maplibre_android_classes.sh app/android/app/proguard-rules.pro app/android/app/build.gradle.kts docs/knowledge/20260716_maplibre_android_jnigen_proguard.md
+git commit -m "fix: MapLibreのAndroidクラスをR8削除から保護"
+```
+
+- [ ] **Step 4: Re-run final evidence after the commit**
+
+```bash
+tool/verify_maplibre_android_classes.sh app/build/app/outputs/flutter-apk/app-release.apk
+git --no-pager diff --check origin/develop...HEAD
+git status --short --branch
+```
+
+Expected: verifier and diff check exit 0; worktree is clean and ahead of `origin/develop`.

--- a/docs/superpowers/specs/2026-07-16-maplibre-android-proguard-design.md
+++ b/docs/superpowers/specs/2026-07-16-maplibre-android-proguard-design.md
@@ -1,0 +1,49 @@
+# MapLibre Android ProGuard 保護設計
+
+## 背景
+
+Android の release ビルドで R8 が有効な場合、MapLibre の
+`org.maplibre.android.style.expressions.Expression$Converter` が APK から削除され、
+jnigen が実行時にクラスを解決できず `ClassNotFoundException` が発生する。
+
+MapLibre Android の consumer rules はパッケージを個別列挙しているが、
+`org.maplibre.android.style.expressions` が含まれていない。一方、jnigen の生成コードは
+Java クラス名を文字列で参照するため、R8 は Dart 側からの利用を静的に検出できない。
+
+## 方針
+
+アプリの ProGuard rules で MapLibre Android SDK 全体を保持する。
+
+```proguard
+-keep class org.maplibre.android.** { *; }
+```
+
+MapLibre のパッケージを個別に列挙せず、今後 jnigen の対象クラスが増えた場合も
+同種の削除を防止する。release ビルド全体の minify と resource shrinking は維持する。
+
+## 変更範囲
+
+- Android アプリ用の ProGuard rules ファイルを追加する。
+- release build type から当該 rules を明示的に読み込む。
+- release APK に `Expression$Converter` が残ることを検証する。
+- 修正前後の APK サイズを比較し、PR に記録する。
+- Android release と jnigen の注意点を `docs/knowledge/` に記録する。
+
+MapLibre fork の参照 commit、Dart のマップ実装、minify の有効・無効は変更しない。
+
+## 検証
+
+1. 修正前の release APK では対象クラスが存在しないことを再現する。
+2. 修正後に同じ条件で release APK を作成する。
+3. APK の DEX を解析し、対象クラスが存在することを確認する。
+4. Android Gradle 設定のテストと Flutter の静的解析を実行する。
+5. 修正前後の APK サイズ差を確認する。
+
+実機で release APK を起動できる場合は、MapLibre を使用する画面を開き、
+同じ `ClassNotFoundException` が発生しないことも確認する。
+
+## リスク
+
+MapLibre Android SDK の難読化・削除が抑止されるため、APK サイズは増加する可能性がある。
+ただし、MapLibre 以外の依存関係には R8 が引き続き適用される。実行時 JNI 解決の確実性を
+優先し、サイズ増加量はビルド成果物で定量確認する。

--- a/tool/verify_maplibre_android_classes.sh
+++ b/tool/verify_maplibre_android_classes.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+apk_path=${1:?Usage: verify_maplibre_android_classes.sh <apk-path>}
+class_name='org.maplibre.android.style.expressions.Expression$Converter'
+
+if ! command -v apkanalyzer >/dev/null 2>&1; then
+  echo 'apkanalyzer is required' >&2
+  exit 2
+fi
+
+if apkanalyzer dex packages --defined-only "$apk_path" | grep -Fq "$class_name"; then
+  echo "Verified $class_name in $apk_path"
+  exit 0
+fi
+
+echo "Missing $class_name in $apk_path" >&2
+exit 1


### PR DESCRIPTION
## 概要

Android release版でMapLibreのJavaクラスがR8に削除され、jnigenからの実行時解決が `ClassNotFoundException` になる問題を修正します。

## 原因

`maplibre_android` はJavaクラスをjnigen/JNI経由で文字列参照します。MapLibre側のconsumer ProGuard rulesには `style.expressions` が含まれず、R8が `Expression$Converter` を未使用クラスとして削除していました。

## 変更内容

- release build typeでアプリ固有のProGuard rulesを読み込む
- `org.maplibre.android.**` の全クラス・メンバーをkeepする
- release APKのDEXを検査するスクリプトを追加する
- jnigenとR8の注意点を `docs/knowledge/` に記録する

## 確認状況

- [x] pre-commit checks（shellcheck、gitleaks、競合マーカー、symlink）
- [x] `git diff --check origin/develop...HEAD`
- [ ] release APK build
- [ ] `Expression$Converter` のAPK内存在確認
- [ ] 修正前後のAPKサイズ比較

release APK buildはローカルGradle環境で `26.0.1` エラーとなり完走していません。CI結果と、必要に応じた同梱スクリプトによる成果物検証を確認後にReadyへ変更します。
