### PR TITLE
fix: 通知設定から通知しないプリセットを削除

### DIFF
--- a/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
+++ b/app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart
@@ -24,11 +24,17 @@ class NotificationPresetSelector extends HookConsumerWidget {
   final NotificationPresetSelectorStyle style;
   final VoidCallback? onCustomSettingsTap;
 
-  static const _presetOrder = <NotificationPreset>[
+  static const _onboardingPresetOrder = <NotificationPreset>[
     NotificationPreset.recommended,
     NotificationPreset.all,
     NotificationPreset.custom,
     NotificationPreset.none,
+  ];
+
+  static const _settingsPresetOrder = <NotificationPreset>[
+    NotificationPreset.recommended,
+    NotificationPreset.all,
+    NotificationPreset.custom,
   ];
 
   @override
@@ -85,7 +91,7 @@ class NotificationPresetSelector extends HookConsumerWidget {
 
     return switch (style) {
       NotificationPresetSelectorStyle.onboarding => _OnboardingPresetList(
-        presets: _presetOrder,
+        presets: _onboardingPresetOrder,
         selectedPreset: selectedPreset,
         isPresetEnabled: isPresetEnabled,
         shouldShowCriticalWarning: shouldShowCriticalWarning,
@@ -94,7 +100,7 @@ class NotificationPresetSelector extends HookConsumerWidget {
             showCriticalAlertPermissionDialog(context, ref),
       ),
       NotificationPresetSelectorStyle.settings => _SettingsPresetGroup(
-        presets: _presetOrder,
+        presets: _settingsPresetOrder,
         selectedPreset: selectedPreset,
         isPresetEnabled: isPresetEnabled,
         shouldShowCriticalWarning: shouldShowCriticalWarning,

--- a/app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
+++ b/app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
@@ -33,6 +33,57 @@ Widget _buildTestWidget({
 
 void main() {
   group('NotificationPresetSelector', () {
+    testWidgets('設定画面では通知しないプリセットを表示しない', (tester) async {
+      final settings = _notificationSettings(
+        authorizationStatus: AuthorizationStatus.authorized,
+      );
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        settings,
+      );
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          messaging: _FakeFirebaseMessaging(settings),
+          permission: permission,
+          child: NotificationPresetSelector(
+            selectedPreset: NotificationPreset.recommended,
+            onChanged: (_) {},
+            style: NotificationPresetSelectorStyle.settings,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('推奨設定'), findsOneWidget);
+      expect(find.text('すべて'), findsOneWidget);
+      expect(find.text('カスタム'), findsOneWidget);
+      expect(find.text('通知しない'), findsNothing);
+    });
+
+    testWidgets('オンボーディングでは通知しないプリセットを表示する', (tester) async {
+      final settings = _notificationSettings(
+        authorizationStatus: AuthorizationStatus.authorized,
+      );
+      final permission = OsNotificationPermission.fromNotificationSettings(
+        settings,
+      );
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          messaging: _FakeFirebaseMessaging(settings),
+          permission: permission,
+          child: NotificationPresetSelector(
+            selectedPreset: NotificationPreset.recommended,
+            onChanged: (_) {},
+            style: NotificationPresetSelectorStyle.onboarding,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('通知しない'), findsOneWidget);
+    });
+
     testWidgets('OS権限オフで無効プリセットをタップすると通知権限ダイアログを表示する', (
       tester,
     ) async {

--- a/docs/superpowers/plans/2026-07-17-remove-none-notification-preset.md
+++ b/docs/superpowers/plans/2026-07-17-remove-none-notification-preset.md
@@ -1,0 +1,105 @@
+# Remove None Notification Preset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 通知設定画面のプリセットを「推奨設定」「すべて」「カスタム」の3択にし、「通知しない」は master toggle に一本化する。
+
+**Architecture:** `NotificationPresetSelector` の表示用リストだけを style ごとに分ける。`NotificationPreset.none` とその永続化・適用処理はオンボーディングおよび既存データ互換性のため維持する。
+
+**Tech Stack:** Flutter, Dart, hooks_riverpod, flutter_test
+
+## Global Constraints
+
+- Flutter / Dart コマンドは `mise exec --` 経由で実行する。
+- settings style は `recommended`, `all`, `custom` の3件だけを表示する。
+- onboarding style は `recommended`, `all`, `custom`, `none` の4件を維持する。
+- `NotificationPreset.none`、保存済み `none` 値、preset applier の動作は変更しない。
+- 推奨設定とすべての通知条件は変更しない。
+
+---
+
+### Task 1: Style ごとのプリセット一覧を分離する
+
+**Files:**
+- Modify: `app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart`
+- Test: `app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart`
+
+**Interfaces:**
+- Consumes: `NotificationPresetSelectorStyle` と既存の `NotificationPreset` enum。
+- Produces: settings style の3択表示と onboarding style の従来どおりの4択表示。
+
+- [ ] **Step 1: 表示差を固定する Widget test を追加する**
+
+authorized permission で selector を描画し、次の2ケースを追加する。
+
+```dart
+testWidgets('設定画面では通知しないプリセットを表示しない', (tester) async {
+  // settings style を描画
+  expect(find.text('推奨設定'), findsOneWidget);
+  expect(find.text('すべて'), findsOneWidget);
+  expect(find.text('カスタム'), findsOneWidget);
+  expect(find.text('通知しない'), findsNothing);
+});
+
+testWidgets('オンボーディングでは通知しないプリセットを表示する', (tester) async {
+  // onboarding style を描画
+  expect(find.text('通知しない'), findsOneWidget);
+});
+```
+
+- [ ] **Step 2: settings のテストが期待どおり失敗することを確認する**
+
+Run:
+
+```bash
+mise exec -- flutter test app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
+```
+
+Expected: settings style で「通知しない」が1件見つかり、`findsNothing` が失敗する。onboarding style の新規テストは成功する。
+
+- [ ] **Step 3: style ごとにプリセット順序を分ける**
+
+`NotificationPresetSelector` の共有 `_presetOrder` を以下の2定数に置き換え、それぞれ対応する子 Widget へ渡す。
+
+```dart
+static const _onboardingPresetOrder = <NotificationPreset>[
+  NotificationPreset.recommended,
+  NotificationPreset.all,
+  NotificationPreset.custom,
+  NotificationPreset.none,
+];
+
+static const _settingsPresetOrder = <NotificationPreset>[
+  NotificationPreset.recommended,
+  NotificationPreset.all,
+  NotificationPreset.custom,
+];
+```
+
+- [ ] **Step 4: selector と preset 適用処理のテストを確認する**
+
+Run:
+
+```bash
+mise exec -- flutter test app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart
+```
+
+Expected: 全テスト成功。
+
+- [ ] **Step 5: 変更ファイルを format・analyze する**
+
+Run:
+
+```bash
+mise exec -- dart format --output=none --set-exit-if-changed app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
+mise exec -- flutter analyze app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
+```
+
+Expected: format 差分なし、analyzer issue なし。
+
+- [ ] **Step 6: 実装をコミットする**
+
+```bash
+git add app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart
+git commit -m "fix: 通知設定から通知しないプリセットを削除"
+```

--- a/docs/superpowers/specs/2026-07-17-remove-none-notification-preset-design.md
+++ b/docs/superpowers/specs/2026-07-17-remove-none-notification-preset-design.md
@@ -1,0 +1,46 @@
+# Remove None Notification Preset Design
+
+## Goal
+
+通知設定画面の通知プリセットから「通知しない」を除外し、通知の有効・無効は既存の「通知を受け取る」toggle に一本化する。
+
+## Scope
+
+- 設定画面のプリセット一覧は「推奨設定」「すべて」「カスタム」の3択にする。
+- オンボーディングのプリセット一覧は既存の4択を維持する。
+- `NotificationPreset.none`、保存済みの `none` 値、プリセット適用処理は維持する。
+- 通知種別、対象地域、最低震度など、各プリセットの適用内容は変更しない。
+
+## Design
+
+`NotificationPresetSelector` が現在共有しているプリセット順序を、用途別に分ける。
+
+- onboarding: `recommended`, `all`, `custom`, `none`
+- settings: `recommended`, `all`, `custom`
+
+Widget の style に応じた一覧だけを子 Widget に渡す。タイトルや説明文、権限未許可時の `none` 自動選択、永続化された `none` の読み込みはそのまま残す。
+
+この境界により、master toggle を持つ設定画面だけ重複した操作を除去し、master toggle を持たないオンボーディングの既存動作と保存データ互換性を保つ。
+
+## Existing Preset Behavior
+
+- 推奨設定は通知を有効化し、現在地について緊急地震速報を予想震度4以上、地震情報を観測震度1以上で通知する。
+- すべては推奨設定に加え、全国について緊急地震速報と地震情報を震度3以上で通知する。
+- 今回の変更では上記の適用値を変更しない。
+
+## Testing
+
+`notification_preset_selector_test.dart` に Widget test を追加する。
+
+- settings style では「通知しない」が表示されず、残り3件が表示される。
+- onboarding style では「通知しない」が引き続き表示される。
+- 既存の OS 権限未許可時の `none` 自動選択テストを維持する。
+
+実装前に settings style のテストが失敗することを確認し、一覧の分離後に selector と preset applier の関連テストを再実行する。
+
+## Out of Scope
+
+- `NotificationPreset.none` の削除や保存値の移行
+- オンボーディング画面の選択肢変更
+- プリセットが適用する通知条件の変更
+- master toggle の動作変更


### PR DESCRIPTION
## 概要

通知設定画面の通知プリセットから「通知しない」を削除します。

## 背景

通知の有効・無効は既存の「通知を受け取る」toggleで操作できるため、プリセット内の「通知しない」は同じ操作を重複して提供していました。

## 変更内容

- 設定画面のプリセットを「推奨設定」「すべて」「カスタム」の3択に変更
- オンボーディングでは従来どおり「通知しない」を含む4択を維持
- `NotificationPreset.none` の保存・適用・OS権限未許可時の動作を維持
- settings / onboarding の表示差を固定するWidget testを追加

## 影響

- 設定画面では通知のOFF操作がmaster toggleに一本化されます。
- 推奨設定・すべてが適用する地域や最低震度は変更しません。
- 保存済みの `none` とオンボーディングの互換性は維持します。

## 検証

- `mise exec -- flutter test --no-pub app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart app/test/feature/settings/features/notification_settings/notification_preset_applier_test.dart`（10件成功）
- `mise exec -- flutter analyze --no-pub app/lib/feature/settings/features/notification_settings/ui/component/notification_preset_selector.dart app/test/feature/settings/features/notification_settings/notification_preset_selector_test.dart`（No issues found）
- `git diff --check origin/develop..HEAD`

## 既知事項

ルートのformatter設定が、base commit時点から存在しない `package:eqmonitor_lints/analysis_options.yaml` を参照しているため、指定ファイルへの厳密なformat checkは別件として失敗します。今回の差分へ無関係な再整形は含めていません。
