### PR TITLE
fix: MapLibreレイヤーのライフサイクルを修正

### DIFF
--- a/app/lib/core/util/map/map_geo_json_source_updater.dart
+++ b/app/lib/core/util/map/map_geo_json_source_updater.dart
@@ -1,0 +1,25 @@
+import 'package:maplibre/maplibre.dart';
+
+/// GeoJSON source の初期化完了待機と重複更新抑止を担う。
+class MapGeoJsonSourceUpdater {
+  String? _latestGeoJson;
+
+  Future<void> update({
+    required StyleController styleController,
+    required String sourceId,
+    required String geoJson,
+    required Future<void>? initialization,
+    required bool Function() isDisposed,
+  }) async {
+    if (initialization != null) {
+      await initialization;
+    }
+    if (isDisposed() || _latestGeoJson == geoJson) {
+      return;
+    }
+    await styleController.updateGeoJsonSource(id: sourceId, data: geoJson);
+    _latestGeoJson = geoJson;
+  }
+
+  void reset() => _latestGeoJson = null;
+}

--- a/app/lib/core/util/map/remove_map_style_resources.dart
+++ b/app/lib/core/util/map/remove_map_style_resources.dart
@@ -1,0 +1,32 @@
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:maplibre/maplibre.dart';
+
+/// MapLibre のリソースを layer → source → image の順で独立して破棄する。
+Future<void> removeMapStyleResources({
+  required StyleController styleController,
+  List<String> layerIds = const [],
+  List<String> sourceIds = const [],
+  List<String> imageIds = const [],
+}) async {
+  for (final id in layerIds) {
+    try {
+      await styleController.removeLayer(id);
+    } on Exception catch (error, stackTrace) {
+      talker.handle(error, stackTrace);
+    }
+  }
+  for (final id in sourceIds) {
+    try {
+      await styleController.removeSource(id);
+    } on Exception catch (error, stackTrace) {
+      talker.handle(error, stackTrace);
+    }
+  }
+  for (final id in imageIds) {
+    try {
+      await styleController.removeImage(id);
+    } on Exception catch (error, stackTrace) {
+      talker.handle(error, stackTrace);
+    }
+  }
+}

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_error_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_error_layer.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
-import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/util/map/hypocenter_error_range_util.dart';
+import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
@@ -35,118 +36,139 @@ class EarthquakeHistoryHypocenterErrorLayer extends HookConsumerWidget {
       EarthquakeHistoryHypocenterErrorLayerBuilder.new,
     );
 
-    final isInitialized = useRef(false);
-    final latestParameter = useRef(parameter);
-    latestParameter.value = parameter;
-    final latestEarthquake = useRef(earthquake);
-    latestEarthquake.value = earthquake;
-    final latestIsDark = useRef(isDark);
-    latestIsDark.value = isDark;
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final isLayerInitialized = useRef(false);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
+    final geoJson = const EarthquakeHistoryHypocenterErrorGeoJsonBuilder()
+        .build(
+          coordinates: earthquake.hypocenter?.coordinates,
+          decimalPlaces:
+              earthquake.telegramTypes.contains(EarthquakeTelegramType.vxse61)
+              ? 3
+              : 1,
+        );
 
     useEffect(() {
       if (styleController == null) {
         return null;
       }
 
-      unawaited(
-        enqueue(() async {
-          try {
-            final coords = latestEarthquake.value.hypocenter?.coordinates;
-            if (coords is! CoordinateLatLng) {
-              return;
-            }
-
-            final decimalPlaces =
-                latestEarthquake.value.telegramTypes.contains(
-                  EarthquakeTelegramType.vxse61,
-                )
-                ? 3
-                : 1;
-            final polygon = hypocenterErrorPolygon(
-              lat: coords.latitude,
-              lon: coords.longitude,
-              decimalPlaces: decimalPlaces,
-            );
-
-            await styleController.addSource(
-              GeoJsonSource(
-                id: EarthquakeHistoryHypocenterErrorLayerBuilder.sourceId,
-                data: jsonEncode({
-                  'type': 'FeatureCollection',
-                  'features': [
-                    {
-                      'type': 'Feature',
-                      'geometry': {
-                        'type': 'Polygon',
-                        'coordinates': [polygon],
-                      },
-                      'properties': <String, dynamic>{},
-                    },
-                  ],
-                }),
-              ),
-            );
-
-            await styleController.addLayer(
-              layerBuilder.buildLineLayer(
-                parameter: latestParameter.value,
-                isDark: latestIsDark.value,
-              ),
-            );
-
-            isInitialized.value = true;
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }),
-      );
+      final token = Object();
+      lifecycleToken.value = token;
+      isLayerInitialized.value = false;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(
+            id: EarthquakeHistoryHypocenterErrorLayerBuilder.sourceId,
+            data: '{"type":"FeatureCollection","features":[]}',
+          ),
+        );
+      });
 
       return () {
-        isInitialized.value = false;
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
         unawaited(
-          enqueue(() async {
-            try {
-              await styleController.removeLayer(
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [
                 EarthquakeHistoryHypocenterErrorLayerBuilder.layerId,
-              );
-              await styleController.removeSource(
+              ],
+              sourceIds: const [
                 EarthquakeHistoryHypocenterErrorLayerBuilder.sourceId,
-              );
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
+              ],
+            ),
+          ),
         );
       };
-    }, [styleController, earthquake, isDark, enqueue, layerBuilder]);
+    }, [styleController]);
 
     useEffect(() {
-      if (styleController == null || !isInitialized.value) {
+      final token = lifecycleToken.value;
+      final initialized = initialization.value;
+      if (styleController == null || token == null || initialized == null) {
         return null;
       }
-
       unawaited(
         enqueue(() async {
-          try {
+          await initialized;
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          if (isLayerInitialized.value) {
             await styleController.removeLayer(
               EarthquakeHistoryHypocenterErrorLayerBuilder.layerId,
             );
-            await styleController.addLayer(
-              layerBuilder.buildLineLayer(
-                parameter: parameter,
-                isDark: latestIsDark.value,
-              ),
-            );
-          } on Exception catch (e) {
-            talker.log(e);
           }
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          await styleController.addLayer(
+            layerBuilder.buildLineLayer(parameter: parameter, isDark: isDark),
+          );
+          isLayerInitialized.value = true;
         }),
       );
-
       return null;
-    }, [styleController, parameter, enqueue, layerBuilder]);
+    }, [styleController, parameter, isDark]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: EarthquakeHistoryHypocenterErrorLayerBuilder.sourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
+      return null;
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
+  }
+}
+
+class EarthquakeHistoryHypocenterErrorGeoJsonBuilder {
+  const EarthquakeHistoryHypocenterErrorGeoJsonBuilder();
+
+  String build({required Coordinate? coordinates, required int decimalPlaces}) {
+    final polygon = switch (coordinates) {
+      CoordinateLatLng() => hypocenterErrorPolygon(
+        lat: coordinates.latitude,
+        lon: coordinates.longitude,
+        decimalPlaces: decimalPlaces,
+      ),
+      _ => null,
+    };
+    return jsonEncode({
+      'type': 'FeatureCollection',
+      'features': <Map<String, dynamic>>[
+        if (polygon != null)
+          {
+            'type': 'Feature',
+            'geometry': {
+              'type': 'Polygon',
+              'coordinates': [polygon],
+            },
+            'properties': <String, dynamic>{},
+          },
+      ],
+    });
   }
 }
 

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_layer.dart
@@ -3,7 +3,8 @@ import 'dart:convert';
 
 import 'package:eqmonitor/core/gen/assets.gen.dart';
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
-import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
@@ -36,113 +37,134 @@ class EarthquakeHistoryHypocenterLayer extends HookConsumerWidget {
     final layerBuilder = useMemoized(
       EarthquakeHistoryHypocenterLayerBuilder.new,
     );
-
-    final isInitialized = useRef(false);
-    final latestParameter = useRef(parameter);
-    latestParameter.value = parameter;
-    final latestEarthquake = useRef(earthquake);
-    latestEarthquake.value = earthquake;
-    final latestDisplayMode = useRef(displayMode);
-    latestDisplayMode.value = displayMode;
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final isLayerInitialized = useRef(false);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
+    final geoJson = const EarthquakeHistoryHypocenterGeoJsonBuilder().build(
+      coordinates: earthquake.hypocenter?.coordinates,
+    );
 
     useEffect(() {
       if (styleController == null) {
         return null;
       }
 
-      unawaited(
-        enqueue(() async {
-          try {
-            await styleController.addImageFromAssets(
-              id: EarthquakeHistoryHypocenterLayerBuilder.iconId,
-              asset: Assets.images.map.normalHypocenter.path,
-            );
-
-            final hyp = latestEarthquake.value.hypocenter;
-            final coords = hyp?.coordinates;
-            final features = <Map<String, dynamic>>[
-              if (coords is CoordinateLatLng)
-                {
-                  'type': 'Feature',
-                  'geometry': {
-                    'type': 'Point',
-                    'coordinates': [coords.longitude, coords.latitude],
-                  },
-                  'properties': <String, dynamic>{},
-                },
-            ];
-
-            await styleController.addSource(
-              GeoJsonSource(
-                id: EarthquakeHistoryHypocenterLayerBuilder.sourceId,
-                data: jsonEncode({
-                  'type': 'FeatureCollection',
-                  'features': features,
-                }),
-              ),
-            );
-
-            await styleController.addLayer(
-              layerBuilder.buildSymbolLayer(
-                parameter: latestParameter.value,
-                displayMode: latestDisplayMode.value,
-              ),
-            );
-
-            isInitialized.value = true;
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }),
-      );
+      final token = Object();
+      lifecycleToken.value = token;
+      isLayerInitialized.value = false;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addImageFromAssets(
+          id: EarthquakeHistoryHypocenterLayerBuilder.iconId,
+          asset: Assets.images.map.normalHypocenter.path,
+        );
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(
+            id: EarthquakeHistoryHypocenterLayerBuilder.sourceId,
+            data: '{"type":"FeatureCollection","features":[]}',
+          ),
+        );
+      });
 
       return () {
-        isInitialized.value = false;
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
         unawaited(
-          enqueue(() async {
-            try {
-              await styleController.removeLayer(
-                EarthquakeHistoryHypocenterLayerBuilder.layerId,
-              );
-              await styleController.removeSource(
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [EarthquakeHistoryHypocenterLayerBuilder.layerId],
+              sourceIds: const [
                 EarthquakeHistoryHypocenterLayerBuilder.sourceId,
-              );
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
+              ],
+              imageIds: const [EarthquakeHistoryHypocenterLayerBuilder.iconId],
+            ),
+          ),
         );
       };
-    }, [styleController, earthquake, displayMode, enqueue, layerBuilder]);
+    }, [styleController]);
 
     useEffect(() {
-      if (styleController == null || !isInitialized.value) {
+      final token = lifecycleToken.value;
+      final initialized = initialization.value;
+      if (styleController == null || token == null || initialized == null) {
         return null;
       }
-
       unawaited(
         enqueue(() async {
-          try {
+          await initialized;
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          if (isLayerInitialized.value) {
             await styleController.removeLayer(
               EarthquakeHistoryHypocenterLayerBuilder.layerId,
             );
-            await styleController.addLayer(
-              layerBuilder.buildSymbolLayer(
-                parameter: parameter,
-                displayMode: latestDisplayMode.value,
-              ),
-            );
-          } on Exception catch (e) {
-            talker.log(e);
           }
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          await styleController.addLayer(
+            layerBuilder.buildSymbolLayer(
+              parameter: parameter,
+              displayMode: displayMode,
+            ),
+          );
+          isLayerInitialized.value = true;
         }),
       );
-
       return null;
-    }, [styleController, parameter, enqueue, layerBuilder]);
+    }, [styleController, parameter, displayMode]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: EarthquakeHistoryHypocenterLayerBuilder.sourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
+      return null;
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
   }
+}
+
+class EarthquakeHistoryHypocenterGeoJsonBuilder {
+  const EarthquakeHistoryHypocenterGeoJsonBuilder();
+
+  String build({required Coordinate? coordinates}) => jsonEncode({
+    'type': 'FeatureCollection',
+    'features': <Map<String, dynamic>>[
+      if (coordinates is CoordinateLatLng)
+        {
+          'type': 'Feature',
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [coordinates.longitude, coordinates.latitude],
+          },
+          'properties': <String, dynamic>{},
+        },
+    ],
+  });
 }
 
 class EarthquakeHistoryHypocenterLayerBuilder {

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
-import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_class.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
@@ -24,8 +25,8 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
   final ShindoDbIntensityTree tree;
   final EarthquakeHistoryMapLayerParameter parameter;
 
-  static const _sourceId = 'eq-history-shindo-db-station';
-  static const _iconLayerId = 'eq-history-shindo-db-station-icon';
+  static const sourceId = 'eq-history-shindo-db-station';
+  static const iconLayerId = 'eq-history-shindo-db-station-icon';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -33,90 +34,148 @@ class EarthquakeHistoryShindoDbStationLayer extends HookConsumerWidget {
     final iconData = ref.watch(intensityIconProvider).value;
     final dbIconData = ref.watch(shindoDbIntensityIconProvider).value;
     final enqueue = useMapOperationQueue();
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final isLayerInitialized = useRef(false);
+    final imagesAdded = useRef(false);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
+    final geoJson = const EarthquakeHistoryShindoDbStationGeoJsonBuilder()
+        .build(tree: tree);
 
     useEffect(() {
-      if (styleController == null || iconData == null || dbIconData == null) {
+      if (styleController == null) {
         return null;
       }
+      final token = Object();
+      lifecycleToken.value = token;
+      isLayerInitialized.value = false;
+      imagesAdded.value = false;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(
+            id: sourceId,
+            data: '{"type":"FeatureCollection","features":[]}',
+          ),
+        );
+      });
 
-      var disposed = false;
+      return () {
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
+        unawaited(
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [iconLayerId],
+              sourceIds: const [sourceId],
+            ),
+          ),
+        );
+      };
+    }, [styleController]);
 
