### PR TITLE
feat: 地震履歴詳細に近傍地震一覧を表示

### DIFF
--- a/app/lib/feature/earthquake_history/data/model/nearby_earthquake_query.dart
+++ b/app/lib/feature/earthquake_history/data/model/nearby_earthquake_query.dart
@@ -1,0 +1,43 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'nearby_earthquake_query.freezed.dart';
+
+@freezed
+abstract class NearbyEarthquakeQuery with _$NearbyEarthquakeQuery {
+  const factory NearbyEarthquakeQuery({
+    required String excludeEventId,
+    required double latitude,
+    required double longitude,
+    required int? depth,
+    required NearbyEarthquakeParameter parameter,
+    required EarthquakeSortBy sortBy,
+    required SortOrder sortOrder,
+  }) = _NearbyEarthquakeQuery;
+
+  const NearbyEarthquakeQuery._();
+
+  double get latitudeGte =>
+      (latitude - parameter.latitudeOffset).clamp(-90, 90).toDouble();
+
+  double get latitudeLte =>
+      (latitude + parameter.latitudeOffset).clamp(-90, 90).toDouble();
+
+  double get longitudeGte =>
+      (longitude - parameter.longitudeOffset).clamp(-180, 180).toDouble();
+
+  double get longitudeLte =>
+      (longitude + parameter.longitudeOffset).clamp(-180, 180).toDouble();
+
+  int? get depthGte => switch (depth) {
+    final int value => (value - parameter.depthOffset).clamp(0, 2000),
+    null => null,
+  };
+
+  int? get depthLte => switch (depth) {
+    final int value => (value + parameter.depthOffset).clamp(0, 2000),
+    null => null,
+  };
+}

