### PR TITLE
feat: デバッグ画面にトークン再送信・デバイス削除・再プロビジョンを追加

### DIFF
--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,0 +1,60 @@
+# Task 4 Report: Flow + Debug UI
+
+## Summary
+
+- Added `DebugDeviceLifecycleFlow` for debug-only device deletion, reprovisioning, and per-token force resync.
+- Added `DebugDeviceLifecycleMessages` and `DebugDeviceLifecycleConfirmDialog` helpers instead of private Flow methods.
+- Added a debug device lifecycle UI section and per-token resend controls in `DebugDeviceSettingsPage`.
+- Kept private page provider invalidation in the UI layer via `MutationSuccess` listeners.
+
+## Verification
+
+- `cd app && mise exec -- dart run build_runner build --delete-conflicting-outputs`
+  - Completed successfully.
+- `cd app && mise exec -- dart format lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart lib/feature/devices/ui/page/debug_device_settings_page.dart`
+  - Completed successfully.
+- `cd app && mise exec -- dart analyze lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart lib/feature/devices/ui/page/debug_device_settings_page.dart`
+  - Failed because `eqmonitor_custom_lints` plugin path is missing at `app/tools/eqmonitor_custom_lints`.
+  - After fixing the missing `PushTokenKind` import, no additional Dart analyzer issues were reported before the plugin setup failure output.
+- Cursor IDE diagnostics reported no linter errors for the changed source files.
+
+## Self Review
+
+- Flow does not access page-private providers.
+- New Flow helpers avoid private methods.
+- New UI widgets do not define additional methods or getters beyond `build`.
+- Delete and reprovision buttons are disabled while either lifecycle mutation is pending.
+- Token resend buttons are hidden for non-applicable or not-yet-loaded token states and disabled while the token is syncing or a force-resync mutation is pending.
+
+## Notes
+
+- `build_runner` also changed provider hash lines in existing notifier `.g.dart` files. They are not part of this task and were left uncommitted.
+- Existing dirty change in `app/lib/feature/map/data/repository/base_map_pmtiles_repository.dart` was left untouched.
+# Task 4 Report: SecureStorage Debug Page UI
+
+## Status
+
+**Completed** — `DebugSecureStoragePage` を作成し、ページファイルのみコミット済み。
+
+## Deliverable
+
+- Created: `app/lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart`
+- `HookConsumerWidget` / AppBar refresh / `AsyncValue.when` / `RefreshIndicator` / `ListView.builder` / FAB を実装
+- 各行に key、マスク既定の value preview、目アイコンの表示切替、削除、編集ダイアログを実装
+- 新規追加ダイアログはキー名と値の `TextField` を持ち、既存 `debugSecureStorageActionProvider` の `write` を使用
+- Routing は未変更（Task 5 担当）
+
+## Verify
+
+- `cd app && mise exec -- dart format lib/feature/settings/children/config/debug/secure_storage/debug_secure_storage_page.dart`: OK
+- `cd app && mise exec -- dart analyze lib/feature/settings/children/config/debug/secure_storage/`: **No issues found!**
+- IDE `ReadLints`: 問題なし
+
+## Commits
+
+- `8dd4e8a0f feat: SecureStorageデバッグ画面のUIを追加`
+
+## Concerns
+
+- `dart format` 実行時に `packages/eqmonitor_lints/lib/analysis_options.yaml` が読めない Warning が出たが、format と analyze は完了。
+- 画面への導線は Task 5 まで未接続。

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -58,3 +58,20 @@
 
 - `dart format` 実行時に `packages/eqmonitor_lints/lib/analysis_options.yaml` が読めない Warning が出たが、format と analyze は完了。
 - 画面への導線は Task 5 まで未接続。
+
+# Final Review Fix: Device Provisioning Migration Guard
+
+## Fix Details
+
+- `DeviceProvisioningNotifier.provision()` の migration 分岐に `wasMigratedFromLegacy()` の確認を追加。
+- legacy ID が残っていても移行済みなら durable migration workflow を再実行せず、通常の `registerDevice` 経路へ進むように修正。
+- `device_provisioning_migration_test.dart` に、移行済みフラグあり + legacy ID 残存時は `migrateFromLegacy` を呼ばず `registerDevice` を呼ぶ回帰テストを追加。
+
+## Test Results
+
+- `cd app && mise exec -- dart format lib/feature/devices/data/notifier/device_provisioning_notifier.dart test/feature/devices/device_provisioning_migration_test.dart`
+  - OK。`packages/eqmonitor_lints/lib/analysis_options.yaml` が読めない Warning は既存環境由来として表示。
+- Cursor IDE diagnostics
+  - 変更ファイルに linter error なし。
+- `cd app && mise exec -- flutter test test/feature/devices/`
+  - OK。91 tests passed。