+    useEffect(() {
+      final token = lifecycleToken.value;
+      final initialized = initialization.value;
+      if (styleController == null ||
+          token == null ||
+          initialized == null ||
+          iconData == null ||
+          dbIconData == null) {
+        return null;
+      }
       unawaited(
         enqueue(() async {
-          try {
-            final geoJson = _buildGeoJson(tree);
-
-            if (disposed) {
-              return;
-            }
-            await styleController.addSource(
-              GeoJsonSource(id: _sourceId, data: geoJson),
-            );
-
-            if (disposed) {
-              return;
-            }
+          await initialized;
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          if (!imagesAdded.value) {
             await styleController.addImages({
               ...iconData.toMapStyleImages,
               ...dbIconData.toMapStyleImages,
             });
-
-            if (disposed) {
-              return;
-            }
-            await styleController.addLayer(
-              SymbolStyleLayer(
-                id: _iconLayerId,
-                sourceId: _sourceId,
-                minZoom: parameter.stationMinZoom,
-                layout: {
-                  'icon-image': ['get', 'iconId'],
-                  'icon-allow-overlap': true,
-                  'icon-ignore-placement': true,
-                  'symbol-sort-key': ['get', 'sortKey'],
-                  'icon-size': [
-                    'interpolate',
-                    ['linear'],
-                    ['zoom'],
-                    3,
-                    parameter.stationIconSizeMin,
-                    7,
-                    parameter.stationIconSizeMid,
-                    20,
-                    parameter.stationIconSizeMax,
-                  ],
-                },
-              ),
-            );
-          } on Exception catch (e) {
-            talker.log(e);
+            imagesAdded.value = true;
           }
+          if (isLayerInitialized.value) {
+            await styleController.removeLayer(iconLayerId);
+          }
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          await styleController.addLayer(
+            EarthquakeHistoryShindoDbStationLayerBuilder.build(
+              parameter: parameter,
+            ),
+          );
+          isLayerInitialized.value = true;
         }),
       );
+      return null;
+    }, [styleController, parameter, iconData, dbIconData]);
 
-      return () {
-        disposed = true;
-        unawaited(
-          enqueue(() async {
-            try {
-              await styleController.removeLayer(_iconLayerId);
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-            try {
-              await styleController.removeSource(_sourceId);
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
-        );
-      };
-    }, [styleController, tree, parameter, iconData, dbIconData]);
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: sourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
+      return null;
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
   }
+}
 
-  static String _buildGeoJson(ShindoDbIntensityTree tree) {
+class EarthquakeHistoryShindoDbStationLayerBuilder {
+  const EarthquakeHistoryShindoDbStationLayerBuilder._();
+
+  static SymbolStyleLayer build({
+    required EarthquakeHistoryMapLayerParameter parameter,
+  }) => SymbolStyleLayer(
+    id: EarthquakeHistoryShindoDbStationLayer.iconLayerId,
+    sourceId: EarthquakeHistoryShindoDbStationLayer.sourceId,
+    minZoom: parameter.stationMinZoom,
+    layout: {
+      'icon-image': ['get', 'iconId'],
+      'icon-allow-overlap': true,
+      'icon-ignore-placement': true,
+      'symbol-sort-key': ['get', 'sortKey'],
+      'icon-size': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        3,
+        parameter.stationIconSizeMin,
+        7,
+        parameter.stationIconSizeMid,
+        20,
+        parameter.stationIconSizeMax,
+      ],
+    },
+  );
+}
+
+class EarthquakeHistoryShindoDbStationGeoJsonBuilder {
+  const EarthquakeHistoryShindoDbStationGeoJsonBuilder();
+
+  String build({required ShindoDbIntensityTree tree}) {
     final features = <Map<String, dynamic>>[];
 
     void addStation(ShindoDbStationNode station, ShindoDbIntensityClass cls) {

--- a/app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart
+++ b/app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart
@@ -2,10 +2,11 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
-import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/theme/model/intensity_colors.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/core/util/converter/color_converter.dart';
+import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
 import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_map_layer_parameter.dart';
@@ -37,12 +38,6 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
   final bool showStationLabel;
   final bool showingLpgmIntensity;
 
-  static const _iconSmallPrefix = 'JmaIntensity.small.';
-  static const _iconSmallNoTextPrefix = 'JmaIntensity.smallWithoutText.';
-  static const _lpgmIconSmallPrefix = 'JmaLpgmIntensity.small.';
-  static const _lpgmIconSmallNoTextPrefix =
-      'JmaLpgmIntensity.smallWithoutText.';
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final intensity = earthquake.intensity;
@@ -54,213 +49,263 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
     final layerBuilder = useMemoized(
       EarthquakeHistoryStationIntensityLayerBuilder.new,
     );
+    final geoJsonBuilder = useMemoized(
+      EarthquakeHistoryStationGeoJsonBuilder.new,
+    );
 
-    final isInitialized = useRef(false);
-    final iconLayerAdded = useRef(false);
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final imagesAdded = useRef(false);
+    final latestLayerConfiguration = useRef<Object?>(null);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
     final latestParameter = useRef(parameter);
     latestParameter.value = parameter;
-    final latestIntensity = useRef(intensity);
-    latestIntensity.value = intensity;
-    final latestColorModel = useRef(colorModel);
-    latestColorModel.value = colorModel;
     final latestStationDisplayMode = useRef(stationDisplayMode);
     latestStationDisplayMode.value = stationDisplayMode;
     final latestShowStationLabel = useRef(showStationLabel);
     latestShowStationLabel.value = showStationLabel;
-    final latestShowingLpgmIntensity = useRef(showingLpgmIntensity);
-    latestShowingLpgmIntensity.value = showingLpgmIntensity;
     final latestIconData = useRef(iconData);
     latestIconData.value = iconData;
-
-    useEffect(
-      () {
-        if (styleController == null || intensity == null) {
-          return null;
-        }
-
-        final currentIntensity = intensity;
-
-        unawaited(
-          enqueue(() async {
-            try {
-              final geoJson = latestShowingLpgmIntensity.value
-                  ? _buildLpgmGeoJson(
-                      currentIntensity,
-                      latestColorModel.value,
-                      latestStationDisplayMode.value,
-                    )
-                  : _buildGeoJson(
-                      currentIntensity,
-                      latestColorModel.value,
-                      latestStationDisplayMode.value,
-                    );
-
-              await styleController.addSource(
-                GeoJsonSource(
-                  id: EarthquakeHistoryStationIntensityLayerBuilder.sourceId,
-                  data: geoJson,
-                ),
-              );
-
-              final cachedBytes = latestIconData.value?.toMapStyleImages;
-              if (cachedBytes != null) {
-                await styleController.addImages(cachedBytes);
-              }
-
-              await styleController.addLayer(
-                layerBuilder.buildCircleLayer(
-                  parameter: latestParameter.value,
-                  stationDisplayMode: latestStationDisplayMode.value,
-                ),
-              );
-
-              if (latestIconData.value != null) {
-                await styleController.addLayer(
-                  layerBuilder.buildIconLayer(parameter: latestParameter.value),
-                );
-                iconLayerAdded.value = true;
-              }
-
-              if (latestShowStationLabel.value) {
-                await styleController.addLayer(
-                  layerBuilder.buildLabelLayer(parameter: latestParameter.value),
-                );
-              }
-
-              isInitialized.value = true;
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
-        );
-
-        return () {
-          isInitialized.value = false;
-          unawaited(
-            enqueue(() async {
-              try {
-                if (latestShowStationLabel.value) {
-                  await styleController.removeLayer(
-                    EarthquakeHistoryStationIntensityLayerBuilder.labelLayerId,
-                  );
-                }
-                if (iconLayerAdded.value) {
-                  await styleController.removeLayer(
-                    EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
-                  );
-                  iconLayerAdded.value = false;
-                }
-                await styleController.removeLayer(
-                  EarthquakeHistoryStationIntensityLayerBuilder.circleLayerId,
-                );
-                await styleController.removeSource(
-                  EarthquakeHistoryStationIntensityLayerBuilder.sourceId,
-                );
-              } on Exception catch (e) {
-                talker.log(e);
-              }
-            }),
-          );
-        };
-      },
-      [
-        styleController,
-        intensity,
-        colorModel,
-        stationDisplayMode,
-        showStationLabel,
-        showingLpgmIntensity,
-        iconData,
-        enqueue,
-        layerBuilder,
-      ],
+    final geoJson = geoJsonBuilder.build(
+      intensity: intensity,
+      colorModel: colorModel,
+      stationDisplayMode: stationDisplayMode,
+      showingLpgmIntensity: showingLpgmIntensity,
     );
 
     useEffect(() {
-      if (styleController == null ||
-          !isInitialized.value ||
-          latestIntensity.value == null) {
+      if (styleController == null) {
         return null;
       }
+      final token = Object();
+      lifecycleToken.value = token;
+      imagesAdded.value = false;
+      latestLayerConfiguration.value = null;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(
+            id: EarthquakeHistoryStationIntensityLayerBuilder.sourceId,
+            data: '{"type":"FeatureCollection","features":[]}',
+          ),
+        );
+        final cachedBytes = latestIconData.value?.toMapStyleImages;
+        if (cachedBytes != null && lifecycleToken.value == token) {
+          await styleController.addImages(cachedBytes);
+          imagesAdded.value = true;
+        }
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addLayer(
+          layerBuilder.buildCircleLayer(
+            parameter: latestParameter.value,
+            stationDisplayMode: latestStationDisplayMode.value,
+          ),
+        );
+        if (latestIconData.value != null) {
+          await styleController.addLayer(
+            layerBuilder.buildIconLayer(parameter: latestParameter.value),
+          );
+        }
+        if (latestShowStationLabel.value) {
+          await styleController.addLayer(
+            layerBuilder.buildLabelLayer(parameter: latestParameter.value),
+          );
+        }
+        latestLayerConfiguration.value = (
+          parameter: latestParameter.value,
+          stationDisplayMode: latestStationDisplayMode.value,
+          showStationLabel: latestShowStationLabel.value,
+          hasIcon: latestIconData.value != null,
+        );
+      });
 
+      return () {
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
+        unawaited(
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [
+                EarthquakeHistoryStationIntensityLayerBuilder.labelLayerId,
+                EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
+                EarthquakeHistoryStationIntensityLayerBuilder.circleLayerId,
+              ],
+              sourceIds: const [
+                EarthquakeHistoryStationIntensityLayerBuilder.sourceId,
+              ],
+            ),
+          ),
+        );
+      };
+    }, [styleController]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      final initialized = initialization.value;
+      if (styleController == null ||
+          token == null ||
+          initialized == null ||
+          iconData == null) {
+        return null;
+      }
       unawaited(
         enqueue(() async {
-          try {
-            if (latestShowStationLabel.value) {
-              await styleController.removeLayer(
-                EarthquakeHistoryStationIntensityLayerBuilder.labelLayerId,
-              );
-            }
-            if (iconLayerAdded.value) {
-              await styleController.removeLayer(
-                EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
-              );
-            }
-            await styleController.removeLayer(
-              EarthquakeHistoryStationIntensityLayerBuilder.circleLayerId,
-            );
+          await initialized;
+          if (lifecycleToken.value != token || imagesAdded.value) {
+            return;
+          }
+          await styleController.addImages(iconData.toMapStyleImages);
+          imagesAdded.value = true;
+        }),
+      );
+      return null;
+    }, [styleController, iconData]);
 
+    useEffect(
+      () {
+        final token = lifecycleToken.value;
+        final initialized = initialization.value;
+        if (styleController == null || token == null || initialized == null) {
+          return null;
+        }
+        final configuration = (
+          parameter: parameter,
+          stationDisplayMode: stationDisplayMode,
+          showStationLabel: showStationLabel,
+          hasIcon: iconData != null,
+        );
+        unawaited(
+          enqueue(() async {
+            await initialized;
+            if (lifecycleToken.value != token ||
+                latestLayerConfiguration.value == configuration) {
+              return;
+            }
+            await removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [
+                EarthquakeHistoryStationIntensityLayerBuilder.labelLayerId,
+                EarthquakeHistoryStationIntensityLayerBuilder.iconLayerId,
+                EarthquakeHistoryStationIntensityLayerBuilder.circleLayerId,
+              ],
+            );
+            if (lifecycleToken.value != token) {
+              return;
+            }
             await styleController.addLayer(
               layerBuilder.buildCircleLayer(
                 parameter: parameter,
-                stationDisplayMode: latestStationDisplayMode.value,
+                stationDisplayMode: stationDisplayMode,
               ),
             );
-
-            if (latestIconData.value != null) {
+            if (iconData != null) {
               await styleController.addLayer(
                 layerBuilder.buildIconLayer(parameter: parameter),
               );
-              iconLayerAdded.value = true;
-            } else {
-              iconLayerAdded.value = false;
             }
-
-            if (latestShowStationLabel.value) {
+            if (showStationLabel) {
               await styleController.addLayer(
                 layerBuilder.buildLabelLayer(parameter: parameter),
               );
             }
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }),
-      );
+            latestLayerConfiguration.value = configuration;
+          }),
+        );
+        return null;
+      },
+      [
+        styleController,
+        parameter,
+        stationDisplayMode,
+        showStationLabel,
+        iconData,
+      ],
+    );
 
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: EarthquakeHistoryStationIntensityLayerBuilder.sourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
       return null;
-    }, [styleController, parameter, enqueue, layerBuilder]);
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
   }
+}
 