--- a/app/lib/feature/earthquake_history/data/model/nearby_earthquake_query.freezed.dart
+++ b/app/lib/feature/earthquake_history/data/model/nearby_earthquake_query.freezed.dart
@@ -1,0 +1,307 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'nearby_earthquake_query.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$NearbyEarthquakeQuery {
+
+ String get excludeEventId; double get latitude; double get longitude; int? get depth; NearbyEarthquakeParameter get parameter; EarthquakeSortBy get sortBy; SortOrder get sortOrder;
+/// Create a copy of NearbyEarthquakeQuery
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NearbyEarthquakeQueryCopyWith<NearbyEarthquakeQuery> get copyWith => _$NearbyEarthquakeQueryCopyWithImpl<NearbyEarthquakeQuery>(this as NearbyEarthquakeQuery, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NearbyEarthquakeQuery&&(identical(other.excludeEventId, excludeEventId) || other.excludeEventId == excludeEventId)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.depth, depth) || other.depth == depth)&&(identical(other.parameter, parameter) || other.parameter == parameter)&&(identical(other.sortBy, sortBy) || other.sortBy == sortBy)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,excludeEventId,latitude,longitude,depth,parameter,sortBy,sortOrder);
+
+@override
+String toString() {
+  return 'NearbyEarthquakeQuery(excludeEventId: $excludeEventId, latitude: $latitude, longitude: $longitude, depth: $depth, parameter: $parameter, sortBy: $sortBy, sortOrder: $sortOrder)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NearbyEarthquakeQueryCopyWith<$Res>  {
+  factory $NearbyEarthquakeQueryCopyWith(NearbyEarthquakeQuery value, $Res Function(NearbyEarthquakeQuery) _then) = _$NearbyEarthquakeQueryCopyWithImpl;
+@useResult
+$Res call({
+ String excludeEventId, double latitude, double longitude, int? depth, NearbyEarthquakeParameter parameter, EarthquakeSortBy sortBy, SortOrder sortOrder
+});
+
+
+$NearbyEarthquakeParameterCopyWith<$Res> get parameter;
+
+}
+/// @nodoc
+class _$NearbyEarthquakeQueryCopyWithImpl<$Res>
+    implements $NearbyEarthquakeQueryCopyWith<$Res> {
+  _$NearbyEarthquakeQueryCopyWithImpl(this._self, this._then);
+
+  final NearbyEarthquakeQuery _self;
+  final $Res Function(NearbyEarthquakeQuery) _then;
+
+/// Create a copy of NearbyEarthquakeQuery
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? excludeEventId = null,Object? latitude = null,Object? longitude = null,Object? depth = freezed,Object? parameter = null,Object? sortBy = null,Object? sortOrder = null,}) {
+  return _then(_self.copyWith(
+excludeEventId: null == excludeEventId ? _self.excludeEventId : excludeEventId // ignore: cast_nullable_to_non_nullable
+as String,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,depth: freezed == depth ? _self.depth : depth // ignore: cast_nullable_to_non_nullable
+as int?,parameter: null == parameter ? _self.parameter : parameter // ignore: cast_nullable_to_non_nullable
+as NearbyEarthquakeParameter,sortBy: null == sortBy ? _self.sortBy : sortBy // ignore: cast_nullable_to_non_nullable
+as EarthquakeSortBy,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as SortOrder,
+  ));
+}
+/// Create a copy of NearbyEarthquakeQuery
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$NearbyEarthquakeParameterCopyWith<$Res> get parameter {
+
+  return $NearbyEarthquakeParameterCopyWith<$Res>(_self.parameter, (value) {
+    return _then(_self.copyWith(parameter: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [NearbyEarthquakeQuery].
+extension NearbyEarthquakeQueryPatterns on NearbyEarthquakeQuery {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NearbyEarthquakeQuery value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NearbyEarthquakeQuery() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NearbyEarthquakeQuery value)  $default,){
+final _that = this;
+switch (_that) {
+case _NearbyEarthquakeQuery():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NearbyEarthquakeQuery value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NearbyEarthquakeQuery() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String excludeEventId,  double latitude,  double longitude,  int? depth,  NearbyEarthquakeParameter parameter,  EarthquakeSortBy sortBy,  SortOrder sortOrder)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NearbyEarthquakeQuery() when $default != null:
+return $default(_that.excludeEventId,_that.latitude,_that.longitude,_that.depth,_that.parameter,_that.sortBy,_that.sortOrder);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String excludeEventId,  double latitude,  double longitude,  int? depth,  NearbyEarthquakeParameter parameter,  EarthquakeSortBy sortBy,  SortOrder sortOrder)  $default,) {final _that = this;
+switch (_that) {
+case _NearbyEarthquakeQuery():
+return $default(_that.excludeEventId,_that.latitude,_that.longitude,_that.depth,_that.parameter,_that.sortBy,_that.sortOrder);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String excludeEventId,  double latitude,  double longitude,  int? depth,  NearbyEarthquakeParameter parameter,  EarthquakeSortBy sortBy,  SortOrder sortOrder)?  $default,) {final _that = this;
+switch (_that) {
+case _NearbyEarthquakeQuery() when $default != null:
+return $default(_that.excludeEventId,_that.latitude,_that.longitude,_that.depth,_that.parameter,_that.sortBy,_that.sortOrder);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _NearbyEarthquakeQuery extends NearbyEarthquakeQuery {
+  const _NearbyEarthquakeQuery({required this.excludeEventId, required this.latitude, required this.longitude, required this.depth, required this.parameter, required this.sortBy, required this.sortOrder}): super._();
+
+
+@override final  String excludeEventId;
+@override final  double latitude;
+@override final  double longitude;
+@override final  int? depth;
+@override final  NearbyEarthquakeParameter parameter;
+@override final  EarthquakeSortBy sortBy;
+@override final  SortOrder sortOrder;
+
+/// Create a copy of NearbyEarthquakeQuery
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NearbyEarthquakeQueryCopyWith<_NearbyEarthquakeQuery> get copyWith => __$NearbyEarthquakeQueryCopyWithImpl<_NearbyEarthquakeQuery>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NearbyEarthquakeQuery&&(identical(other.excludeEventId, excludeEventId) || other.excludeEventId == excludeEventId)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude)&&(identical(other.depth, depth) || other.depth == depth)&&(identical(other.parameter, parameter) || other.parameter == parameter)&&(identical(other.sortBy, sortBy) || other.sortBy == sortBy)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,excludeEventId,latitude,longitude,depth,parameter,sortBy,sortOrder);
+
+@override
+String toString() {
+  return 'NearbyEarthquakeQuery(excludeEventId: $excludeEventId, latitude: $latitude, longitude: $longitude, depth: $depth, parameter: $parameter, sortBy: $sortBy, sortOrder: $sortOrder)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$NearbyEarthquakeQueryCopyWith<$Res> implements $NearbyEarthquakeQueryCopyWith<$Res> {
+  factory _$NearbyEarthquakeQueryCopyWith(_NearbyEarthquakeQuery value, $Res Function(_NearbyEarthquakeQuery) _then) = __$NearbyEarthquakeQueryCopyWithImpl;
+@override @useResult
+$Res call({
+ String excludeEventId, double latitude, double longitude, int? depth, NearbyEarthquakeParameter parameter, EarthquakeSortBy sortBy, SortOrder sortOrder
+});
+
+
+@override $NearbyEarthquakeParameterCopyWith<$Res> get parameter;
+
+}
+/// @nodoc
+class __$NearbyEarthquakeQueryCopyWithImpl<$Res>
+    implements _$NearbyEarthquakeQueryCopyWith<$Res> {
+  __$NearbyEarthquakeQueryCopyWithImpl(this._self, this._then);
+
+  final _NearbyEarthquakeQuery _self;
+  final $Res Function(_NearbyEarthquakeQuery) _then;
+
+/// Create a copy of NearbyEarthquakeQuery
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? excludeEventId = null,Object? latitude = null,Object? longitude = null,Object? depth = freezed,Object? parameter = null,Object? sortBy = null,Object? sortOrder = null,}) {
+  return _then(_NearbyEarthquakeQuery(
+excludeEventId: null == excludeEventId ? _self.excludeEventId : excludeEventId // ignore: cast_nullable_to_non_nullable
+as String,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,depth: freezed == depth ? _self.depth : depth // ignore: cast_nullable_to_non_nullable
+as int?,parameter: null == parameter ? _self.parameter : parameter // ignore: cast_nullable_to_non_nullable
+as NearbyEarthquakeParameter,sortBy: null == sortBy ? _self.sortBy : sortBy // ignore: cast_nullable_to_non_nullable
+as EarthquakeSortBy,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as SortOrder,
+  ));
+}
+
+/// Create a copy of NearbyEarthquakeQuery
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$NearbyEarthquakeParameterCopyWith<$Res> get parameter {
+
+  return $NearbyEarthquakeParameterCopyWith<$Res>(_self.parameter, (value) {
+    return _then(_self.copyWith(parameter: value));
+  });
+}
+}
+
+// dart format on

--- a/app/lib/feature/earthquake_history/data/provider/nearby_earthquakes_provider.dart
+++ b/app/lib/feature/earthquake_history/data/provider/nearby_earthquakes_provider.dart
@@ -1,0 +1,31 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_query.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'nearby_earthquakes_provider.g.dart';
+
+@riverpod
+Future<List<EarthquakePartial>> nearbyEarthquakes(
+  Ref ref,
+  NearbyEarthquakeQuery query,
+) async {
+  final repository = await ref.watch(
+    earthquakeHistoryRepositoryProvider.future,
+  );
+  final response = await repository.fetchEarthquakeList(
+    limit: 6,
+    latitudeGte: query.latitudeGte,
+    latitudeLte: query.latitudeLte,
+    longitudeGte: query.longitudeGte,
+    longitudeLte: query.longitudeLte,
+    depthGte: query.depthGte,
+    depthLte: query.depthLte,
+    sortBy: query.sortBy,
+    sortOrder: query.sortOrder,
+  );
+  return response.items
+      .where((item) => item.earthquake.eventId != query.excludeEventId)
+      .take(5)
+      .toList();
+}

--- a/app/lib/feature/earthquake_history/data/provider/nearby_earthquakes_provider.g.dart
+++ b/app/lib/feature/earthquake_history/data/provider/nearby_earthquakes_provider.g.dart
@@ -1,0 +1,93 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'nearby_earthquakes_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(nearbyEarthquakes)
+final nearbyEarthquakesProvider = NearbyEarthquakesFamily._();
+
+final class NearbyEarthquakesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<EarthquakePartial>>,
+          List<EarthquakePartial>,
+          FutureOr<List<EarthquakePartial>>
+        >
+    with
+        $FutureModifier<List<EarthquakePartial>>,
+        $FutureProvider<List<EarthquakePartial>> {
+  NearbyEarthquakesProvider._({
+    required NearbyEarthquakesFamily super.from,
+    required NearbyEarthquakeQuery super.argument,
+  }) : super(
+         retry: null,
+         name: r'nearbyEarthquakesProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$nearbyEarthquakesHash();
+
+  @override
+  String toString() {
+    return r'nearbyEarthquakesProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<EarthquakePartial>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<EarthquakePartial>> create(Ref ref) {
+    final argument = this.argument as NearbyEarthquakeQuery;
+    return nearbyEarthquakes(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is NearbyEarthquakesProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$nearbyEarthquakesHash() => r'2044f93838750351c4d1db4d627c75e4f2501cc9';
+
+final class NearbyEarthquakesFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<List<EarthquakePartial>>,
+          NearbyEarthquakeQuery
+        > {
+  NearbyEarthquakesFamily._()
+    : super(
+        retry: null,
+        name: r'nearbyEarthquakesProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  NearbyEarthquakesProvider call(NearbyEarthquakeQuery query) =>
+      NearbyEarthquakesProvider._(argument: query, from: this);
+
+  @override
+  String toString() => r'nearbyEarthquakesProvider';
+}

--- a/app/lib/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart
+++ b/app/lib/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart
@@ -1,9 +1,10 @@
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// 震源近傍の地震探索パラメータを調整する BottomSheet
-class NearbyEarthquakeParameterSheet extends StatefulWidget {
+class NearbyEarthquakeParameterSheet extends HookWidget {
   const NearbyEarthquakeParameterSheet({
     required this.initial,
     required this.hasDepth,
@@ -16,26 +17,10 @@ class NearbyEarthquakeParameterSheet extends StatefulWidget {
   final bool hasDepth;
 
   @override
-  State<NearbyEarthquakeParameterSheet> createState() =>
-      _NearbyEarthquakeParameterSheetState();
-}
-
-class _NearbyEarthquakeParameterSheetState
-    extends State<NearbyEarthquakeParameterSheet> {
-  late double _latitudeOffset;
-  late double _longitudeOffset;
-  late int _depthOffset;
-
-  @override
-  void initState() {
-    super.initState();
-    _latitudeOffset = widget.initial.latitudeOffset;
-    _longitudeOffset = widget.initial.longitudeOffset;
-    _depthOffset = widget.initial.depthOffset;
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final latitudeOffset = useState(initial.latitudeOffset);
+    final longitudeOffset = useState(initial.longitudeOffset);
+    final depthOffset = useState(initial.depthOffset);
     final theme = Theme.of(context);
 
     return SafeArea(
@@ -66,39 +51,39 @@ class _NearbyEarthquakeParameterSheetState
             const SizedBox(height: 20),
             _SliderRow(
               label: '緯度範囲',
-              value: _latitudeOffset,
+              value: latitudeOffset.value,
               min: 0.1,
               max: 3,
               divisions: 29,
-              displayText: '±${_latitudeOffset.toStringAsFixed(1)}°',
-              onChanged: (v) => setState(() => _latitudeOffset = v),
+              displayText: '±${latitudeOffset.value.toStringAsFixed(1)}°',
+              onChanged: (value) => latitudeOffset.value = value,
             ),
             _SliderRow(
               label: '経度範囲',
-              value: _longitudeOffset,
+              value: longitudeOffset.value,
               min: 0.1,
               max: 3,
               divisions: 29,
-              displayText: '±${_longitudeOffset.toStringAsFixed(1)}°',
-              onChanged: (v) => setState(() => _longitudeOffset = v),
+              displayText: '±${longitudeOffset.value.toStringAsFixed(1)}°',
+              onChanged: (value) => longitudeOffset.value = value,
             ),
-            if (widget.hasDepth)
+            if (hasDepth)
               _SliderRow(
                 label: '深さ範囲',
-                value: _depthOffset.toDouble(),
+                value: depthOffset.value.toDouble(),
                 min: 10,
                 max: 200,
                 divisions: 19,
-                displayText: '±${_depthOffset}km',
-                onChanged: (v) => setState(() => _depthOffset = v.round()),
+                displayText: '±${depthOffset.value}km',
+                onChanged: (value) => depthOffset.value = value.round(),
               ),
             const SizedBox(height: 16),
             FilledButton(
               onPressed: () => Navigator.of(context).pop(
                 NearbyEarthquakeParameter(
-                  latitudeOffset: _latitudeOffset,
-                  longitudeOffset: _longitudeOffset,
-                  depthOffset: _depthOffset,
+                  latitudeOffset: latitudeOffset.value,
+                  longitudeOffset: longitudeOffset.value,
+                  depthOffset: depthOffset.value,
                 ),
               ),
               style: FilledButton.styleFrom(

--- a/app/lib/feature/earthquake_history/ui/components/nearby_earthquake_card.dart
+++ b/app/lib/feature/earthquake_history/ui/components/nearby_earthquake_card.dart
@@ -1,0 +1,345 @@
+import 'package:eqmonitor/core/component/container/bordered_container.dart';
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/router/router.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_query.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/nearby_earthquakes_provider.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class NearbyEarthquakeCard extends HookConsumerWidget {
+  const NearbyEarthquakeCard({required this.earthquake, super.key});
+
+  final Earthquake earthquake;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final coordinates = earthquake.hypocenter?.coordinates;
+    if (coordinates is! CoordinateLatLng) {
+      return const SizedBox.shrink();
+    }
+
+    final depth = switch (earthquake.hypocenter?.depth) {
+      EarthquakeDepthShallow() => 0,
+      EarthquakeDepthValue(:final value) => value,
+      EarthquakeDepthOver700km() => 700,
+      EarthquakeDepthUnknown() || null => null,
+    };
+    final parameter = useState(const NearbyEarthquakeParameter());
+    final sortBy = useState(EarthquakeSortBy.maxIntensity);
+    final sortOrder = useState(SortOrder.desc);
+    final query = NearbyEarthquakeQuery(
+      excludeEventId: earthquake.eventId,
+      latitude: coordinates.latitude,
+      longitude: coordinates.longitude,
+      depth: depth,
+      parameter: parameter.value,
+      sortBy: sortBy.value,
+      sortOrder: sortOrder.value,
+    );
+    final searchParameter = EarthquakeHistoryParameter.all(
+      sortBy: sortBy.value,
+      sortOrder: sortOrder.value,
+      latitudeGte: query.latitudeGte,
+      latitudeLte: query.latitudeLte,
+      longitudeGte: query.longitudeGte,
+      longitudeLte: query.longitudeLte,
+      depthGte: query.depthGte,
+      depthLte: query.depthLte,
+    );
+    final state = ref.watch(nearbyEarthquakesProvider(query));
+
+    return BorderedContainer(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _NearbyEarthquakeHeader(
+            onSettingsPressed: () async {
+              final result =
+                  await showModalBottomSheet<NearbyEarthquakeParameter>(
+                    context: context,
+                    builder: (context) => NearbyEarthquakeParameterSheet(
+                      initial: parameter.value,
+                      hasDepth: depth != null,
+                    ),
+                  );
+              if (result != null) {
+                parameter.value = result;
+              }
+            },
+          ),
+          _NearbyEarthquakeParameterSummary(
+            parameter: parameter.value,
+            hasDepth: depth != null,
+          ),
+          const SizedBox(height: 8),
+          _NearbyEarthquakeSortChips(
+            sortBy: sortBy.value,
+            sortOrder: sortOrder.value,
+            onChanged: (value) {
+              if (sortBy.value == value) {
+                sortOrder.value = switch (sortOrder.value) {
+                  .asc => .desc,
+                  .desc => .asc,
+                };
+                return;
+              }
+              sortBy.value = value;
+              sortOrder.value = switch (value) {
+                .depth => .asc,
+                _ => .desc,
+              };
+            },
+          ),
+          const SizedBox(height: 8),
+          switch (state) {
+            AsyncLoading() => const _NearbyEarthquakeLoading(),
+            AsyncError() => _NearbyEarthquakeError(
+              onRetry: () => ref.invalidate(nearbyEarthquakesProvider(query)),
+            ),
+            AsyncData(:final value) when value.isEmpty =>
+              const _NearbyEarthquakeEmpty(),
+            AsyncData(:final value) => _NearbyEarthquakeList(
+              items: value.take(5).toList(),
+              searchParameter: searchParameter,
+              onShowAll: () async => EarthquakeHistoryRoute(
+                $extra: searchParameter,
+              ).push<void>(context),
+            ),
+          },
+        ],
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeHeader extends StatelessWidget {
+  const _NearbyEarthquakeHeader({required this.onSettingsPressed});
+
+  final VoidCallback onSettingsPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 4, 0),
+      child: Row(
+        children: [
+          Icon(
+            Icons.location_searching,
+            size: 18,
+            color: context.designSystem.colorTheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              'この震源の近傍で発生した地震',
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.tune, size: 20),
+            tooltip: '探索パラメータを変更',
+            visualDensity: VisualDensity.compact,
+            onPressed: onSettingsPressed,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeParameterSummary extends StatelessWidget {
+  const _NearbyEarthquakeParameterSummary({
+    required this.parameter,
+    required this.hasDepth,
+  });
+
+  final NearbyEarthquakeParameter parameter;
+  final bool hasDepth;
+
+  @override
+  Widget build(BuildContext context) {
+    final depthText = hasDepth ? '  深さ±${parameter.depthOffset}km' : '';
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Text(
+        '緯度±${parameter.latitudeOffset.toStringAsFixed(1)}°  '
+        '経度±${parameter.longitudeOffset.toStringAsFixed(1)}°$depthText',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: context.designSystem.colorTheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeSortChips extends StatelessWidget {
+  const _NearbyEarthquakeSortChips({
+    required this.sortBy,
+    required this.sortOrder,
+    required this.onChanged,
+  });
+
+  final EarthquakeSortBy sortBy;
+  final SortOrder sortOrder;
+  final ValueChanged<EarthquakeSortBy> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    const options = [
+      (EarthquakeSortBy.eventId, '発生時刻'),
+      (EarthquakeSortBy.magnitude, 'M'),
+      (EarthquakeSortBy.maxIntensity, '最大震度'),
+      (EarthquakeSortBy.depth, '深さ'),
+    ];
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 4,
+        children: [
+          for (final (value, label) in options)
+            FilterChip(
+              selected: sortBy == value,
+              showCheckmark: false,
+              label: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(label),
+                  if (sortBy == value) ...[
+                    const SizedBox(width: 2),
+                    Icon(switch (sortOrder) {
+                      .asc => Icons.arrow_upward,
+                      .desc => Icons.arrow_downward,
+                    }, size: 14),
+                  ],
+                ],
+              ),
+              onSelected: (_) => onChanged(value),
+              visualDensity: VisualDensity.compact,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeLoading extends StatelessWidget {
+  const _NearbyEarthquakeLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 16),
+        child: SizedBox.square(
+          dimension: 24,
+          child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeError extends StatelessWidget {
+  const _NearbyEarthquakeError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: [
+          const Icon(Icons.error_outline, size: 16),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '近傍の地震の取得に失敗しました',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          TextButton(onPressed: onRetry, child: const Text('再試行')),
+        ],
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeEmpty extends StatelessWidget {
+  const _NearbyEarthquakeEmpty();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+      child: Center(
+        child: Text(
+          '該当する地震がありません',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: context.designSystem.colorTheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NearbyEarthquakeList extends StatelessWidget {
+  const _NearbyEarthquakeList({
+    required this.items,
+    required this.searchParameter,
+    required this.onShowAll,
+  });
+
+  final List<EarthquakePartial> items;
+  final EarthquakeHistoryParameter searchParameter;
+  final VoidCallback onShowAll;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListView.separated(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final item = items[index];
+            return EarthquakeHistoryListTile(
+              item: item,
+              searchParameter: searchParameter,
+              onTap: () async => EarthquakeHistoryDetailsRoute(
+                eventId: item.earthquake.eventId,
+              ).push<void>(context),
+              showBackgroundColor: false,
+              intensityIconSize: 32,
+              dense: true,
+            );
+          },
+          separatorBuilder: (context, index) =>
+              const Divider(height: 1, indent: 12, endIndent: 12),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          child: TextButton(onPressed: onShowAll, child: const Text('すべて表示')),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -18,6 +18,7 @@ import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_hi
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_hypocenter_information_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_intensity_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/modal/estimated_intensity_notice_dialog.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/nearby_earthquake_card.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/shindo_db_event_notes.dart';
 import 'package:eqmonitor/feature/earthquake_history/ui/components/shindo_db_hypocenter_information_card.dart';
 import 'package:flutter/material.dart';
@@ -203,6 +204,7 @@ class _LoadedContent extends HookConsumerWidget {
                           DateTime.now().difference(earthquake.originTime!) >
                               const Duration(hours: 24))
                         const AdBanner(),
+                      NearbyEarthquakeCard(earthquake: earthquake),
                       _TelegramListButton(eventId: earthquake.eventId),
                     ],
                   ),

--- a/app/test/feature/earthquake_history/data/nearby_earthquake_query_test.dart
+++ b/app/test/feature/earthquake_history/data/nearby_earthquake_query_test.dart
@@ -1,0 +1,66 @@
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_query.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NearbyEarthquakeQuery', () {
+    test('初期値は緯度経度±0.5度と深さ±50kmに変換される', () {
+      const query = NearbyEarthquakeQuery(
+        excludeEventId: 'current',
+        latitude: 35,
+        longitude: 139,
+        depth: 40,
+        parameter: NearbyEarthquakeParameter(),
+        sortBy: EarthquakeSortBy.maxIntensity,
+        sortOrder: SortOrder.desc,
+      );
+
+      expect(query.latitudeGte, 34.5);
+      expect(query.latitudeLte, 35.5);
+      expect(query.longitudeGte, 138.5);
+      expect(query.longitudeLte, 139.5);
+      expect(query.depthGte, 0);
+      expect(query.depthLte, 90);
+    });
+
+    test('緯度経度と深さをAPIの入力範囲に丸める', () {
+      const query = NearbyEarthquakeQuery(
+        excludeEventId: 'current',
+        latitude: 89.9,
+        longitude: -179.9,
+        depth: 1950,
+        parameter: NearbyEarthquakeParameter(
+          latitudeOffset: 3,
+          longitudeOffset: 3,
+          depthOffset: 200,
+        ),
+        sortBy: EarthquakeSortBy.maxIntensity,
+        sortOrder: SortOrder.desc,
+      );
+
+      expect(query.latitudeGte, 86.9);
+      expect(query.latitudeLte, 90);
+      expect(query.longitudeGte, -180);
+      expect(query.longitudeLte, -176.9);
+      expect(query.depthGte, 1750);
+      expect(query.depthLte, 2000);
+    });
+
+    test('深さ不明なら深さ条件を作らない', () {
+      const query = NearbyEarthquakeQuery(
+        excludeEventId: 'current',
+        latitude: 35,
+        longitude: 139,
+        depth: null,
+        parameter: NearbyEarthquakeParameter(),
+        sortBy: EarthquakeSortBy.maxIntensity,
+        sortOrder: SortOrder.desc,
+      );
+
+      expect(query.depthGte, isNull);
+      expect(query.depthLte, isNull);
+    });
+  });
+}

--- a/app/test/feature/earthquake_history/data/nearby_earthquakes_provider_test.dart
+++ b/app/test/feature/earthquake_history/data/nearby_earthquakes_provider_test.dart
@@ -1,0 +1,205 @@
+import 'package:core/core.dart';
+import 'package:dio/dio.dart';
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/intensity/jma_lpgm_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart' as app;
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_search_response.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_query.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/nearby_earthquakes_provider.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/repository/earthquake_history_repository.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_metadata.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:eqmonitor/feature/parameter/data/model/shindo_db/shindo_db_stations_parameter.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test('検索範囲と並び順を渡し、自身を除外して最大5件を返す', () async {
+    final repository = _SpyEarthquakeHistoryRepository(
+      items: [
+        _earthquake('current'),
+        _earthquake('event-1'),
+        _earthquake('event-2'),
+        _earthquake('event-3'),
+        _earthquake('event-4'),
+        _earthquake('event-5'),
+      ],
+    );
+    final container = ProviderContainer(
+      overrides: [
+        earthquakeHistoryRepositoryProvider.overrideWith(
+          (ref) async => repository,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(
+      nearbyEarthquakesProvider(
+        const NearbyEarthquakeQuery(
+          excludeEventId: 'current',
+          latitude: 35,
+          longitude: 139,
+          depth: 40,
+          parameter: NearbyEarthquakeParameter(),
+          sortBy: EarthquakeSortBy.maxIntensity,
+          sortOrder: SortOrder.desc,
+        ),
+      ).future,
+    );
+
+    expect(repository.limit, 6);
+    expect(repository.latitudeGte, 34.5);
+    expect(repository.latitudeLte, 35.5);
+    expect(repository.longitudeGte, 138.5);
+    expect(repository.longitudeLte, 139.5);
+    expect(repository.depthGte, 0);
+    expect(repository.depthLte, 90);
+    expect(repository.sortBy, EarthquakeSortBy.maxIntensity);
+    expect(repository.sortOrder, SortOrder.desc);
+    expect(result.map((item) => item.earthquake.eventId), [
+      'event-1',
+      'event-2',
+      'event-3',
+      'event-4',
+      'event-5',
+    ]);
+  });
+
+  test('深さ不明ならRepositoryへ深さ条件を渡さない', () async {
+    final repository = _SpyEarthquakeHistoryRepository(items: const []);
+    final container = ProviderContainer(
+      overrides: [
+        earthquakeHistoryRepositoryProvider.overrideWith(
+          (ref) async => repository,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(
+      nearbyEarthquakesProvider(
+        const NearbyEarthquakeQuery(
+          excludeEventId: 'current',
+          latitude: 35,
+          longitude: 139,
+          depth: null,
+          parameter: NearbyEarthquakeParameter(),
+          sortBy: EarthquakeSortBy.eventId,
+          sortOrder: SortOrder.asc,
+        ),
+      ).future,
+    );
+
+    expect(repository.depthGte, isNull);
+    expect(repository.depthLte, isNull);
+  });
+}
+
+EarthquakePartialNormal _earthquake(String eventId) => EarthquakePartialNormal(
+  eventId: eventId,
+  status: app.TelegramStatus.normal,
+  originTime: null,
+  originTimePrecision: OriginTimePrecision.second,
+  arrivalTime: null,
+  dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+  hypocenter: null,
+  intensity: null,
+  earthquakeType: EarthquakeType.normal,
+  telegramTypes: const [],
+  estimatedIntensityTileUrl: null,
+);
+
+final class _SpyEarthquakeHistoryRepository
+    extends EarthquakeHistoryRepository {
+  _SpyEarthquakeHistoryRepository({required this.items})
+    : super(
+        earthquake: api.ApiClient(Dio()).earthquake,
+        earthquakeParameter: _earthquakeParameter,
+        shindoDbStations: _shindoDbStations,
+      );
+
+  final List<EarthquakePartialNormal> items;
+  int? limit;
+  int? depthGte;
+  int? depthLte;
+  double? latitudeGte;
+  double? latitudeLte;
+  double? longitudeGte;
+  double? longitudeLte;
+  EarthquakeSortBy? sortBy;
+  SortOrder? sortOrder;
+
+  @override
+  Future<PaginatedResponse<EarthquakePartial>> fetchEarthquakeList({
+    int? limit,
+    String? cursor,
+    double? magnitudeGte,
+    double? magnitudeLte,
+    int? depthGte,
+    int? depthLte,
+    JmaIntensity? intensityGte,
+    JmaIntensity? intensityLte,
+    List<app.TelegramStatus>? statuses,
+    List<int>? epicenterCodes,
+    EarthquakeType? earthquakeType,
+    EarthquakeDataSource? datasource,
+    List<EarthquakeTelegramType>? telegramTypes,
+    Date? originTimeGte,
+    Date? originTimeLte,
+    JmaLpgmIntensity? maxLpgmIntensityGte,
+    JmaLpgmIntensity? maxLpgmIntensityLte,
+    double? latitudeGte,
+    double? latitudeLte,
+    double? longitudeGte,
+    double? longitudeLte,
+    EarthquakeSortBy? sortBy,
+    SortOrder? sortOrder,
+    api.ApiClient? client,
+  }) async {
+    this.limit = limit;
+    this.depthGte = depthGte;
+    this.depthLte = depthLte;
+    this.latitudeGte = latitudeGte;
+    this.latitudeLte = latitudeLte;
+    this.longitudeGte = longitudeGte;
+    this.longitudeLte = longitudeLte;
+    this.sortBy = sortBy;
+    this.sortOrder = sortOrder;
+    return PaginatedResponse(items: items, nextToken: null);
+  }
+}
+
+const _earthquakeParameter = EarthquakeParameter(
+  metadata: ParameterMetadata(
+    type: ParameterType.jmaCodeTable,
+    schemaVersion: 1,
+    sourceVersion: 'test',
+    sourceUpdatedAt: null,
+    sourceUrls: [],
+    sha256: 'test',
+  ),
+  prefectures: [],
+);
+
+const _shindoDbStations = ShindoDbStationsParameter(
+  metadata: ParameterMetadata(
+    type: ParameterType.shindoDbStations,
+    schemaVersion: 1,
+    sourceVersion: 'test',
+    sourceUpdatedAt: null,
+    sourceUrls: [],
+    sha256: 'test',
+  ),
+  stations: [],
+);

--- a/app/test/feature/earthquake_history/ui/components/nearby_earthquake_card_test.dart
+++ b/app/test/feature/earthquake_history/ui/components/nearby_earthquake_card_test.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_sort_by.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_query.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/sort_order.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/nearby_earthquakes_provider.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/earthquake_history_list_tile.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/nearby_earthquake_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/misc.dart';
+
+void main() {
+  testWidgets('震源座標が不明ならカードを表示しない', (tester) async {
+    await _pumpCard(
+      tester,
+      earthquake: _earthquake(coordinates: const Coordinate.unknown()),
+      override: nearbyEarthquakesProvider.overrideWith(
+        (ref, query) async => const [],
+      ),
+    );
+
+    expect(find.text('この震源の近傍で発生した地震'), findsNothing);
+  });
+
+  testWidgets('取得中はカード内にインジケーターを表示する', (tester) async {
+    final completer = Completer<List<EarthquakePartial>>();
+    addTearDown(() => completer.complete(const []));
+
+    await _pumpCard(
+      tester,
+      earthquake: _earthquake(),
+      override: nearbyEarthquakesProvider.overrideWith(
+        (ref, query) => completer.future,
+      ),
+    );
+
+    expect(find.text('この震源の近傍で発生した地震'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('取得失敗時は固定文言を表示し、再試行できる', (tester) async {
+    var callCount = 0;
+
+    await _pumpCard(
+      tester,
+      earthquake: _earthquake(),
+      override: nearbyEarthquakesProvider.overrideWith((ref, query) async {
+        callCount += 1;
+        throw Exception('raw api error');
+      }),
+    );
+    await tester.pump();
+
+    expect(find.text('近傍の地震の取得に失敗しました'), findsOneWidget);
+    expect(find.textContaining('raw api error'), findsNothing);
+
+    await tester.tap(find.text('再試行'));
+    await tester.pump();
+
+    expect(callCount, 2);
+  });
+
+  testWidgets('初期条件で最大5件を表示する', (tester) async {
+    NearbyEarthquakeQuery? capturedQuery;
+
+    await _pumpCard(
+      tester,
+      earthquake: _earthquake(),
+      override: nearbyEarthquakesProvider.overrideWith((ref, query) async {
+        capturedQuery = query;
+        return List.generate(6, (index) => _partial('event-$index'));
+      }),
+    );
+    await tester.pump();
+
+    expect(find.byType(EarthquakeHistoryListTile), findsNWidgets(5));
+    expect(find.text('すべて表示'), findsOneWidget);
+    expect(
+      capturedQuery,
+      isA<NearbyEarthquakeQuery>()
+          .having((query) => query.latitude, 'latitude', 35)
+          .having((query) => query.longitude, 'longitude', 139)
+          .having((query) => query.depth, 'depth', 40)
+          .having(
+            (query) => query.sortBy,
+            'sortBy',
+            EarthquakeSortBy.maxIntensity,
+          )
+          .having((query) => query.sortOrder, 'sortOrder', SortOrder.desc),
+    );
+  });
+}
+
+Future<void> _pumpCard(
+  WidgetTester tester, {
+  required Earthquake earthquake,
+  required Override override,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [override],
+      retry: (_, _) => null,
+      child: MaterialApp(
+        theme: ThemeData.light().copyWith(
+          extensions: [DesignSystemThemeExtension.light()],
+        ),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: NearbyEarthquakeCard(earthquake: earthquake),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Earthquake _earthquake({
+  Coordinate coordinates = const Coordinate.latLng(
+    latitude: 35,
+    longitude: 139,
+  ),
+}) => Earthquake(
+  eventId: 'current',
+  status: TelegramStatus.normal,
+  originTime: DateTime.utc(2026),
+  originTimePrecision: OriginTimePrecision.second,
+  arrivalTime: null,
+  dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+  telegramTypes: const [],
+  hypocenter: EarthquakeHypocenter(
+    code: '001',
+    name: 'テスト震源',
+    coordinates: coordinates,
+    magnitude: const EarthquakeMagnitude.value(value: 4.5),
+    depth: const EarthquakeDepth.value(value: 40),
+    detailedCode: null,
+    detailedName: null,
+  ),
+  intensity: null,
+  estimatedIntensityTileUrl: null,
+);
+
+EarthquakePartialNormal _partial(String eventId) => EarthquakePartialNormal(
+  eventId: eventId,
+  status: TelegramStatus.normal,
+  originTime: DateTime.utc(2025),
+  originTimePrecision: OriginTimePrecision.second,
+  arrivalTime: null,
+  dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+  hypocenter: null,
+  intensity: null,
+  earthquakeType: EarthquakeType.normal,
+  telegramTypes: const [],
+  estimatedIntensityTileUrl: null,
+);

--- a/app/test/feature/earthquake_history/ui/components/nearby_earthquake_parameter_sheet_test.dart
+++ b/app/test/feature/earthquake_history/ui/components/nearby_earthquake_parameter_sheet_test.dart
@@ -1,0 +1,70 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/nearby_earthquake_parameter.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('初期探索範囲を表示し、適用時に値を返す', (tester) async {
+    await _pumpHost(tester);
+    final context = tester.element(find.byType(Scaffold));
+
+    final resultFuture = showModalBottomSheet<NearbyEarthquakeParameter>(
+      context: context,
+      builder: (context) => const NearbyEarthquakeParameterSheet(
+        initial: NearbyEarthquakeParameter(
+          latitudeOffset: 1.2,
+          longitudeOffset: 1.3,
+          depthOffset: 80,
+        ),
+        hasDepth: true,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('±1.2°'), findsOneWidget);
+    expect(find.text('±1.3°'), findsOneWidget);
+    expect(find.text('±80km'), findsOneWidget);
+
+    await tester.tap(find.text('適用'));
+    await tester.pumpAndSettle();
+
+    expect(
+      await resultFuture,
+      const NearbyEarthquakeParameter(
+        latitudeOffset: 1.2,
+        longitudeOffset: 1.3,
+        depthOffset: 80,
+      ),
+    );
+  });
+
+  testWidgets('深さ不明時は深さ範囲を表示しない', (tester) async {
+    await _pumpHost(tester);
+    final context = tester.element(find.byType(Scaffold));
+
+    showModalBottomSheet<NearbyEarthquakeParameter>(
+      context: context,
+      builder: (context) => const NearbyEarthquakeParameterSheet(
+        initial: NearbyEarthquakeParameter(),
+        hasDepth: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('深さ範囲'), findsNothing);
+  });
+}
+
+Future<void> _pumpHost(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(800, 1000));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData.light().copyWith(
+        extensions: [DesignSystemThemeExtension.light()],
+      ),
+      home: const Scaffold(body: SizedBox.expand()),
+    ),
+  );
+}

--- a/app/test/feature/earthquake_history/ui/earthquake_history_details_nearby_card_test.dart
+++ b/app/test/feature/earthquake_history/ui/earthquake_history_details_nearby_card_test.dart
@@ -1,0 +1,72 @@
+import 'package:eqmonitor/core/designsystem/extensions/design_system_theme_extension.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/notifier/earthquake_history_details_notifier.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/provider/nearby_earthquakes_provider.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/earthquake_history_details_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  testWidgets('詳細シートに近傍地震カードを表示する', (tester) async {
+    const eventId = 'current';
+    final earthquake = Earthquake(
+      eventId: eventId,
+      status: TelegramStatus.normal,
+      originTime: null,
+      originTimePrecision: OriginTimePrecision.second,
+      arrivalTime: null,
+      dataSources: const [EarthquakeDataSource.jmaDisasterInformationXml],
+      telegramTypes: const [],
+      hypocenter: const EarthquakeHypocenter(
+        code: '001',
+        name: 'テスト震源',
+        coordinates: Coordinate.latLng(latitude: 35, longitude: 139),
+        magnitude: EarthquakeMagnitude.value(value: 4.5),
+        depth: EarthquakeDepth.value(value: 40),
+        detailedCode: null,
+        detailedName: null,
+      ),
+      intensity: null,
+      estimatedIntensityTileUrl: null,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          earthquakeHistoryDetailsProvider(
+            eventId,
+          ).overrideWith(() => _StubDetailsNotifier(earthquake)),
+          nearbyEarthquakesProvider.overrideWith(
+            (ref, query) async => const [],
+          ),
+        ],
+        child: MaterialApp(
+          theme: ThemeData.light().copyWith(
+            extensions: [DesignSystemThemeExtension.light()],
+          ),
+          home: const EarthquakeHistoryDetailsPage(eventId: eventId),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('この震源の近傍で発生した地震'), findsOneWidget);
+  });
+}
+
+final class _StubDetailsNotifier extends EarthquakeHistoryDetailsNotifier {
+  _StubDetailsNotifier(this.earthquake);
+
+  final Earthquake earthquake;
+
+  @override
+  Future<Earthquake> build(String eventId) async => earthquake;
+}

--- a/docs/knowledge/20260720_flutter_native_assets_linux_compiler.md
+++ b/docs/knowledge/20260720_flutter_native_assets_linux_compiler.md
@@ -1,0 +1,27 @@
+# Flutter Native Assets の Linux コンパイラ要件
+
+Linux で `libserialport_plus` など Native Assets を含む依存関係を利用する場合、
+Flutter のテストや解析でもホスト上の C コンパイラが必要になる。
+
+## 症状
+
+`flutter test` などが次のエラーで失敗する。
+
+```text
+No compiler configured on host 'linux_x64'
+```
+
+## 対応
+
+Ubuntu / Debian 環境では Clang をインストールし、Flutter / Dart コマンドは
+プロジェクト規約どおり `mise exec --` 経由で実行する。
+
+```shell
+sudo apt-get update
+sudo apt-get install -y clang
+command -v clang
+mise exec -- flutter test
+```
+
+依存関係更新後にこのエラーが発生した場合は、コードの回帰と判断する前に
+コンパイラの有無を確認し、同じコミットで対象テストを再実行する。

--- a/docs/superpowers/plans/2026-07-20-nearby-earthquakes-detail-sheet.md
+++ b/docs/superpowers/plans/2026-07-20-nearby-earthquakes-detail-sheet.md
@@ -1,0 +1,250 @@
+# 地震履歴詳細シート 近傍地震一覧 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 地震履歴詳細シートに、震源位置と深さによる近傍地震を最大5件表示し、探索範囲・並び順の変更と全件表示を可能にする。
+
+**Architecture:** 検索条件を `NearbyEarthquakeQuery` に集約し、Riverpod family provider が既存 Repository の地震一覧 API を呼ぶ。UI は provider を監視するカードとして構成し、既存の `EarthquakeHistoryListTile`、探索パラメータシート、地震履歴一覧ルートを再利用する。
+
+**Tech Stack:** Flutter、Dart、Riverpod code generation、Freezed、flutter_hooks、go_router、flutter_test。
+
+## Global Constraints
+
+- Flutter / Dart コマンドは必ず `mise exec --` 経由で実行する。
+- `StatefulWidget`、`dynamic`、`Object`、null assertion (`!`) を新規利用しない。
+- Widget に関数や getter を定義せず、ロジックは Data / Provider 層へ分離する。
+- API エラーの例外文字列を UI に直接表示しない。
+- 既存 API、ルート、Preferences キーは変更しない。
+- 生成ファイルは `dart run build_runner build --delete-conflicting-outputs` で更新する。
+
+---
+
+### Task 1: 近傍地震検索条件と Provider
+
+**Files:**
+- Create: `app/lib/feature/earthquake_history/data/model/nearby_earthquake_query.dart`
+- Create: `app/lib/feature/earthquake_history/data/provider/nearby_earthquakes_provider.dart`
+- Generate: `app/lib/feature/earthquake_history/data/model/nearby_earthquake_query.freezed.dart`
+- Generate: `app/lib/feature/earthquake_history/data/provider/nearby_earthquakes_provider.g.dart`
+- Test: `app/test/feature/earthquake_history/data/nearby_earthquake_query_test.dart`
+- Test: `app/test/feature/earthquake_history/data/nearby_earthquakes_provider_test.dart`
+
+**Interfaces:**
+- Consumes: `EarthquakeHistoryRepository.fetchEarthquakeList`、`NearbyEarthquakeParameter`、`EarthquakeSortBy`、`SortOrder`。
+- Produces: `NearbyEarthquakeQuery`、`nearbyEarthquakesProvider(NearbyEarthquakeQuery query)` → `Future<List<EarthquakePartial>>`。
+
+- [ ] **Step 1: 検索範囲の失敗テストを書く**
+
+```dart
+test('初期値は緯度経度±0.5度と深さ±50kmに変換される', () {
+  const query = NearbyEarthquakeQuery(
+    excludeEventId: 'current',
+    latitude: 35,
+    longitude: 139,
+    depth: 40,
+    parameter: NearbyEarthquakeParameter(),
+    sortBy: EarthquakeSortBy.maxIntensity,
+    sortOrder: SortOrder.desc,
+  );
+  expect(query.latitudeGte, 34.5);
+  expect(query.latitudeLte, 35.5);
+  expect(query.longitudeGte, 138.5);
+  expect(query.longitudeLte, 139.5);
+  expect(query.depthGte, 0);
+  expect(query.depthLte, 90);
+});
+```
+
+極域・日付変更線・深さ上限の clamp と `depth: null` も別テストにする。
+
+- [ ] **Step 2: テストが未実装で失敗することを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/data/nearby_earthquake_query_test.dart`
+
+Expected: `NearbyEarthquakeQuery` が存在しないため FAIL。
+
+- [ ] **Step 3: 最小の query モデルと範囲 getter を実装する**
+
+```dart
+@freezed
+abstract class NearbyEarthquakeQuery with _$NearbyEarthquakeQuery {
+  const factory NearbyEarthquakeQuery({
+    required String excludeEventId,
+    required double latitude,
+    required double longitude,
+    required int? depth,
+    required NearbyEarthquakeParameter parameter,
+    required EarthquakeSortBy sortBy,
+    required SortOrder sortOrder,
+  }) = _NearbyEarthquakeQuery;
+  const NearbyEarthquakeQuery._();
+}
+```
+
+緯度 `[-90, 90]`、経度 `[-180, 180]`、深さ `[0, 2000]` の getter を追加する。
+
+- [ ] **Step 4: query テストを通す**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/data/nearby_earthquake_query_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 5: Provider の失敗テストを書く**
+
+Repository provider を override し、`limit: 6` と query の上下限・並び順が渡ること、自身を除外して最大5件になることを検証する。
+
+- [ ] **Step 6: Provider テストが未実装で失敗することを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/data/nearby_earthquakes_provider_test.dart`
+
+Expected: provider が存在しないため FAIL。
+
+- [ ] **Step 7: Provider を実装して生成する**
+
+```dart
+@riverpod
+Future<List<EarthquakePartial>> nearbyEarthquakes(
+  Ref ref,
+  NearbyEarthquakeQuery query,
+) async {
+  final repository = await ref.watch(earthquakeHistoryRepositoryProvider.future);
+  final response = await repository.fetchEarthquakeList(
+    limit: 6,
+    latitudeGte: query.latitudeGte,
+    latitudeLte: query.latitudeLte,
+    longitudeGte: query.longitudeGte,
+    longitudeLte: query.longitudeLte,
+    depthGte: query.depthGte,
+    depthLte: query.depthLte,
+    sortBy: query.sortBy,
+    sortOrder: query.sortOrder,
+  );
+  return response.items
+      .where((item) => item.eventId != query.excludeEventId)
+      .take(5)
+      .toList();
+}
+```
+
+Run: `cd app && mise exec -- dart run build_runner build --delete-conflicting-outputs`
+
+- [ ] **Step 8: Provider と query のテストを通す**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/data/nearby_earthquake_query_test.dart test/feature/earthquake_history/data/nearby_earthquakes_provider_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 9: Data 層をコミットする**
+
+```bash
+git add app/lib/feature/earthquake_history/data app/test/feature/earthquake_history/data
+git commit -m 'feat: 近傍地震の検索条件と取得処理を追加'
+```
+
+### Task 2: 近傍地震カードと探索パラメータシート
+
+**Files:**
+- Create: `app/lib/feature/earthquake_history/ui/components/nearby_earthquake_card.dart`
+- Modify: `app/lib/feature/earthquake_history/ui/components/modal/nearby_earthquake_parameter_sheet.dart`
+- Test: `app/test/feature/earthquake_history/ui/components/nearby_earthquake_card_test.dart`
+- Test: `app/test/feature/earthquake_history/ui/components/nearby_earthquake_parameter_sheet_test.dart`
+
+**Interfaces:**
+- Consumes: `nearbyEarthquakesProvider`、`EarthquakeHistoryListTile`、`EarthquakeHistoryRoute`、`EarthquakeHistoryDetailsRoute`。
+- Produces: `NearbyEarthquakeCard({required Earthquake earthquake})`。
+
+- [ ] **Step 1: カードの状態別表示の失敗テストを書く**
+
+座標不明で非表示、loading で indicator、error で固定文言と再試行、空配列で空表示、6件相当の provider 結果でも最大5タイルを検証する。Provider は `overrideWith` し、実 API は呼ばない。
+
+- [ ] **Step 2: カードテストが未実装で失敗することを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/components/nearby_earthquake_card_test.dart`
+
+Expected: `NearbyEarthquakeCard` が存在しないため FAIL。
+
+- [ ] **Step 3: カードを private Widget 群で実装する**
+
+`HookConsumerWidget` の state は `NearbyEarthquakeParameter`、`EarthquakeSortBy.maxIntensity`、`SortOrder.desc` の3つに限定する。結果一覧は `ListView.separated(shrinkWrap: true, physics: NeverScrollableScrollPhysics())` を使う。ハンドラは inline closure とし、Widget メソッドを作らない。
+
+- [ ] **Step 4: カードテストを通す**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/components/nearby_earthquake_card_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 5: パラメータシートの失敗テストを書く**
+
+初期値の表示、深さ不明時の深さスライダー非表示、「適用」で `NearbyEarthquakeParameter` を返すことを検証する。
+
+- [ ] **Step 6: 現行 StatefulWidget に対するテスト結果を確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/components/nearby_earthquake_parameter_sheet_test.dart`
+
+Expected: 挙動テストは PASS。これは HookWidget 化前の characterization test とする。
+
+- [ ] **Step 7: シートを HookWidget へ置き換える**
+
+3つの値を `useState` で保持し、既存の表示文言・範囲・戻り値を変えない。
+
+- [ ] **Step 8: UI テストを再実行する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/components/nearby_earthquake_card_test.dart test/feature/earthquake_history/ui/components/nearby_earthquake_parameter_sheet_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 9: UI をコミットする**
+
+```bash
+git add app/lib/feature/earthquake_history/ui/components app/test/feature/earthquake_history/ui/components
+git commit -m 'feat: 近傍地震カードを追加'
+```
+
+### Task 3: 詳細シート統合と最終検証
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart`
+- Modify: `app/test/feature/earthquake_history/ui/earthquake_details_source_toggle_widget_test.dart`
+
+**Interfaces:**
+- Consumes: `NearbyEarthquakeCard`。
+- Produces: 詳細シートから近傍地震一覧へ到達できる統合済み UI。
+
+- [ ] **Step 1: 詳細シート統合の失敗テストを書く**
+
+既存詳細画面テストの provider override に近傍地震 provider を加え、座標ありの地震で「この震源の近傍で発生した地震」が表示されることを検証する。
+
+- [ ] **Step 2: 統合前に失敗することを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/earthquake_details_source_toggle_widget_test.dart`
+
+Expected: 近傍地震見出しが見つからず FAIL。
+
+- [ ] **Step 3: 詳細シートへカードを配置する**
+
+`earthquake_history_details_page.dart` で `NearbyEarthquakeCard(earthquake: earthquake)` を広告の後、電文一覧ボタンの前へ追加する。
+
+- [ ] **Step 4: 統合テストを通す**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/earthquake_details_source_toggle_widget_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 5: format、analyze、関連テストを実行する**
+
+```bash
+cd app
+mise exec -- dart format lib/feature/earthquake_history test/feature/earthquake_history
+mise exec -- flutter analyze lib/feature/earthquake_history test/feature/earthquake_history
+mise exec -- flutter test test/feature/earthquake_history
+```
+
+Expected: analyze 0 issues、全テスト PASS。
+
+- [ ] **Step 6: 差分検査と統合コミットを行う**
+
+```bash
+git diff --check
+git add app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart app/test/feature/earthquake_history/ui/earthquake_details_source_toggle_widget_test.dart
+git commit -m 'feat: 地震詳細に近傍地震一覧を表示'
+```

--- a/docs/superpowers/specs/2026-07-20-nearby-earthquakes-detail-sheet-design.md
+++ b/docs/superpowers/specs/2026-07-20-nearby-earthquakes-detail-sheet-design.md
@@ -1,0 +1,112 @@
+# 地震履歴詳細シート 近傍地震一覧 設計
+
+作成日: 2026-07-20
+
+## 目的
+
+地震履歴詳細シートに、表示中の地震と震源位置・深さが近い地震を一覧表示する。利用者は過去の周辺地震を詳細シートから確認でき、必要に応じて探索範囲や並び順を変更し、既存の地震履歴一覧で全件を閲覧できる。
+
+## 調査結果と採用方針
+
+過去に次の2方式が実装されていた。
+
+1. `GET /v2/earthquake/{eventId}/similar` の独自スコアを A〜E の類似度として表示する方式
+2. 既存の `GET /v2/earthquake` に緯度・経度・深さの範囲を指定し、近傍地震を表示する方式
+
+専用 `similar` エンドポイントは現行 API クライアントに存在しない。一方、現行の `EarthquakeHistoryRepository.fetchEarthquakeList` は緯度・経度・深さ・並び順をすべて受け取れる。このため、追加のバックエンド変更が不要で、既存検索条件と結果の意味が一致する2を採用する。
+
+## 表示仕様
+
+- 詳細シートの電文一覧ボタンより前に「この震源の近傍で発生した地震」カードを表示する。
+- 初期探索範囲は震源座標から緯度 `±0.5°`、経度 `±0.5°`、震源の深さ `±50km` とする。
+- 震源座標が不明な場合はカードを表示しない。
+- 深さが「不明」の場合は深さ条件を付けず、探索パラメータシートにも深さ設定を表示しない。
+- 「ごく浅い」は `0km`、「700km以上」は `700km` を検索中心として扱う。これは過去実装と既存 API の深さ範囲表現に合わせる。
+- 表示中の地震自身は `eventId` で結果から除外する。
+- カード内には最大5件を表示する。
+- 初期並び順は「最大震度・降順」とする。
+- 並び替え項目は「発生時刻」「マグニチュード」「最大震度」「震源の深さ」。選択中の項目を再度押すと昇順・降順を切り替える。
+- 地震行は既存の `EarthquakeHistoryListTile` を再利用し、タップすると対象地震の詳細へ遷移する。
+- 「すべて表示」を押すと、現在の探索範囲と並び順を `EarthquakeHistoryParameter.all` に渡して既存の地震履歴一覧へ遷移する。
+- 設定ボタンから既存の探索パラメータシートを開き、緯度・経度・深さの範囲を変更できる。
+
+## 状態別表示
+
+- 読み込み中: カード内に小さい `CircularProgressIndicator.adaptive` を表示する。
+- 取得失敗: 詳細画面全体は維持し、カード内に短いエラー文と再試行ボタンを表示する。例外文字列は直接表示しない。
+- 0件: カード内に「該当する地震がありません」と表示する。
+- 1件以上: 最大5件と「すべて表示」を表示する。
+
+## アーキテクチャ
+
+### Data / Provider
+
+`NearbyEarthquakeQuery` を追加し、検索の入力を1つの不変オブジェクトにまとめる。
+
+- 除外対象 `eventId`
+- 中心の緯度・経度
+- 中心の深さ（不明時は `null`）
+- `NearbyEarthquakeParameter`
+- `EarthquakeSortBy`
+- `SortOrder`
+
+`nearbyEarthquakesProvider(query)` は `EarthquakeHistoryRepository.fetchEarthquakeList` を呼び、探索範囲を API 条件へ変換する。カードで5件を確実に得られるよう API には6件を要求し、自身を除外した後に先頭5件を返す。これにより、自身が取得結果に含まれた場合でも表示枠が4件に減ることを避ける。
+
+緯度は `[-90, 90]`、経度は `[-180, 180]`、深さ下限は `0` に丸め、API の入力範囲を超えないようにする。深さ上限は現行 API 契約の最大値 `2000` に丸める。
+
+### UI
+
+`NearbyEarthquakeCard` を `HookConsumerWidget` として追加する。並び順と探索パラメータのみを hooks で保持し、検索条件の組み立てや取得処理は Provider に委譲する。
+
+カード内部は責務別の private Widget に分割する。
+
+- ヘッダーと設定ボタン
+- 現在の探索範囲の要約
+- 並び替え行
+- 非同期状態表示
+- `ListView.separated` による最大5件の一覧
+
+既存の `NearbyEarthquakeParameterSheet` は今回触れる範囲で `StatefulWidget` から `HookWidget` へ変更し、既存挙動を維持しながら現行規約へ合わせる。
+
+### 遷移
+
+- 各行: `EarthquakeHistoryDetailsRoute(eventId: ...).push(context)`
+- 全件: `EarthquakeHistoryRoute($extra: EarthquakeHistoryParameter.all(...)).push(context)`
+
+新しいルートは追加しない。
+
+## データフロー
+
+1. 詳細 API から取得した `Earthquake` の震源座標と深さをカードへ渡す。
+2. カードが画面内の探索パラメータと並び順から `NearbyEarthquakeQuery` を生成する。
+3. Provider が query を緯度・経度・深さの上下限へ変換する。
+4. Repository が既存の地震一覧 API を呼び出す。
+5. Provider が表示中の `eventId` を除外し、最大5件を返す。
+6. カードが既存の地震履歴タイルとして表示する。
+
+## テスト方針
+
+- Provider テスト
+  - 初期値から緯度・経度 `±0.5°`、深さ `±50km` が Repository に渡る。
+  - 緯度・経度・深さが API 入力範囲に丸められる。
+  - 深さ不明時は深さ条件を渡さない。
+  - 表示中の `eventId` を除外する。
+  - 自身を除外した後も最大5件を返す。
+- Widget テスト
+  - 座標不明時はカードを表示しない。
+  - loading、error、empty、data の各状態を表示できる。
+  - data 状態は最大5件を表示する。
+  - 並び替え操作と再試行操作が Provider の条件に反映される。
+  - 一覧行タップと「すべて表示」の遷移条件を確認する。
+  - 探索パラメータシートが初期値を表示し、変更値を返す。
+
+## 影響範囲
+
+- `app/lib/feature/earthquake_history/data/model/`
+- `app/lib/feature/earthquake_history/data/provider/`
+- `app/lib/feature/earthquake_history/ui/components/`
+- `app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart`
+- 対応する `app/test/feature/earthquake_history/` 配下のテスト
+- Riverpod / Freezed の生成物
+
+バックエンド、API スキーマ、新規ルート、Preferences は変更しない。


### PR DESCRIPTION
## 概要

- 地震履歴詳細シートに、震源近傍で発生した地震を最大5件表示
- 緯度・経度・深さの探索範囲と並び順を調整可能
- 現在の探索条件を引き継いで地震履歴一覧へ遷移

## 実装

- 既存の `GET /v2/earthquake` の範囲検索を再利用
- 表示中の地震を結果から除外
- 座標・深さのAPI入力範囲を安全に補正
- 読み込み中・エラー・空・取得成功の各状態を表示
- 既存の探索パラメータシートを `HookWidget` に更新
- LinuxでFlutter Native Assetsを利用する際のコンパイラ要件を記録

## テスト

- `mise exec -- flutter analyze <変更した10ファイル>`
  - No issues found
- `mise exec -- flutter test test/feature/earthquake_history`
  - 196 tests passed
- `git diff --check origin/develop...HEAD`
  - 問題なし