--- a/app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart
+++ b/app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart
@@ -1,0 +1,190 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
+import 'package:eqmonitor/feature/devices/data/model/push_token_force_resync_result.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/push_token_sync_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_device_lifecycle_flow.g.dart';
+
+@riverpod
+DebugDeviceLifecycleFlow debugDeviceLifecycleFlow(Ref ref) =>
+    DebugDeviceLifecycleFlow();
+
+class DebugDeviceLifecycleFlow {
+  DebugDeviceLifecycleFlow({
+    DebugDeviceLifecycleMessages? messages,
+    DebugDeviceLifecycleConfirmDialog? confirmDialog,
+  }) : messages = messages ?? DebugDeviceLifecycleMessages(),
+       confirmDialog = confirmDialog ?? DebugDeviceLifecycleConfirmDialog();
+
+  final DebugDeviceLifecycleMessages messages;
+  final DebugDeviceLifecycleConfirmDialog confirmDialog;
+
+  Future<void> confirmAndDelete(WidgetRef ref, BuildContext context) async {
+    final confirmed = await confirmDialog.show(
+      context: context,
+      title: 'デバイスを削除',
+      content: 'サーバー上のデバイスとローカル認証情報を削除します。よろしいですか？',
+      confirmLabel: '削除',
+      isDestructive: true,
+    );
+    if (confirmed == false || context.mounted == false) {
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await DeviceProvisioningNotifier.deleteMutation.run(
+        ref,
+        (tsx) async => tsx
+            .get(deviceProvisioningProvider.notifier)
+            .deleteDeviceAndClearLocal(),
+      );
+      if (context.mounted == false) {
+        return;
+      }
+      messenger.showSnackBar(const SnackBar(content: Text('デバイスを削除しました')));
+    } on Object catch (error) {
+      if (context.mounted == false) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(messages.errorMessage(error)),
+          backgroundColor: context.designSystem.colorTheme.error,
+        ),
+      );
+      rethrow;
+    }
+  }
+
+  Future<void> confirmAndReprovision(
+    WidgetRef ref,
+    BuildContext context,
+  ) async {
+    final confirmed = await confirmDialog.show(
+      context: context,
+      title: '再プロビジョニング',
+      content: '削除してから再登録します。通知トークンも再同期されます。よろしいですか？',
+      confirmLabel: '実行',
+      isDestructive: true,
+    );
+    if (confirmed == false || context.mounted == false) {
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await DeviceProvisioningNotifier.reprovisionMutation.run(
+        ref,
+        (tsx) async =>
+            tsx.get(deviceProvisioningProvider.notifier).reprovision(),
+      );
+      if (context.mounted == false) {
+        return;
+      }
+      messenger.showSnackBar(const SnackBar(content: Text('再プロビジョニングが完了しました')));
+    } on Object catch (error) {
+      if (context.mounted == false) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(messages.errorMessage(error)),
+          backgroundColor: context.designSystem.colorTheme.error,
+        ),
+      );
+      rethrow;
+    }
+  }
+
+  Future<void> forceResyncToken(
+    WidgetRef ref,
+    BuildContext context, {
+    required PushTokenKind kind,
+  }) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final result = await PushTokenSyncNotifier.forceResyncMutation.run(
+        ref,
+        (tsx) async =>
+            tsx.get(pushTokenSyncProvider.notifier).forceResync(kind: kind),
+      );
+      if (context.mounted == false) {
+        return;
+      }
+      final message = switch (result) {
+        PushTokenForceResyncResult.started =>
+          '${messages.kindLabel(kind)} の再送信を開始しました',
+        PushTokenForceResyncResult.tokenAbsent => 'トークン未取得のため再送信できません',
+        PushTokenForceResyncResult.notApplicable =>
+          '${messages.kindLabel(kind)} はこの端末では非対応です',
+      };
+      messenger.showSnackBar(SnackBar(content: Text(message)));
+    } on Object catch (error) {
+      if (context.mounted == false) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(messages.errorMessage(error)),
+          backgroundColor: context.designSystem.colorTheme.error,
+        ),
+      );
+      rethrow;
+    }
+  }
+}
+
+class DebugDeviceLifecycleMessages {
+  String errorMessage(Object error) {
+    if (error is DeviceProvisioningException) {
+      return error.userMessage;
+    }
+    return error.toString();
+  }
+
+  String kindLabel(PushTokenKind kind) => switch (kind) {
+    PushTokenKind.fcm => 'FCM',
+    PushTokenKind.apnsNotification => 'APNs（通知）',
+    PushTokenKind.apnsPushToStart => 'Push to Start',
+  };
+}
+
+class DebugDeviceLifecycleConfirmDialog {
+  Future<bool> show({
+    required BuildContext context,
+    required String title,
+    required String content,
+    required String confirmLabel,
+    required bool isDestructive,
+  }) async {
+    final confirmed = await showAdaptiveDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog.adaptive(
+        title: Text(title),
+        content: Text(content),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            style: isDestructive
+                ? TextButton.styleFrom(
+                    foregroundColor:
+                        dialogContext.designSystem.colorTheme.error,
+                  )
+                : null,
+            child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+}

--- a/app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.g.dart
+++ b/app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'debug_device_lifecycle_flow.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(debugDeviceLifecycleFlow)
+final debugDeviceLifecycleFlowProvider = DebugDeviceLifecycleFlowProvider._();
+
+final class DebugDeviceLifecycleFlowProvider
+    extends
+        $FunctionalProvider<
+          DebugDeviceLifecycleFlow,
+          DebugDeviceLifecycleFlow,
+          DebugDeviceLifecycleFlow
+        >
+    with $Provider<DebugDeviceLifecycleFlow> {
+  DebugDeviceLifecycleFlowProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'debugDeviceLifecycleFlowProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$debugDeviceLifecycleFlowHash();
+
+  @$internal
+  @override
+  $ProviderElement<DebugDeviceLifecycleFlow> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  DebugDeviceLifecycleFlow create(Ref ref) {
+    return debugDeviceLifecycleFlow(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DebugDeviceLifecycleFlow value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DebugDeviceLifecycleFlow>(value),
+    );
+  }
+}
+
+String _$debugDeviceLifecycleFlowHash() =>
+    r'd25aed33d91a808779961748f83856174b98b1cb';

--- a/app/lib/feature/devices/data/model/push_token_force_resync_result.dart
+++ b/app/lib/feature/devices/data/model/push_token_force_resync_result.dart
@@ -1,0 +1,1 @@
+enum PushTokenForceResyncResult { started, tokenAbsent, notApplicable }

--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
@@ -107,4 +107,32 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
     state = const AsyncData(DeviceProvisioningStatus.notRequired);
     ref.invalidate(pushTokenSyncProvider, asReload: true);
   }
+
+  static final deleteMutation = Mutation<void>();
+  Future<void> deleteDeviceAndClearLocal() async {
+    final deviceRepo = await ref.read(deviceRepositoryProvider.future);
+    final provisioningRepo = await ref.read(
+      deviceProvisioningRepositoryProvider.future,
+    );
+    final deviceId = await ref.read(deviceIdProvider.future);
+
+    final result = await deviceRepo.deleteDevice(deviceId);
+    switch (result) {
+      case Success():
+        break;
+      case Failure(:final exception, :final stackTrace):
+        Error.throwWithStackTrace(exception, stackTrace ?? StackTrace.empty);
+    }
+
+    await provisioningRepo.clearProvisioned();
+    _retryController.reset();
+    state = const AsyncData(DeviceProvisioningStatus.required);
+    ref.invalidate(pushTokenSyncProvider, asReload: true);
+  }
+
+  static final reprovisionMutation = Mutation<void>();
+  Future<void> reprovision() async {
+    await deleteDeviceAndClearLocal();
+    await provision();
+  }
 }