-  String _iconIdForStation(
-    String intensityName,
-    bool isFocused,
-    StationDisplayMode stationDisplayMode,
-  ) {
+class EarthquakeHistoryStationGeoJsonBuilder {
+  const EarthquakeHistoryStationGeoJsonBuilder();
+
+  static const iconSmallPrefix = 'JmaIntensity.small.';
+  static const iconSmallNoTextPrefix = 'JmaIntensity.smallWithoutText.';
+  static const lpgmIconSmallPrefix = 'JmaLpgmIntensity.small.';
+  static const lpgmIconSmallNoTextPrefix = 'JmaLpgmIntensity.smallWithoutText.';
+
+  String build({
+    required EarthquakeIntensity? intensity,
+    required IntensityColors colorModel,
+    required StationDisplayMode stationDisplayMode,
+    required bool showingLpgmIntensity,
+  }) => showingLpgmIntensity
+      ? buildLpgmGeoJson(
+          intensity: intensity,
+          colorModel: colorModel,
+          stationDisplayMode: stationDisplayMode,
+        )
+      : buildJmaGeoJson(
+          intensity: intensity,
+          colorModel: colorModel,
+          stationDisplayMode: stationDisplayMode,
+        );
+
+  String iconIdForStation({
+    required String intensityName,
+    required bool isFocused,
+    required StationDisplayMode stationDisplayMode,
+  }) {
     final useSmall = switch (stationDisplayMode) {
       StationDisplayMode.normal => true,
       StationDisplayMode.maxFocused => isFocused,
       StationDisplayMode.allMinimized => false,
     };
-    final prefix = useSmall ? _iconSmallPrefix : _iconSmallNoTextPrefix;
+    final prefix = useSmall ? iconSmallPrefix : iconSmallNoTextPrefix;
     return '$prefix$intensityName';
   }
 
-  String _lpgmIconIdForStation(
-    String lpgmName,
-    StationDisplayMode stationDisplayMode,
-  ) {
+  String lpgmIconIdForStation({
+    required String lpgmName,
+    required StationDisplayMode stationDisplayMode,
+  }) {
     final useSmall = stationDisplayMode != StationDisplayMode.allMinimized;
-    final prefix = useSmall ? _lpgmIconSmallPrefix : _lpgmIconSmallNoTextPrefix;
+    final prefix = useSmall ? lpgmIconSmallPrefix : lpgmIconSmallNoTextPrefix;
     return '$prefix$lpgmName';
   }
 
-  String _buildGeoJson(
-    EarthquakeIntensity? intensity,
-    IntensityColors colorModel,
-    StationDisplayMode stationDisplayMode,
-  ) {
+  String buildJmaGeoJson({
+    required EarthquakeIntensity? intensity,
+    required IntensityColors colorModel,
+    required StationDisplayMode stationDisplayMode,
+  }) {
     if (intensity == null) {
       return jsonEncode({'type': 'FeatureCollection', 'features': <dynamic>[]});
     }
@@ -279,10 +324,10 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
                 .background
                 .toHexStringRGB();
             final isFocused = intensity.maxIntensity == jmaIntensity;
-            final iconId = _iconIdForStation(
-              jmaIntensity.name,
-              isFocused,
-              stationDisplayMode,
+            final iconId = iconIdForStation(
+              intensityName: jmaIntensity.name,
+              isFocused: isFocused,
+              stationDisplayMode: stationDisplayMode,
             );
             final station = stationNode.station;
             features.add({
@@ -307,11 +352,11 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
     return jsonEncode({'type': 'FeatureCollection', 'features': features});
   }
 
-  String _buildLpgmGeoJson(
-    EarthquakeIntensity? intensity,
-    IntensityColors colorModel,
-    StationDisplayMode stationDisplayMode,
-  ) {
+  String buildLpgmGeoJson({
+    required EarthquakeIntensity? intensity,
+    required IntensityColors colorModel,
+    required StationDisplayMode stationDisplayMode,
+  }) {
     if (intensity == null) {
       return jsonEncode({'type': 'FeatureCollection', 'features': <dynamic>[]});
     }
@@ -329,9 +374,9 @@ class EarthquakeHistoryStationIntensityLayer extends HookConsumerWidget {
                 .fromJmaLpgmIntensity(lpgmIntensity)
                 .background
                 .toHexStringRGB();
-            final iconId = _lpgmIconIdForStation(
-              lpgmIntensity.name,
-              stationDisplayMode,
+            final iconId = lpgmIconIdForStation(
+              lpgmName: lpgmIntensity.name,
+              stationDisplayMode: stationDisplayMode,
             );
             final station = stationNode.station;
             features.add({

--- a/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:eqmonitor/core/gen/assets.gen.dart';
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -207,12 +208,14 @@ class EewHypocenterLayer extends HookConsumerWidget {
 
       return () {
         unawaited(
-          enqueue(() async {
+          enqueue(() {
             isInitialized.value = false;
-            await styleController.removeLayer(layerId.normal);
-            await styleController.removeLayer(layerId.lowPrecise);
-            await styleController.removeSource(sourceId.normal);
-            await styleController.removeSource(sourceId.lowPrecise);
+            return removeMapStyleResources(
+              styleController: styleController,
+              layerIds: [layerId.normal, layerId.lowPrecise],
+              sourceIds: [sourceId.normal, sourceId.lowPrecise],
+              imageIds: const ['normal-hypocenter', 'low-precise-hypocenter'],
+            );
           }),
         );
       };

--- a/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/core/provider/clock/app_clock.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/travel_time/provider/travel_time_provider.dart';
@@ -152,13 +153,20 @@ class _EewPsWaveLayerBody extends HookConsumerWidget {
         disposed.value = true;
         isInitialized.value = false;
         unawaited(
-          enqueue(() async {
-            await styleController.removeLayer(EewPsWaveLayer.layerId.pWaveLine);
-            await styleController.removeLayer(EewPsWaveLayer.layerId.sWaveLine);
-            await styleController.removeLayer(EewPsWaveLayer.layerId.sWaveFill);
-            await styleController.removeSource(EewPsWaveLayer.sourceId.pWave);
-            await styleController.removeSource(EewPsWaveLayer.sourceId.sWave);
-          }),
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: [
+                EewPsWaveLayer.layerId.pWaveLine,
+                EewPsWaveLayer.layerId.sWaveLine,
+                EewPsWaveLayer.layerId.sWaveFill,
+              ],
+              sourceIds: [
+                EewPsWaveLayer.sourceId.pWave,
+                EewPsWaveLayer.sourceId.sWave,
+              ],
+            ),
+          ),
         );
       };
     }, [styleController]);

--- a/app/lib/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:developer';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
 import 'package:eqmonitor/feature/home/data/provider/kyoshin_monitor_points_provider.dart';
@@ -44,11 +45,13 @@ class _KyoshinMonitorObservationLayerBody extends HookConsumerWidget {
     );
     final radiusScaleFactor = switch (markerSize) {
       HomeKmoniMarkerSize.small => 0.65,
-      HomeKmoniMarkerSize.medium => 1,
+      HomeKmoniMarkerSize.medium => 1.0,
       HomeKmoniMarkerSize.large => 1.35,
     };
 
-    final isInitialized = useRef(false);
+    final isLayerInitialized = useRef(false);
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
     final enqueue = useMapOperationQueue();
 
     useEffect(() {
@@ -56,66 +59,74 @@ class _KyoshinMonitorObservationLayerBody extends HookConsumerWidget {
         return null;
       }
 
-      unawaited(
-        enqueue(() async {
-          await styleController.addSource(
-            GeoJsonSource(
-              id: KyoshinMonitorObservationLayer._sourceId,
-              data: jsonEncode({
-                'type': 'FeatureCollection',
-                'features': <Map<String, dynamic>>[],
-              }),
-            ),
-          );
-
-          await styleController.addLayer(
-            CircleStyleLayer(
-              id: KyoshinMonitorObservationLayer._layerId,
-              sourceId: KyoshinMonitorObservationLayer._sourceId,
-              paint: {
-                'circle-radius': [
-                  'interpolate',
-                  ['linear'],
-                  ['zoom'],
-                  3,
-                  1,
-                  10,
-                  10,
-                ],
-                'circle-color': ['get', 'color'],
-                'circle-stroke-color': '#808080',
-                'circle-stroke-width': [
-                  'interpolate',
-                  ['linear'],
-                  ['zoom'],
-                  3,
-                  0.2 * radiusScaleFactor,
-                  10,
-                  radiusScaleFactor,
-                ],
-              },
-            ),
-          );
-          isInitialized.value = true;
-        }),
-      );
+      final token = Object();
+      lifecycleToken.value = token;
+      isLayerInitialized.value = false;
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          GeoJsonSource(
+            id: KyoshinMonitorObservationLayer._sourceId,
+            data: jsonEncode({
+              'type': 'FeatureCollection',
+              'features': <Map<String, dynamic>>[],
+            }),
+          ),
+        );
+      });
       return () {
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
         unawaited(
-          enqueue(() async {
-            isInitialized.value = false;
-            await styleController.removeLayer(
-              KyoshinMonitorObservationLayer._layerId,
-            );
-            await styleController.removeSource(
-              KyoshinMonitorObservationLayer._sourceId,
+          enqueue(() {
+            return removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [KyoshinMonitorObservationLayer._layerId],
+              sourceIds: const [KyoshinMonitorObservationLayer._sourceId],
             );
           }),
         );
       };
+    }, [styleController]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      final initialized = initialization.value;
+      if (styleController == null || token == null || initialized == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(() async {
+          await initialized;
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          if (isLayerInitialized.value) {
+            await styleController.removeLayer(
+              KyoshinMonitorObservationLayer._layerId,
+            );
+          }
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          await styleController.addLayer(
+            const KyoshinMonitorObservationLayerBuilder().build(
+              radiusScaleFactor: radiusScaleFactor,
+            ),
+          );
+          isLayerInitialized.value = true;
+        }),
+      );
+      return null;
     }, [styleController, radiusScaleFactor]);
 
     useEffect(() {
-      if (styleController == null) {
+      final token = lifecycleToken.value;
+      final initialized = initialization.value;
+      if (styleController == null || token == null || initialized == null) {
         return null;
       }
 
@@ -124,7 +135,8 @@ class _KyoshinMonitorObservationLayerBody extends HookConsumerWidget {
         (_, next) {
           unawaited(
             enqueue(() async {
-              if (!isInitialized.value) {
+              await initialized;
+              if (lifecycleToken.value != token) {
                 return;
               }
               final sw = Stopwatch()..start();
@@ -143,10 +155,43 @@ class _KyoshinMonitorObservationLayerBody extends HookConsumerWidget {
             }),
           );
         },
+        fireImmediately: true,
       );
       return subscription.close;
     }, [styleController]);
 
     return const SizedBox.shrink();
   }
+}
+
+class KyoshinMonitorObservationLayerBuilder {
+  const KyoshinMonitorObservationLayerBuilder();
+
+  CircleStyleLayer build({required double radiusScaleFactor}) =>
+      CircleStyleLayer(
+        id: KyoshinMonitorObservationLayer._layerId,
+        sourceId: KyoshinMonitorObservationLayer._sourceId,
+        paint: {
+          'circle-radius': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            3,
+            1,
+            10,
+            10,
+          ],
+          'circle-color': ['get', 'color'],
+          'circle-stroke-color': '#808080',
+          'circle-stroke-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            3,
+            0.2 * radiusScaleFactor,
+            10,
+            radiusScaleFactor,
+          ],
+        },
+      );
 }

--- a/app/lib/feature/home/ui/component/map/layer/shake_detection_layer.dart
+++ b/app/lib/feature/home/ui/component/map/layer/shake_detection_layer.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
@@ -130,14 +131,17 @@ class _ShakeDetectionLayerBody extends HookConsumerWidget {
         disposed.value = true;
         isInitialized.value = false;
         unawaited(
-          enqueue(() async {
-            await styleController.removeLayer(
-              ShakeDetectionLayer._centerLayerId,
-            );
-            await styleController.removeLayer(ShakeDetectionLayer._fillLayerId);
-            await styleController.removeLayer(ShakeDetectionLayer._lineLayerId);
-            await styleController.removeSource(ShakeDetectionLayer.sourceId);
-          }),
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [
+                ShakeDetectionLayer._centerLayerId,
+                ShakeDetectionLayer._fillLayerId,
+                ShakeDetectionLayer._lineLayerId,
+              ],
+              sourceIds: const [ShakeDetectionLayer.sourceId],
+            ),
+          ),
         );
       };
     }, [styleController]);

--- a/app/lib/feature/seismicity/ui/layer/seismicity_epicenter_layer.dart
+++ b/app/lib/feature/seismicity/ui/layer/seismicity_epicenter_layer.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
-import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/seismicity/data/model/seismicity_color_mode.dart';
 import 'package:eqmonitor/feature/seismicity/data/model/seismicity_event.dart';
 import 'package:flutter/material.dart';
@@ -24,8 +25,9 @@ class SeismicityEpicenterLayer extends HookConsumerWidget {
   final List<SeismicityEvent> events;
   final SeismicityColorMode colorMode;
 
-  static const _sourceId = 'seismicity-epicenter';
-  static const _layerId = 'seismicity-epicenter-circle';
+  static const sourceId = 'seismicity-epicenter';
+  static const layerId = 'seismicity-epicenter-circle';
+  static const _emptyGeoJson = '{"type":"FeatureCollection","features":[]}';
 
   /// 経過時間色分け時の再計算間隔。色スケールは日〜月単位のため十分な粒度。
   static const _elapsedTimeRefreshInterval = Duration(minutes: 10);
@@ -35,6 +37,14 @@ class SeismicityEpicenterLayer extends HookConsumerWidget {
     final styleController = MapController.maybeOf(context)?.style;
     final enqueue = useMapOperationQueue();
     final tick = useState(0);
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final isLayerInitialized = useRef(false);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
+    final geoJson = const SeismicityEpicenterGeoJsonBuilder().build(
+      events: events,
+      now: DateTime.now().toUtc(),
+    );
 
     useEffect(() {
       if (colorMode != SeismicityColorMode.elapsedTime) {
@@ -50,114 +60,170 @@ class SeismicityEpicenterLayer extends HookConsumerWidget {
       if (styleController == null) {
         return null;
       }
-
-      unawaited(
-        enqueue(() async {
-          try {
-            await styleController.addSource(
-              GeoJsonSource(
-                id: _sourceId,
-                data: jsonEncode(_toGeoJson(events)),
-              ),
-            );
-            await styleController.addLayer(
-              CircleStyleLayer(
-                id: _layerId,
-                sourceId: _sourceId,
-                paint: {
-                  'circle-color': _colorExpression(colorMode),
-                  'circle-radius': _radiusExpression(),
-                  'circle-opacity': 0.75,
-                  'circle-stroke-width': 0.5,
-                  'circle-stroke-color': '#00000080',
-                },
-              ),
-            );
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }),
-      );
+      final token = Object();
+      lifecycleToken.value = token;
+      isLayerInitialized.value = false;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(id: sourceId, data: _emptyGeoJson),
+        );
+      });
 
       return () {
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
         unawaited(
-          enqueue(() async {
-            try {
-              await styleController.removeLayer(_layerId);
-              await styleController.removeSource(_sourceId);
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [layerId],
+              sourceIds: const [sourceId],
+            ),
+          ),
         );
       };
-    }, [styleController, events, colorMode, tick.value]);
+    }, [styleController]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      final initialized = initialization.value;
+      if (styleController == null || token == null || initialized == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(() async {
+          await initialized;
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          if (isLayerInitialized.value) {
+            await styleController.removeLayer(layerId);
+          }
+          if (lifecycleToken.value != token) {
+            return;
+          }
+          await styleController.addLayer(
+            const SeismicityEpicenterStyleBuilder().build(colorMode: colorMode),
+          );
+          isLayerInitialized.value = true;
+        }),
+      );
+      return null;
+    }, [styleController, colorMode]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: sourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
+      return null;
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
   }
 
-  Map<String, dynamic> _toGeoJson(List<SeismicityEvent> events) {
-    final now = DateTime.now().toUtc();
-    return {
-      'type': 'FeatureCollection',
-      'features': [
-        for (final event in events)
-          {
-            'type': 'Feature',
-            'geometry': {
-              'type': 'Point',
-              'coordinates': [event.longitude, event.latitude],
-            },
-            'properties': {
-              'event_id': event.eventId,
-              'magnitude': event.magnitude ?? 0.0,
-              'elapsed_hours': elapsedHours(
-                originTime: event.originTime,
-                now: now,
-              ),
-            },
-          },
-      ],
-    };
-  }
+  static double elapsedHours({
+    required DateTime originTime,
+    required DateTime now,
+  }) => SeismicityEpicenterGeoJsonBuilder.elapsedHours(
+    originTime: originTime,
+    now: now,
+  );
+}
 
-  /// [originTime] から [now] までの経過時間(時間単位)。純粋関数としてテスト可能。
+class SeismicityEpicenterGeoJsonBuilder {
+  const SeismicityEpicenterGeoJsonBuilder();
+
+  String build({
+    required List<SeismicityEvent> events,
+    required DateTime now,
+  }) => jsonEncode({
+    'type': 'FeatureCollection',
+    'features': [
+      for (final event in events)
+        {
+          'type': 'Feature',
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [event.longitude, event.latitude],
+          },
+          'properties': {
+            'event_id': event.eventId,
+            'magnitude': event.magnitude ?? 0.0,
+            'elapsed_hours': SeismicityEpicenterGeoJsonBuilder.elapsedHours(
+              originTime: event.originTime,
+              now: now,
+            ),
+          },
+        },
+    ],
+  });
+
   static double elapsedHours({
     required DateTime originTime,
     required DateTime now,
   }) => now.toUtc().difference(originTime.toUtc()).inHours.toDouble();
+}
 
-  /// マグニチュードに応じた円半径(px)。M2〜M7 を 3px〜18px へ線形補間。
-  List<dynamic> _radiusExpression() => [
-    'interpolate',
-    ['linear'],
-    ['get', 'magnitude'],
-    2,
-    3,
-    7,
-    18,
-  ];
+class SeismicityEpicenterStyleBuilder {
+  const SeismicityEpicenterStyleBuilder();
 
-  List<dynamic> _colorExpression(SeismicityColorMode mode) => switch (mode) {
-    SeismicityColorMode.magnitude => [
-      'interpolate',
-      ['linear'],
-      ['get', 'magnitude'],
-      2,
-      '#9e9e9e',
-      4,
-      '#ffca28',
-      6,
-      '#e53935',
-    ],
-    SeismicityColorMode.elapsedTime => [
-      'interpolate',
-      ['linear'],
-      ['get', 'elapsed_hours'],
-      0,
-      '#e53935',
-      24 * 30,
-      '#9e9e9e',
-    ],
-  };
+  CircleStyleLayer build({required SeismicityColorMode colorMode}) =>
+      CircleStyleLayer(
+        id: SeismicityEpicenterLayer.layerId,
+        sourceId: SeismicityEpicenterLayer.sourceId,
+        paint: {
+          'circle-color': switch (colorMode) {
+            SeismicityColorMode.magnitude => [
+              'interpolate',
+              ['linear'],
+              ['get', 'magnitude'],
+              2,
+              '#9e9e9e',
+              4,
+              '#ffca28',
+              6,
+              '#e53935',
+            ],
+            SeismicityColorMode.elapsedTime => [
+              'interpolate',
+              ['linear'],
+              ['get', 'elapsed_hours'],
+              0,
+              '#e53935',
+              24 * 30,
+              '#9e9e9e',
+            ],
+          },
+          'circle-radius': [
+            'interpolate',
+            ['linear'],
+            ['get', 'magnitude'],
+            2,
+            3,
+            7,
+            18,
+          ],
+          'circle-opacity': 0.75,
+          'circle-stroke-width': 0.5,
+          'circle-stroke-color': '#00000080',
+        },
+      );
 }

--- a/app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart
+++ b/app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart
@@ -7,9 +7,10 @@ import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/gen/assets.gen.dart';
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
 import 'package:eqmonitor/core/provider/jma_parameter/jma_parameter.dart';
-import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
 import 'package:eqmonitor/core/util/converter/color_converter.dart';
+import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
 import 'package:eqmonitor/feature/home/data/model/home_configuration_model.dart';
 import 'package:eqmonitor/feature/home/data/notifier/home_configuration_notifier.dart';
 import 'package:eqmonitor/feature/home/ui/component/map/home_map_options.dart';
@@ -181,182 +182,85 @@ class _TsunamiRegionLineLayer extends HookConsumerWidget {
     final styleController = MapController.maybeOf(context)?.style;
     final jmaMapAsync = ref.watch(jmaMapProvider);
     final enqueue = useMapOperationQueue();
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
+    const geoJsonBuilder = TsunamiMapGeoJsonBuilder();
+    final jmaMap = jmaMapAsync.value;
+    final geoJson = jmaMap == null
+        ? TsunamiMapGeoJsonBuilder.emptyFeatureCollection
+        : geoJsonBuilder.buildRegions(
+            tsunamiMapData: jmaMap.areaTsunami,
+            regions: tsunami.regions,
+          );
+    final layerIds = TsunamiMapLayerBuilder.warningKinds
+        .map((kind) => TsunamiMapLayerBuilder.regionLayerId(kind: kind))
+        .toList();
 
     useEffect(() {
       if (styleController == null) {
         return null;
       }
-      final jmaMap = jmaMapAsync.value;
-      if (jmaMap == null) {
-        return null;
-      }
-
-      final addedLayerIds = <String>[];
-
-      unawaited(
-        enqueue(() async {
-          try {
-            final tsunamiMapData = jmaMap.areaTsunami;
-            final geoJson = _buildTsunamiRegionGeoJson(
-              tsunamiMapData,
-              tsunami.regions,
-            );
-
-            await styleController.addSource(
-              GeoJsonSource(
-                id: _MapContent._tsunamiLineSourceId,
-                data: geoJson,
-              ),
-            );
-
-            // 警報種別ごとにラインレイヤーを追加（重要度順: 予報 → 注意報 → 警報 → 大津波警報）
-            final kindOrder = [
-              TsunamiWarningKind.forecast,
-              TsunamiWarningKind.advisory,
-              TsunamiWarningKind.warning,
-              TsunamiWarningKind.majorWarning,
-            ];
-
-            for (final kind in kindOrder) {
-              final color = TsunamiWarningColor.mapBorderColor(
-                kind,
-              ).toHexStringRGB();
-              final layerId =
-                  '${_MapContent._tsunamiLineLayerIdPrefix}${kind.name}';
-              await styleController.addLayer(
-                LineStyleLayer(
-                  id: layerId,
-                  sourceId: _MapContent._tsunamiLineSourceId,
-                  filter: [
-                    '==',
-                    ['get', 'kind'],
-                    kind.name,
-                  ],
-                  paint: {
-                    'line-color': color,
-                    'line-width': switch (kind) {
-                      .majorWarning => 5.0,
-                      .warning => 4.0,
-                      .advisory => 3.0,
-                      .forecast => 2.0,
-                      .none => 1.0,
-                      .advisoryCancel => 0,
-                      .warningCancel => 0,
-                    },
-                    'line-opacity': 0.9,
-                  },
-                ),
-              );
-              addedLayerIds.add(layerId);
-            }
-          } on Exception catch (e) {
-            talker.log(e);
+      final token = Object();
+      lifecycleToken.value = token;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(
+            id: _MapContent._tsunamiLineSourceId,
+            data: TsunamiMapGeoJsonBuilder.emptyFeatureCollection,
+          ),
+        );
+        for (final kind in TsunamiMapLayerBuilder.warningKinds) {
+          if (lifecycleToken.value != token) {
+            return;
           }
-        }),
-      );
+          await styleController.addLayer(
+            TsunamiMapLayerBuilder.buildRegionLineLayer(kind: kind),
+          );
+        }
+      });
 
       return () {
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
         unawaited(
-          enqueue(() async {
-            for (final id in addedLayerIds.reversed) {
-              try {
-                await styleController.removeLayer(id);
-              } on Exception catch (e) {
-                talker.log(e);
-              }
-            }
-            try {
-              await styleController.removeSource(
-                _MapContent._tsunamiLineSourceId,
-              );
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: layerIds.reversed.toList(),
+              sourceIds: const [_MapContent._tsunamiLineSourceId],
+            ),
+          ),
         );
       };
-    }, [styleController, jmaMapAsync, tsunami.regions]);
+    }, [styleController]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: _MapContent._tsunamiLineSourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
+      return null;
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
-  }
-
-  /// JMA protobuf の津波予報区 LINE_STRING/MULTI_LINE_STRING データから
-  /// GeoJSON FeatureCollection を構築する。
-  String _buildTsunamiRegionGeoJson(
-    JmaMap_JmaMapData tsunamiMapData,
-    List<TsunamiRegion> regions,
-  ) {
-    // forecastRegion の code → kind マッピング
-    final codeToKind = <String, TsunamiWarningKind>{};
-    for (final region in regions) {
-      codeToKind[region.code] = region.kind;
-    }
-
-    final features = <Map<String, dynamic>>[];
-
-    for (final item in tsunamiMapData.data) {
-      final code = item.property.code;
-      final kind = codeToKind[code];
-      if (kind == null || kind == .none) {
-        continue;
-      }
-
-      final bytes = Uint8List.fromList(item.bytes);
-      final geometry = _decodeGeometry(item.dataType, bytes);
-      if (geometry == null) {
-        continue;
-      }
-
-      features.add({
-        'type': 'Feature',
-        'geometry': geometry,
-        'properties': {
-          'code': code,
-          'name': item.property.name,
-          'kind': kind.name,
-        },
-      });
-    }
-
-    return jsonEncode({'type': 'FeatureCollection', 'features': features});
-  }
-
-  /// protobuf バイナリを GeoJSON geometry オブジェクトにデコードする。
-  Map<String, dynamic>? _decodeGeometry(
-    JmaMap_JmaMapData_DataType dataType,
-    Uint8List bytes,
-  ) {
-    switch (dataType) {
-      case JmaMap_JmaMapData_DataType.LINE_STRING:
-        final lineString = geo.LineString.decode(bytes);
-        return {
-          'type': 'LineString',
-          'coordinates': _chainToCoordinates(lineString.chain),
-        };
-      case JmaMap_JmaMapData_DataType.MULTI_LINE_STRING:
-        final multiLineString = geo.MultiLineString.decode(bytes);
-        return {
-          'type': 'MultiLineString',
-          'coordinates': [
-            for (final chain in multiLineString.chains)
-              _chainToCoordinates(chain),
-          ],
-        };
-      case JmaMap_JmaMapData_DataType.POLYGON:
-      case JmaMap_JmaMapData_DataType.MULTI_POLYGON:
-        // 津波予報区はライン系ジオメトリのみ
-        return null;
-    }
-    return null;
-  }
-
-  /// PositionSeries を GeoJSON coordinates 配列 ([[lng, lat], ...]) に変換。
-  List<List<double>> _chainToCoordinates(geo.PositionSeries chain) {
-    final coords = <List<double>>[];
-    for (var i = 0; i < chain.positionCount; i++) {
-      coords.add([chain.x(i), chain.y(i)]);
-    }
-    return coords;
   }
 }
 
