### PR TITLE
feat: SecureStorageデバッグ画面とPreferencesキー監査

### DIFF
--- a/app/lib/core/data/preferences/secure/secure_storage_key.dart
+++ b/app/lib/core/data/preferences/secure/secure_storage_key.dart
@@ -1,6 +1,10 @@
 enum SecureStorageKey {
   userId('user_id'),
   deviceToken('device_token'),
+  hinetBosaiUserId('hinet_bosai_user_id'),
+  hinetBosaiPassword('hinet_bosai_password'),
+  knetBosaiUserId('knet_bosai_user_id'),
+  knetBosaiPassword('knet_bosai_password'),
   ;
 
   const SecureStorageKey(this.key);

--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -57,6 +57,7 @@ import 'package:eqmonitor/feature/settings/children/config/debug/navigation/navi
 import 'package:eqmonitor/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/playground/playground_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/shake_detection/debug_shake_detection_card_page.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/shared_preferences/debug_shared_preferences_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/telemetry/debug_telemetry_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/tsunami/debug_tsunami_details_page.dart';
@@ -376,6 +377,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
         TypedGoRoute<DebugNavigationRoute>(path: 'navigation'),
         TypedGoRoute<DebugAppGroupRoute>(path: 'app-group'),
         TypedGoRoute<DebugSharedPreferencesRoute>(path: 'shared-preferences'),
+        TypedGoRoute<DebugSecureStorageRoute>(path: 'secure-storage'),
         TypedGoRoute<DebugHttpCacheRoute>(path: 'http-cache'),
         TypedGoRoute<DebugIntensityIconRoute>(path: 'intensity-icon'),
         TypedGoRoute<DebugTelemetryRoute>(path: 'telemetry'),
@@ -710,6 +712,16 @@ class DebugSharedPreferencesRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const DebugSharedPreferencesPage();
+  }
+}
+
+class DebugSecureStorageRoute extends GoRouteData
+    with $DebugSecureStorageRoute {
+  const DebugSecureStorageRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const DebugSecureStoragePage();
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -620,6 +620,10 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           factory: $DebugSharedPreferencesRoute._fromState,
         ),
         GoRouteData.$route(
+          path: 'secure-storage',
+          factory: $DebugSecureStorageRoute._fromState,
+        ),
+        GoRouteData.$route(
           path: 'http-cache',
           factory: $DebugHttpCacheRoute._fromState,
         ),
@@ -1406,6 +1410,28 @@ mixin $DebugSharedPreferencesRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/settings/debug/shared-preferences');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DebugSecureStorageRoute on GoRouteData {
+  static DebugSecureStorageRoute _fromState(GoRouterState state) =>
+      const DebugSecureStorageRoute();
+
+  @override
+  String get location =>
+      GoRouteData.$location('/settings/debug/secure-storage');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart
+++ b/app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart
@@ -1,11 +1,9 @@
-import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
 import 'package:riverpod/experimental/mutation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'knet_credentials_provider.g.dart';
-
-const _knetUserIdKey = 'knet_bosai_user_id';
-const _knetPasswordKey = 'knet_bosai_password';
 
 /// BOSAI 認証情報（ユーザーID + パスワード）
 class KnetCredentials {
@@ -23,9 +21,11 @@ class KnetCredentialsNotifier extends _$KnetCredentialsNotifier {
 
   @override
   Future<KnetCredentials?> build() async {
-    final storage = await ref.watch(secureStorageProvider.future);
-    final userId = await storage.read(key: _knetUserIdKey);
-    final password = await storage.read(key: _knetPasswordKey);
+    final ds = await ref.watch(securePreferencesDataSourceProvider.future);
+    final userId = await ds.getString(key: SecureStorageKey.knetBosaiUserId);
+    final password = await ds.getString(
+      key: SecureStorageKey.knetBosaiPassword,
+    );
     if (userId == null || password == null) {
       return null;
     }
@@ -36,16 +36,19 @@ class KnetCredentialsNotifier extends _$KnetCredentialsNotifier {
     required String userId,
     required String password,
   }) async {
-    final storage = await ref.read(secureStorageProvider.future);
-    await storage.write(key: _knetUserIdKey, value: userId);
-    await storage.write(key: _knetPasswordKey, value: password);
+    final ds = await ref.read(securePreferencesDataSourceProvider.future);
+    await ds.setString(key: SecureStorageKey.knetBosaiUserId, value: userId);
+    await ds.setString(
+      key: SecureStorageKey.knetBosaiPassword,
+      value: password,
+    );
     state = AsyncData(KnetCredentials(userId: userId, password: password));
   }
 
   Future<void> clear() async {
-    final storage = await ref.read(secureStorageProvider.future);
-    await storage.delete(key: _knetUserIdKey);
-    await storage.delete(key: _knetPasswordKey);
+    final ds = await ref.read(securePreferencesDataSourceProvider.future);
+    await ds.remove(key: SecureStorageKey.knetBosaiUserId);
+    await ds.remove(key: SecureStorageKey.knetBosaiPassword);
     state = const AsyncData(null);
   }
 }

--- a/app/lib/feature/settings/children/config/debug/app_group/app_group_values_provider.dart
+++ b/app/lib/feature/settings/children/config/debug/app_group/app_group_values_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:eqmonitor/core/provider/app_group_preferences.dart';
+import 'package:eqmonitor/core/provider/app_group_settings_writer.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'app_group_values_provider.g.dart';
@@ -13,7 +14,7 @@ Future<AppGroupValues> appGroupValues(Ref ref) async {
     return (apiServerUrl: null, debugMode: null);
   }
   final prefs = await ref.watch(appGroupPreferencesProvider.future);
-  final apiServerUrl = await prefs.getString('apiServerUrl');
-  final debugMode = await prefs.getBool('debugMode');
+  final apiServerUrl = await prefs.getString(AppGroupKeys.apiServerUrl);
+  final debugMode = await prefs.getBool(AppGroupKeys.debugMode);
   return (apiServerUrl: apiServerUrl, debugMode: debugMode);
 }

