### PR TITLE
feat: Debug 画面に Live Activity テスト機能を追加

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -53,6 +53,7 @@ import 'package:eqmonitor/feature/settings/children/config/debug/http_cache/debu
 import 'package:eqmonitor/feature/settings/children/config/debug/intensity_icon/intensity_icon_debug_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/jma_map/debug_jma_map_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/kyoshin_monitor/debug_kyoshin_monitor.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/ui/page/debug_live_activity_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/navigation/navigation_debug_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/notification/debug_notification_delivery_log_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/playground/playground_page.dart';
@@ -373,6 +374,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
           path: 'notification-delivery-log',
         ),
         TypedGoRoute<DebugDeviceAdminRoute>(path: 'device-admin'),
+        TypedGoRoute<DebugLiveActivityRoute>(path: 'live-activity'),
         TypedGoRoute<DebugDeviceSettingsRoute>(path: 'device-settings'),
         TypedGoRoute<DebugNavigationRoute>(path: 'navigation'),
         TypedGoRoute<DebugAppGroupRoute>(path: 'app-group'),
@@ -674,6 +676,15 @@ class DebugDeviceAdminRoute extends GoRouteData with $DebugDeviceAdminRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const DebugDeviceAdminPage();
+  }
+}
+
+class DebugLiveActivityRoute extends GoRouteData with $DebugLiveActivityRoute {
+  const DebugLiveActivityRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const DebugLiveActivityPage();
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -604,6 +604,10 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           factory: $DebugDeviceAdminRoute._fromState,
         ),
         GoRouteData.$route(
+          path: 'live-activity',
+          factory: $DebugLiveActivityRoute._fromState,
+        ),
+        GoRouteData.$route(
           path: 'device-settings',
           factory: $DebugDeviceSettingsRoute._fromState,
         ),
