### PR TITLE
feat: Release ModeでもChuckを有効化

### DIFF
--- a/app/lib/core/provider/chuck_build_mode_policy.dart
+++ b/app/lib/core/provider/chuck_build_mode_policy.dart
@@ -1,0 +1,10 @@
+class ChuckBuildModePolicy {
+  const ChuckBuildModePolicy({required bool isDebugMode})
+    : captureTraffic = true,
+      showInspector = true,
+      showNotification = isDebugMode;
+
+  final bool captureTraffic;
+  final bool showInspector;
+  final bool showNotification;
+}

--- a/app/lib/core/provider/chuck_provider.dart
+++ b/app/lib/core/provider/chuck_provider.dart
@@ -1,13 +1,16 @@
 import 'package:chuck_interceptor/chuck_interceptor.dart';
 import 'package:eqmonitor/app.dart';
+import 'package:eqmonitor/core/provider/chuck_build_mode_policy.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'chuck_provider.g.dart';
 
+const chuckBuildModePolicy = ChuckBuildModePolicy(isDebugMode: kDebugMode);
+
 @Riverpod(keepAlive: true)
 Chuck chuck(Ref ref) => Chuck(
   navigatorKey: App.navigatorKey,
   // ignore: avoid_redundant_argument_values
-  showNotification: kDebugMode,
+  showNotification: chuckBuildModePolicy.showNotification,
 );

--- a/app/lib/core/provider/dio_provider.dart
+++ b/app/lib/core/provider/dio_provider.dart
@@ -12,7 +12,6 @@ import 'package:eqmonitor/core/provider/interceptor/device_id_interceptor.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/provider/telegram_url/provider/telegram_url_provider.dart';
-import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:talker_dio_logger/talker_dio_logger_interceptor.dart';
 import 'package:talker_dio_logger/talker_dio_logger_settings.dart';