--- a/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
+++ b/app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
@@ -47,7 +47,7 @@ class DebugAppGroupAction {
       return;
     }
     final prefs = await ref.read(appGroupPreferencesProvider.future);
-    await prefs.setString('apiServerUrl', result);
+    await prefs.setString(AppGroupKeys.apiServerUrl, result);
     ref
       ..invalidate(appGroupValuesProvider, asReload: true)
       ..invalidate(appGroupSettingsWriterProvider, asReload: true);
@@ -55,7 +55,7 @@ class DebugAppGroupAction {
 
   Future<void> setDebugMode(WidgetRef ref, {required bool value}) async {
     final prefs = await ref.read(appGroupPreferencesProvider.future);
-    await prefs.setBool('debugMode', value);
+    await prefs.setBool(AppGroupKeys.debugMode, value);
     ref
       ..invalidate(appGroupValuesProvider, asReload: true)
       ..invalidate(appGroupSettingsWriterProvider, asReload: true);

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -142,6 +142,13 @@ class _DebugWidget extends ConsumerWidget {
               onTap: () async =>
                   const DebugSharedPreferencesRoute().push<void>(context),
             ),
+            ListTile(
+              title: const Text('SecureStorage'),
+              subtitle: const Text('保存されている Key-Value の一覧・編集'),
+              leading: const Icon(Icons.lock_outline),
+              onTap: () async =>
+                  const DebugSecureStorageRoute().push<void>(context),
+            ),
             Builder(
               builder: (context) {
                 final isDisabled =

--- a/app/lib/feature/settings/children/config/debug/hinet_seismicity/data/provider/hinet_credentials_provider.dart
+++ b/app/lib/feature/settings/children/config/debug/hinet_seismicity/data/provider/hinet_credentials_provider.dart
@@ -1,11 +1,9 @@
-import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
 import 'package:riverpod/experimental/mutation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'hinet_credentials_provider.g.dart';
-
-const _hinetUserIdKey = 'hinet_bosai_user_id';
-const _hinetPasswordKey = 'hinet_bosai_password';
 
 /// Hi-net(BOSAI)認証情報(ユーザーID + パスワード)。
 ///
@@ -28,9 +26,11 @@ class HinetCredentialsNotifier extends _$HinetCredentialsNotifier {
 
   @override
   Future<HinetCredentials?> build() async {
-    final storage = await ref.watch(secureStorageProvider.future);
-    final userId = await storage.read(key: _hinetUserIdKey);
-    final password = await storage.read(key: _hinetPasswordKey);
+    final ds = await ref.watch(securePreferencesDataSourceProvider.future);
+    final userId = await ds.getString(key: SecureStorageKey.hinetBosaiUserId);
+    final password = await ds.getString(
+      key: SecureStorageKey.hinetBosaiPassword,
+    );
     if (userId == null || password == null) {
       return null;
     }
@@ -38,16 +38,19 @@ class HinetCredentialsNotifier extends _$HinetCredentialsNotifier {
   }
 
   Future<void> save({required String userId, required String password}) async {
-    final storage = await ref.read(secureStorageProvider.future);
-    await storage.write(key: _hinetUserIdKey, value: userId);
-    await storage.write(key: _hinetPasswordKey, value: password);
+    final ds = await ref.read(securePreferencesDataSourceProvider.future);
+    await ds.setString(key: SecureStorageKey.hinetBosaiUserId, value: userId);
+    await ds.setString(
+      key: SecureStorageKey.hinetBosaiPassword,
+      value: password,
+    );
     state = AsyncData(HinetCredentials(userId: userId, password: password));
   }
 
   Future<void> clear() async {
-    final storage = await ref.read(secureStorageProvider.future);
-    await storage.delete(key: _hinetUserIdKey);
-    await storage.delete(key: _hinetPasswordKey);
+    final ds = await ref.read(securePreferencesDataSourceProvider.future);
+    await ds.remove(key: SecureStorageKey.hinetBosaiUserId);
+    await ds.remove(key: SecureStorageKey.hinetBosaiPassword);
     state = const AsyncData(null);
   }
 }

--- a/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_action.dart
+++ b/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_action.dart
@@ -1,0 +1,28 @@
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_secure_storage_action.g.dart';
+
+@riverpod
+DebugSecureStorageAction debugSecureStorageAction(Ref ref) =>
+    DebugSecureStorageAction();
+
+class DebugSecureStorageAction {
+  Future<void> write(
+    WidgetRef ref, {
+    required String key,
+    required String value,
+  }) async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.write(key: key, value: value);
+    ref.invalidate(debugSecureStorageEntriesProvider);
+  }
+
+  Future<void> remove(WidgetRef ref, {required String key}) async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.delete(key: key);
+    ref.invalidate(debugSecureStorageEntriesProvider);
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_action.g.dart
+++ b/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_action.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_secure_storage_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugSecureStorageAction)
+final debugSecureStorageActionProvider = DebugSecureStorageActionProvider._();
+
+final class DebugSecureStorageActionProvider
+    extends
+        $FunctionalProvider<
+          DebugSecureStorageAction,
+          DebugSecureStorageAction,
+          DebugSecureStorageAction
+        >
+    with $Provider<DebugSecureStorageAction> {
+  DebugSecureStorageActionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugSecureStorageActionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugSecureStorageActionHash();
+
+  @$internal
+  @override
+  $ProviderElement<DebugSecureStorageAction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DebugSecureStorageAction create(Ref ref) {
+    return debugSecureStorageAction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DebugSecureStorageAction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DebugSecureStorageAction>(value),
+    );
+  }
+}
+
+String _$debugSecureStorageActionHash() =>
+    r'ddaedb0974ee1edb8d538238c0fe53eac98b523e';

--- a/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart
+++ b/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart
@@ -1,0 +1,27 @@
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_secure_storage_entries_provider.g.dart';
+
+@riverpod
+Future<List<({String key, String value})>> debugSecureStorageEntries(
+  Ref ref,
+) async {
+  final storage = await ref.watch(secureStorageProvider.future);
+  final all = await storage.readAll();
+  final knownKeys = SecureStorageKey.values.map((e) => e.key).toSet();
+
+  final unknown = <String>[];
+  final known = <String>[];
+  for (final key in all.keys) {
+    (knownKeys.contains(key) ? known : unknown).add(key);
+  }
+  unknown.sort();
+  known.sort();
+
+  return [
+    for (final key in [...unknown, ...known])
+      (key: key, value: all[key] ?? ''),
+  ];
+}

--- a/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.g.dart
+++ b/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_secure_storage_entries_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugSecureStorageEntries)
+final debugSecureStorageEntriesProvider = DebugSecureStorageEntriesProvider._();
+
+final class DebugSecureStorageEntriesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<({String key, String value})>>,
+          List<({String key, String value})>,
+          FutureOr<List<({String key, String value})>>
+        >
+    with
+        $FutureModifier<List<({String key, String value})>>,
+        $FutureProvider<List<({String key, String value})>> {
+  DebugSecureStorageEntriesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugSecureStorageEntriesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugSecureStorageEntriesHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<({String key, String value})>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<({String key, String value})>> create(Ref ref) {
+    return debugSecureStorageEntries(ref);
+  }
+}
+
+String _$debugSecureStorageEntriesHash() =>
+    r'5da2ee33ba5a9ece115c39a83bcace947d5ee8c1';

--- a/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart
+++ b/app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart
@@ -1,0 +1,228 @@
+import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/secure_storage/debug_secure_storage_action.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DebugSecureStoragePage extends HookConsumerWidget {
+  const DebugSecureStoragePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entries = ref.watch(debugSecureStorageEntriesProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('SecureStorage'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: '再取得',
+            onPressed: () => ref.invalidate(debugSecureStorageEntriesProvider),
+          ),
+        ],
+      ),
+      body: _EntriesList(entries: entries),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await showDialog<void>(
+            context: context,
+            builder: (context) => const _AddDialog(),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class _EntriesList extends HookConsumerWidget {
+  const _EntriesList({required this.entries});
+
+  final AsyncValue<List<({String key, String value})>> entries;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final revealedKeys = useState<Set<String>>({});
+
+    return entries.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text('エラー: $error')),
+      data: (list) {
+        if (list.isEmpty) {
+          return RefreshIndicator(
+            onRefresh: () async {
+              ref.invalidate(debugSecureStorageEntriesProvider);
+            },
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: const [
+                SizedBox(height: 200),
+                Center(child: Text('エントリがありません')),
+              ],
+            ),
+          );
+        }
+
+        return RefreshIndicator(
+          onRefresh: () async {
+            ref.invalidate(debugSecureStorageEntriesProvider);
+          },
+          child: ListView.builder(
+            itemCount: list.length,
+            itemBuilder: (context, index) {
+              final entry = list[index];
+              final isRevealed = revealedKeys.value.contains(entry.key);
+              final preview = isRevealed
+                  ? entry.value
+                  : '•••••••• (${entry.value.length})';
+
+              return ListTile(
+                title: Text(entry.key),
+                subtitle: Text(
+                  preview,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontFamily: FontFamily.googleSansCode),
+                ),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: Icon(
+                        isRevealed
+                            ? Icons.visibility_off_outlined
+                            : Icons.visibility_outlined,
+                      ),
+                      tooltip: isRevealed ? 'マスク' : '表示',
+                      onPressed: () {
+                        final next = {...revealedKeys.value};
+                        if (isRevealed) {
+                          next.remove(entry.key);
+                        } else {
+                          next.add(entry.key);
+                        }
+                        revealedKeys.value = next;
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: '削除',
+                      onPressed: () async {
+                        final action = ref.read(
+                          debugSecureStorageActionProvider,
+                        );
+                        await action.remove(ref, key: entry.key);
+                      },
+                    ),
+                  ],
+                ),
+                onTap: () async {
+                  await showDialog<void>(
+                    context: context,
+                    builder: (context) => _EditDialog(entry: entry),
+                  );
+                },
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _EditDialog extends HookConsumerWidget {
+  const _EditDialog({required this.entry});
+
+  final ({String key, String value}) entry;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = useTextEditingController(text: entry.value);
+
+    return AlertDialog(
+      title: Text(entry.key),
+      content: TextField(
+        controller: controller,
+        maxLines: 8,
+        minLines: 1,
+        style: const TextStyle(fontFamily: FontFamily.googleSansCode),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: () async {
+            final action = ref.read(debugSecureStorageActionProvider);
+            await action.write(ref, key: entry.key, value: controller.text);
+            if (context.mounted) {
+              Navigator.of(context).pop();
+            }
+          },
+          child: const Text('保存'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AddDialog extends HookConsumerWidget {
+  const _AddDialog();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final keyController = useTextEditingController();
+    final valueController = useTextEditingController();
+
+    return AlertDialog(
+      title: const Text('新規追加'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: keyController,
+              decoration: const InputDecoration(labelText: 'キー名'),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: valueController,
+              decoration: const InputDecoration(labelText: '値'),
+              maxLines: 8,
+              minLines: 1,
+              style: const TextStyle(fontFamily: FontFamily.googleSansCode),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: () async {
+            final key = keyController.text.trim();
+            if (key.isEmpty) {
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(const SnackBar(content: Text('キー名を入力してください')));
+              return;
+            }
+
+            final action = ref.read(debugSecureStorageActionProvider);
+            await action.write(ref, key: key, value: valueController.text);
+            if (context.mounted) {
+              Navigator.of(context).pop();
+            }
+          },
+          child: const Text('保存'),
+        ),
+      ],
+    );
+  }
+}

--- a/docs/superpowers/plans/2026-07-18-secure-storage-debug.md
+++ b/docs/superpowers/plans/2026-07-18-secure-storage-debug.md
@@ -1,0 +1,502 @@
+# SecureStorage デバッグ画面 & Preferences キー監査 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** デバッグ画面に SecureStorage の Key-Value CRUD（マスク表示付き）を追加し、Hi-net/Knet と App Group デバッグの enum 外キー参照を是正する。
+
+**Architecture:** SharedPreferences デバッグと同型の専用ページを新設。一覧は `readAll()`、CRUD はデバッグ例外として raw `write`/`delete`。本番の Hi-net/Knet は `SecureStorageKey` + `SecurePreferencesDataSource` に統一。App Group デバッグは `AppGroupKeys` を参照する。
+
+**Tech Stack:** Flutter, Riverpod (`@riverpod`), flutter_hooks, go_router_builder, flutter_secure_storage, Material 3
+
+**Spec:** `docs/superpowers/specs/2026-07-18-secure-storage-debug-design.md`
+
+## Global Constraints
+
+- テストは追加しない（仕様で不要と明記）。既存テストが壊れた場合のみ最小修正する
+- Flutter / Dart コマンドは常に `mise exec --` 経由
+- コード生成: `cd app && mise exec -- dart run build_runner build --delete-conflicting-outputs`
+- top-level / プライベート関数禁止。ロジックはクラス、イベントは Action、単純変換はインライン変数
+- Widget に関数・ゲッターを定義しない。`StatefulWidget` 禁止（`HookConsumerWidget`）
+- `!` 禁止。`dynamic` / `Object` は `Map<String, dynamic>` 以外禁止
+- Action: `ref` / `context` はコンストラクタに渡さずメソッド引数で受け取る
+- コミットメッセージ: 英語1単語 prefix + 日本語1行
+- Spec / Plan ドキュメント単体ではコミット・プッシュしない（実装差分とまとめる）
+- workflow 動的キー（`_wf:`）はスコープ外
+
+---
+
+## File Structure
+
+新規:
+- `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart` — エントリ一覧
+- `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_action.dart` — 追加/編集/削除
+- `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart` — 画面
+
+変更:
+- `app/lib/core/data/preferences/secure/secure_storage_key.dart` — Hi-net/Knet キー追加
+- `app/lib/feature/settings/children/config/debug/hinet_seismicity/data/provider/hinet_credentials_provider.dart` — DataSource 経由
+- `app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart` — DataSource 経由
+- `app/lib/feature/settings/children/config/debug/app_group/app_group_values_provider.dart` — `AppGroupKeys`
+- `app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart` — `AppGroupKeys`
+- `app/lib/core/router/router.dart` — `DebugSecureStorageRoute`
+- `app/lib/feature/settings/children/config/debug/debug_page.dart` — 導線
+
+生成（手編集禁止）:
+- `debug_secure_storage_entries_provider.g.dart`
+- `debug_secure_storage_action.g.dart`
+- `hinet_credentials_provider.g.dart` / `knet_credentials_provider.g.dart`（必要なら）
+- `router.g.dart`
+
+---
+
+### Task 1: SecureStorageKey 追加 + Hi-net/Knet を DataSource 経由に変更
+
+**Files:**
+- Modify: `app/lib/core/data/preferences/secure/secure_storage_key.dart`
+- Modify: `app/lib/feature/settings/children/config/debug/hinet_seismicity/data/provider/hinet_credentials_provider.dart`
+- Modify: `app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart`
+- Possibly fix: `app/test/feature/settings/children/config/debug/hinet_seismicity/hinet_credentials_provider_test.dart`（壊れた場合のみ）
+
+**Interfaces:**
+- Produces:
+  ```dart
+  enum SecureStorageKey {
+    userId('user_id'),
+    deviceToken('device_token'),
+    hinetBosaiUserId('hinet_bosai_user_id'),
+    hinetBosaiPassword('hinet_bosai_password'),
+    knetBosaiUserId('knet_bosai_user_id'),
+    knetBosaiPassword('knet_bosai_password'),
+    ;
+    const SecureStorageKey(this.key);
+    final String key;
+  }
+  ```
+- Consumes: `securePreferencesDataSourceProvider`（`getString` / `setString` / `remove`）
+
+- [ ] **Step 1: `SecureStorageKey` に 4 キーを追加**
+
+`app/lib/core/data/preferences/secure/secure_storage_key.dart` を以下で置き換える:
+
+```dart
+enum SecureStorageKey {
+  userId('user_id'),
+  deviceToken('device_token'),
+  hinetBosaiUserId('hinet_bosai_user_id'),
+  hinetBosaiPassword('hinet_bosai_password'),
+  knetBosaiUserId('knet_bosai_user_id'),
+  knetBosaiPassword('knet_bosai_password'),
+  ;
+
+  const SecureStorageKey(this.key);
+  final String key;
+}
+```
+
+- [ ] **Step 2: Hi-net credentials を DataSource 経由に変更**
+
+`hinet_credentials_provider.dart`:
+- `import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';` を削除
+- `secure_preferences_data_source.dart` と `secure_storage_key.dart` を import
+- `const _hinetUserIdKey` / `_hinetPasswordKey` を削除
+- `build` / `save` / `clear` を次の形にする:
+
+```dart
+@override
+Future<HinetCredentials?> build() async {
+  final ds = await ref.watch(securePreferencesDataSourceProvider.future);
+  final userId = await ds.getString(key: SecureStorageKey.hinetBosaiUserId);
+  final password = await ds.getString(key: SecureStorageKey.hinetBosaiPassword);
+  if (userId == null || password == null) {
+    return null;
+  }
+  return HinetCredentials(userId: userId, password: password);
+}
+
+Future<void> save({required String userId, required String password}) async {
+  final ds = await ref.read(securePreferencesDataSourceProvider.future);
+  await ds.setString(key: SecureStorageKey.hinetBosaiUserId, value: userId);
+  await ds.setString(
+    key: SecureStorageKey.hinetBosaiPassword,
+    value: password,
+  );
+  state = AsyncData(HinetCredentials(userId: userId, password: password));
+}
+
+Future<void> clear() async {
+  final ds = await ref.read(securePreferencesDataSourceProvider.future);
+  await ds.remove(key: SecureStorageKey.hinetBosaiUserId);
+  await ds.remove(key: SecureStorageKey.hinetBosaiPassword);
+  state = const AsyncData(null);
+}
+```
+
+- [ ] **Step 3: Knet credentials を同様に変更**
+
+`knet_credentials_provider.dart` でも同じパターン:
+- `SecureStorageKey.knetBosaiUserId` / `SecureStorageKey.knetBosaiPassword`
+- `securePreferencesDataSourceProvider` 経由
+- `const _knetUserIdKey` / `_knetPasswordKey` を削除
+
+- [ ] **Step 4: 既存 Hi-net テストが通るか確認**
+
+Run:
+
+```bash
+cd app && mise exec -- flutter test test/feature/settings/children/config/debug/hinet_seismicity/hinet_credentials_provider_test.dart
+```
+
+Expected: PASS。FAIL した場合は、既存の MethodChannel モックが `secureStorageProvider` → DataSource 経由で引き続き動くはずなので、`SharedPreferences.setMockInitialValues` と channel mock を維持したまま原因を最小修正する（新規テストは追加しない）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  app/lib/core/data/preferences/secure/secure_storage_key.dart \
+  app/lib/feature/settings/children/config/debug/hinet_seismicity/data/provider/hinet_credentials_provider.dart \
+  app/lib/feature/knet_waveform/data/provider/knet_credentials_provider.dart \
+  app/test/feature/settings/children/config/debug/hinet_seismicity/hinet_credentials_provider_test.dart
+git commit -m "$(cat <<'EOF'
+fix: Hi-net/Knet認証をSecureStorageKey経由に統一
+
+EOF
+)"
+```
+
+（テスト未変更なら test ファイルは `git add` から外す）
+
+---
+
+### Task 2: App Group デバッグのキーを `AppGroupKeys` に統一
+
+**Files:**
+- Modify: `app/lib/feature/settings/children/config/debug/app_group/app_group_values_provider.dart`
+- Modify: `app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart`
+
+**Interfaces:**
+- Consumes: `AppGroupKeys.apiServerUrl` / `AppGroupKeys.debugMode`（`app/lib/core/provider/app_group_settings_writer.dart`）
+- Produces: 挙動不変。文字列リテラルを定数参照に置換のみ
+
+- [ ] **Step 1: `app_group_values_provider.dart` を修正**
+
+`import 'package:eqmonitor/core/provider/app_group_settings_writer.dart';` を追加し:
+
+```dart
+final apiServerUrl = await prefs.getString(AppGroupKeys.apiServerUrl);
+final debugMode = await prefs.getBool(AppGroupKeys.debugMode);
+```
+
+- [ ] **Step 2: `debug_app_group_action.dart` を修正**
+
+既に `app_group_settings_writer.dart` を import 済み。次を置換:
+
+```dart
+await prefs.setString(AppGroupKeys.apiServerUrl, result);
+// ...
+await prefs.setBool(AppGroupKeys.debugMode, value);
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add \
+  app/lib/feature/settings/children/config/debug/app_group/app_group_values_provider.dart \
+  app/lib/feature/settings/children/config/debug/app_group/debug_app_group_action.dart
+git commit -m "$(cat <<'EOF'
+fix: App Groupデバッグのキー参照をAppGroupKeysに統一
+
+EOF
+)"
+```
+
+---
+
+### Task 3: SecureStorage エントリ Provider + Action
+
+**Files:**
+- Create: `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart`
+- Create: `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_action.dart`
+
+**Interfaces:**
+- Consumes: `secureStorageProvider`（`app/lib/core/data/preferences/secure/secure_storage.dart`）、`SecureStorageKey`
+- Produces:
+  ```dart
+  @riverpod
+  Future<List<({String key, String value})>> debugSecureStorageEntries(Ref ref);
+
+  @riverpod
+  DebugSecureStorageAction debugSecureStorageAction(Ref ref);
+
+  class DebugSecureStorageAction {
+    Future<void> write(WidgetRef ref, {required String key, required String value});
+    Future<void> remove(WidgetRef ref, {required String key});
+  }
+  ```
+
+- [ ] **Step 1: entries provider を作成**
+
+`debug_secure_storage_entries_provider.dart`:
+
+```dart
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage_key.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_secure_storage_entries_provider.g.dart';
+
+@riverpod
+Future<List<({String key, String value})>> debugSecureStorageEntries(
+  Ref ref,
+) async {
+  final storage = await ref.watch(secureStorageProvider.future);
+  final all = await storage.readAll();
+  final knownKeys = SecureStorageKey.values.map((e) => e.key).toSet();
+
+  final unknown = <String>[];
+  final known = <String>[];
+  for (final key in all.keys) {
+    (knownKeys.contains(key) ? known : unknown).add(key);
+  }
+  unknown.sort();
+  known.sort();
+
+  return [
+    for (final key in [...unknown, ...known])
+      (key: key, value: all[key] ?? ''),
+  ];
+}
+```
+
+- [ ] **Step 2: Action を作成**
+
+`debug_secure_storage_action.dart`:
+
+```dart
+import 'package:eqmonitor/core/data/preferences/secure/secure_storage.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_secure_storage_action.g.dart';
+
+@riverpod
+DebugSecureStorageAction debugSecureStorageAction(Ref ref) =>
+    DebugSecureStorageAction();
+
+class DebugSecureStorageAction {
+  Future<void> write(
+    WidgetRef ref, {
+    required String key,
+    required String value,
+  }) async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.write(key: key, value: value);
+    ref.invalidate(debugSecureStorageEntriesProvider);
+  }
+
+  Future<void> remove(WidgetRef ref, {required String key}) async {
+    final storage = await ref.read(secureStorageProvider.future);
+    await storage.delete(key: key);
+    ref.invalidate(debugSecureStorageEntriesProvider);
+  }
+}
+```
+
+- [ ] **Step 3: コード生成**
+
+```bash
+cd app && mise exec -- dart run build_runner build --delete-conflicting-outputs
+```
+
+Expected: `debug_secure_storage_entries_provider.g.dart` と `debug_secure_storage_action.g.dart` が生成される。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add \
+  app/lib/feature/settings/children/config/debug/secure_storage/
+git commit -m "$(cat <<'EOF'
+feat: SecureStorageデバッグ用のentries ProviderとActionを追加
+
+EOF
+)"
+```
+
+---
+
+### Task 4: SecureStorage デバッグページ UI
+
+**Files:**
+- Create: `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart`
+
+**Interfaces:**
+- Consumes: `debugSecureStorageEntriesProvider`、`debugSecureStorageActionProvider`
+- Produces: `DebugSecureStoragePage`（`HookConsumerWidget`）
+
+- [ ] **Step 1: ページを実装**
+
+`debug_secure_storage_page.dart` の要件:
+
+1. `Scaffold` + `AppBar(title: Text('SecureStorage'))` + refresh `IconButton`（`debugSecureStorageEntriesProvider` を invalidate）
+2. body: `AsyncValue.when` で一覧。空なら「エントリがありません」
+3. `ListView.builder` + `RefreshIndicator`
+4. 各行:
+   - `title`: key
+   - `subtitle`: マスク時は `•••••••• (${value.length})`、平文時は value。`FontFamily.googleSansCode`
+   - `trailing`: 目アイコン（マスクトグル）+ 削除アイコン
+   - 行タップ: 編集ダイアログ（平文 `TextField` maxLines: 8）
+5. マスク状態: `useState<Set<String>>({})` でキー集合を管理（エフェメラル）
+6. FAB: 新規追加ダイアログ（キー名 + 値の TextField、保存で `action.write`）
+7. 確認ダイアログなし
+8. 削除は `action.remove` を直接呼ぶ
+9. private Widget class（`_EntriesList` 等）で分割。Widget にメソッド/ゲッターを定義しない
+10. top-level 関数を作らない。マスク文字列は build 内のローカル変数で組み立てる:
+
+```dart
+final preview = isRevealed
+    ? entry.value
+    : '•••••••• (${entry.value.length})';
+```
+
+参考 UI パターン: `debug_shared_preferences_page.dart`（一覧・FAB・ダイアログ）。ただし型選択 UI は不要（常に String）。
+
+- [ ] **Step 2: analyze**
+
+```bash
+cd app && mise exec -- dart analyze lib/feature/settings/children/config/debug/secure_storage/
+```
+
+Expected: No issues.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart
+git commit -m "$(cat <<'EOF'
+feat: SecureStorageデバッグ画面のUIを追加
+
+EOF
+)"
+```
+
+---
+
+### Task 5: ルーティングとデバッグメニュー導線
+
+**Files:**
+- Modify: `app/lib/core/router/router.dart`
+- Modify: `app/lib/feature/settings/children/config/debug/debug_page.dart`
+
+**Interfaces:**
+- Produces:
+  ```dart
+  class DebugSecureStorageRoute extends GoRouteData with $DebugSecureStorageRoute {
+    const DebugSecureStorageRoute();
+    @override
+    Widget build(BuildContext context, GoRouterState state) {
+      return const DebugSecureStoragePage();
+    }
+  }
+  ```
+- Path: `secure-storage`（親は既存 debug 配下 → `/settings/debug/secure-storage`）
+
+- [ ] **Step 1: router にルート追加**
+
+1. import:
+
+```dart
+import 'package:eqmonitor/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart';
+```
+
+2. `TypedGoRoute<DebugSharedPreferencesRoute>(path: 'shared-preferences'),` の直後に追加:
+
+```dart
+TypedGoRoute<DebugSecureStorageRoute>(path: 'secure-storage'),
+```
+
+3. `DebugSharedPreferencesRoute` クラスの直後にルートクラスを追加（上記 Interfaces どおり）。
+
+- [ ] **Step 2: go_router コード生成**
+
+```bash
+cd app && mise exec -- dart run build_runner build --delete-conflicting-outputs
+```
+
+Expected: `router.g.dart` に `$DebugSecureStorageRoute` が生成される。
+
+- [ ] **Step 3: debug_page に ListTile 追加**
+
+`SharedPreferences` の `ListTile` の直後に追加:
+
+```dart
+ListTile(
+  title: const Text('SecureStorage'),
+  subtitle: const Text('保存されている Key-Value の一覧・編集'),
+  leading: const Icon(Icons.lock_outline),
+  onTap: () async =>
+      const DebugSecureStorageRoute().push<void>(context),
+),
+```
+
+`DebugSecureStorageRoute` が使えるよう、router の生成 mixin 経由で import されることを確認（既存の `DebugSharedPreferencesRoute` と同様。`debug_page.dart` が router を import しているなら追加 import 不要の場合あり。必要なら `router.dart` から export される型を import）。
+
+- [ ] **Step 4: analyze**
+
+```bash
+cd app && mise exec -- dart analyze \
+  lib/core/router/router.dart \
+  lib/feature/settings/children/config/debug/debug_page.dart \
+  lib/feature/settings/children/config/debug/secure_storage/
+```
+
+Expected: No issues.
+
+- [ ] **Step 5: Commit（仕様・プランもまとめて）**
+
+```bash
+git add \
+  app/lib/core/router/router.dart \
+  app/lib/core/router/router.g.dart \
+  app/lib/feature/settings/children/config/debug/debug_page.dart \
+  docs/superpowers/specs/2026-07-18-secure-storage-debug-design.md \
+  docs/superpowers/plans/2026-07-18-secure-storage-debug.md
+git commit -m "$(cat <<'EOF'
+feat: SecureStorageデバッグ画面への導線とルートを追加
+
+EOF
+)"
+```
+
+（仕様が既に別コミット済みでも、プランは実装と一緒に入れる。仕様の再コミットは差分がなければ skip）
+
+---
+
+### Task 6: 手動確認チェックリスト
+
+テストコードは追加しない。実装後に手動で確認する。
+
+- [ ] **Step 1: アプリ起動 → デバッグメニュー**
+
+- [ ] SecureStorage 行がある
+- [ ] タップで `/settings/debug/secure-storage` 相当の画面が開く
+
+- [ ] **Step 2: CRUD**
+
+- [ ] 既存キー（`user_id` / `device_token` / Hi-net 等）が一覧に出る
+- [ ] 値がデフォルトでマスクされている
+- [ ] 目アイコンまたはトグルで平文表示できる
+- [ ] 編集・追加・削除が動作する
+- [ ] pull-to-refresh / AppBar refresh で再取得できる
+
+- [ ] **Step 3: 回帰**
+
+- [ ] Hi-net / Knet 認証の保存・読み込み・クリアが従来どおり
+- [ ] App Group デバッグで API URL / debugMode の読み書きが動作（iOS）
+
+---
+
+## Self-Review
+
+1. **Spec coverage:** 機能① UI/CRUD/マスク、機能② Hi-net/Knet、機能③ AppGroupKeys、スコープ外 `_wf:`、テスト不要 → すべて Task に対応
+2. **Placeholder scan:** TBD / 「適切に」系なし
+3. **Type consistency:** entries は `({String key, String value})`、Action は `write`/`remove`、Route は `DebugSecureStorageRoute`

--- a/docs/superpowers/specs/2026-07-18-secure-storage-debug-design.md
+++ b/docs/superpowers/specs/2026-07-18-secure-storage-debug-design.md
@@ -1,0 +1,121 @@
+# SecureStorage デバッグ画面 & Preferences キー監査 設計
+
+作成日: 2026-07-18
+
+## 概要
+
+デバッグ画面に SecureStorage の Key-Value 一覧・追加・編集・削除機能を追加する。あわせて、SecureStorage / App Group デバッグにおける enum 外キー参照を是正する。
+
+SharedPreferences デバッグ画面と同型の専用ページを新設する（タブ統合はしない）。
+
+## 決定事項
+
+| 項目 | 内容 |
+|------|------|
+| 操作範囲 | 一覧・追加・編集・削除（SharedPreferences と同程度） |
+| 値表示 | デフォルトはマスク、行単位でタップ/アイコンにより平文トグル |
+| キー収集 | `readAll()` で実在する全キー（未知キー含む） |
+| 値型 | SecureStorage は常に String。型選択 UI は不要 |
+| 確認ダイアログ | なし・即時反映 |
+| テスト | 不要（手動確認） |
+| workflow 動的キー (`_wf:`) | スコープ外 |
+
+## 機能① SecureStorage デバッグページ
+
+### 仕様
+
+- デバッグメニューに「SecureStorage」行を追加（SharedPreferences の近く）
+- 新規 `DebugSecureStoragePage`
+- ルート: `/settings/debug/secure-storage`（`DebugSecureStorageRoute`）
+- **並び順**: `SecureStorageKey` に含まれないキーを先頭（key 昇順）→ 既知キー（key 昇順）
+- **表示**: キー名 + マスクされた値プレビュー（文字数付き可）。monospace フォント
+- **マスク解除**: 行タップまたは目アイコンでその行だけ平文トグル
+- **編集**: ダイアログ内は平文の複数行テキスト。保存で `write`
+- **新規追加**: キー名 + 文字列値。FAB から追加
+- **削除**: 各行の削除ボタン。`delete`
+
+### データアクセス
+
+- 一覧: `FlutterSecureStorage.readAll()`（デバッグ例外）
+- 書き込み/削除: raw `write` / `delete`（デバッグ例外）
+- 本番コードは引き続き `SecurePreferencesDataSource` + `SecureStorageKey` のみ
+
+### 実装（新規）
+
+- `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart`
+- `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_entries_provider.dart`
+
+### 変更
+
+- `debug_page.dart` … 導線追加
+- `router.dart` … `DebugSecureStorageRoute` 追加
+
+### 既知の制約
+
+- raw 操作のため、編集してもアプリ側の Riverpod 状態は自動更新されない場合がある（再起動が必要な場合あり）。デバッグ専用として許容する。
+
+## 機能② SecureStorage キー監査修正（本番）
+
+### 現状の違反
+
+| ファイル | 内容 |
+|----------|------|
+| `hinet_credentials_provider.dart` | `hinet_bosai_user_id` / `hinet_bosai_password` を const 直書き + `FlutterSecureStorage` 直接操作 |
+| `knet_credentials_provider.dart` | `knet_bosai_user_id` / `knet_bosai_password` も同様 |
+
+### 修正
+
+- `SecureStorageKey` に以下を追加:
+  - `hinetBosaiUserId('hinet_bosai_user_id')`
+  - `hinetBosaiPassword('hinet_bosai_password')`
+  - `knetBosaiUserId('knet_bosai_user_id')`
+  - `knetBosaiPassword('knet_bosai_password')`
+- Hi-net / Knet Notifier は `securePreferencesDataSourceProvider` 経由の `getString` / `setString` / `remove` に変更
+- キー文字列の変更はしない（既存保存データとの互換を維持）
+
+## 機能③ App Group デバッグのキー統一
+
+### 現状の違反
+
+| ファイル | 内容 |
+|----------|------|
+| `debug_app_group_action.dart` | `'apiServerUrl'` / `'debugMode'` を文字列直書き |
+| `app_group_values_provider.dart` | 同上 |
+
+### 修正
+
+- いずれも `AppGroupKeys.apiServerUrl` / `AppGroupKeys.debugMode` を参照する
+
+## スコープ外
+
+- `shared_preferences_workflow_persistence.dart` の動的キー（`_wf:<instanceId>:...`）
+- SharedPreferences デバッグ画面の raw キー操作（既存の明示例外）
+- ユニットテスト / Widget テストの追加
+
+## 例外の明文化
+
+- **デバッグ画面**の raw SecureStorage / SharedPreferences / App Group 操作は例外（一覧・任意キー CRUD のため）
+- **本番コード**では `SecureStorageKey` / `SharedPreferencesKey` / `AppGroupKeys` 外のキー文字列による読み書きを禁止
+- アクセスは原則 DataSource（Secure / Shared）経由。デバッグ画面と DataSource 本体、初期化処理は例外
+
+## 影響範囲まとめ
+
+| 種別 | ファイル |
+|------|----------|
+| 新規 | `.../debug/secure_storage/debug_secure_storage_page.dart` |
+| 新規 | `.../debug/secure_storage/debug_secure_storage_entries_provider.dart` |
+| 変更 | `secure_storage_key.dart` |
+| 変更 | `hinet_credentials_provider.dart` |
+| 変更 | `knet_credentials_provider.dart` |
+| 変更 | `debug_page.dart` |
+| 変更 | `router.dart` |
+| 変更 | `debug_app_group_action.dart` |
+| 変更 | `app_group_values_provider.dart` |
+
+コード生成（`build_runner`）と `dart analyze` / `dart format` を最後に実行する。
+
+## 手動確認
+
+- デバッグメニュー → SecureStorage で一覧表示・マスク/平文トグル・追加・編集・削除
+- Hi-net / Knet 認証の保存・読み込み・クリアが従来どおり動作すること
+- App Group デバッグ画面で API URL / debugMode の読み書きが動作すること


### PR DESCRIPTION
## Summary
- デバッグ画面に SecureStorage の Key-Value 一覧・追加・編集・削除を追加（デフォルトマスク、行単位で平文トグル）
- Hi-net / Knet 認証を `SecureStorageKey` + `SecurePreferencesDataSource` 経由に統一（キー文字列は互換維持）
- App Group デバッグのキー参照を `AppGroupKeys` に統一

## Test plan
- [ ] デバッグメニュー → SecureStorage で一覧表示・マスク/平文トグルを確認
- [ ] 追加・編集・削除が動作すること
- [ ] Hi-net / Knet 認証の保存・読み込み・クリアが従来どおり動作すること
- [ ] iOS で App Group デバッグの API URL / debugMode 読み書きが動作すること


Made with [Cursor](https://cursor.com)