### PR TITLE
Fix seismicityのGeoJSON取得にHTTPキャッシュを追加

### DIFF
--- a/app/lib/feature/seismicity/data/provider/seismicity_repository_provider.dart
+++ b/app/lib/feature/seismicity/data/provider/seismicity_repository_provider.dart
@@ -1,4 +1,6 @@
+import 'package:cache/cache.dart';
 import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/api/http_cache_store_provider.dart';
 import 'package:eqmonitor/core/provider/dio_base_options.dart';
 import 'package:eqmonitor/core/provider/dio_provider.dart';
 import 'package:eqmonitor/feature/seismicity/data/repository/seismicity_repository.dart';
@@ -7,16 +9,18 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'seismicity_repository_provider.g.dart';
 
 @Riverpod(keepAlive: true)
-Dio seismicityGeoJsonDio(Ref ref) {
+Future<Dio> seismicityGeoJsonDio(Ref ref) async {
+  final httpCache = await ref.watch(httpCacheStoreProvider.future);
   final dio = Dio(buildApiBaseOptions(baseUrl: ''));
   dio.options.connectTimeout = const Duration(milliseconds: 10000);
   dio.options.sendTimeout = const Duration(milliseconds: 10000);
+  dio.interceptors.add(HttpCacheInterceptor(httpCache));
   return dio;
 }
 
 @Riverpod(keepAlive: true)
 Future<SeismicityRepository> seismicityRepository(Ref ref) async {
   final manifestDio = await ref.watch(dioProvider.future);
-  final geoJsonDio = ref.watch(seismicityGeoJsonDioProvider);
+  final geoJsonDio = await ref.watch(seismicityGeoJsonDioProvider.future);
   return SeismicityRepository(manifestDio: manifestDio, geoJsonDio: geoJsonDio);
 }

--- a/app/lib/feature/seismicity/data/provider/seismicity_repository_provider.g.dart
+++ b/app/lib/feature/seismicity/data/provider/seismicity_repository_provider.g.dart
@@ -15,8 +15,8 @@ part of 'seismicity_repository_provider.dart';
 final seismicityGeoJsonDioProvider = SeismicityGeoJsonDioProvider._();
 
 final class SeismicityGeoJsonDioProvider
-    extends $FunctionalProvider<Dio, Dio, Dio>
-    with $Provider<Dio> {
+    extends $FunctionalProvider<AsyncValue<Dio>, Dio, FutureOr<Dio>>
+    with $FutureModifier<Dio>, $FutureProvider<Dio> {
   SeismicityGeoJsonDioProvider._()
     : super(
         from: null,
@@ -33,25 +33,17 @@ final class SeismicityGeoJsonDioProvider
 
   @$internal
   @override
-  $ProviderElement<Dio> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $FutureProviderElement<Dio> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
-  Dio create(Ref ref) {
+  FutureOr<Dio> create(Ref ref) {
     return seismicityGeoJsonDio(ref);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Dio value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<Dio>(value),
-    );
   }
 }
 
 String _$seismicityGeoJsonDioHash() =>
-    r'f6fa820d8c9f733da99ca8f1adaac1d2b09194fc';
+    r'547a196b006ad32a3937f4026b8cb514b6b2f613';
 
 @ProviderFor(seismicityRepository)
 final seismicityRepositoryProvider = SeismicityRepositoryProvider._();
@@ -93,4 +85,4 @@ final class SeismicityRepositoryProvider
 }
 
 String _$seismicityRepositoryHash() =>
-    r'ef8c92b707fd167688724154a109bf1f29211a3a';
+    r'6a1352b0e51ebf8eb247d2a2ebc62ef156bfeddd';

--- a/app/test/feature/seismicity/data/notifier/seismicity_dataset_notifier_test.dart
+++ b/app/test/feature/seismicity/data/notifier/seismicity_dataset_notifier_test.dart
@@ -93,7 +93,7 @@ void main() {
           return Dio(BaseOptions(baseUrl: 'https://example.com'))
             ..httpClientAdapter = _SuccessAdapter();
         }),
-        seismicityGeoJsonDioProvider.overrideWith((ref) {
+        seismicityGeoJsonDioProvider.overrideWith((ref) async {
           return Dio(BaseOptions(baseUrl: ''))
             ..httpClientAdapter = _SuccessAdapter();
         }),

--- a/app/test/feature/seismicity/data/provider/seismicity_repository_provider_test.dart
+++ b/app/test/feature/seismicity/data/provider/seismicity_repository_provider_test.dart
@@ -1,0 +1,26 @@
+import 'package:cache/cache.dart';
+import 'package:drift/native.dart';
+import 'package:eqmonitor/core/api/http_cache_store_provider.dart';
+import 'package:eqmonitor/feature/seismicity/data/provider/seismicity_repository_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod/riverpod.dart';
+
+void main() {
+  test('GeoJSON 用 Dio に HTTP キャッシュを設定する', () async {
+    final db = CacheDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    final store = HttpCacheStore(
+      db: db,
+      schemaVersion: 1,
+      appBuild: '3.0.0+100',
+    );
+    final container = ProviderContainer(
+      overrides: [httpCacheStoreProvider.overrideWith((ref) async => store)],
+    );
+    addTearDown(container.dispose);
+
+    final dio = await container.read(seismicityGeoJsonDioProvider.future);
+
+    expect(dio.interceptors.whereType<HttpCacheInterceptor>(), hasLength(1));
+  });
+}


### PR DESCRIPTION
## 概要

- seismicity の GeoJSON 専用 Dio に既存の `HttpCacheInterceptor` を追加
- GeoJSON 用 Provider を非同期化し、共有 `HttpCacheStore` を利用
- manifest 用の通常 Dio と分離したまま、端末ID・認証・App Check の interceptor は GeoJSON リクエストへ追加しない

## 背景

PR #1481 で GeoJSON リクエストから端末ID等を分離した際、通常 Dio が持っていた HTTP キャッシュも外れていました。その結果、ページ表示や期間変更のたびに静的 GeoJSON を再取得していました。

レビューコメント: https://github.com/YumNumm/EQMonitor/pull/1481#discussion_r3572203824

## 影響

GeoJSON の ETag/304 キャッシュを再び利用しつつ、外部配信先へ端末IDや認証情報を送信しない分離を維持します。

## 検証

- `mise exec -- flutter test test/feature/seismicity/data/provider/seismicity_repository_provider_test.dart test/feature/seismicity/data/repository/seismicity_repository_test.dart test/feature/seismicity/data/notifier/seismicity_dataset_notifier_test.dart`
- `mise exec -- flutter analyze --no-pub lib/feature/seismicity/data/provider/seismicity_repository_provider.dart test/feature/seismicity/data/notifier/seismicity_dataset_notifier_test.dart test/feature/seismicity/data/provider/seismicity_repository_provider_test.dart`
- `git diff --cached --check`