@@ -373,89 +277,83 @@ class _TsunamiHypocenterLayer extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final styleController = MapController.maybeOf(context)?.style;
     final enqueue = useMapOperationQueue();
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
+    final coords = tsunami.earthquakes.firstOrNull?.hypocenter.coordinates;
+    final geoJson = const TsunamiMapGeoJsonBuilder().buildHypocenter(
+      latitude: coords?.latitude.toDouble(),
+      longitude: coords?.longitude.toDouble(),
+    );
 
     useEffect(() {
       if (styleController == null) {
         return null;
       }
-
-      final coords = tsunami.earthquakes.firstOrNull?.hypocenter.coordinates;
-      if (coords == null) {
-        return null;
-      }
-
-      unawaited(
-        enqueue(() async {
-          try {
-            await styleController.addImageFromAssets(
-              id: _MapContent._hypocenterIconId,
-              asset: Assets.images.map.normalHypocenter.path,
-            );
-
-            await styleController.addSource(
-              GeoJsonSource(
-                id: _MapContent._hypocenterSourceId,
-                data: jsonEncode({
-                  'type': 'FeatureCollection',
-                  'features': [
-                    {
-                      'type': 'Feature',
-                      'geometry': {
-                        'type': 'Point',
-                        'coordinates': [coords.longitude, coords.latitude],
-                      },
-                      'properties': <String, dynamic>{},
-                    },
-                  ],
-                }),
-              ),
-            );
-
-            await styleController.addLayer(
-              const SymbolStyleLayer(
-                id: _MapContent._hypocenterLayerId,
-                sourceId: _MapContent._hypocenterSourceId,
-                layout: {
-                  'icon-allow-overlap': true,
-                  'icon-ignore-placement': true,
-                  'icon-image': _MapContent._hypocenterIconId,
-                  'icon-size': [
-                    'interpolate',
-                    ['linear'],
-                    ['zoom'],
-                    3,
-                    0.15,
-                    20,
-                    0.4,
-                  ],
-                },
-              ),
-            );
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }),
-      );
+      final token = Object();
+      lifecycleToken.value = token;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addImageFromAssets(
+          id: _MapContent._hypocenterIconId,
+          asset: Assets.images.map.normalHypocenter.path,
+        );
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(
+            id: _MapContent._hypocenterSourceId,
+            data: TsunamiMapGeoJsonBuilder.emptyFeatureCollection,
+          ),
+        );
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addLayer(
+          TsunamiMapLayerBuilder.buildHypocenterLayer(),
+        );
+      });
 
       return () {
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
         unawaited(
-          enqueue(() async {
-            try {
-              await styleController.removeLayer(_MapContent._hypocenterLayerId);
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-            try {
-              await styleController.removeSource(
-                _MapContent._hypocenterSourceId,
-              );
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [_MapContent._hypocenterLayerId],
+              sourceIds: const [_MapContent._hypocenterSourceId],
+              imageIds: const [_MapContent._hypocenterIconId],
+            ),
+          ),
         );
       };
-    }, [styleController, tsunami.earthquakes]);
+    }, [styleController]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: _MapContent._hypocenterSourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
+      return null;
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
   }