--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
@@ -57,7 +57,8 @@ class DeviceProvisioningNotifier extends _$DeviceProvisioningNotifier {
     await _retryController.run(() async {
       try {
         final legacy = await repo.readLegacyDeviceId();
-        if (legacy != null && legacy.isNotEmpty) {
+        final alreadyMigrated = await repo.wasMigratedFromLegacy();
+        if (legacy != null && legacy.isNotEmpty && !alreadyMigrated) {
           talker.info(
             '[Provisioning] legacy device detected; '
             'running v2→v3 migration workflow',

--- a/app/lib/feature/devices/data/notifier/device_provisioning_notifier.g.dart
+++ b/app/lib/feature/devices/data/notifier/device_provisioning_notifier.g.dart
@@ -74,7 +74,7 @@ final class DeviceProvisioningNotifierProvider
 }
 
 String _$deviceProvisioningNotifierHash() =>
-    r'6d9a2206876270657a7b1d4e8a6b1fb63fb570d3';
+    r'64d765064d129eaaa08c93e55b95a9c7b01960ae';
 
 abstract class _$DeviceProvisioningNotifier
     extends $AsyncNotifier<DeviceProvisioningStatus> {

--- a/app/lib/feature/devices/data/notifier/push_token_sync_notifier.dart
+++ b/app/lib/feature/devices/data/notifier/push_token_sync_notifier.dart
@@ -6,9 +6,11 @@ import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
 import 'package:eqmonitor/feature/devices/data/exception/dio_exception_mapper.dart';
 import 'package:eqmonitor/feature/devices/data/model/notification_token.dart';
+import 'package:eqmonitor/feature/devices/data/model/push_token_force_resync_result.dart';
 import 'package:eqmonitor/feature/devices/data/model/push_token_sync_snapshot.dart';
 import 'package:eqmonitor/feature/devices/data/model/push_token_sync_worker_state.dart';
 import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/devices/data/provider/notification_token_stream.dart';
 import 'package:eqmonitor/feature/devices/data/provider/push_token_platform_capabilities.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_provisioning_repository.dart';
 import 'package:eqmonitor/feature/devices/data/repository/device_repository.dart';
@@ -125,6 +127,7 @@ class PushTokenSyncNotifier extends _$PushTokenSyncNotifier {
   }
 
   static final syncMutation = Mutation<void>();
+  static final forceResyncMutation = Mutation<PushTokenForceResyncResult>();
 
   void accept(NotificationToken token) {
     final fcmToken = token.fcmToken;
@@ -151,6 +154,39 @@ class PushTokenSyncNotifier extends _$PushTokenSyncNotifier {
     if (_apnsPushToStartWorker?.state is PushTokenSyncWorkerFailed) {
       _apnsPushToStartWorker?.retry();
     }
+  }
+
+  Future<PushTokenForceResyncResult> forceResync({
+    required PushTokenKind kind,
+  }) async {
+    final worker = switch (kind) {
+      PushTokenKind.fcm => _fcmWorker,
+      PushTokenKind.apnsNotification => _apnsNotificationWorker,
+      PushTokenKind.apnsPushToStart => _apnsPushToStartWorker,
+    };
+    if (worker == null) {
+      return PushTokenForceResyncResult.notApplicable;
+    }
+
+    final notificationToken = ref.read(notificationTokenStreamProvider).value;
+    final streamToken = switch (kind) {
+      PushTokenKind.fcm => notificationToken?.fcmToken,
+      PushTokenKind.apnsNotification => notificationToken?.apnsToken,
+      PushTokenKind.apnsPushToStart => notificationToken?.apnsPushToStartToken,
+    };
+    if (streamToken != null && streamToken.isNotEmpty) {
+      worker.accept(token: streamToken);
+      worker.forceResync();
+      return PushTokenForceResyncResult.started;
+    }
+
+    if (worker.state is PushTokenSyncWorkerAbsent ||
+        worker.state is PushTokenSyncWorkerDisposed) {
+      return PushTokenForceResyncResult.tokenAbsent;
+    }
+
+    worker.forceResync();
+    return PushTokenForceResyncResult.started;
   }
 
   Future<void> sync() async {

--- a/app/lib/feature/devices/data/notifier/push_token_sync_notifier.g.dart
+++ b/app/lib/feature/devices/data/notifier/push_token_sync_notifier.g.dart
@@ -37,7 +37,7 @@ final class PushTokenSyncNotifierProvider
 }
 
 String _$pushTokenSyncNotifierHash() =>
-    r'4045dc1b23a3cc4cc0a3910a4d2a9052e21b3563';
+    r'1463ec56b34316b57bae7960fad1b7d378f15f10';
 
 abstract class _$PushTokenSyncNotifier
     extends $AsyncNotifier<PushTokenSyncSnapshot> {

--- a/app/lib/feature/devices/data/repository/push_token_sync_worker.dart
+++ b/app/lib/feature/devices/data/repository/push_token_sync_worker.dart
@@ -90,6 +90,23 @@ final class PushTokenSyncWorker {
     }
   }
 
+  void forceResync() {
+    if (_disposed) {
+      return;
+    }
+    final token = _latestToken;
+    if (token == null || token.isEmpty) {
+      return;
+    }
+
+    _attempt = 0;
+    _blockedToken = null;
+    _lastSyncedToken = null;
+    _latestToken = null;
+    _backoff.interrupt();
+    accept(token: token);
+  }
+
   Future<void> process() async {
     while (!_disposed) {
       final attemptedToken = _latestToken;

--- a/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
+++ b/app/lib/feature/devices/ui/page/debug_device_settings_page.dart
@@ -7,6 +7,8 @@ import 'package:eqmonitor/core/foundation/result.dart';
 import 'package:eqmonitor/core/gen/fonts.gen.dart';
 import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/core/provider/firebase/firebase_messaging.dart';
+import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
+import 'package:eqmonitor/feature/devices/data/flow/debug_device_lifecycle_flow.dart';
 import 'package:eqmonitor/feature/devices/data/model/push_token_sync_snapshot.dart';
 import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
 import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
@@ -55,6 +57,7 @@ class DebugDeviceSettingsPage extends HookConsumerWidget {
               children: [
                 const SizedBox(height: 8),
                 _ProvisioningStartupSection(deviceIdAsync: deviceIdAsync),
+                _DeviceLifecycleSection(deviceIdAsync: deviceIdAsync),
                 _DeviceInfoSection(deviceIdAsync: deviceIdAsync),
                 const _NotificationPermissionSection(),
                 _TokenSection(syncSnapshot: syncSnapshot),
@@ -289,6 +292,106 @@ class _StatusChip extends StatelessWidget {
   }
 }
 
+// ── デバイス操作セクション ───────────────────────────────────────────────────
+
+class _DeviceLifecycleSection extends HookConsumerWidget {
+  const _DeviceLifecycleSection({required this.deviceIdAsync});
+
+  final AsyncValue<String> deviceIdAsync;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final deleteMutation = ref.watch(DeviceProvisioningNotifier.deleteMutation);
+    final reprovisionMutation = ref.watch(
+      DeviceProvisioningNotifier.reprovisionMutation,
+    );
+    final isDeleting = deleteMutation is MutationPending;
+    final isReprovisioning = reprovisionMutation is MutationPending;
+    final isProcessing = isDeleting || isReprovisioning;
+    final colorTheme = context.designSystem.colorTheme;
+
+    ref.listen(DeviceProvisioningNotifier.deleteMutation, (_, next) {
+      if (next is MutationSuccess) {
+        ref.invalidate(_isProvisionedProvider, asReload: true);
+        ref.invalidate(_deviceTokenPresentProvider, asReload: true);
+        if (deviceIdAsync.value case final deviceId? when deviceId.isNotEmpty) {
+          ref.invalidate(_deviceInfoProvider(deviceId), asReload: true);
+        }
+      }
+    });
+    ref.listen(DeviceProvisioningNotifier.reprovisionMutation, (_, next) {
+      if (next is MutationSuccess) {
+        ref.invalidate(_isProvisionedProvider, asReload: true);
+        ref.invalidate(_deviceTokenPresentProvider, asReload: true);
+        if (deviceIdAsync.value case final deviceId? when deviceId.isNotEmpty) {
+          ref.invalidate(_deviceInfoProvider(deviceId), asReload: true);
+        }
+      }
+    });
+
+    return _SectionCard(
+      title: 'デバイス操作',
+      subtitle: 'サーバー登録とローカル認証情報を検証用に操作します',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              FilledButton.tonalIcon(
+                onPressed: isProcessing
+                    ? null
+                    : () {
+                        unawaited(
+                          ref
+                              .read(debugDeviceLifecycleFlowProvider)
+                              .confirmAndDelete(ref, context)
+                              .onError<Object>((_, _) {}),
+                        );
+                      },
+                style: FilledButton.styleFrom(
+                  foregroundColor: colorTheme.error,
+                ),
+                icon: const Icon(Icons.delete_outline),
+                label: const Text('削除'),
+              ),
+              FilledButton.icon(
+                onPressed: isProcessing
+                    ? null
+                    : () {
+                        unawaited(
+                          ref
+                              .read(debugDeviceLifecycleFlowProvider)
+                              .confirmAndReprovision(ref, context)
+                              .onError<Object>((_, _) {}),
+                        );
+                      },
+                icon: const Icon(Icons.sync),
+                label: const Text('再プロビジョニング'),
+              ),
+            ],
+          ),
+          if (isProcessing) ...[
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                ),
+                const SizedBox(width: 8),
+                Text(isDeleting ? 'デバイスを削除中…' : '再プロビジョニング中…'),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
 // ── OS通知許可セクション ──────────────────────────────────────────────────────
 
 class _NotificationPermissionSection extends ConsumerWidget {
@@ -420,30 +523,88 @@ Future<RegisteredDevice> _deviceInfo(Ref ref, String deviceId) async {
 
 // ── プッシュトークン同期 ────────────────────────────────────────────────────
 
-class _TokenSection extends StatelessWidget {
+class _TokenSection extends HookConsumerWidget {
   const _TokenSection({required this.syncSnapshot});
 
   final AsyncValue<PushTokenSyncSnapshot> syncSnapshot;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final snapshot = syncSnapshot.value;
+    final forceResyncMutation = ref.watch(
+      PushTokenSyncNotifier.forceResyncMutation,
+    );
+    final isForceResyncing = forceResyncMutation is MutationPending;
+    final flow = ref.read(debugDeviceLifecycleFlowProvider);
 
     return _SectionCard(
       title: 'プッシュトークン同期',
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _TokenStatusRow(label: 'FCM', kindState: snapshot?.fcm),
+          _TokenStatusRow(
+            label: 'FCM',
+            kindState: snapshot?.fcm,
+            onResend: switch (snapshot?.fcm) {
+              NotApplicableTokenState() || null => null,
+              _ => () {
+                unawaited(
+                  flow
+                      .forceResyncToken(ref, context, kind: PushTokenKind.fcm)
+                      .onError<Object>((_, _) {}),
+                );
+              },
+            },
+            isResendEnabled: switch (snapshot?.fcm) {
+              SyncingTokenState() => false,
+              _ => isForceResyncing == false,
+            },
+          ),
           const SizedBox(height: 6),
           _TokenStatusRow(
             label: 'APNs（通知）',
             kindState: snapshot?.apnsNotification,
+            onResend: switch (snapshot?.apnsNotification) {
+              NotApplicableTokenState() || null => null,
+              _ => () {
+                unawaited(
+                  flow
+                      .forceResyncToken(
+                        ref,
+                        context,
+                        kind: PushTokenKind.apnsNotification,
+                      )
+                      .onError<Object>((_, _) {}),
+                );
+              },
+            },
+            isResendEnabled: switch (snapshot?.apnsNotification) {
+              SyncingTokenState() => false,
+              _ => isForceResyncing == false,
+            },
           ),
           const SizedBox(height: 6),
           _TokenStatusRow(
             label: 'Push to Start',
             kindState: snapshot?.apnsPushToStart,
+            onResend: switch (snapshot?.apnsPushToStart) {
+              NotApplicableTokenState() || null => null,
+              _ => () {
+                unawaited(
+                  flow
+                      .forceResyncToken(
+                        ref,
+                        context,
+                        kind: PushTokenKind.apnsPushToStart,
+                      )
+                      .onError<Object>((_, _) {}),
+                );
+              },
+            },
+            isResendEnabled: switch (snapshot?.apnsPushToStart) {
+              SyncingTokenState() => false,
+              _ => isForceResyncing == false,
+            },
           ),
         ],
       ),
@@ -452,10 +613,17 @@ class _TokenSection extends StatelessWidget {
 }
 
 class _TokenStatusRow extends StatelessWidget {
-  const _TokenStatusRow({required this.label, required this.kindState});
+  const _TokenStatusRow({
+    required this.label,
+    required this.kindState,
+    required this.isResendEnabled,
+    this.onResend,
+  });
 
   final String label;
   final PushTokenKindState? kindState;
+  final bool isResendEnabled;
+  final VoidCallback? onResend;
 
   @override
   Widget build(BuildContext context) {
@@ -500,6 +668,14 @@ class _TokenStatusRow extends StatelessWidget {
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ),
+        if (onResend case final resend?) ...[
+          const SizedBox(width: 8),
+          TextButton.icon(
+            onPressed: isResendEnabled ? resend : null,
+            icon: const Icon(Icons.send_outlined, size: 16),
+            label: const Text('再送信'),
+          ),
+        ],
       ],
     );
   }

--- a/app/test/feature/devices/device_provisioning_migration_test.dart
+++ b/app/test/feature/devices/device_provisioning_migration_test.dart
@@ -105,6 +105,30 @@ void main() {
     expect(prefs.getBool(SharedPreferencesKey.deviceProvisioned.key), isTrue);
   });
 
+  test('移行済みなら legacy ID が残っていても registerDevice のみを呼ぶ', () async {
+    final (container, deviceRepo, prefs) = await buildContainer(
+      initialPrefs: {
+        SharedPreferencesKey.legacyDeviceId.key: _legacyId,
+        SharedPreferencesKey.deviceMigratedFromLegacy.key: true,
+      },
+      deviceRepo: FakeDeviceRepository(
+        getResult: () => const Success(_fakeDevice),
+        putResult: () => const Success(_fakeDevice),
+        migrateResult: () => const Success(null),
+      ),
+    );
+
+    await container.read(deviceProvisioningProvider.notifier).provision();
+
+    expect(deviceRepo.migrateCalls, 0);
+    expect(deviceRepo.putCalls, 1);
+    expect(
+      prefs.getBool(SharedPreferencesKey.deviceMigratedFromLegacy.key),
+      isTrue,
+    );
+    expect(prefs.getBool(SharedPreferencesKey.deviceProvisioned.key), isTrue);
+  });
+
   test('migrate が非再試行エラー(400)なら例外が伝播しフラグは立たない', () async {
     final (container, deviceRepo, prefs) = await buildContainer(
       initialPrefs: {SharedPreferencesKey.legacyDeviceId.key: _legacyId},

--- a/app/test/feature/devices/push_token_sync_wiring_test.dart
+++ b/app/test/feature/devices/push_token_sync_wiring_test.dart
@@ -10,6 +10,7 @@ import 'package:eqmonitor/core/provider/device_id.dart';
 import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
 import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
 import 'package:eqmonitor/feature/devices/data/model/notification_token.dart';
+import 'package:eqmonitor/feature/devices/data/model/push_token_force_resync_result.dart';
 import 'package:eqmonitor/feature/devices/data/model/push_token_platform_capabilities.dart';
 import 'package:eqmonitor/feature/devices/data/model/registered_device.dart';
 import 'package:eqmonitor/feature/devices/data/model/push_token_sync_snapshot.dart';
@@ -296,6 +297,73 @@ void main() {
       hasLength(1),
     );
   });
+
+  test('forceResync re-upserts the current stream token', () async {
+    SharedPreferences.setMockInitialValues({
+      SharedPreferencesKey.deviceProvisioned.key: true,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final harness = _createHarness(prefs: prefs);
+    addTearDown(harness.dispose);
+    await harness.start();
+
+    harness.tokens.add(const NotificationToken(fcmToken: 'same-token'));
+    await harness.waitFor((snapshot) => snapshot.fcm is SyncedTokenState);
+    final resyncCall = harness.repository.callEvents.stream.firstWhere(
+      (call) =>
+          call.kind == PushTokenKind.fcm &&
+          call.token == 'same-token' &&
+          harness.repository.calls.length == 2,
+    );
+
+    final result = await harness.container
+        .read(pushTokenSyncProvider.notifier)
+        .forceResync(kind: PushTokenKind.fcm);
+
+    await resyncCall.timeout(const Duration(seconds: 5));
+    expect(result, PushTokenForceResyncResult.started);
+    expect(harness.repository.calls, [
+      (kind: PushTokenKind.fcm, token: 'same-token'),
+      (kind: PushTokenKind.fcm, token: 'same-token'),
+    ]);
+  });
+
+  test('forceResync returns tokenAbsent when no token is available', () async {
+    SharedPreferences.setMockInitialValues({
+      SharedPreferencesKey.deviceProvisioned.key: true,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final harness = _createHarness(prefs: prefs);
+    addTearDown(harness.dispose);
+    await harness.start();
+
+    final result = await harness.container
+        .read(pushTokenSyncProvider.notifier)
+        .forceResync(kind: PushTokenKind.fcm);
+
+    expect(result, PushTokenForceResyncResult.tokenAbsent);
+    expect(harness.repository.calls, isEmpty);
+  });
+
+  test(
+    'forceResync returns notApplicable for unsupported token kind',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        SharedPreferencesKey.deviceProvisioned.key: true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final harness = _createHarness(prefs: prefs);
+      addTearDown(harness.dispose);
+      await harness.start();
+
+      final result = await harness.container
+          .read(pushTokenSyncProvider.notifier)
+          .forceResync(kind: PushTokenKind.apnsNotification);
+
+      expect(result, PushTokenForceResyncResult.notApplicable);
+      expect(harness.repository.calls, isEmpty);
+    },
+  );
 
   test(
     'in-flight auth failure after disposal uses resolved dependencies',

--- a/app/test/feature/devices/push_token_sync_worker_test.dart
+++ b/app/test/feature/devices/push_token_sync_worker_test.dart
@@ -355,6 +355,63 @@ void main() {
         expect(upserts, ['token-a', 'token-b']);
       },
     );
+
+    test('forceResync upserts again after the same token was synced', () async {
+      final upserts = <String>[];
+      final worker = PushTokenSyncWorker(
+        upsert: (token) async => upserts.add(token),
+        backoff: InterruptibleBackoff(delayOverride: (_) async {}),
+      );
+      addTearDown(worker.dispose);
+
+      worker.accept(token: 'same-token');
+      await worker.states.whereState<PushTokenSyncWorkerSynced>().first;
+      expect(upserts, ['same-token']);
+
+      final nextSynced = worker.states
+          .whereState<PushTokenSyncWorkerSynced>()
+          .first;
+      worker.forceResync();
+      await nextSynced;
+      expect(upserts, ['same-token', 'same-token']);
+    });
+
+    test('forceResync clears a non-retryable failure and upserts again', () async {
+      var calls = 0;
+      final worker = PushTokenSyncWorker(
+        upsert: (_) async {
+          calls++;
+          if (calls == 1) {
+            throw const InvalidRequestException(statusCode: 400);
+          }
+        },
+        backoff: InterruptibleBackoff(delayOverride: (_) async {}),
+      );
+      addTearDown(worker.dispose);
+
+      worker.accept(token: 'blocked-token');
+      await worker.states.whereState<PushTokenSyncWorkerFailed>().first;
+      expect(calls, 1);
+
+      final synced = worker.states.whereState<PushTokenSyncWorkerSynced>().first;
+      worker.forceResync();
+      await synced;
+      expect(calls, 2);
+    });
+
+    test('forceResync is a no-op when no token has been accepted', () async {
+      final upserts = <String>[];
+      final worker = PushTokenSyncWorker(
+        upsert: (token) async => upserts.add(token),
+        backoff: InterruptibleBackoff(delayOverride: (_) async {}),
+      );
+      addTearDown(worker.dispose);
+
+      worker.forceResync();
+      await Future<void>.delayed(Duration.zero);
+      expect(upserts, isEmpty);
+      expect(worker.state, isA<PushTokenSyncWorkerAbsent>());
+    });
   });
 }
 

--- a/docs/superpowers/plans/2026-07-20-debug-device-token-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-20-debug-device-token-lifecycle.md
@@ -1,0 +1,668 @@
+# Debug Device Token Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** デバッグ「デバイス・通知」画面に、プッシュトークン種類別の強制再送信と、デバイス削除・再プロビジョニング操作を追加する。
+
+**Architecture:** Worker に `forceResync()` を追加し、Notifier 経由で種類別に呼び出す。削除・再プロビジョンは `DeviceProvisioningNotifier` に正規 API として追加し、確認ダイアログ付き Flow から Mutation 実行する。UI は既存 `DebugDeviceSettingsPage` のみ拡張する。
+
+**Tech Stack:** Flutter / Dart, Riverpod 3 (Mutation), flutter_hooks, HookConsumerWidget
+
+## Global Constraints
+
+- 配置は既存の `DebugDeviceSettingsPage`（`/settings/debug/device-settings`）のみ。新ルート禁止
+- トークン再送信は FCM / APNs（通知） / Push to Start ごと。同期済みでも強制 upsert
+- 再プロビジョニングは「サーバー削除 → ローカルクリア → 再登録」
+- 削除単体はサーバー削除後、ローカル（Bearer / `device_provisioned`）もクリア
+- `debug_device_admin` と本番 `DeviceProvisioningBanner` は変更しない
+- Flutter / Dart コマンドは常に `mise exec --` 経由
+- `!` 禁止、top-level / クラス内プライベートメソッド禁止（既存ファイルの既存プライベートは触らない）、Widget に関数/getter 禁止
+- 依存は `flutter pub add` / `mise exec --` 経由のみ（pubspec 手編集禁止）
+- コミットメッセージ: 英語1単語 prefix + 簡潔な日本語1行。コミット後 push
+- 生成ファイル（`.g.dart`）は手編集禁止。`build_runner` で再生成
+
+## File Structure
+
+| ファイル | 責務 |
+|----------|------|
+| `app/lib/feature/devices/data/repository/push_token_sync_worker.dart` | `forceResync()` |
+| `app/lib/feature/devices/data/model/push_token_force_resync_result.dart` | 再送信結果 enum |
+| `app/lib/feature/devices/data/notifier/push_token_sync_notifier.dart` | 種類別 `forceResync` + Mutation |
+| `app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart` | `deleteDeviceAndClearLocal` / `reprovision` + Mutation |
+| `app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart` | 確認ダイアログ → Mutation → SnackBar |
+| `app/lib/feature/devices/ui/page/debug_device_settings_page.dart` | デバイス操作セクション・トークン再送信 UI |
+| `app/test/feature/devices/push_token_sync_worker_test.dart` | `forceResync` テスト追加 |
+
+---
+
+### Task 1: PushTokenSyncWorker.forceResync
+
+**Files:**
+- Modify: `app/lib/feature/devices/data/repository/push_token_sync_worker.dart`
+- Test: `app/test/feature/devices/push_token_sync_worker_test.dart`
+
+**Interfaces:**
+- Consumes: 既存 `accept` / `retry` / `InterruptibleBackoff`
+- Produces: `void forceResync()` — `_latestToken` が無い場合は no-op。ある場合は `_lastSyncedToken` / `_blockedToken` をクリアし、同一トークンでも再 upsert する
+
+- [ ] **Step 1: Write the failing tests**
+
+`app/test/feature/devices/push_token_sync_worker_test.dart` の `group('PushTokenSyncWorker')` 末尾（既存テストの後、`});` の前）に追加:
+
+```dart
+    test('forceResync upserts again after the same token was synced', () async {
+      final upserts = <String>[];
+      final worker = PushTokenSyncWorker(
+        upsert: (token) async => upserts.add(token),
+        backoff: InterruptibleBackoff(delayOverride: (_) async {}),
+      );
+      addTearDown(worker.dispose);
+
+      worker.accept(token: 'same-token');
+      await worker.states.whereState<PushTokenSyncWorkerSynced>().first;
+      expect(upserts, ['same-token']);
+
+      final nextSynced = worker.states
+          .whereState<PushTokenSyncWorkerSynced>()
+          .first;
+      worker.forceResync();
+      await nextSynced;
+      expect(upserts, ['same-token', 'same-token']);
+    });
+
+    test('forceResync clears a non-retryable failure and upserts again', () async {
+      var calls = 0;
+      final worker = PushTokenSyncWorker(
+        upsert: (_) async {
+          calls++;
+          if (calls == 1) {
+            throw const InvalidRequestException(statusCode: 400);
+          }
+        },
+        backoff: InterruptibleBackoff(delayOverride: (_) async {}),
+      );
+      addTearDown(worker.dispose);
+
+      worker.accept(token: 'blocked-token');
+      await worker.states.whereState<PushTokenSyncWorkerFailed>().first;
+      expect(calls, 1);
+
+      final synced = worker.states.whereState<PushTokenSyncWorkerSynced>().first;
+      worker.forceResync();
+      await synced;
+      expect(calls, 2);
+    });
+
+    test('forceResync is a no-op when no token has been accepted', () async {
+      final upserts = <String>[];
+      final worker = PushTokenSyncWorker(
+        upsert: (token) async => upserts.add(token),
+        backoff: InterruptibleBackoff(delayOverride: (_) async {}),
+      );
+      addTearDown(worker.dispose);
+
+      worker.forceResync();
+      await Future<void>.delayed(Duration.zero);
+      expect(upserts, isEmpty);
+      expect(worker.state, isA<PushTokenSyncWorkerAbsent>());
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd app && mise exec -- flutter test test/feature/devices/push_token_sync_worker_test.dart
+```
+
+Expected: FAIL — `forceResync` 未定義
+
+- [ ] **Step 3: Implement forceResync**
+
+`push_token_sync_worker.dart` の `retry()` の直後に追加:
+
+```dart
+  void forceResync() {
+    if (_disposed) {
+      return;
+    }
+    final token = _latestToken;
+    if (token == null || token.isEmpty) {
+      return;
+    }
+
+    _attempt = 0;
+    _blockedToken = null;
+    _lastSyncedToken = null;
+    _latestToken = null;
+    _backoff.interrupt();
+    accept(token: token);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd app && mise exec -- flutter test test/feature/devices/push_token_sync_worker_test.dart
+```
+
+Expected: PASS（全テスト）
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add app/lib/feature/devices/data/repository/push_token_sync_worker.dart \
+  app/test/feature/devices/push_token_sync_worker_test.dart
+git commit -m "$(cat <<'EOF'
+feat: PushTokenSyncWorker に forceResync を追加
+
+EOF
+)"
+git push -u origin HEAD
+```
+
+---
+
+### Task 2: PushTokenSyncNotifier.forceResync
+
+**Files:**
+- Create: `app/lib/feature/devices/data/model/push_token_force_resync_result.dart`
+- Modify: `app/lib/feature/devices/data/notifier/push_token_sync_notifier.dart`
+- Regenerate: `push_token_sync_notifier.g.dart`（必要なら）
+
+**Interfaces:**
+- Consumes: Task 1 の `PushTokenSyncWorker.forceResync()`、`notificationTokenStreamProvider`、`PushTokenKind`
+- Produces:
+  - `enum PushTokenForceResyncResult { started, tokenAbsent, notApplicable }`
+  - `Future<PushTokenForceResyncResult> forceResync({required PushTokenKind kind})`
+  - `static final forceResyncMutation = Mutation<PushTokenForceResyncResult>()`
+
+- [ ] **Step 1: Add result enum**
+
+Create `app/lib/feature/devices/data/model/push_token_force_resync_result.dart`:
+
+```dart
+enum PushTokenForceResyncResult {
+  started,
+  tokenAbsent,
+  notApplicable,
+}
+```
+
+- [ ] **Step 2: Add forceResync to notifier**
+
+`push_token_sync_notifier.dart` に import を追加し、`syncMutation` の近くに:
+
+```dart
+  static final forceResyncMutation = Mutation<PushTokenForceResyncResult>();
+```
+
+`retryFailed()` の近くにメソッドを追加:
+
+```dart
+  Future<PushTokenForceResyncResult> forceResync({
+    required PushTokenKind kind,
+  }) async {
+    final worker = switch (kind) {
+      PushTokenKind.fcm => _fcmWorker,
+      PushTokenKind.apnsNotification => _apnsNotificationWorker,
+      PushTokenKind.apnsPushToStart => _apnsPushToStartWorker,
+    };
+    if (worker == null) {
+      return PushTokenForceResyncResult.notApplicable;
+    }
+
+    final notificationToken = ref.read(notificationTokenStreamProvider).value;
+    final streamToken = switch (kind) {
+      PushTokenKind.fcm => notificationToken?.fcmToken,
+      PushTokenKind.apnsNotification => notificationToken?.apnsToken,
+      PushTokenKind.apnsPushToStart => notificationToken?.apnsPushToStartToken,
+    };
+    if (streamToken != null && streamToken.isNotEmpty) {
+      worker.accept(token: streamToken);
+      worker.forceResync();
+      return PushTokenForceResyncResult.started;
+    }
+
+    if (worker.state is PushTokenSyncWorkerAbsent ||
+        worker.state is PushTokenSyncWorkerDisposed) {
+      return PushTokenForceResyncResult.tokenAbsent;
+    }
+
+    worker.forceResync();
+    return PushTokenForceResyncResult.started;
+  }
+```
+
+必要な import:
+- `package:eqmonitor/feature/devices/data/model/push_token_force_resync_result.dart`
+- `package:eqmonitor/feature/devices/data/provider/notification_token_stream.dart`
+
+- [ ] **Step 3: Analyze**
+
+Run:
+
+```bash
+cd app && mise exec -- dart analyze lib/feature/devices/data/notifier/push_token_sync_notifier.dart \
+  lib/feature/devices/data/model/push_token_force_resync_result.dart
+```
+
+Expected: No issues
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add app/lib/feature/devices/data/model/push_token_force_resync_result.dart \
+  app/lib/feature/devices/data/notifier/push_token_sync_notifier.dart
+git commit -m "$(cat <<'EOF'
+feat: PushTokenSyncNotifier に種類別 forceResync を追加
+
+EOF
+)"
+git push
+```
+
+---
+
+### Task 3: DeviceProvisioningNotifier 削除・再プロビジョン
+
+**Files:**
+- Modify: `app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart`
+
+**Interfaces:**
+- Consumes: `DeviceRepository.deleteDevice`、`DeviceProvisioningRepository.clearProvisioned`、既存 `provision()`
+- Produces:
+  - `static final deleteMutation = Mutation<void>()`
+  - `static final reprovisionMutation = Mutation<void>()`
+  - `Future<void> deleteDeviceAndClearLocal()`
+  - `Future<void> reprovision()`
+
+- [ ] **Step 1: Add delete and reprovision methods**
+
+`device_provisioning_notifier.dart` の `provisionMutation` 付近に Mutation を追加し、`provision()` の後に:
+
+```dart
+  static final deleteMutation = Mutation<void>();
+  static final reprovisionMutation = Mutation<void>();
+
+  Future<void> deleteDeviceAndClearLocal() async {
+    final deviceRepo = await ref.read(deviceRepositoryProvider.future);
+    final provisioningRepo = await ref.read(
+      deviceProvisioningRepositoryProvider.future,
+    );
+    final deviceId = await ref.read(deviceIdProvider.future);
+
+    final result = await deviceRepo.deleteDevice(deviceId);
+    switch (result) {
+      case Success():
+        break;
+      case Failure(:final exception, :final stackTrace):
+        Error.throwWithStackTrace(
+          exception,
+          stackTrace ?? StackTrace.empty,
+        );
+    }
+
+    await provisioningRepo.clearProvisioned();
+    _retryController.reset();
+    state = const AsyncData(DeviceProvisioningStatus.required);
+    ref.invalidate(pushTokenSyncProvider, asReload: true);
+  }
+
+  Future<void> reprovision() async {
+    await deleteDeviceAndClearLocal();
+    await provision();
+  }
+```
+
+`deleteDevice` がサーバー削除 + Bearer クリア済みのため、追加で必要なのは `clearProvisioned` のみ。`Success` / `Failure` は既存の `core/foundation/result.dart` を使用。
+
+- [ ] **Step 2: Analyze**
+
+Run:
+
+```bash
+cd app && mise exec -- dart analyze lib/feature/devices/data/notifier/device_provisioning_notifier.dart
+```
+
+Expected: No issues
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add app/lib/feature/devices/data/notifier/device_provisioning_notifier.dart
+git commit -m "$(cat <<'EOF'
+feat: デバイス削除と再プロビジョニング API を Notifier に追加
+
+EOF
+)"
+git push
+```
+
+---
+
+### Task 4: Flow + Debug UI
+
+**Files:**
+- Create: `app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart`
+- Create: `app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.g.dart`（build_runner）
+- Modify: `app/lib/feature/devices/ui/page/debug_device_settings_page.dart`
+- Regenerate: `debug_device_settings_page.g.dart`（変更があれば）
+
+**Interfaces:**
+- Consumes: Task 2/3 の Mutation とメソッド、確認ダイアログ文言は仕様どおり
+- Produces: `DebugDeviceLifecycleFlow` with:
+  - `Future<void> confirmAndDelete(WidgetRef ref, BuildContext context)`
+  - `Future<void> confirmAndReprovision(WidgetRef ref, BuildContext context)`
+  - `Future<void> forceResyncToken(WidgetRef ref, BuildContext context, {required PushTokenKind kind})`
+
+- [ ] **Step 1: Create flow**
+
+Create `app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart`:
+
+```dart
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/feature/devices/data/exception/device_provisioning_exception.dart';
+import 'package:eqmonitor/feature/devices/data/model/push_token_force_resync_result.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/device_provisioning_notifier.dart';
+import 'package:eqmonitor/feature/devices/data/notifier/push_token_sync_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'debug_device_lifecycle_flow.g.dart';
+
+@riverpod
+DebugDeviceLifecycleFlow debugDeviceLifecycleFlow(Ref ref) =>
+    DebugDeviceLifecycleFlow();
+
+class DebugDeviceLifecycleFlow {
+  Future<void> confirmAndDelete(WidgetRef ref, BuildContext context) async {
+    final confirmed = await _confirm(
+      context: context,
+      title: 'デバイスを削除',
+      content: 'サーバー上のデバイスとローカル認証情報を削除します。よろしいですか？',
+      confirmLabel: '削除',
+      isDestructive: true,
+    );
+    if (!confirmed || !context.mounted) {
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await DeviceProvisioningNotifier.deleteMutation.run(
+        ref,
+        (tsx) async =>
+            tsx.get(deviceProvisioningProvider.notifier).deleteDeviceAndClearLocal(),
+      );
+      if (!context.mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        const SnackBar(content: Text('デバイスを削除しました')),
+      );
+    } on Object catch (error) {
+      if (!context.mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(_errorMessage(error)),
+          backgroundColor: context.designSystem.colorTheme.error,
+        ),
+      );
+    }
+  }
+
+  Future<void> confirmAndReprovision(
+    WidgetRef ref,
+    BuildContext context,
+  ) async {
+    final confirmed = await _confirm(
+      context: context,
+      title: '再プロビジョニング',
+      content: '削除してから再登録します。通知トークンも再同期されます。よろしいですか？',
+      confirmLabel: '実行',
+      isDestructive: true,
+    );
+    if (!confirmed || !context.mounted) {
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await DeviceProvisioningNotifier.reprovisionMutation.run(
+        ref,
+        (tsx) async =>
+            tsx.get(deviceProvisioningProvider.notifier).reprovision(),
+      );
+      if (!context.mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        const SnackBar(content: Text('再プロビジョニングが完了しました')),
+      );
+    } on Object catch (error) {
+      if (!context.mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(_errorMessage(error)),
+          backgroundColor: context.designSystem.colorTheme.error,
+        ),
+      );
+    }
+  }
+
+  Future<void> forceResyncToken(
+    WidgetRef ref,
+    BuildContext context, {
+    required PushTokenKind kind,
+  }) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final result = await PushTokenSyncNotifier.forceResyncMutation.run(
+        ref,
+        (tsx) async => tsx
+            .get(pushTokenSyncProvider.notifier)
+            .forceResync(kind: kind),
+      );
+      if (!context.mounted) {
+        return;
+      }
+      final message = switch (result) {
+        PushTokenForceResyncResult.started => '${_kindLabel(kind)} の再送信を開始しました',
+        PushTokenForceResyncResult.tokenAbsent =>
+          'トークン未取得のため再送信できません',
+        PushTokenForceResyncResult.notApplicable =>
+          '${_kindLabel(kind)} はこの端末では非対応です',
+      };
+      messenger.showSnackBar(SnackBar(content: Text(message)));
+    } on Object catch (error) {
+      if (!context.mounted) {
+        return;
+      }
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(_errorMessage(error)),
+          backgroundColor: context.designSystem.colorTheme.error,
+        ),
+      );
+    }
+  }
+
+  Future<bool> _confirm({
+    required BuildContext context,
+    required String title,
+    required String content,
+    required String confirmLabel,
+    required bool isDestructive,
+  }) async {
+    var confirmed = false;
+    await showAdaptiveDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog.adaptive(
+        title: Text(title),
+        content: Text(content),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () {
+              confirmed = true;
+              Navigator.of(dialogContext).pop();
+            },
+            style: isDestructive
+                ? TextButton.styleFrom(
+                    foregroundColor:
+                        dialogContext.designSystem.colorTheme.error,
+                  )
+                : null,
+            child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+    return confirmed;
+  }
+
+  String _errorMessage(Object error) {
+    if (error is DeviceProvisioningException) {
+      return error.userMessage;
+    }
+    return error.toString();
+  }
+
+  String _kindLabel(PushTokenKind kind) => switch (kind) {
+    PushTokenKind.fcm => 'FCM',
+    PushTokenKind.apnsNotification => 'APNs（通知）',
+    PushTokenKind.apnsPushToStart => 'Push to Start',
+  };
+}
+```
+
+注意: プロジェクト規約でクラス内プライベートメソッドは原則禁止。Flow 内の `_confirm` / `_errorMessage` / `_kindLabel` は、既存 Flow（例: ads）が短いヘルパーを持つ場合に合わせるか、インライン化すること。**実装時はプライベートメソッドを避け、確認ダイアログ用に別クラス `DebugDeviceLifecycleConfirmDialog` を同ファイルまたは別ファイルに切り出す。** `_errorMessage` / `_kindLabel` は extension または top-level 禁止のため、同ファイルの専用クラス（例: `DebugDeviceLifecycleMessages`）に置く。
+
+推奨の切り出し:
+
+```dart
+class DebugDeviceLifecycleMessages {
+  String errorMessage(Object error) { ... }
+  String kindLabel(PushTokenKind kind) { ... }
+}
+
+class DebugDeviceLifecycleConfirmDialog {
+  Future<bool> show({
+    required BuildContext context,
+    required String title,
+    required String content,
+    required String confirmLabel,
+    required bool isDestructive,
+  }) async { ... }
+}
+```
+
+Flow はこれらのクラスを保持（コンストラクタ注入可、デフォルト生成）。
+
+- [ ] **Step 2: Run build_runner for the flow**
+
+Run:
+
+```bash
+cd app && mise exec -- dart run build_runner build --delete-conflicting-outputs
+```
+
+Expected: `debug_device_lifecycle_flow.g.dart` 生成
+
+- [ ] **Step 3: Update DebugDeviceSettingsPage UI**
+
+`debug_device_settings_page.dart` の `SliverList.list` children を次の順にする:
+
+1. `_ProvisioningStartupSection`（既存）
+2. **`_DeviceLifecycleSection`（新設）**
+3. `_DeviceInfoSection`（既存）
+4. `_NotificationPermissionSection`（既存）
+5. `_TokenSection`（拡張）
+6. 以降既存どおり
+
+**`_DeviceLifecycleSection`（新設、HookConsumerWidget）:**
+
+- title: `デバイス操作`
+- `deleteMutation` / `reprovisionMutation` を watch
+- どちらか Pending なら両ボタン disabled + 進捗
+- `FilledButton.tonalIcon` 危険色相当で「削除」→ `debugDeviceLifecycleFlowProvider` の `confirmAndDelete`
+- `FilledButton.icon` 「再プロビジョニング」→ `confirmAndReprovision`
+- 削除成功後に `_deviceInfoProvider` / `_isProvisionedProvider` / `_deviceTokenPresentProvider` を invalidate
+
+**`_TokenSection` を HookConsumerWidget に変更:**
+
+- 各 `_TokenStatusRow` に再送信ボタンを渡す
+- `NotApplicableTokenState` ではボタン非表示
+- `SyncingTokenState` では disabled
+- `forceResyncMutation` Pending 時も対象行を disabled（または全行 disabled）
+- 押下で `forceResyncToken(ref, context, kind: ...)`
+
+`_TokenStatusRow` は `onResend`（`VoidCallback?`）を受け取り、非 null のときだけボタン表示。ロジックは親で組み立てる（Widget にメソッドを定義しない）。
+
+削除後の invalidate 例（Flow 成功後、またはセクション内）:
+
+```dart
+ref.invalidate(_isProvisionedProvider, asReload: true);
+ref.invalidate(_deviceTokenPresentProvider, asReload: true);
+if (deviceId.isNotEmpty) {
+  ref.invalidate(_deviceInfoProvider(deviceId), asReload: true);
+}
+```
+
+invalidate は Flow 成功直後に UI 側で行うか、Flow に deviceId を渡して行う。Flow が WidgetRef を持つので Flow 内で invalidate してよい（プライベート `@riverpod` は page ファイル内のため、**UI セクション側で invalidate** する）。
+
+- [ ] **Step 4: Analyze changed UI/flow files**
+
+Run:
+
+```bash
+cd app && mise exec -- dart analyze \
+  lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart \
+  lib/feature/devices/ui/page/debug_device_settings_page.dart
+```
+
+Expected: No issues
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.dart \
+  app/lib/feature/devices/data/flow/debug_device_lifecycle_flow.g.dart \
+  app/lib/feature/devices/ui/page/debug_device_settings_page.dart \
+  app/lib/feature/devices/ui/page/debug_device_settings_page.g.dart
+git commit -m "$(cat <<'EOF'
+feat: デバッグ画面にトークン再送信とデバイス操作を追加
+
+EOF
+)"
+git push
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec 要件 | Task |
+|-----------|------|
+| Worker `forceResync` | Task 1 |
+| Notifier 種類別 forceResync + Mutation | Task 2 |
+| 削除 + ローカルクリア | Task 3 |
+| 再プロビジョン（削除→再登録） | Task 3 |
+| 確認ダイアログ Flow | Task 4 |
+| UI: デバイス操作セクション | Task 4 |
+| UI: トークン行ごとの再送信 | Task 4 |
+| SnackBar 文言（未取得含む） | Task 4 |
+| Worker テスト | Task 1 |
+| debug_device_admin / 本番バナー非変更 | 全 Task（触らない） |

--- a/docs/superpowers/specs/2026-07-20-debug-device-token-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-20-debug-device-token-lifecycle-design.md
@@ -1,0 +1,131 @@
+# デバッグ画面: トークン再送信・デバイス削除・再プロビジョニング 設計
+
+作成日: 2026-07-20
+
+## 概要
+
+デバッグの「デバイス・通知」画面（`DebugDeviceSettingsPage`）に、プッシュトークンの送信状態と種類別の強制再送信、およびデバイス削除・再プロビジョニング操作を追加する。
+
+## 決定事項
+
+| 項目 | 内容 |
+|------|------|
+| 配置 | 既存の `DebugDeviceSettingsPage`（`/settings/debug/device-settings`）のみ |
+| トークン再送信 | FCM / APNs（通知） / Push to Start ごとにボタン。同期済みでも強制 upsert |
+| 再プロビジョニング | サーバー削除 → ローカルクリア → 再登録 |
+| 削除単体 | サーバー削除後、ローカル（Bearer / `device_provisioned`）もクリア |
+| デバイス管理画面 | 変更しない（既存導線は残す） |
+| 本番バナー | 変更しない |
+| 実装方針 | Notifier / Worker に正規 API を追加し、UI は表示と確認ダイアログに専念 |
+
+## 現状
+
+- `_TokenSection` で FCM / APNs / Push to Start の同期ステータスは表示済みだが、再送信ボタンはない
+- `PushTokenSyncWorker.accept` は同一トークンをスキップし、`_lastSyncedToken` 一致時は upsert しない
+- `retryFailed()` は `Failed`（`_blockedToken` あり）のときだけ再開する
+- 未登録時のプロビジョニングボタンはあるが、登録済みからの強制再プロビジョンはない
+- `DeviceRepository.deleteDevice` はサーバー削除 + Bearer クリアまで。`device_provisioned` はクリアしない
+- 削除 UI は `debug_device_admin` にあり、ローカルフラグは残る
+
+## 機能① プッシュトークン強制再送信
+
+### Worker
+
+`PushTokenSyncWorker` に `forceResync()` を追加する。
+
+- `_lastSyncedToken` / `_blockedToken` をクリア
+- `_attempt = 0`
+- `_latestToken` があれば、同一トークンでも再 upsert するよう再投入する
+- `_latestToken` が無い場合は no-op
+
+### Notifier
+
+`PushTokenSyncNotifier` に以下を追加する。
+
+- `forceResync({required PushTokenKind kind})`
+- `forceResyncMutation`（Riverpod 3 Mutation）
+- Worker にトークンが無い場合は、`notificationTokenStream` の最新値を `accept` してから `forceResync` する（取得できない場合は UI で「未取得」を通知）
+
+### UI
+
+`_TokenSection` を拡張する。
+
+- 各トークン行に「再送信」ボタン
+- `NotApplicable` はボタン非表示
+- `Syncing` 中は disabled
+- 結果は SnackBar（成功 / 失敗 / 未取得）
+
+## 機能② デバイス削除
+
+### Notifier
+
+`DeviceProvisioningNotifier` に `deleteDeviceAndClearLocal` を追加する。
+
+1. `DeviceRepository.deleteDevice`（既存: サーバー削除 + Bearer クリア）
+2. `DeviceProvisioningRepository.clearProvisioned()`
+3. 関連 Provider を invalidate（`deviceProvisioning` / `pushTokenSync` / デバッグ用 device info 等）
+
+結果として画面状態は「未登録」になる。
+
+### UI / Flow
+
+- 「デバイス操作」セクションに削除ボタン（危険色）
+- 確認ダイアログ: 「サーバー上のデバイスとローカル認証情報を削除します」
+- 実行中は操作ボタンを disabled + 進捗表示
+- 成否は SnackBar
+
+## 機能③ 再プロビジョニング
+
+### Notifier
+
+`DeviceProvisioningNotifier` に `reprovision` を追加する。
+
+1. 機能②と同じ削除・ローカルクリア
+2. 既存の `provision()` を実行（再登録 → `markProvisioned` → push token sync 再開）
+
+途中失敗時は SnackBar で理由を出す。ローカルは可能な範囲でクリア済みのままにし、再実行可能にする。
+
+### UI / Flow
+
+- 「デバイス操作」セクションに「再プロビジョニング」ボタン
+- 確認ダイアログ: 「削除してから再登録します。通知トークンも再同期されます」
+- 実行中は削除ボタンも含めて disabled
+
+## UI 配置順
+
+1. 起動時プロビジョニング（既存）
+2. **デバイス操作（新設）** — 削除 / 再プロビジョニング
+3. デバイス（サーバー情報）（既存・操作後に再取得）
+4. 通知許可状態（既存）
+5. **プッシュトークン同期（拡張）** — 状態 + 種類別再送信
+6. 以降は現状どおり
+
+## エラー表示
+
+- API / プロビジョン失敗: SnackBar。`userMessage` があれば優先
+- トークン未取得時の再送信: 「トークン未取得のため再送信できません」
+- 確認ダイアログキャンセル時は何もしない
+
+## テスト
+
+- `PushTokenSyncWorker.forceResync`: 同期済み同一トークンでも upsert が再実行されること
+- Failed 状態からの `forceResync` でブロック解除されること
+- 削除後に `device_provisioned == false` かつ Bearer 不在になること（Notifier 単体、可能な範囲）
+
+## スコープ外
+
+- `debug_device_admin` の改修・統合
+- 本番 `DeviceProvisioningBanner` の挙動変更
+- トークン値や同期ステータスの SharedPreferences 永続化
+- 新ルートの追加（既存 `DebugDeviceSettingsRoute` を利用）
+
+## 主な変更ファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `push_token_sync_worker.dart` | `forceResync()` |
+| `push_token_sync_notifier.dart` | 種類別 `forceResync` + Mutation |
+| `device_provisioning_notifier.dart` | `deleteDeviceAndClearLocal` / `reprovision` + Mutation |
+| `debug_device_settings_page.dart` | デバイス操作セクション・トークン再送信 UI |
+| `data/flow/debug_device_lifecycle_flow.dart` | 確認ダイアログ → Mutation → SnackBar |
+| `push_token_sync_worker_test.dart` | `forceResync` の単体テスト追加 |


### PR DESCRIPTION
## Summary
- デバッグ「デバイス・通知」画面に FCM / APNs / Push to Start の同期状態表示と種類別の強制再送信ボタンを追加
- デバイス削除（サーバー削除 + Bearer / provisioned クリア）と再プロビジョニング（削除 → 再登録）を追加
- 移行済み端末で再プロビジョン時に durable migration が再登録をスキップしないよう `wasMigratedFromLegacy` 判定を追加

## Test plan
- [ ] `/settings/debug/device-settings` でトークン各行の再送信が動き、SnackBar が出る
- [ ] NotApplicable のトークンに再送信ボタンが出ないこと
- [ ] Syncing 中は再送信が disabled であること
- [ ] 「削除」確認後、Bearer / provisioned がクリアされ未登録表示になること
- [ ] 「再プロビジョニング」確認後、再登録されトークン同期が再開すること
- [ ] 移行済み端末でも再プロビジョンが通常の `registerDevice` 経路になること
- [ ] `mise exec -- flutter test test/feature/devices/` が通ること


Made with [Cursor](https://cursor.com)