### PR TITLE
feat: 地震履歴のソートを「発生時刻」に統一しデフォルト時のUI/戻る挙動を改善

### DIFF
--- a/app/lib/core/component/chip/sort_filter_chip.dart
+++ b/app/lib/core/component/chip/sort_filter_chip.dart
@@ -15,7 +15,7 @@ class SortFilterChip extends StatelessWidget {
 
   final EarthquakeSortBy? sortBy;
   final SortOrder? sortOrder;
-  final void Function(EarthquakeSortBy?, SortOrder?)? onChanged;
+  final void Function(EarthquakeSortBy, SortOrder)? onChanged;
 
   /// true のとき、モーダル内の並び替え項目選択を非表示にする。
   /// 地域絞り込み中など sortBy が固定される場合に使用する。
@@ -23,14 +23,14 @@ class SortFilterChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDefault = sortBy == null && sortOrder == null;
     final displaySortBy = sortBy ?? .eventId;
     final displayOrder = sortOrder ?? .desc;
+    final isDefault = displaySortBy == .eventId && displayOrder == .desc;
 
     return RawChip(
       onSelected: (_) async {
         final result =
-            await showModalBottomSheet<(EarthquakeSortBy?, SortOrder?)?>(
+            await showModalBottomSheet<(EarthquakeSortBy, SortOrder)?>(
               clipBehavior: Clip.antiAlias,
               context: context,
               builder: (context) => _SortFilterModal(
@@ -43,13 +43,11 @@ class SortFilterChip extends StatelessWidget {
           onChanged?.call(result.$1, result.$2);
         }
       },
-      label: isDefault
-          ? const Text('新しい順')
-          : Text(
-              '${displaySortBy.label} ${displayOrder.arrow}',
-              style: const TextStyle(fontWeight: FontWeight.bold),
-            ),
-      onDeleted: isDefault ? null : () => onChanged?.call(null, null),
+      label: Text(
+        '${displaySortBy.label} ${displayOrder.arrow}',
+        style: isDefault ? null : const TextStyle(fontWeight: FontWeight.bold),
+      ),
+      onDeleted: isDefault ? null : () => onChanged?.call(.eventId, .desc),
       selected: !isDefault,
       selectedColor: context.designSystem.colorTheme.secondaryContainer,
     );
@@ -150,15 +148,9 @@ class _SortFilterModal extends HookWidget {
                   child: const Text('キャンセル'),
                 ),
                 TextButton(
-                  onPressed: () {
-                    final isDefault =
-                        sortBy.value == .eventId && sortOrder.value == .desc;
-                    Navigator.of(context).pop(
-                      isDefault
-                          ? (null, null)
-                          : (sortBy.value, sortOrder.value),
-                    );
-                  },
+                  onPressed: () => Navigator.of(
+                    context,
+                  ).pop((sortBy.value, sortOrder.value)),
                   child: const Text('完了'),
                 ),
               ],

--- a/app/lib/feature/earthquake_history/data/model/earthquake_history_parameter.g.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_history_parameter.g.dart
@@ -164,7 +164,6 @@ const _$EarthquakeSortByEnumMap = {
   EarthquakeSortBy.maxIntensity: 'maxIntensity',
   EarthquakeSortBy.maxLpgmIntensity: 'maxLpgmIntensity',
   EarthquakeSortBy.depth: 'depth',
-  EarthquakeSortBy.originTime: 'originTime',
 };
 
 const _$SortOrderEnumMap = {SortOrder.asc: 'asc', SortOrder.desc: 'desc'};

--- a/app/lib/feature/earthquake_history/data/model/earthquake_sort_by.dart
+++ b/app/lib/feature/earthquake_history/data/model/earthquake_sort_by.dart
@@ -1,32 +1,32 @@
 import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
 
 /// 地震一覧のソート項目
+///
+/// 発生時刻順は eventId ソートで代用する
+/// (eventId は発生時刻ベースの採番のため並びが一致する)。
 enum EarthquakeSortBy {
   eventId,
   magnitude,
   maxIntensity,
   maxLpgmIntensity,
-  depth,
-  originTime;
+  depth;
 
   String get label => switch (this) {
-    .eventId => '新しい順',
+    .eventId => '発生時刻',
     .magnitude => 'マグニチュード',
     .maxIntensity => '最大震度',
     .maxLpgmIntensity => '長周期階級',
     .depth => '震源の深さ',
-    .originTime => '発生時刻',
   };
 }
 
 extension EarthquakeSortByApiExtension on api.EarthquakeSortBy {
   EarthquakeSortBy get toEarthquakeSortBy => switch (this) {
-    .eventId => .eventId,
+    .eventId || .originTime => .eventId,
     .magnitude => .magnitude,
     .maxIntensity => .maxIntensity,
     .maxLpgmIntensity => .maxLpgmIntensity,
     .depth => .depth,
-    .originTime => .originTime,
   };
 }
 
@@ -37,6 +37,5 @@ extension EarthquakeSortByToApiExtension on EarthquakeSortBy {
     .maxIntensity => .maxIntensity,
     .maxLpgmIntensity => .maxLpgmIntensity,
     .depth => .depth,
-    .originTime => .originTime,
   };
 }

--- a/app/lib/feature/earthquake_history/ui/components/earthquake_history_parameter_persistent_delegate.dart
+++ b/app/lib/feature/earthquake_history/ui/components/earthquake_history_parameter_persistent_delegate.dart
@@ -84,12 +84,9 @@ class _FilterChipBar extends ConsumerWidget {
           sortBy: parameter.sortBy,
           sortOrder: parameter.sortOrder,
           sortByLocked: isRegionFiltered,
-          onChanged: (sortBy, sortOrder) {
-            if (sortBy == null || sortOrder == null) {
-              return;
-            }
-            onChanged(parameter.copyWith(sortBy: sortBy, sortOrder: sortOrder));
-          },
+          onChanged: (sortBy, sortOrder) => onChanged(
+            parameter.copyWith(sortBy: sortBy, sortOrder: sortOrder),
+          ),
         ),
       ),
       (

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_page.dart
@@ -5,6 +5,8 @@ import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_data_source.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_not_found.dart';
@@ -45,18 +47,35 @@ class _SliverListBody extends HookConsumerWidget {
       earthquakeHistoryDataSourceProvider(parameter.value),
     );
 
-    return dataSourceAsync.when(
-      loading: () => const _EarthquakeHistorySkeleton(),
-      error: (error, _) => ErrorCard(
-        error: error,
-        onReload: () async =>
-            ref.refresh(earthquakeHistoryDataSourceProvider(parameter.value)),
-      ),
-      data: (dataSource) => _PagingBody(
-        dataSource: dataSource,
-        parameter: parameter,
-        onParameterChanged: (result) => parameter.value = result,
-        onRefresh: () => dataSource.refresh(),
+    // デフォルト(発生時刻↓)以外のソート中は、戻る操作でページを閉じずに
+    // ソートをデフォルトへ戻す
+    final isDefaultSort =
+        parameter.value.sortBy == EarthquakeSortBy.eventId &&
+        parameter.value.sortOrder == SortOrder.desc;
+
+    return PopScope(
+      canPop: isDefaultSort,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) {
+          parameter.value = parameter.value.copyWith(
+            sortBy: EarthquakeSortBy.eventId,
+            sortOrder: SortOrder.desc,
+          );
+        }
+      },
+      child: dataSourceAsync.when(
+        loading: () => const _EarthquakeHistorySkeleton(),
+        error: (error, _) => ErrorCard(
+          error: error,
+          onReload: () async =>
+              ref.refresh(earthquakeHistoryDataSourceProvider(parameter.value)),
+        ),
+        data: (dataSource) => _PagingBody(
+          dataSource: dataSource,
+          parameter: parameter,
+          onParameterChanged: (result) => parameter.value = result,
+          onRefresh: () => dataSource.refresh(),
+        ),
       ),
     );
   }

--- a/app/test/feature/earthquake_history/data/earthquake_history_parameter_test.dart
+++ b/app/test/feature/earthquake_history/data/earthquake_history_parameter_test.dart
@@ -66,7 +66,7 @@ void main() {
 
     test('city variant でも往復できること', () {
       const original = EarthquakeHistoryParameter.city(
-        sortBy: EarthquakeSortBy.originTime,
+        sortBy: EarthquakeSortBy.maxIntensity,
         sortOrder: SortOrder.desc,
         cityCode: '13101',
         depthGte: 10,


### PR DESCRIPTION
## 概要

地震履歴一覧ページのソート周りを改善します。

## 変更内容

### 「新しい順」と「発生時刻」の統合
- `EarthquakeSortBy` から `originTime` を削除し、`eventId` のラベルを「発生時刻」に変更しました
- eventId は発生時刻ベースの採番のため、発生時刻順ソートは eventId ソートで代用できます（API へは `event_id` ソートとして送信）
- API 側の `originTime` からの変換は `eventId` にマップします

### ソートChipの表示
- デフォルト（発生時刻↓）のときは Chip に ✗（削除アイコン）を表示せず、非選択・非太字で「発生時刻 ↓」を表示します
- デフォルト以外のソート中のみ ✗ を表示し、タップで発生時刻↓に戻します

### 戻るボタンの挙動
- 発生時刻↓以外のソート中に戻る操作（AppBar の戻る・システムバック）をした場合、ページを閉じずにソートを発生時刻↓へ戻します（`PopScope`）
- 発生時刻↓のときは通常どおりページを閉じます

## テスト
- `dart analyze`（変更箇所）: No issues found
- `flutter test test/feature/earthquake_history`: 182件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)