@@ -475,130 +373,182 @@ class _TsunamiObservationStationLayer extends HookConsumerWidget {
     final styleController = MapController.maybeOf(context)?.style;
     final jmaParamAsync = ref.watch(jmaParameterProvider);
     final enqueue = useMapOperationQueue();
+    final lifecycleToken = useRef<Object?>(null);
+    final initialization = useRef<Future<void>?>(null);
+    final geoJsonUpdater = useMemoized(MapGeoJsonSourceUpdater.new);
+    final tsunamiParameter = jmaParamAsync.value?.tsunami;
+    final geoJson = tsunamiParameter == null
+        ? TsunamiMapGeoJsonBuilder.emptyFeatureCollection
+        : const TsunamiMapGeoJsonBuilder().buildObservationStations(
+            tsunami: tsunami,
+            tsunamiParameter: tsunamiParameter,
+          );
 
     useEffect(() {
       if (styleController == null) {
         return null;
       }
-      final jmaParam = jmaParamAsync.value;
-      if (jmaParam == null) {
-        return null;
-      }
-
-      var labelLayerAdded = false;
-
-      unawaited(
-        enqueue(() async {
-          try {
-            final geoJson = _buildObservationStationGeoJson(
-              tsunami,
-              jmaParam.tsunami,
-            );
-
-            await styleController.addSource(
-              GeoJsonSource(id: _MapContent._stationSourceId, data: geoJson),
-            );
-
-            await styleController.addLayer(
-              const CircleStyleLayer(
-                id: _MapContent._stationCircleLayerId,
-                sourceId: _MapContent._stationSourceId,
-                paint: {
-                  'circle-radius': [
-                    'interpolate',
-                    ['linear'],
-                    ['zoom'],
-                    3,
-                    3,
-                    10,
-                    8,
-                  ],
-                  'circle-color': ['get', 'color'],
-                  'circle-stroke-color': '#ffffff',
-                  'circle-stroke-width': [
-                    'interpolate',
-                    ['linear'],
-                    ['zoom'],
-                    3,
-                    0.3,
-                    10,
-                    1.5,
-                  ],
-                },
-              ),
-            );
-
-            await styleController.addLayer(
-              const SymbolStyleLayer(
-                id: _MapContent._stationLabelLayerId,
-                sourceId: _MapContent._stationSourceId,
-                minZoom: 8,
-                layout: {
-                  'text-field': ['get', 'name'],
-                  'text-size': 10,
-                  'text-offset': [0, 1.2],
-                  'text-anchor': 'top',
-                  'text-allow-overlap': false,
-                  'text-ignore-placement': true,
-                },
-                paint: {
-                  'text-color': '#ffffff',
-                  'text-halo-color': '#000000',
-                  'text-halo-width': 1,
-                },
-              ),
-            );
-            labelLayerAdded = true;
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }),
-      );
+      final token = Object();
+      lifecycleToken.value = token;
+      geoJsonUpdater.reset();
+      initialization.value = enqueue(() async {
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addSource(
+          const GeoJsonSource(
+            id: _MapContent._stationSourceId,
+            data: TsunamiMapGeoJsonBuilder.emptyFeatureCollection,
+          ),
+        );
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addLayer(
+          TsunamiMapLayerBuilder.buildStationCircleLayer(),
+        );
+        if (lifecycleToken.value != token) {
+          return;
+        }
+        await styleController.addLayer(
+          TsunamiMapLayerBuilder.buildStationLabelLayer(),
+        );
+      });
 
       return () {
+        if (lifecycleToken.value == token) {
+          lifecycleToken.value = null;
+        }
+        geoJsonUpdater.reset();
         unawaited(
-          enqueue(() async {
-            if (labelLayerAdded) {
-              try {
-                await styleController.removeLayer(
-                  _MapContent._stationLabelLayerId,
-                );
-              } on Exception catch (e) {
-                talker.log(e);
-              }
-            }
-            try {
-              await styleController.removeLayer(
+          enqueue(
+            () => removeMapStyleResources(
+              styleController: styleController,
+              layerIds: const [
+                _MapContent._stationLabelLayerId,
                 _MapContent._stationCircleLayerId,
-              );
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-            try {
-              await styleController.removeSource(_MapContent._stationSourceId);
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
+              ],
+              sourceIds: const [_MapContent._stationSourceId],
+            ),
+          ),
         );
       };
-    }, [styleController, jmaParamAsync, tsunami]);
+    }, [styleController]);
+
+    useEffect(() {
+      final token = lifecycleToken.value;
+      if (styleController == null || token == null) {
+        return null;
+      }
+      unawaited(
+        enqueue(
+          () => geoJsonUpdater.update(
+            styleController: styleController,
+            sourceId: _MapContent._stationSourceId,
+            geoJson: geoJson,
+            initialization: initialization.value,
+            isDisposed: () => lifecycleToken.value != token,
+          ),
+        ),
+      );
+      return null;
+    }, [styleController, geoJson]);
 
     return const SizedBox.shrink();
   }
+}
 
-  /// 津波観測点を GeoJSON FeatureCollection に構築する。
-  ///
-  /// forecastRegions 内の observation.stations と TsunamiParameter の
-  /// 観測点位置情報を照合し、色を maxHeight の条件に基づいて決定する。
-  String _buildObservationStationGeoJson(
-    TsunamiState tsunami,
-    TsunamiParameter tsunamiParam,
-  ) {
-    // TsunamiParameter から観測点コード → 位置のマップを構築
+class TsunamiMapGeoJsonBuilder {
+  const TsunamiMapGeoJsonBuilder();
+
+  static const emptyFeatureCollection =
+      '{"type":"FeatureCollection","features":[]}';
+
+  String buildHypocenter({
+    required double? latitude,
+    required double? longitude,
+  }) => jsonEncode({
+    'type': 'FeatureCollection',
+    'features': <Map<String, dynamic>>[
+      if (latitude != null && longitude != null)
+        {
+          'type': 'Feature',
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [longitude, latitude],
+          },
+          'properties': <String, dynamic>{},
+        },
+    ],
+  });
+
+  String buildRegions({
+    required JmaMap_JmaMapData tsunamiMapData,
+    required List<TsunamiRegion> regions,
+  }) {
+    final codeToKind = {for (final region in regions) region.code: region.kind};
+    final features = <Map<String, dynamic>>[];
+    for (final item in tsunamiMapData.data) {
+      final code = item.property.code;
+      final kind = codeToKind[code];
+      if (kind == null || kind == .none) {
+        continue;
+      }
+      final geometry = decodeGeometry(
+        dataType: item.dataType,
+        bytes: Uint8List.fromList(item.bytes),
+      );
+      if (geometry == null) {
+        continue;
+      }
+      features.add({
+        'type': 'Feature',
+        'geometry': geometry,
+        'properties': {
+          'code': code,
+          'name': item.property.name,
+          'kind': kind.name,
+        },
+      });
+    }
+    return jsonEncode({'type': 'FeatureCollection', 'features': features});
+  }
+
+  Map<String, dynamic>? decodeGeometry({
+    required JmaMap_JmaMapData_DataType dataType,
+    required Uint8List bytes,
+  }) => switch (dataType) {
+    JmaMap_JmaMapData_DataType.LINE_STRING => {
+      'type': 'LineString',
+      'coordinates': chainToCoordinates(
+        chain: geo.LineString.decode(bytes).chain,
+      ),
+    },
+    JmaMap_JmaMapData_DataType.MULTI_LINE_STRING => {
+      'type': 'MultiLineString',
+      'coordinates': [
+        for (final chain in geo.MultiLineString.decode(bytes).chains)
+          chainToCoordinates(chain: chain),
+      ],
+    },
+    JmaMap_JmaMapData_DataType.POLYGON ||
+    JmaMap_JmaMapData_DataType.MULTI_POLYGON => null,
+    _ => null,
+  };
+
+  List<List<double>> chainToCoordinates({required geo.PositionSeries chain}) =>
+      [
+        for (var index = 0; index < chain.positionCount; index++)
+          [chain.x(index), chain.y(index)],
+      ];
+
+  String buildObservationStations({
+    required TsunamiState tsunami,
+    required TsunamiParameter tsunamiParameter,
+  }) {
     final stationLocations = <String, ({double lat, double lon})>{};
-    for (final pref in tsunamiParam.prefectures) {
-      for (final area in pref.areas) {
+    for (final prefecture in tsunamiParameter.prefectures) {
+      for (final area in prefecture.areas) {
         for (final station in area.stations) {
           stationLocations[station.code] = (
             lat: station.location.lat,
@@ -607,21 +557,13 @@ class _TsunamiObservationStationLayer extends HookConsumerWidget {
         }
       }
     }
-
     final features = <Map<String, dynamic>>[];
-
-    // regions 内の observation stations
     for (final region in tsunami.regions) {
       for (final station in region.stations) {
-        if (station.observation == null) {
-          continue;
-        }
         final location = stationLocations[station.code];
-        if (location == null) {
+        if (station.observation == null || location == null) {
           continue;
         }
-
-        final color = _stationColor(station);
         features.add({
           'type': 'Feature',
           'geometry': {
@@ -630,88 +572,171 @@ class _TsunamiObservationStationLayer extends HookConsumerWidget {
           },
           'properties': {
             'name': station.name,
-            'color': color,
+            'color': stationColor(station: station),
             'code': station.code,
           },
         });
       }
     }
-
-    // offshoreStations（沖合観測点）
-    for (final obs in tsunami.offshoreStations) {
-      final location = stationLocations[obs.code];
+    for (final station in tsunami.offshoreStations) {
+      final location = stationLocations[station.code];
       if (location == null) {
         continue;
       }
-
-      final color = _offshoreStationColor(obs);
       features.add({
         'type': 'Feature',
         'geometry': {
           'type': 'Point',
           'coordinates': [location.lon, location.lat],
         },
-        'properties': {'name': obs.name, 'color': color, 'code': obs.code},
+        'properties': {
+          'name': station.name,
+          'color': offshoreStationColor(station: station),
+          'code': station.code,
+        },
       });
     }
-
     return jsonEncode({'type': 'FeatureCollection', 'features': features});
   }
 
-  /// 観測点の色を maxHeight の条件に基づいて決定する。
-  ///
-  /// - IMPORTANT or >= 1.0m → 赤
-  /// - OBSERVING or isRising → オレンジ
-  /// - MINOR or < 1.0m → 黄
-  /// - データなし → グレー
-  String _stationColor(TsunamiRegionStation station) {
+  String stationColor({required TsunamiRegionStation station}) {
     final maxHeight = station.observation?.maxHeight;
-    if (maxHeight == null) {
-      return '#9E9E9E'; // grey
-    }
-
-    if (maxHeight.condition == ObservationMaxHeightCondition.important ||
-        (maxHeight.value != null && maxHeight.value! >= 1.0)) {
-      return '#F44336'; // red
-    }
-
-    if (maxHeight.condition == ObservationMaxHeightCondition.observing ||
-        (maxHeight.isRising ?? false)) {
-      return '#FF9800'; // orange
-    }
-
-    if (maxHeight.condition == ObservationMaxHeightCondition.minor ||
-        (maxHeight.value != null && maxHeight.value! < 1.0)) {
-      return '#FFEB3B'; // yellow
-    }
-
-    return '#9E9E9E'; // grey
+    return observationColor(
+      condition: maxHeight?.condition,
+      value: maxHeight?.value,
+      isRising: maxHeight?.isRising,
+    );
   }
 
-  /// 沖合観測点の色を同様のロジックで決定する。
-  String _offshoreStationColor(TsunamiOffshoreStation obs) {
-    final maxHeight = obs.maxHeight;
-    if (maxHeight == null) {
-      return '#9E9E9E'; // grey
-    }
+  String offshoreStationColor({required TsunamiOffshoreStation station}) =>
+      observationColor(
+        condition: station.maxHeight?.condition,
+        value: station.maxHeight?.value,
+        isRising: station.maxHeight?.isRising,
+      );
 
-    if (maxHeight.condition == ObservationMaxHeightCondition.important ||
-        (maxHeight.value != null && maxHeight.value! >= 1.0)) {
-      return '#F44336'; // red
+  String observationColor({
+    required ObservationMaxHeightCondition? condition,
+    required num? value,
+    required bool? isRising,
+  }) {
+    if (condition == ObservationMaxHeightCondition.important ||
+        (value != null && value >= 1)) {
+      return '#F44336';
     }
-
-    if (maxHeight.condition == ObservationMaxHeightCondition.observing ||
-        (maxHeight.isRising ?? false)) {
-      return '#FF9800'; // orange
+    if (condition == ObservationMaxHeightCondition.observing ||
+        (isRising ?? false)) {
+      return '#FF9800';
     }
-
-    if (maxHeight.condition == ObservationMaxHeightCondition.minor ||
-        (maxHeight.value != null && maxHeight.value! < 1.0)) {
-      return '#FFEB3B'; // yellow
+    if (condition == ObservationMaxHeightCondition.minor ||
+        (value != null && value < 1)) {
+      return '#FFEB3B';
     }
-
-    return '#9E9E9E'; // grey
+    return '#9E9E9E';
   }
+}
+
+class TsunamiMapLayerBuilder {
+  const TsunamiMapLayerBuilder._();
+
+  static const warningKinds = [
+    TsunamiWarningKind.forecast,
+    TsunamiWarningKind.advisory,
+    TsunamiWarningKind.warning,
+    TsunamiWarningKind.majorWarning,
+  ];
+
+  static String regionLayerId({required TsunamiWarningKind kind}) =>
+      '${_MapContent._tsunamiLineLayerIdPrefix}${kind.name}';
+
+  static LineStyleLayer buildRegionLineLayer({
+    required TsunamiWarningKind kind,
+  }) => LineStyleLayer(
+    id: regionLayerId(kind: kind),
+    sourceId: _MapContent._tsunamiLineSourceId,
+    filter: [
+      '==',
+      ['get', 'kind'],
+      kind.name,
+    ],
+    paint: {
+      'line-color': TsunamiWarningColor.mapBorderColor(kind).toHexStringRGB(),
+      'line-width': switch (kind) {
+        .majorWarning => 5.0,
+        .warning => 4.0,
+        .advisory => 3.0,
+        .forecast => 2.0,
+        .none => 1.0,
+        .advisoryCancel || .warningCancel => 0,
+      },
+      'line-opacity': 0.9,
+    },
+  );
+
+  static SymbolStyleLayer buildHypocenterLayer() => const SymbolStyleLayer(
+    id: _MapContent._hypocenterLayerId,
+    sourceId: _MapContent._hypocenterSourceId,
+    layout: {
+      'icon-allow-overlap': true,
+      'icon-ignore-placement': true,
+      'icon-image': _MapContent._hypocenterIconId,
+      'icon-size': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        3,
+        0.15,
+        20,
+        0.4,
+      ],
+    },
+  );
+
+  static CircleStyleLayer buildStationCircleLayer() => const CircleStyleLayer(
+    id: _MapContent._stationCircleLayerId,
+    sourceId: _MapContent._stationSourceId,
+    paint: {
+      'circle-radius': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        3,
+        3,
+        10,
+        8,
+      ],
+      'circle-color': ['get', 'color'],
+      'circle-stroke-color': '#ffffff',
+      'circle-stroke-width': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        3,
+        0.3,
+        10,
+        1.5,
+      ],
+    },
+  );
+
+  static SymbolStyleLayer buildStationLabelLayer() => const SymbolStyleLayer(
+    id: _MapContent._stationLabelLayerId,
+    sourceId: _MapContent._stationSourceId,
+    minZoom: 8,
+    layout: {
+      'text-field': ['get', 'name'],
+      'text-size': 10,
+      'text-offset': [0, 1.2],
+      'text-anchor': 'top',
+      'text-allow-overlap': false,
+      'text-ignore-placement': true,
+    },
+    paint: {
+      'text-color': '#ffffff',
+      'text-halo-color': '#000000',
+      'text-halo-width': 1,
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/app/test/core/util/map/fake_style_controller.dart
+++ b/app/test/core/util/map/fake_style_controller.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import 'package:maplibre/maplibre.dart';
+
+class FakeStyleController implements StyleController {
+  FakeStyleController({
+    this.failingLayerIds = const {},
+    this.failingSourceIds = const {},
+    this.failingImageIds = const {},
+  });
+
+  final Set<String> failingLayerIds;
+  final Set<String> failingSourceIds;
+  final Set<String> failingImageIds;
+
+  final addedSources = <Source>[];
+  final addedLayers = <StyleLayer>[];
+  final addedImageIds = <String>[];
+  final updatedGeoJsonSources = <({String id, String data})>[];
+  final removedLayerIds = <String>[];
+  final removedSourceIds = <String>[];
+  final removedImageIds = <String>[];
+
+  @override
+  Future<void> addSource(Source source) async => addedSources.add(source);
+
+  @override
+  Future<void> addLayer(
+    StyleLayer layer, {
+    String? belowLayerId,
+    String? aboveLayerId,
+    int? atIndex,
+  }) async => addedLayers.add(layer);
+
+  @override
+  Future<void> addImage(String id, Uint8List bytes) async {
+    addedImageIds.add(id);
+  }
+
+  @override
+  Future<void> updateGeoJsonSource({
+    required String id,
+    required String data,
+  }) async {
+    updatedGeoJsonSources.add((id: id, data: data));
+  }
+
+  @override
+  Future<void> removeLayer(String id) async {
+    removedLayerIds.add(id);
+    if (failingLayerIds.contains(id)) {
+      throw Exception('removeLayer failed: $id');
+    }
+  }
+
+  @override
+  Future<void> removeSource(String id) async {
+    removedSourceIds.add(id);
+    if (failingSourceIds.contains(id)) {
+      throw Exception('removeSource failed: $id');
+    }
+  }
+
+  @override
+  Future<void> removeImage(String id) async {
+    removedImageIds.add(id);
+    if (failingImageIds.contains(id)) {
+      throw Exception('removeImage failed: $id');
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/app/test/core/util/map/map_geo_json_source_updater_test.dart
+++ b/app/test/core/util/map/map_geo_json_source_updater_test.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/util/map/map_geo_json_source_updater.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_style_controller.dart';
+
+void main() {
+  const emptyGeoJson = '{"type":"FeatureCollection","features":[]}';
+
+  test('初期化完了後に GeoJSON を更新する', () async {
+    final style = FakeStyleController();
+    final initialization = Completer<void>();
+    final updater = MapGeoJsonSourceUpdater();
+
+    final update = updater.update(
+      styleController: style,
+      sourceId: 'source',
+      geoJson: emptyGeoJson,
+      initialization: initialization.future,
+      isDisposed: () => false,
+    );
+
+    expect(style.updatedGeoJsonSources, isEmpty);
+    initialization.complete();
+    await update;
+
+    expect(style.updatedGeoJsonSources, [(id: 'source', data: emptyGeoJson)]);
+  });
+
+  test('同一 GeoJSON を重複更新しない', () async {
+    final style = FakeStyleController();
+    final updater = MapGeoJsonSourceUpdater();
+
+    for (var index = 0; index < 2; index++) {
+      await updater.update(
+        styleController: style,
+        sourceId: 'source',
+        geoJson: emptyGeoJson,
+        initialization: Future<void>.value(),
+        isDisposed: () => false,
+      );
+    }
+
+    expect(style.updatedGeoJsonSources, hasLength(1));
+  });
+
+  test('初期化待機中に破棄された場合は更新しない', () async {
+    final style = FakeStyleController();
+    final initialization = Completer<void>();
+    final updater = MapGeoJsonSourceUpdater();
+    var disposed = false;
+
+    final update = updater.update(
+      styleController: style,
+      sourceId: 'source',
+      geoJson: emptyGeoJson,
+      initialization: initialization.future,
+      isDisposed: () => disposed,
+    );
+    disposed = true;
+    initialization.complete();
+    await update;
+
+    expect(style.updatedGeoJsonSources, isEmpty);
+  });
+
+  test('reset 後は同一 GeoJSON でも再度更新する', () async {
+    final style = FakeStyleController();
+    final updater = MapGeoJsonSourceUpdater();
+
+    await updater.update(
+      styleController: style,
+      sourceId: 'source',
+      geoJson: emptyGeoJson,
+      initialization: Future<void>.value(),
+      isDisposed: () => false,
+    );
+    updater.reset();
+    await updater.update(
+      styleController: style,
+      sourceId: 'source',
+      geoJson: emptyGeoJson,
+      initialization: Future<void>.value(),
+      isDisposed: () => false,
+    );
+
+    expect(style.updatedGeoJsonSources, hasLength(2));
+  });
+}

--- a/app/test/core/util/map/remove_map_style_resources_test.dart
+++ b/app/test/core/util/map/remove_map_style_resources_test.dart
@@ -1,0 +1,43 @@
+import 'package:eqmonitor/core/provider/log/talker.dart' as talker_lib;
+import 'package:eqmonitor/core/util/map/remove_map_style_resources.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+
+import 'fake_style_controller.dart';
+
+void main() {
+  setUpAll(() {
+    try {
+      talker_lib.talker = Talker();
+      // ignore: avoid_catching_errors
+    } on Error catch (_) {}
+  });
+
+  test('先頭 layer の削除失敗後も残りの resource を削除する', () async {
+    final style = FakeStyleController(failingLayerIds: {'first'});
+
+    await removeMapStyleResources(
+      styleController: style,
+      layerIds: const ['first', 'second'],
+      sourceIds: const ['source'],
+      imageIds: const ['image'],
+    );
+
+    expect(style.removedLayerIds, ['first', 'second']);
+    expect(style.removedSourceIds, ['source']);
+    expect(style.removedImageIds, ['image']);
+  });
+
+  test('source の削除失敗後も残りの source と image を削除する', () async {
+    final style = FakeStyleController(failingSourceIds: {'first-source'});
+
+    await removeMapStyleResources(
+      styleController: style,
+      sourceIds: const ['first-source', 'second-source'],
+      imageIds: const ['image'],
+    );
+
+    expect(style.removedSourceIds, ['first-source', 'second-source']);
+    expect(style.removedImageIds, ['image']);
+  });
+}

--- a/app/test/core/util/map/remove_map_style_resources_test.dart
+++ b/app/test/core/util/map/remove_map_style_resources_test.dart
@@ -40,4 +40,26 @@ void main() {
     expect(style.removedSourceIds, ['first-source', 'second-source']);
     expect(style.removedImageIds, ['image']);
   });
+
+  test('複数 layer/source の途中失敗でも全 resource を順に試行する', () async {
+    final style = FakeStyleController(
+      failingLayerIds: {'second-layer'},
+      failingSourceIds: {'first-source'},
+    );
+
+    await removeMapStyleResources(
+      styleController: style,
+      layerIds: const ['first-layer', 'second-layer', 'third-layer'],
+      sourceIds: const ['first-source', 'second-source'],
+      imageIds: const ['first-image', 'second-image'],
+    );
+
+    expect(style.removedLayerIds, [
+      'first-layer',
+      'second-layer',
+      'third-layer',
+    ]);
+    expect(style.removedSourceIds, ['first-source', 'second-source']);
+    expect(style.removedImageIds, ['first-image', 'second-image']);
+  });
 }

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_error_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_error_layer_lifecycle_test.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_error_layer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('座標精度変更時も固定 source ID 向けの Polygon を生成する', () {
+    const builder = EarthquakeHistoryHypocenterErrorGeoJsonBuilder();
+    const coordinates = Coordinate.latLng(latitude: 35, longitude: 139);
+    final coarse = builder.build(coordinates: coordinates, decimalPlaces: 1);
+    final precise = builder.build(coordinates: coordinates, decimalPlaces: 3);
+    final decoded = jsonDecode(precise) as Map<String, dynamic>;
+
+    expect(coarse, isNot(precise));
+    expect(decoded['features'], hasLength(1));
+    expect(EarthquakeHistoryHypocenterErrorLayerBuilder.sourceId, isNotEmpty);
+  });
+}

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_layer_lifecycle_test.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/coordinate.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_layer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('座標変更時も固定 source ID 向けの GeoJSON を生成する', () {
+    const builder = EarthquakeHistoryHypocenterGeoJsonBuilder();
+    final first = builder.build(
+      coordinates: const Coordinate.latLng(latitude: 35, longitude: 139),
+    );
+    final second = builder.build(
+      coordinates: const Coordinate.latLng(latitude: 36, longitude: 140),
+    );
+    final decoded = jsonDecode(second) as Map<String, dynamic>;
+    final feature =
+        (decoded['features'] as List<dynamic>).single as Map<String, dynamic>;
+
+    expect(first, isNot(second));
+    expect((feature['geometry'] as Map<String, dynamic>)['coordinates'], [
+      140,
+      36,
+    ]);
+    expect(EarthquakeHistoryHypocenterLayerBuilder.sourceId, isNotEmpty);
+  });
+}

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/earthquake_history/data/model/shindo_db_intensity_tree.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('tree が空でも固定 source ID 向けの空 GeoJSON を生成する', () {
+    final geoJson = const EarthquakeHistoryShindoDbStationGeoJsonBuilder()
+        .build(
+          tree: const ShindoDbIntensityTree(
+            tree: {},
+            unresolvedStations: {},
+            totalStationCount: 0,
+          ),
+        );
+    final decoded = jsonDecode(geoJson) as Map<String, dynamic>;
+
+    expect(decoded['features'], isEmpty);
+    expect(EarthquakeHistoryShindoDbStationLayer.sourceId, isNotEmpty);
+    expect(EarthquakeHistoryShindoDbStationLayer.iconLayerId, isNotEmpty);
+  });
+}

--- a/app/test/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer_lifecycle_test.dart
+++ b/app/test/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer_lifecycle_test.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/core/theme/model/app_theme.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_history_config_model.dart';
+import 'package:eqmonitor/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('観測点データがない場合も更新可能な空 GeoJSON を生成する', () {
+    final geoJson = const EarthquakeHistoryStationGeoJsonBuilder().build(
+      intensity: null,
+      colorModel: AppTheme.eqmonitorDefault().light!.intensity,
+      stationDisplayMode: StationDisplayMode.normal,
+      showingLpgmIntensity: false,
+    );
+    final decoded = jsonDecode(geoJson) as Map<String, dynamic>;
+
+    expect(decoded['features'], isEmpty);
+    expect(EarthquakeHistoryStationIntensityLayerBuilder.sourceId, isNotEmpty);
+  });
+}

--- a/app/test/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer_test.dart
+++ b/app/test/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer_test.dart
@@ -1,0 +1,16 @@
+import 'package:eqmonitor/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('marker size変更では同じ source の layer 定義だけが変わる', () {
+    const builder = KyoshinMonitorObservationLayerBuilder();
+    final small = builder.build(radiusScaleFactor: 0.65);
+    final large = builder.build(radiusScaleFactor: 1.35);
+
+    expect(small.sourceId, large.sourceId);
+    expect(
+      small.paint['circle-stroke-width'],
+      isNot(large.paint['circle-stroke-width']),
+    );
+  });
+}

--- a/app/test/feature/seismicity/ui/layer/seismicity_epicenter_layer_test.dart
+++ b/app/test/feature/seismicity/ui/layer/seismicity_epicenter_layer_test.dart
@@ -1,7 +1,59 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/seismicity/data/model/seismicity_event.dart';
 import 'package:eqmonitor/feature/seismicity/ui/layer/seismicity_epicenter_layer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('SeismicityEpicenterGeoJsonBuilder', () {
+    test('イベントの座標と表示プロパティを GeoJSON に変換する', () {
+      final geoJson = const SeismicityEpicenterGeoJsonBuilder().build(
+        events: [
+          SeismicityEvent(
+            eventId: 'event-1',
+            originTime: DateTime.utc(2026, 7, 20, 9),
+            magnitude: 4.2,
+            depth: 30,
+            latitude: 35.5,
+            longitude: 139.7,
+            maxIntensity: '4',
+          ),
+        ],
+        now: DateTime.utc(2026, 7, 20, 12),
+      );
+      final decoded = jsonDecode(geoJson) as Map<String, dynamic>;
+      final features = decoded['features'] as List<dynamic>;
+      final feature = features.single as Map<String, dynamic>;
+
+      expect((feature['geometry'] as Map<String, dynamic>)['coordinates'], [
+        139.7,
+        35.5,
+      ]);
+      expect(feature['properties'], {
+        'event_id': 'event-1',
+        'magnitude': 4.2,
+        'elapsed_hours': 3.0,
+      });
+    });
+
+    test('イベント更新で同じ source 向けの GeoJSON だけが変化する', () {
+      const builder = SeismicityEpicenterGeoJsonBuilder();
+      final now = DateTime.utc(2026, 7, 20, 12);
+      final first = builder.build(
+        events: [_event(eventId: 'first', longitude: 139)],
+        now: now,
+      );
+      final second = builder.build(
+        events: [_event(eventId: 'second', longitude: 140)],
+        now: now,
+      );
+
+      expect(first, isNot(second));
+      expect(SeismicityEpicenterLayer.sourceId, 'seismicity-epicenter');
+      expect(SeismicityEpicenterLayer.layerId, 'seismicity-epicenter-circle');
+    });
+  });
+
   group('SeismicityEpicenterLayer.elapsedHours', () {
     test('originTime から now までの経過時間を時間単位で返す', () {
       final now = DateTime.utc(2026, 7, 4, 12);
@@ -43,3 +95,14 @@ void main() {
     });
   });
 }
+
+SeismicityEvent _event({required String eventId, required double longitude}) =>
+    SeismicityEvent(
+      eventId: eventId,
+      originTime: DateTime.utc(2026, 7, 20, 9),
+      magnitude: 3,
+      depth: 10,
+      latitude: 35,
+      longitude: longitude,
+      maxIntensity: null,
+    );

--- a/app/test/feature/tsunami/ui/components/tsunami_map_geo_json_builder_test.dart
+++ b/app/test/feature/tsunami/ui/components/tsunami_map_geo_json_builder_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_metadata.dart'
+    as parameter;
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_type.dart'
+    as parameter;
+import 'package:eqmonitor/feature/parameter/data/model/tsunami/tsunami_parameter.dart';
+import 'package:eqmonitor/feature/tsunami/ui/components/tsunami_details_map_view.dart';
+import 'package:eqmonitor_api/eqmonitor_api.dart' as api;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jma_map/jma_map.dart';
+
+void main() {
+  const builder = TsunamiMapGeoJsonBuilder();
+
+  test('震源座標を Point GeoJSON に変換する', () {
+    final geoJson = builder.buildHypocenter(latitude: 35, longitude: 139);
+    final decoded = jsonDecode(geoJson) as Map<String, dynamic>;
+    final feature =
+        (decoded['features'] as List<dynamic>).single as Map<String, dynamic>;
+
+    expect((feature['geometry'] as Map<String, dynamic>)['coordinates'], [
+      139,
+      35,
+    ]);
+  });
+
+  test('予報区データが空なら空 FeatureCollection を返す', () {
+    final geoJson = builder.buildRegions(
+      tsunamiMapData: JmaMap_JmaMapData(),
+      regions: const [],
+    );
+
+    expect((jsonDecode(geoJson) as Map<String, dynamic>)['features'], isEmpty);
+  });
+
+  test('観測点データが空なら空 FeatureCollection を返す', () {
+    final geoJson = builder.buildObservationStations(
+      tsunami: api.TsunamiState(
+        id: 'test',
+        eventIds: const [],
+        isActive: true,
+        isCanceled: false,
+        updatedAt: DateTime.utc(2026),
+        earthquakes: const [],
+        latestTelegrams: const [],
+        regions: const [],
+        offshoreStations: const [],
+      ),
+      tsunamiParameter: const TsunamiParameter(
+        metadata: parameter.ParameterMetadata(
+          type: parameter.ParameterType.tsunamiStations,
+          schemaVersion: 1,
+          sourceVersion: 'test',
+          sourceUpdatedAt: null,
+          sourceUrls: [],
+          sha256: 'test',
+        ),
+        prefectures: [],
+      ),
+    );
+
+    expect((jsonDecode(geoJson) as Map<String, dynamic>)['features'], isEmpty);
+  });
+}

--- a/docs/knowledge/20260720_maplibre_layer_lifecycle.md
+++ b/docs/knowledge/20260720_maplibre_layer_lifecycle.md
@@ -1,0 +1,63 @@
+# MapLibre レイヤーのライフサイクル
+
+## 規約
+
+- `addSource`、`addImage`、`addLayer` は原則として style ごとに一度だけ実行する。
+- 可変 GeoJSON は source を削除・再登録せず、`updateGeoJsonSource` で更新する。
+- filter は `updateFilter` で更新する。paint/layout に更新 API がない場合は layer だけを差し替え、source と image は維持する。
+- データ更新は source 初期化 Future の完了を待つ。初期化中に Widget が破棄された場合は lifecycle token を照合し、後続の追加・更新を中止する。
+- cleanup は layer、source、image の順に行い、各削除を独立して試行する。一件の失敗で後続 resource の削除を止めない。
+- `VectorSource.url` など source 定義そのものが変わる場合だけ、source の再作成を許可する。
+
+## 実装例
+
+GeoJSON source は空の FeatureCollection で初期化し、更新側では共通 updater を使う。
+
+```dart
+final updater = useMemoized(MapGeoJsonSourceUpdater.new);
+final initialization = useRef<Future<void>?>(null);
+
+initialization.value = enqueue(
+  () => style.addSource(
+    const GeoJsonSource(id: sourceId, data: emptyGeoJson),
+  ),
+);
+
+unawaited(
+  enqueue(
+    () => updater.update(
+      styleController: style,
+      sourceId: sourceId,
+      geoJson: latestGeoJson,
+      initialization: initialization.value,
+      isDisposed: () => lifecycleToken.value != token,
+    ),
+  ),
+);
+```
+
+cleanup は `removeMapStyleResources` に全 ID を渡す。存在しない途中 resource があっても残りの削除が継続される。
+
+## 監査方法
+
+```bash
+rg -l '\.(addSource|addImage|addImages|addImageFromAssets|addLayer|removeSource|removeImage|removeLayer|updateGeoJsonSource|updateFilter)\(' app/lib -g '*.dart'
+rg -n 'removeLayer\(|removeSource\(|removeImage\(' app/lib -g '*.dart'
+```
+
+監査では次に分類する。
+
+- 静的 source/layer: style だけに依存して初期化する。
+- GeoJSON 更新分離済み: P/S 波、揺れ検知など。cleanup が独立していることも確認する。
+- source 定義変更: PMTiles URL の変更など。完全再作成を許可するが、初期化中断と独立 cleanup は必要。
+- 修正対象: 可変データ、表示設定、timer tick を初期化 effect の依存に含み、同じ ID の source/image/layer を再登録するもの。
+
+## 検証
+
+```bash
+cd app
+mise exec -- flutter test test/core/util/map
+mise exec -- flutter test test/feature/seismicity
+mise exec -- flutter test test/feature/earthquake_history/ui/layer
+mise exec -- flutter test test/feature/tsunami
+```

--- a/docs/superpowers/plans/2026-07-20-map-layer-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-20-map-layer-lifecycle.md
@@ -1,0 +1,368 @@
+# MapLibre Layer Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** MapLibre の全 source/image/layer 操作を監査し、可変データ更新・非同期初期化・cleanup 競合で描画が消失または復旧不能になる不具合を修正する。
+
+**Architecture:** source/image/layer の初期登録を style lifecycle に限定し、GeoJSON は `updateGeoJsonSource`、filter は `updateFilter`、paint/layout は layer 単位の差し替えで更新する。共通 helper は GeoJSON 更新の重複抑止・初期化待機と、独立 cleanup の二点だけに限定する。
+
+**Tech Stack:** Flutter 3.44、Dart 3.11、flutter_hooks、Riverpod 3、MapLibre、flutter_test。
+
+## Global Constraints
+
+- Flutter / Dart コマンドは `mise exec --` 経由で実行する。
+- source/image/layer の再登録は、既存 API で定義更新できない場合だけ許可する。
+- cleanup の一件失敗で後続 cleanup を止めない。
+- production code を変更する前に対応する failing test を実行する。
+- 既存の未コミット差分と backend submodule は変更しない。
+
+---
+
+### Task 1: MapLibre lifecycle 共通 helper
+
+**Files:**
+- Create: `app/lib/core/util/map/map_geo_json_source_updater.dart`
+- Create: `app/lib/core/util/map/remove_map_style_resources.dart`
+- Create: `app/test/core/util/map/map_geo_json_source_updater_test.dart`
+- Create: `app/test/core/util/map/remove_map_style_resources_test.dart`
+- Create: `app/test/core/util/map/fake_style_controller.dart`
+
+**Interfaces:**
+- Produces: `MapGeoJsonSourceUpdater.update({required StyleController styleController, required String sourceId, required String geoJson, required Future<void>? initialization, required bool Function() isDisposed})`。
+- Produces: `removeMapStyleResources({required StyleController styleController, List<String> layerIds, List<String> sourceIds, List<String> imageIds})`。
+
+- [ ] **Step 1: GeoJSON updater の failing test を追加する**
+
+```dart
+test('初期化完了後に一度だけ GeoJSON を更新する', () async {
+  final style = FakeStyleController();
+  final init = Completer<void>();
+  final updater = MapGeoJsonSourceUpdater();
+  final update = updater.update(
+    styleController: style,
+    sourceId: 'source',
+    geoJson: '{"type":"FeatureCollection","features":[]}',
+    initialization: init.future,
+    isDisposed: () => false,
+  );
+  expect(style.updatedGeoJsonSources, isEmpty);
+  init.complete();
+  await update;
+  await updater.update(
+    styleController: style,
+    sourceId: 'source',
+    geoJson: '{"type":"FeatureCollection","features":[]}',
+    initialization: Future<void>.value(),
+    isDisposed: () => false,
+  );
+  expect(style.updatedGeoJsonSources, hasLength(1));
+});
+```
+
+- [ ] **Step 2: cleanup の failing test を追加する**
+
+```dart
+test('先頭 layer の削除失敗後も残りの layer/source/image を削除する', () async {
+  final style = FakeStyleController(failingLayerIds: {'first'});
+  await removeMapStyleResources(
+    styleController: style,
+    layerIds: const ['first', 'second'],
+    sourceIds: const ['source'],
+    imageIds: const ['image'],
+  );
+  expect(style.removedLayerIds, ['first', 'second']);
+  expect(style.removedSourceIds, ['source']);
+  expect(style.removedImageIds, ['image']);
+});
+```
+
+- [ ] **Step 3: RED を確認する**
+
+Run: `cd app && mise exec -- flutter test test/core/util/map/map_geo_json_source_updater_test.dart test/core/util/map/remove_map_style_resources_test.dart`
+
+Expected: helper が未定義のため FAIL。
+
+- [ ] **Step 4: helper を最小実装する**
+
+```dart
+class MapGeoJsonSourceUpdater {
+  String? _latestGeoJson;
+
+  Future<void> update({
+    required StyleController styleController,
+    required String sourceId,
+    required String geoJson,
+    required Future<void>? initialization,
+    required bool Function() isDisposed,
+  }) async {
+    await initialization;
+    if (isDisposed() || _latestGeoJson == geoJson) return;
+    await styleController.updateGeoJsonSource(id: sourceId, data: geoJson);
+    _latestGeoJson = geoJson;
+  }
+
+  void reset() => _latestGeoJson = null;
+}
+```
+
+`removeMapStyleResources` は layer、source、image の順に全 ID を巡回し、各呼び出しを独立した `try/on Exception` で実行する。
+
+- [ ] **Step 5: GREEN を確認する**
+
+Run: `cd app && mise exec -- flutter test test/core/util/map/map_geo_json_source_updater_test.dart test/core/util/map/remove_map_style_resources_test.dart`
+
+Expected: PASS。
+
+- [ ] **Step 6: helper をコミットする**
+
+```bash
+git add app/lib/core/util/map app/test/core/util/map
+git commit -m "fix: MapLibre更新と破棄の共通処理を追加"
+```
+
+---
+
+### Task 2: Seismicity source lifecycle
+
+**Files:**
+- Modify: `app/lib/feature/seismicity/ui/layer/seismicity_epicenter_layer.dart`
+- Modify: `app/test/feature/seismicity/ui/layer/seismicity_epicenter_layer_test.dart`
+
+**Interfaces:**
+- Consumes: `MapGeoJsonSourceUpdater`、`removeMapStyleResources`。
+- Produces: style load ごとの一回限りの source/layer 登録と、events/tick ごとの GeoJSON 更新。
+
+- [ ] **Step 1: builder と lifecycle の failing tests を追加する**
+
+`SeismicityEpicenterGeoJsonBuilder.build({required List<SeismicityEvent> events, required DateTime now})` が feature 数と座標・プロパティを保持すること、events 更新時に source/layer の再登録が不要な updater 入力を生成できることを検証する。
+
+- [ ] **Step 2: RED を確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/seismicity/ui/layer/seismicity_epicenter_layer_test.dart`
+
+Expected: builder が未定義のため FAIL。
+
+- [ ] **Step 3: 初期化と更新を分離する**
+
+```dart
+final disposed = useRef(false);
+final initFuture = useRef<Future<void>?>(null);
+final updater = useMemoized(MapGeoJsonSourceUpdater.new);
+
+useEffect(() {
+  if (styleController == null) return null;
+  disposed.value = false;
+  initFuture.value = enqueue(() async {
+    await styleController.addSource(
+      const GeoJsonSource(id: _sourceId, data: _emptyGeoJson),
+    );
+    if (disposed.value) return;
+    await styleController.addLayer(buildLayer(colorMode));
+  });
+  return () {
+    disposed.value = true;
+    updater.reset();
+    unawaited(enqueue(() => removeMapStyleResources(
+      styleController: styleController,
+      layerIds: const [_layerId],
+      sourceIds: const [_sourceId],
+    )));
+  };
+}, [styleController]);
+```
+
+events/tick effect は `MapGeoJsonSourceUpdater.update` のみ実行する。色モード変更 effect は source を維持して layer のみ差し替える。
+
+- [ ] **Step 4: GREEN と既存テストを確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/seismicity`
+
+Expected: PASS。
+
+- [ ] **Step 5: seismicity をコミットする**
+
+```bash
+git add app/lib/feature/seismicity app/test/feature/seismicity
+git commit -m "fix: seismicityレイヤーの更新をsource差し替えに分離"
+```
+
+---
+
+### Task 3: 地震履歴 GeoJSON lifecycle
+
+**Files:**
+- Modify: `app/lib/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_layer.dart`
+- Modify: `app/lib/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_error_layer.dart`
+- Modify: `app/lib/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer.dart`
+- Modify: `app/lib/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer.dart`
+- Create: `app/test/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_layer_lifecycle_test.dart`
+- Create: `app/test/feature/earthquake_history/ui/layer/earthquake_history_hypocenter_error_layer_lifecycle_test.dart`
+- Create: `app/test/feature/earthquake_history/ui/layer/earthquake_history_station_intensity_layer_lifecycle_test.dart`
+- Create: `app/test/feature/earthquake_history/ui/layer/earthquake_history_shindo_db_station_layer_lifecycle_test.dart`
+
+**Interfaces:**
+- Consumes: lifecycle helpers from Task 1。
+- Produces: earthquake/tree/color/display-mode 更新時の source/image 再登録を排除した各レイヤー。
+
+- [ ] **Step 1: 各 GeoJSON builder の更新回帰テストを追加する**
+
+震源、誤差 Polygon、観測点、震度DB観測点について、入力変更で GeoJSON が変わる一方、source ID と image ID が不変であることを検証する。
+
+- [ ] **Step 2: RED を確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/layer`
+
+Expected: 現行の private builder または lifecycle API では更新契約を検証できず FAIL。
+
+- [ ] **Step 3: source/image 初期化を style lifecycle に限定する**
+
+各 Widget で `initFuture`、`disposed`、`MapGeoJsonSourceUpdater` を保持する。earthquake/tree/color/display mode はデータ更新 effect に移し、parameter や label 表示は layer だけを差し替える。画像は style ごとに一度だけ登録する。
+
+- [ ] **Step 4: cleanup を共通 helper へ置き換える**
+
+station label、icon、circle、source の削除は独立して全件試行する。部分初期化後の cleanup でも後続 source 削除が実行されるようにする。
+
+- [ ] **Step 5: GREEN を確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/earthquake_history/ui/layer`
+
+Expected: PASS。
+
+- [ ] **Step 6: 地震履歴をコミットする**
+
+```bash
+git add app/lib/feature/earthquake_history/ui/layer app/test/feature/earthquake_history/ui/layer
+git commit -m "fix: 地震履歴レイヤーのsource再登録を解消"
+```
+
+---
+
+### Task 4: 津波詳細 GeoJSON lifecycle
+
+**Files:**
+- Modify: `app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart`
+- Create: `app/test/feature/tsunami/ui/components/tsunami_map_geo_json_builder_test.dart`
+
+**Interfaces:**
+- Consumes: lifecycle helpers from Task 1。
+- Produces: 予報区、震源、観測点 source を style ごとに一度だけ登録し、tsunami state 更新を GeoJSON 差し替えで反映する。
+
+- [ ] **Step 1: 3種類の GeoJSON builder 回帰テストを追加する**
+
+予報区の warning kind、震源座標、観測点の高さ・色・名称が state 更新後の GeoJSON に反映されることを検証する。
+
+- [ ] **Step 2: RED を確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/tsunami/ui/components/tsunami_map_geo_json_builder_test.dart`
+
+Expected: testable builder が未定義のため FAIL。
+
+- [ ] **Step 3: builder を UI から分離し、source 更新 effect を追加する**
+
+source は空 FeatureCollection で初期化し、JMA parameter 未取得時も Widget lifecycle を維持する。parameter 到着後または tsunami 更新後に updater で差し替える。warning kind ごとの layer filter は固定のため再作成しない。
+
+- [ ] **Step 4: GREEN を確認する**
+
+Run: `cd app && mise exec -- flutter test test/feature/tsunami`
+
+Expected: PASS。
+
+- [ ] **Step 5: 津波詳細をコミットする**
+
+```bash
+git add app/lib/feature/tsunami app/test/feature/tsunami
+git commit -m "fix: 津波詳細レイヤーのGeoJSON更新を分離"
+```
+
+---
+
+### Task 5: 全レイヤー cleanup 監査と修正
+
+**Files:**
+- Modify: `app/lib/feature/home/ui/component/map/layer/eew_hypocenter_layer.dart`
+- Modify: `app/lib/feature/home/ui/component/map/layer/eew_ps_wave_layer.dart`
+- Modify: `app/lib/feature/home/ui/component/map/layer/kyoshin_monitor_observation_layer.dart`
+- Modify: `app/lib/feature/home/ui/component/map/layer/shake_detection_layer.dart`
+- Create: `docs/knowledge/20260720_maplibre_layer_lifecycle.md`
+
+**Interfaces:**
+- Consumes: `removeMapStyleResources`。
+- Produces: 全 MapLibre layer について、一件の削除失敗で後続 resource が残留しない cleanup。
+
+- [ ] **Step 1: 全操作箇所を再検索して監査表を確定する**
+
+Run: `rg -l 'addSource\(|addLayer\(|removeSource\(|removeLayer\(|updateGeoJsonSource\(' app/lib --glob '*.dart'`
+
+各ファイルを「安全な静的」「安全な update 分離」「source 再作成修正済み」「cleanup 修正対象」に分類する。
+
+- [ ] **Step 2: cleanup helper の回帰テストを対象リソース数で拡張する**
+
+複数 layer と複数 source の途中失敗でも、全 ID が順番どおり試行されることを追加する。
+
+- [ ] **Step 3: grouped cleanup を helper へ置換する**
+
+EEW震源、P/S波、強震モニタ、揺れ検知を含む全該当箇所で layer → source の順序を明示する。既に個別 cleanup 済みの実装は変更しない。
+
+- [ ] **Step 4: knowledge を記録する**
+
+規約、代表コード、監査用 `rg`、focused test コマンドを `docs/knowledge/20260720_maplibre_layer_lifecycle.md` に記載する。
+
+- [ ] **Step 5: focused tests を実行する**
+
+Run: `cd app && mise exec -- flutter test test/core/util/map test/feature/seismicity test/feature/earthquake_history/ui/layer test/feature/tsunami`
+
+Expected: PASS。
+
+- [ ] **Step 6: cleanup 監査をコミットする**
+
+```bash
+git add app/lib/feature docs/knowledge/20260720_maplibre_layer_lifecycle.md app/test
+git commit -m "fix: MapLibreレイヤーの破棄を全件独立化"
+```
+
+---
+
+### Task 6: 全体検証と draft PR
+
+**Files:**
+- No planned file changes; scoped defects found by verification return to the owning task.
+
+**Interfaces:**
+- Consumes: all previous tasks。
+- Produces: verified branch and draft PR。
+
+- [ ] **Step 1: format を実行する**
+
+Run: `cd app && mise exec -- dart format lib/core/util/map lib/feature/seismicity lib/feature/earthquake_history/ui/layer lib/feature/tsunami test/core/util/map test/feature/seismicity test/feature/earthquake_history/ui/layer test/feature/tsunami`
+
+- [ ] **Step 2: focused tests を再実行する**
+
+Run: `cd app && mise exec -- flutter test test/core/util/map test/feature/seismicity test/feature/earthquake_history/ui/layer test/feature/tsunami`
+
+Expected: PASS。
+
+- [ ] **Step 3: analyze を実行する**
+
+Run: `cd app && mise exec -- flutter analyze`
+
+Expected: 0 issues。既存の無関係 failure がある場合は touched seam の analyze を追加し、双方を記録する。
+
+- [ ] **Step 4: repository gates を実行する**
+
+Run: `git diff --check develop...HEAD`
+
+Run: `git status --short`
+
+Expected: whitespace error なし、未コミット差分なし。
+
+- [ ] **Step 5: PR 前レビューを実施する**
+
+仕様適合、全操作箇所の監査漏れ、非同期 race、テストの実効性を diff 上で再確認し、指摘があれば修正・再検証する。
+
+- [ ] **Step 6: push と draft PR を作成する**
+
+Branch: `codex/fix-map-layer-lifecycle`
+
+PR title: `fix: MapLibreレイヤーのライフサイクルを修正`
+
+PR body には原因、修正対象、監査で安全と判断したパターン、RED/GREEN テスト、最終検証結果を記載する。

--- a/docs/superpowers/specs/2026-07-20-map-layer-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-20-map-layer-lifecycle-design.md
@@ -1,0 +1,104 @@
+# MapLibre レイヤーライフサイクル修正設計
+
+## 目的
+
+`SeismicityEpicenterLayer` を起点に、アプリ内の MapLibre source/image/layer 操作を全件監査し、可変データ更新や非同期初期化・破棄の競合によってレイヤーが消失、重複、復旧不能になる不具合を修正する。
+
+## 対象範囲
+
+`app/lib` 配下で次の API を使用するすべての実装を監査対象とする。
+
+- `StyleController.addSource` / `removeSource`
+- `StyleController.addImage` / `addImages` / `addImageFromAssets`
+- `StyleController.addLayer` / `removeLayer`
+- `StyleController.updateGeoJsonSource` / `updateFilter`
+
+監査では、ホーム、緊急地震速報、地震履歴、震度履歴、地震活動、揺れ検知、津波詳細の各地図を確認する。修正は監査基準に違反する実装だけに限定し、静的レイヤーや source URL の変更に完全再作成が必要な実装は維持する。
+
+## 採用方針
+
+各レイヤーを個別に修正し、既存の `MapOperationQueueScope` と `useMapOperationQueue` を利用する。全レイヤーを新しい汎用 lifecycle abstraction や宣言的 layer API へ移行する大規模変更は行わない。
+
+テストでは共通の fake `StyleController` / `MapController` harness を用意し、Widget から発行される実際の MapLibre 操作列を検証する。これにより production code にテスト専用 API を追加せず、各レイヤーの登録・更新・破棄動作を同じ基準で検証する。
+
+## ライフサイクル規約
+
+### 初期化
+
+- source、image、layer の初期登録 effect は原則として `styleController` と、登録可否を決める不変依存だけを持つ。
+- 初期化時に可変データの最新版が必要な場合は `useRef` から読み取る。
+- 初期化完了を `isInitialized` と初期化 Future で追跡する。
+- 非同期初期化中に unmount された場合、後続の source/image/layer 登録を `disposed` で中止する。
+
+### 更新
+
+- GeoJSON の内容変更には `updateGeoJsonSource` を使用し、source を再登録しない。
+- filter の変更には `updateFilter` を使用する。
+- paint/layout の変更に MapLibre API がない場合は layer だけを削除・再追加し、source と image は維持する。
+- 更新処理は初期化 Future の完了後に実行し、破棄開始後は実行しない。
+- 同一 GeoJSON の重複更新は最新値キャッシュで抑止する。
+
+### 破棄
+
+- layer を逆順で削除してから source を削除する。
+- 各 `removeLayer`、`removeSource`、必要な `removeImage` は個別に例外処理し、一件の失敗で後続 cleanup を止めない。
+- cleanup は共有 `MapOperationQueue` に積み、同一マップ上の再初期化との順序を保証する。
+- 完全には初期化されなかった状態でも cleanup が安全に完走することを保証する。
+
+### 完全再作成を許可する条件
+
+- `VectorSource.url` など、既存 API で更新できない source 定義自体が変更された場合。
+- 表示対象の有無によって Widget 自体が mount/unmount される場合。
+- その場合も非同期初期化の中断と個別 cleanup を必須とする。
+
+## 監査上の分類
+
+### 既に望ましい分離がある実装
+
+P/S 波、揺れ検知、強震モニタ観測点など、初期化 effect と `updateGeoJsonSource` effect が分離されている実装は参照パターンとして使用する。ただし cleanup の個別例外処理と初期化 Future 待機は改めて確認する。
+
+### 修正が必要と判定した実装
+
+少なくとも次を同型不具合として修正対象に含める。
+
+- `SeismicityEpicenterLayer`: events、色モード、10分 tick ごとに source/layer を完全再作成している。
+- 地震履歴の震源・震源誤差・震度DB観測点: earthquake/tree や表示設定の変更で source/image/layer を再登録している。
+- 津波詳細の予報区・震源・観測点: tsunami state や parameter provider の更新で source/image/layer を再登録している。
+
+残りのレイヤーも同じ基準で監査し、違反が確認できたものは同じ PR に含める。
+
+## データフロー
+
+1. MapLibre の style load 後、レイヤー Widget が空または最新の GeoJSON source と静的 layer/image を一度登録する。
+2. provider、引数、タイマーから可変データが更新される。
+3. データ専用 effect が初期化完了を待ち、GeoJSON source、filter、または layer 定義の必要最小単位だけを更新する。
+4. Widget の破棄時は更新を停止し、登録済みリソースを逆順・個別例外処理で削除する。
+
+## エラー処理
+
+- MapLibre 操作エラーは `talker.handle` または既存の `talker.log` 方針に従って記録する。
+- cleanup は best effort だが、すべての対象リソースを必ず試行する。
+- add/update の失敗を成功扱いにせず、`isInitialized` や最新 GeoJSON キャッシュを成功後だけ更新する。
+- 更新失敗後の次回更新で再試行できる状態を保つ。
+
+## テスト戦略
+
+- `SeismicityEpicenterLayer` が初回に source/layer を一度だけ登録する。
+- events または tick 更新時は `updateGeoJsonSource` のみを呼び、source/layer を再登録しない。
+- 色モード変更時は source を維持し、必要最小限の layer 更新だけを行う。
+- cleanup で一つの layer 削除が失敗しても、残りの layer/source 削除を試行する。
+- 非同期初期化中に破棄しても、破棄後の layer 登録を行わない。
+- 監査で修正した各レイヤーについて、可変データ変更時に source/image の再登録がないことを focused test で検証する。
+- 対象テスト、`flutter analyze`、`git diff --check` を最終ゲートとする。
+
+## ドキュメント
+
+今回確立した MapLibre の初期化・更新・破棄規約とテスト方法を `docs/knowledge/20260720_maplibre_layer_lifecycle.md` に残す。
+
+## 完了条件
+
+- 全 MapLibre 操作箇所の監査結果が説明可能である。
+- 監査基準に違反する全レイヤーが修正されている。
+- lifecycle 回帰テストが修正前に失敗し、修正後に成功する。
+- focused tests、analyze、diff check が成功する。
+- 変更がコミット・push され、draft PR が作成されている。


### PR DESCRIPTION
## 概要

MapLibre の source/image/layer 操作を全件監査し、可変データ更新時に同一 ID のリソースを削除・再登録して描画が消えるライフサイクル不具合を修正します。

## 原因

`seismicity_epicenter_layer` では events、色モード、10分 tick を初期化 effect の依存に含めていたため、更新のたびに source/layer の非同期 cleanup と再登録が競合していました。同型の構造が地震履歴・津波詳細・強震モニタにもあり、複数 resource の cleanup が一件の例外で中断する実装も残っていました。

## 変更内容

- source/image/layer の初期登録を style lifecycle に限定
- GeoJSON 更新を `updateGeoJsonSource` に分離し、初期化 Future 待機・重複更新抑止・破棄後更新防止を追加
- seismicity、地震履歴4レイヤー、津波詳細3レイヤー、強震モニタを修正
- EEW震源・P/S波・揺れ検知を含む cleanup を layer → source → image の順で全件独立化
- GeoJSON builder と lifecycle helper の回帰テストを追加
- MapLibre lifecycle 規約と監査方法を knowledge に記録

PMTiles URL など source 定義自体が変わる実装は、完全再作成が必要なため維持しています。

## 検証

- `mise exec -- flutter test test/core/util/map test/feature/seismicity test/feature/earthquake_history/ui/layer test/feature/tsunami test/feature/home/ui/component/map/layer`
  - 204 tests passed
- `mise exec -- flutter analyze app --no-pub`
  - 変更箇所の指摘なし
  - 既存の3 warningsのみ（lint include、inner plugin、未変更ファイルのdead code）
- `git diff --check develop...HEAD`
  - pass