@@ -1324,6 +1328,27 @@ mixin $DebugDeviceAdminRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/settings/debug/device-admin');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DebugLiveActivityRoute on GoRouteData {
+  static DebugLiveActivityRoute _fromState(GoRouterState state) =>
+      const DebugLiveActivityRoute();
+
+  @override
+  String get location => GoRouteData.$location('/settings/debug/live-activity');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -205,7 +205,9 @@ class _DebugWidget extends ConsumerWidget {
             Builder(
               builder: (context) {
                 final isAllowed =
-                    ref.watch(estimatedIntensityOnEewReplayAllowedProvider).value ??
+                    ref
+                        .watch(estimatedIntensityOnEewReplayAllowedProvider)
+                        .value ??
                     false;
                 return ListTile(
                   title: const Text('EEW 推定震度表示'),
@@ -365,6 +367,14 @@ class _DebugWidget extends ConsumerWidget {
               onTap: () async =>
                   const DebugDeviceAdminRoute().push<void>(context),
             ),
+            if (Platform.isIOS)
+              ListTile(
+                title: const Text('Live Activity テスト'),
+                subtitle: const Text('開始 / 更新 / 終了（自デバイス）'),
+                leading: const Icon(Icons.live_tv_outlined),
+                onTap: () async =>
+                    const DebugLiveActivityRoute().push<void>(context),
+              ),
             const Divider(),
             const _BackgroundLocationDebugSection(),
             const Divider(),

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart
@@ -1,0 +1,13 @@
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+
+class DebugLiveActivitySession {
+  const DebugLiveActivitySession({
+    required this.liveActivityId,
+    required this.eventId,
+    required this.startTrigger,
+  });
+
+  final String liveActivityId;
+  final String eventId;
+  final api.LiveActivityStartTrigger startTrigger;
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_parser.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_parser.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_live_activity_json_parser.g.dart';
+
+@riverpod
+DebugLiveActivityJsonParser debugLiveActivityJsonParser(Ref ref) =>
+    DebugLiveActivityJsonParser();
+
+class DebugLiveActivityJsonParser {
+  Result<Map<String, dynamic>?, FormatException> parseOptionalObjectJson({
+    required String raw,
+  }) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) {
+      return const Success(null);
+    }
+
+    try {
+      final decoded = jsonDecode(trimmed);
+      return switch (decoded) {
+        final Map<String, dynamic> json => Success(json),
+        _ => Failure(
+          FormatException('JSON root must be an object', trimmed),
+        ),
+      };
+    } on FormatException catch (exception, stackTrace) {
+      return Failure(exception, stackTrace);
+    }
+  }
+
+  Result<api.Alert?, FormatException> parseOptionalAlertJson({
+    required String raw,
+  }) {
+    final result = parseOptionalObjectJson(raw: raw);
+    return switch (result) {
+      Success(value: null) => const Success(null),
+      Success(value: final Map<String, dynamic> value) => switch ((
+        value['title'],
+        value['body'],
+      )) {
+        (final String title, final String body) => Success(
+          api.Alert(title: title, body: body),
+        ),
+        _ => Failure(
+          FormatException(
+            'Alert JSON must include title and body as strings',
+            raw,
+          ),
+        ),
+      },
+      Failure(:final exception, :final stackTrace) => Failure(
+        exception,
+        stackTrace,
+      ),
+    };
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_parser.g.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_parser.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_live_activity_json_parser.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugLiveActivityJsonParser)
+final debugLiveActivityJsonParserProvider =
+    DebugLiveActivityJsonParserProvider._();
+
+final class DebugLiveActivityJsonParserProvider
+    extends
+        $FunctionalProvider<
+          DebugLiveActivityJsonParser,
+          DebugLiveActivityJsonParser,
+          DebugLiveActivityJsonParser
+        >
+    with $Provider<DebugLiveActivityJsonParser> {
+  DebugLiveActivityJsonParserProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugLiveActivityJsonParserProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugLiveActivityJsonParserHash();
+
+  @$internal
+  @override
+  $ProviderElement<DebugLiveActivityJsonParser> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DebugLiveActivityJsonParser create(Ref ref) {
+    return debugLiveActivityJsonParser(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DebugLiveActivityJsonParser value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DebugLiveActivityJsonParser>(value),
+    );
+  }
+}
+
+String _$debugLiveActivityJsonParserHash() =>
+    r'abff57d62a2905d09fad3f5c6d3f9134ce8b24ef';

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_repository.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_repository.dart
@@ -1,0 +1,61 @@
+import 'package:eqmonitor/core/api/api_client_provider.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_live_activity_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<DebugLiveActivityRepository> debugLiveActivityRepository(Ref ref) async =>
+    DebugLiveActivityRepository(api: await ref.watch(apiClientProvider.future));
+
+class DebugLiveActivityRepository {
+  const DebugLiveActivityRepository({required api.ApiClient api}) : _api = api;
+
+  final api.ApiClient _api;
+
+  Future<Result<DebugLiveActivitySession, Exception>> start({
+    required api.LiveActivityStartTrigger startTrigger,
+    api.LiveActivityContentState? contentState,
+    api.Alert? alert,
+  }) => Result.capture(() async {
+    final response = await _api.device.postV2DeviceMeLiveActivityTest(
+      body: api.TestLiveActivityStartRequest(
+        startTrigger: startTrigger,
+        contentState: contentState,
+        alert: alert,
+      ),
+    );
+    final data = response.data;
+    return DebugLiveActivitySession(
+      liveActivityId: data.liveActivityId,
+      eventId: data.eventId,
+      startTrigger: data.startTrigger,
+    );
+  });
+
+  Future<Result<api.TestLiveActivitySendResponse, Exception>> update({
+    required String liveActivityId,
+    required api.LiveActivityContentState contentState,
+  }) => Result.capture(() async {
+    final response = await _api.device
+        .postV2DeviceMeLiveActivityTestLiveActivityIdUpdate(
+          liveActivityId: liveActivityId,
+          body: api.TestLiveActivityUpdateRequest(contentState: contentState),
+        );
+    return response.data;
+  });
+
+  Future<Result<api.TestLiveActivitySendResponse, Exception>> end({
+    required String liveActivityId,
+    api.LiveActivityContentState? contentState,
+  }) => Result.capture(() async {
+    final response = await _api.device
+        .postV2DeviceMeLiveActivityTestLiveActivityIdEnd(
+          liveActivityId: liveActivityId,
+          body: api.TestLiveActivityEndRequest(contentState: contentState),
+        );
+    return response.data;
+  });
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_repository.g.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_repository.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_live_activity_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugLiveActivityRepository)
+final debugLiveActivityRepositoryProvider =
+    DebugLiveActivityRepositoryProvider._();
+
+final class DebugLiveActivityRepositoryProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<DebugLiveActivityRepository>,
+          DebugLiveActivityRepository,
+          FutureOr<DebugLiveActivityRepository>
+        >
+    with
+        $FutureModifier<DebugLiveActivityRepository>,
+        $FutureProvider<DebugLiveActivityRepository> {
+  DebugLiveActivityRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugLiveActivityRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugLiveActivityRepositoryHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<DebugLiveActivityRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<DebugLiveActivityRepository> create(Ref ref) {
+    return debugLiveActivityRepository(ref);
+  }
+}
+
+String _$debugLiveActivityRepositoryHash() =>
+    r'f0d79d397cb2b9320c812bdf4f7f2a05401b5adb';

--- a/app/lib/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.dart
@@ -1,0 +1,184 @@
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/foundation/result.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_json_parser.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/repository/debug_live_activity_repository.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_live_activity_action.g.dart';
+
+@riverpod
+DebugLiveActivityAction debugLiveActivityAction(Ref ref) =>
+    DebugLiveActivityAction();
+
+class DebugLiveActivityAction {
+  Future<DebugLiveActivitySession?> start(
+    WidgetRef ref,
+    BuildContext context, {
+    required api.LiveActivityStartTrigger startTrigger,
+    required String contentStateJson,
+    required String alertJson,
+  }) async {
+    const snackBar = DebugLiveActivitySnackBar();
+    final parser = ref.read(debugLiveActivityJsonParserProvider);
+    final contentStateResult = parser.parseOptionalObjectJson(
+      raw: contentStateJson,
+    );
+    final contentState = switch (contentStateResult) {
+      Success(:final value) => value,
+      Failure(:final exception) => snackBar.showJsonError(context, exception),
+    };
+    if (contentStateResult is Failure) {
+      return null;
+    }
+
+    final alertResult = parser.parseOptionalAlertJson(raw: alertJson);
+    final alert = switch (alertResult) {
+      Success(:final value) => value,
+      Failure(:final exception) => snackBar.showJsonError(context, exception),
+    };
+    if (alertResult is Failure) {
+      return null;
+    }
+
+    final repository = await ref.read(
+      debugLiveActivityRepositoryProvider.future,
+    );
+    final result = await repository.start(
+      startTrigger: startTrigger,
+      contentState: contentState,
+      alert: alert,
+    );
+    return switch (result) {
+      Success(:final value) => snackBar.showStartSuccess(context, value),
+      Failure(:final exception) => snackBar.showApiError(context, exception),
+    };
+  }
+
+  Future<bool> update(
+    WidgetRef ref,
+    BuildContext context, {
+    required String liveActivityId,
+    required String contentStateJson,
+  }) async {
+    const snackBar = DebugLiveActivitySnackBar();
+    final trimmedId = liveActivityId.trim();
+    if (trimmedId.isEmpty) {
+      snackBar.show(context, 'live_activity_id を入力してください');
+      return false;
+    }
+    if (contentStateJson.trim().isEmpty) {
+      snackBar.show(context, '更新には ContentState JSON が必要です');
+      return false;
+    }
+
+    final parser = ref.read(debugLiveActivityJsonParserProvider);
+    final contentStateResult = parser.parseOptionalObjectJson(
+      raw: contentStateJson,
+    );
+    final contentState = switch (contentStateResult) {
+      Success(value: final api.LiveActivityContentState value?) => value,
+      Success(value: null) => null,
+      Failure(:final exception) => snackBar.showJsonError(context, exception),
+    };
+    if (contentState == null) {
+      return false;
+    }
+
+    final repository = await ref.read(
+      debugLiveActivityRepositoryProvider.future,
+    );
+    final result = await repository.update(
+      liveActivityId: trimmedId,
+      contentState: contentState,
+    );
+    return switch (result) {
+      Success() => snackBar.showSuccess(context, 'Live Activity を更新しました'),
+      Failure(:final exception) =>
+        snackBar.showApiError(context, exception) != null,
+    };
+  }
+
+  Future<bool> end(
+    WidgetRef ref,
+    BuildContext context, {
+    required String liveActivityId,
+    required String contentStateJson,
+  }) async {
+    const snackBar = DebugLiveActivitySnackBar();
+    final trimmedId = liveActivityId.trim();
+    if (trimmedId.isEmpty) {
+      snackBar.show(context, 'live_activity_id を入力してください');
+      return false;
+    }
+
+    final parser = ref.read(debugLiveActivityJsonParserProvider);
+    final contentStateResult = parser.parseOptionalObjectJson(
+      raw: contentStateJson,
+    );
+    final contentState = switch (contentStateResult) {
+      Success(:final value) => value,
+      Failure(:final exception) => snackBar.showJsonError(context, exception),
+    };
+    if (contentStateResult is Failure) {
+      return false;
+    }
+
+    final repository = await ref.read(
+      debugLiveActivityRepositoryProvider.future,
+    );
+    final result = await repository.end(
+      liveActivityId: trimmedId,
+      contentState: contentState,
+    );
+    return switch (result) {
+      Success() => snackBar.showSuccess(context, 'Live Activity を終了しました'),
+      Failure(:final exception) =>
+        snackBar.showApiError(context, exception) != null,
+    };
+  }
+}
+
+class DebugLiveActivitySnackBar {
+  const DebugLiveActivitySnackBar();
+
+  Null showJsonError(BuildContext context, FormatException exception) {
+    show(context, 'JSON が不正です: ${exception.message}');
+    return null;
+  }
+
+  DebugLiveActivitySession showStartSuccess(
+    BuildContext context,
+    DebugLiveActivitySession session,
+  ) {
+    show(context, 'Live Activity を開始しました');
+    return session;
+  }
+
+  bool showSuccess(BuildContext context, String message) {
+    show(context, message);
+    return true;
+  }
+
+  Null showApiError(BuildContext context, Exception exception) {
+    final message = switch (exception) {
+      DioException(response: final response) when response?.statusCode == 409 =>
+        'API エラー: updateToken 未登録の可能性があります',
+      _ => 'API エラー: $exception',
+    };
+    show(context, message);
+    return null;
+  }
+
+  void show(BuildContext context, String message) {
+    if (!context.mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.g.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_live_activity_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugLiveActivityAction)
+final debugLiveActivityActionProvider = DebugLiveActivityActionProvider._();
+
+final class DebugLiveActivityActionProvider
+    extends
+        $FunctionalProvider<
+          DebugLiveActivityAction,
+          DebugLiveActivityAction,
+          DebugLiveActivityAction
+        >
+    with $Provider<DebugLiveActivityAction> {
+  DebugLiveActivityActionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugLiveActivityActionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugLiveActivityActionHash();
+
+  @$internal
+  @override
+  $ProviderElement<DebugLiveActivityAction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DebugLiveActivityAction create(Ref ref) {
+    return debugLiveActivityAction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DebugLiveActivityAction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DebugLiveActivityAction>(value),
+    );
+  }
+}
+
+String _$debugLiveActivityActionHash() =>
+    r'8bf91751efa9f60113a4b67669096e15d44463bf';

--- a/app/lib/feature/settings/children/config/debug/live_activity/ui/page/debug_live_activity_page.dart
+++ b/app/lib/feature/settings/children/config/debug/live_activity/ui/page/debug_live_activity_page.dart
@@ -1,0 +1,290 @@
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/data/model/debug_live_activity_session.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/live_activity/ui/action/debug_live_activity_action.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DebugLiveActivityPage extends HookConsumerWidget {
+  const DebugLiveActivityPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final trigger = useState(api.LiveActivityStartTrigger.eew);
+    final session = useState<DebugLiveActivitySession?>(null);
+    final isBusy = useState(false);
+    final contentStateController = useTextEditingController();
+    final alertController = useTextEditingController();
+    final liveActivityIdController = useTextEditingController();
+    final action = ref.watch(debugLiveActivityActionProvider);
+
+    final body = ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        _TriggerSelector(trigger: trigger),
+        const SizedBox(height: 16),
+        _JsonTextField(
+          controller: contentStateController,
+          label: 'ContentState JSON',
+          hintText: '空ならサーバ既定を利用します',
+        ),
+        const SizedBox(height: 16),
+        _JsonTextField(
+          controller: alertController,
+          label: 'Alert JSON',
+          hintText: '任意。例: {"title":"テスト","body":"本文"}',
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: liveActivityIdController,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'live_activity_id',
+            hintText: '開始後に自動反映。手入力も可能です',
+          ),
+        ),
+        const SizedBox(height: 16),
+        _ActionButtons(
+          isBusy: isBusy.value,
+          onStart: () async {
+            isBusy.value = true;
+            try {
+              final startedSession = await action.start(
+                ref,
+                context,
+                startTrigger: trigger.value,
+                contentStateJson: contentStateController.text,
+                alertJson: alertController.text,
+              );
+              if (startedSession == null || !context.mounted) {
+                return;
+              }
+              session.value = startedSession;
+              liveActivityIdController.text = startedSession.liveActivityId;
+            } finally {
+              if (context.mounted) {
+                isBusy.value = false;
+              }
+            }
+          },
+          onUpdate: () async {
+            isBusy.value = true;
+            try {
+              await action.update(
+                ref,
+                context,
+                liveActivityId: liveActivityIdController.text,
+                contentStateJson: contentStateController.text,
+              );
+            } finally {
+              if (context.mounted) {
+                isBusy.value = false;
+              }
+            }
+          },
+          onEnd: () async {
+            isBusy.value = true;
+            try {
+              final ended = await action.end(
+                ref,
+                context,
+                liveActivityId: liveActivityIdController.text,
+                contentStateJson: contentStateController.text,
+              );
+              if (ended && context.mounted) {
+                session.value = null;
+              }
+            } finally {
+              if (context.mounted) {
+                isBusy.value = false;
+              }
+            }
+          },
+        ),
+        const SizedBox(height: 16),
+        _SessionCard(session: session.value),
+      ],
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Live Activity テスト')),
+      body: body,
+    );
+  }
+}
+
+class _TriggerSelector extends StatelessWidget {
+  const _TriggerSelector({required this.trigger});
+
+  final ValueNotifier<api.LiveActivityStartTrigger> trigger;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('開始トリガー', style: Theme.of(context).textTheme.titleSmall),
+        const SizedBox(height: 8),
+        SegmentedButton<api.LiveActivityStartTrigger>(
+          segments: const [
+            ButtonSegment(
+              value: api.LiveActivityStartTrigger.eew,
+              label: Text('EEW'),
+              icon: Icon(Icons.flash_on),
+            ),
+            ButtonSegment(
+              value: api.LiveActivityStartTrigger.shakeDetection,
+              label: Text('揺れ検知'),
+              icon: Icon(Icons.sensors),
+            ),
+          ],
+          selected: {trigger.value},
+          onSelectionChanged: (selected) => trigger.value = selected.first,
+        ),
+      ],
+    );
+  }
+}
+
+class _JsonTextField extends StatelessWidget {
+  const _JsonTextField({
+    required this.controller,
+    required this.label,
+    required this.hintText,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final String hintText;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      minLines: 4,
+      maxLines: 10,
+      keyboardType: TextInputType.multiline,
+      decoration: InputDecoration(
+        alignLabelWithHint: true,
+        border: const OutlineInputBorder(),
+        labelText: label,
+        hintText: hintText,
+      ),
+    );
+  }
+}
+
+class _ActionButtons extends StatelessWidget {
+  const _ActionButtons({
+    required this.isBusy,
+    required this.onStart,
+    required this.onUpdate,
+    required this.onEnd,
+  });
+
+  final bool isBusy;
+  final VoidCallback onStart;
+  final VoidCallback onUpdate;
+  final VoidCallback onEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        FilledButton.icon(
+          onPressed: isBusy ? null : onStart,
+          icon: const Icon(Icons.play_arrow),
+          label: const Text('開始'),
+        ),
+        FilledButton.tonalIcon(
+          onPressed: isBusy ? null : onUpdate,
+          icon: const Icon(Icons.refresh),
+          label: const Text('更新'),
+        ),
+        OutlinedButton.icon(
+          onPressed: isBusy ? null : onEnd,
+          icon: const Icon(Icons.stop),
+          label: const Text('終了'),
+        ),
+        if (isBusy)
+          const Padding(
+            padding: EdgeInsets.all(8),
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+      ],
+    );
+  }
+}
+
+class _SessionCard extends StatelessWidget {
+  const _SessionCard({required this.session});
+
+  final DebugLiveActivitySession? session;
+
+  @override
+  Widget build(BuildContext context) {
+    final currentSession = session;
+    if (currentSession == null) {
+      return const Card(
+        child: ListTile(
+          leading: Icon(Icons.info_outline),
+          title: Text('セッションなし'),
+          subtitle: Text(
+            '開始に成功すると live_activity_id / event_id / trigger を表示します',
+          ),
+        ),
+      );
+    }
+
+    final triggerLabel = switch (currentSession.startTrigger) {
+      api.LiveActivityStartTrigger.eew => 'EEW',
+      api.LiveActivityStartTrigger.shakeDetection => '揺れ検知',
+    };
+
+    return Card(
+      child: Column(
+        children: [
+          const ListTile(
+            leading: Icon(Icons.live_tv_outlined),
+            title: Text('現在のセッション'),
+            subtitle: Text('各行をタップすると Clipboard にコピーします'),
+          ),
+          _CopyListTile(
+            title: 'live_activity_id',
+            value: currentSession.liveActivityId,
+          ),
+          _CopyListTile(title: 'event_id', value: currentSession.eventId),
+          _CopyListTile(title: 'trigger', value: triggerLabel),
+        ],
+      ),
+    );
+  }
+}
+
+class _CopyListTile extends StatelessWidget {
+  const _CopyListTile({required this.title, required this.value});
+
+  final String title;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title),
+      subtitle: Text(value),
+      trailing: const Icon(Icons.copy),
+      onTap: () async {
+        await Clipboard.setData(ClipboardData(text: value));
+        if (!context.mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('$title をコピーしました')));
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Debug 画面（iOS）から自デバイス向けテスト用 Live Activity の開始・更新・終了を呼べるようにした
- `POST /v2/device/me/live-activity/test` 系 API を Repository 経由で利用し、ContentState / Alert は空ならサーバ既定・入力時は JSON 自由編集
- ルート: `/settings/debug/live-activity`

## Test plan
- [ ] iOS 実機で Debug Page →「Live Activity テスト」が表示されること（Android では非表示）
- [ ] EEW / 揺れ検知を切り替えて「開始」し、Live Activity が起動すること
- [ ] ContentState / Alert JSON を空のまま開始できること（サーバ既定）
- [ ] 不正 JSON で SnackBar が出て API が呼ばれないこと
- [ ] updateToken 登録後に「更新」「終了」が成功すること
- [ ] updateToken 未登録で更新すると 409 相当の SnackBar（updateToken 未登録の文言）が出ること


Made with [Cursor](https://cursor.com)