@@ -44,7 +43,7 @@ Future<Dio> dio(Ref ref) async {
   dio.interceptors.add(deviceIdInterceptor);
   dio.interceptors.add(deviceAuthTokenInterceptor);
 
-  if (kDebugMode) {
+  if (chuckBuildModePolicy.captureTraffic) {
     final chuck = ref.watch(chuckProvider);
     dio.interceptors.add(chuck.dioInterceptor);
   }

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -67,7 +67,7 @@ class _DebugWidget extends ConsumerWidget {
                   .read(debugProvider.notifier)
                   .save(isEnabled: !isDebugEnabled),
             ),
-            if (kDebugMode)
+            if (chuckBuildModePolicy.showInspector)
               ListTile(
                 title: const Text('Chuck'),
                 leading: const Icon(Icons.list),

--- a/app/test/core/provider/chuck_build_mode_policy_test.dart
+++ b/app/test/core/provider/chuck_build_mode_policy_test.dart
@@ -1,0 +1,22 @@
+import 'package:eqmonitor/core/provider/chuck_build_mode_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ChuckBuildModePolicy', () {
+    test('Release相当では通信記録とInspectorを有効にし通知を無効にする', () {
+      const policy = ChuckBuildModePolicy(isDebugMode: false);
+
+      expect(policy.captureTraffic, isTrue);
+      expect(policy.showInspector, isTrue);
+      expect(policy.showNotification, isFalse);
+    });
+
+    test('Debug相当では通信記録とInspectorと通知を有効にする', () {
+      const policy = ChuckBuildModePolicy(isDebugMode: true);
+
+      expect(policy.captureTraffic, isTrue);
+      expect(policy.showInspector, isTrue);
+      expect(policy.showNotification, isTrue);
+    });
+  });
+}

--- a/docs/superpowers/plans/2026-07-16-enable-chuck-release.md
+++ b/docs/superpowers/plans/2026-07-16-enable-chuck-release.md
@@ -1,0 +1,140 @@
+# Release Mode Chuck Enablement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Release Mode でも Chuck の通信記録と Inspector 導線を有効にし、通知だけは Debug Mode に限定する。
+
+**Architecture:** ビルドモードから Chuck の3機能の有効状態を決める immutable なポリシーを追加する。Chuck provider、Dio provider、デバッグ設定画面は同じポリシーを参照し、Release と Debug の差を単体テストで固定する。
+
+**Tech Stack:** Flutter 3.44.4、Dart、Riverpod、flutter_test、chuck_interceptor
+
+## Global Constraints
+
+- Flutter / Dart コマンドは `mise exec --` 経由で実行する。
+- Release Mode では通信記録と Inspector 導線を有効にする。
+- Release Mode では Chuck の通知を表示しない。
+- 地震情報や API 応答へ固定値のフォールバックを追加しない。
+
+---
+
+### Task 1: Chuck build mode policy と既存配線
+
+**Files:**
+- Create: `app/lib/core/provider/chuck_build_mode_policy.dart`
+- Create: `app/test/core/provider/chuck_build_mode_policy_test.dart`
+- Modify: `app/lib/core/provider/chuck_provider.dart`
+- Modify: `app/lib/core/provider/dio_provider.dart`
+- Modify: `app/lib/feature/settings/children/config/debug/debug_page.dart`
+
+**Interfaces:**
+- Consumes: Flutter の compile-time 定数 `kDebugMode`
+- Produces: `ChuckBuildModePolicy` と `chuckBuildModePolicy`
+
+- [ ] **Step 1: Release と Debug の期待値を表す失敗テストを書く**
+
+```dart
+import 'package:eqmonitor/core/provider/chuck_build_mode_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ChuckBuildModePolicy', () {
+    test('Release相当では通信記録とInspectorを有効にし通知を無効にする', () {
+      const policy = ChuckBuildModePolicy(isDebugMode: false);
+
+      expect(policy.captureTraffic, isTrue);
+      expect(policy.showInspector, isTrue);
+      expect(policy.showNotification, isFalse);
+    });
+
+    test('Debug相当では通信記録とInspectorと通知を有効にする', () {
+      const policy = ChuckBuildModePolicy(isDebugMode: true);
+
+      expect(policy.captureTraffic, isTrue);
+      expect(policy.showInspector, isTrue);
+      expect(policy.showNotification, isTrue);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: テストを実行し、未実装の型で失敗することを確認する**
+
+Run: `cd app && mise exec -- flutter test test/core/provider/chuck_build_mode_policy_test.dart`
+
+Expected: FAIL because `chuck_build_mode_policy.dart` or `ChuckBuildModePolicy` does not exist.
+
+- [ ] **Step 3: 最小のポリシー実装を追加する**
+
+```dart
+class ChuckBuildModePolicy {
+  const ChuckBuildModePolicy({required bool isDebugMode})
+    : captureTraffic = true,
+      showInspector = true,
+      showNotification = isDebugMode;
+
+  final bool captureTraffic;
+  final bool showInspector;
+  final bool showNotification;
+}
+```
+
+- [ ] **Step 4: ポリシーのテストが成功することを確認する**
+
+Run: `cd app && mise exec -- flutter test test/core/provider/chuck_build_mode_policy_test.dart`
+
+Expected: PASS with 2 tests.
+
+- [ ] **Step 5: 既存の Chuck 配線をポリシーへ接続する**
+
+`chuck_provider.dart` に次を追加し、`showNotification` に利用する。
+
+```dart
+const chuckBuildModePolicy = ChuckBuildModePolicy(isDebugMode: kDebugMode);
+
+showNotification: chuckBuildModePolicy.showNotification,
+```
+
+`dio_provider.dart` の Chuck 登録条件を次へ置き換える。
+
+```dart
+if (chuckBuildModePolicy.captureTraffic) {
+  final chuck = ref.watch(chuckProvider);
+  dio.interceptors.add(chuck.dioInterceptor);
+}
+```
+
+`debug_page.dart` の Inspector 導線条件を次へ置き換える。
+
+```dart
+if (chuckBuildModePolicy.showInspector)
+  ListTile(
+    title: const Text('Chuck'),
+    leading: const Icon(Icons.list),
+    onTap: () async => ref.read(chuckProvider).showInspector(),
+  ),
+```
+
+- [ ] **Step 6: format、対象テスト、静的解析を実行する**
+
+Run: `mise exec -- dart format app/lib/core/provider/chuck_build_mode_policy.dart app/lib/core/provider/chuck_provider.dart app/lib/core/provider/dio_provider.dart app/lib/feature/settings/children/config/debug/debug_page.dart app/test/core/provider/chuck_build_mode_policy_test.dart`
+
+Expected: formatter exits 0.
+
+Run: `cd app && mise exec -- flutter test test/core/provider/chuck_build_mode_policy_test.dart test/core/provider/dio_list_format_test.dart test/feature/settings/data/contact/contact_url_builder_test.dart`
+
+Expected: PASS with 6 tests.
+
+Run: `mise exec -- dart analyze app/lib/core/provider/chuck_build_mode_policy.dart app/lib/core/provider/chuck_provider.dart app/lib/core/provider/dio_provider.dart app/lib/feature/settings/children/config/debug/debug_page.dart app/test/core/provider/chuck_build_mode_policy_test.dart`
+
+Expected: No issues found.
+
+- [ ] **Step 7: 実装をコミットする**
+
+```bash
+git add app/lib/core/provider/chuck_build_mode_policy.dart \
+  app/lib/core/provider/chuck_provider.dart \
+  app/lib/core/provider/dio_provider.dart \
+  app/lib/feature/settings/children/config/debug/debug_page.dart \
+  app/test/core/provider/chuck_build_mode_policy_test.dart
+git commit -m "feat: Release ModeでもChuckを有効化"
+```

--- a/docs/superpowers/specs/2026-07-16-enable-chuck-release-design.md
+++ b/docs/superpowers/specs/2026-07-16-enable-chuck-release-design.md
@@ -1,0 +1,33 @@
+# Release Mode Chuck 有効化設計
+
+## 目的
+
+Release Mode でも Chuck が HTTP 通信を記録し、デバッグ設定画面から Inspector を開けるようにする。
+
+## 方針
+
+- ビルドモードごとの Chuck 機能を表す小さなポリシーを追加する。
+- ポリシーに従い、Dio へ Chuck の interceptor をビルドモードに関係なく登録する。
+- ポリシーに従い、デバッグ設定画面へ Chuck の Inspector 導線をビルドモードに関係なく表示する。
+- Chuck の通知は `kDebugMode` のときだけ表示し、Release Mode の一般利用者には露出させない。
+- Chuck の依存関係、保存形式、Inspector の実装には変更を加えない。
+
+## 検討した選択肢
+
+1. `kDebugMode` の有効化ゲートをポリシーへ置き換える。変更範囲を小さく保ちつつ Release 相当の挙動を単体テストできるため採用する。
+2. runtime の設定値で Chuck 全体を切り替える。運用要件にない状態管理が増えるため採用しない。
+3. flavor や `dart-define` で切り替える。すべての Release Mode で有効にする要求と一致せず、ビルド設定も複雑になるため採用しない。
+
+## データフロー
+
+ビルドモードから作成した Chuck ポリシーを provider と UI が参照する。`dioProvider` が作成する Dio に Chuck interceptor を常に追加し、取得した通信を Chuck 内部へ記録する。利用者がデバッグ設定画面の Chuck 項目を選択すると、既存の `chuckProvider` が Inspector を表示する。
+
+## エラー処理と安全性
+
+Chuck の既存エラー処理をそのまま利用する。通知は Release Mode で無効のままとし、通常利用時の不要な通知を防ぐ。地震情報や API 応答にフォールバック値を追加する変更は行わない。
+
+## テスト
+
+- Release 相当の `isDebugMode: false` で、通信記録と Inspector 導線が有効、通知だけが無効となるポリシーを単体テストする。
+- Debug 相当の `isDebugMode: true` で、3機能がすべて有効となることを単体テストする。
+- 関連テストと静的解析を実行する。


### PR DESCRIPTION
## 概要

Release ModeでもChuckによるHTTP通信記録とInspector表示を利用できるようにします。

## 変更内容

- ビルドモードごとのChuck機能を表す`ChuckBuildModePolicy`を追加
- Release ModeでもDioへChuck interceptorを登録
- Release Modeでもデバッグ設定画面にChuckのInspector導線を表示
- Chuckの通知は従来どおりDebug Modeのみに限定
- Release相当・Debug相当のポリシーを単体テストで固定

## 影響

Release Modeでもデバッグ設定画面から通信内容を確認できます。通常利用者へChuckの通知は表示されません。

## 検証

```console
mise exec -- flutter test --no-pub test/core/provider/chuck_build_mode_policy_test.dart test/core/provider/dio_list_format_test.dart test/feature/settings/data/contact/contact_url_builder_test.dart
```

6 tests passed.
