### PR TITLE
fix: 地図ラベルの初期表示を無効化

### DIFF
--- a/app/lib/feature/home/data/model/home_map_label_parameter.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.dart
@@ -6,8 +6,8 @@ part 'home_map_label_parameter.g.dart';
 @freezed
 abstract class HomeMapLabelParameter with _$HomeMapLabelParameter {
   const factory HomeMapLabelParameter({
-    @Default(true) bool showRegionLabel,
-    @Default(true) bool showCityLabel,
+    @Default(false) bool showRegionLabel,
+    @Default(false) bool showCityLabel,
     @Default(5.0) double regionLabelMinZoom,
     @Default(9.0) double cityLabelMinZoom,
     @Default(14) double regionTextSize,

--- a/app/lib/feature/home/data/model/home_map_label_parameter.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.dart
@@ -6,8 +6,8 @@ part 'home_map_label_parameter.g.dart';
 @freezed
 abstract class HomeMapLabelParameter with _$HomeMapLabelParameter {
   const factory HomeMapLabelParameter({
-    @Default(false) bool showRegionLabel,
-    @Default(false) bool showCityLabel,
+    @JsonKey(defaultValue: true) @Default(false) bool showRegionLabel,
+    @JsonKey(defaultValue: true) @Default(false) bool showCityLabel,
     @Default(5.0) double regionLabelMinZoom,
     @Default(9.0) double cityLabelMinZoom,
     @Default(14) double regionTextSize,

--- a/app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart
@@ -215,7 +215,7 @@ return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZo
 @JsonSerializable()
 
 class _HomeMapLabelParameter implements HomeMapLabelParameter {
-  const _HomeMapLabelParameter({this.showRegionLabel = true, this.showCityLabel = true, this.regionLabelMinZoom = 5.0, this.cityLabelMinZoom = 9.0, this.regionTextSize = 14, this.cityTextSize = 12, this.textHaloWidth = 1.0});
+  const _HomeMapLabelParameter({this.showRegionLabel = false, this.showCityLabel = false, this.regionLabelMinZoom = 5.0, this.cityLabelMinZoom = 9.0, this.regionTextSize = 14, this.cityTextSize = 12, this.textHaloWidth = 1.0});
   factory _HomeMapLabelParameter.fromJson(Map<String, dynamic> json) => _$HomeMapLabelParameterFromJson(json);
 
 @override@JsonKey() final  bool showRegionLabel;

--- a/app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$HomeMapLabelParameter {
 
- bool get showRegionLabel; bool get showCityLabel; double get regionLabelMinZoom; double get cityLabelMinZoom; double get regionTextSize; double get cityTextSize; double get textHaloWidth;
+@JsonKey(defaultValue: true) bool get showRegionLabel;@JsonKey(defaultValue: true) bool get showCityLabel; double get regionLabelMinZoom; double get cityLabelMinZoom; double get regionTextSize; double get cityTextSize; double get textHaloWidth;
 /// Create a copy of HomeMapLabelParameter
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $HomeMapLabelParameterCopyWith<$Res>  {
   factory $HomeMapLabelParameterCopyWith(HomeMapLabelParameter value, $Res Function(HomeMapLabelParameter) _then) = _$HomeMapLabelParameterCopyWithImpl;
 @useResult
 $Res call({
- bool showRegionLabel, bool showCityLabel, double regionLabelMinZoom, double cityLabelMinZoom, double regionTextSize, double cityTextSize, double textHaloWidth
+@JsonKey(defaultValue: true) bool showRegionLabel,@JsonKey(defaultValue: true) bool showCityLabel, double regionLabelMinZoom, double cityLabelMinZoom, double regionTextSize, double cityTextSize, double textHaloWidth
 });
 
 
@@ -159,7 +159,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool showRegionLabel,  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(defaultValue: true)  bool showRegionLabel, @JsonKey(defaultValue: true)  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _HomeMapLabelParameter() when $default != null:
 return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZoom,_that.cityLabelMinZoom,_that.regionTextSize,_that.cityTextSize,_that.textHaloWidth);case _:
@@ -180,7 +180,7 @@ return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZo
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool showRegionLabel,  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(defaultValue: true)  bool showRegionLabel, @JsonKey(defaultValue: true)  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)  $default,) {final _that = this;
 switch (_that) {
 case _HomeMapLabelParameter():
 return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZoom,_that.cityLabelMinZoom,_that.regionTextSize,_that.cityTextSize,_that.textHaloWidth);case _:
@@ -200,7 +200,7 @@ return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZo
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool showRegionLabel,  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(defaultValue: true)  bool showRegionLabel, @JsonKey(defaultValue: true)  bool showCityLabel,  double regionLabelMinZoom,  double cityLabelMinZoom,  double regionTextSize,  double cityTextSize,  double textHaloWidth)?  $default,) {final _that = this;
 switch (_that) {
 case _HomeMapLabelParameter() when $default != null:
 return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZoom,_that.cityLabelMinZoom,_that.regionTextSize,_that.cityTextSize,_that.textHaloWidth);case _:
@@ -215,11 +215,11 @@ return $default(_that.showRegionLabel,_that.showCityLabel,_that.regionLabelMinZo
 @JsonSerializable()
 
 class _HomeMapLabelParameter implements HomeMapLabelParameter {
-  const _HomeMapLabelParameter({this.showRegionLabel = false, this.showCityLabel = false, this.regionLabelMinZoom = 5.0, this.cityLabelMinZoom = 9.0, this.regionTextSize = 14, this.cityTextSize = 12, this.textHaloWidth = 1.0});
+  const _HomeMapLabelParameter({@JsonKey(defaultValue: true) this.showRegionLabel = false, @JsonKey(defaultValue: true) this.showCityLabel = false, this.regionLabelMinZoom = 5.0, this.cityLabelMinZoom = 9.0, this.regionTextSize = 14, this.cityTextSize = 12, this.textHaloWidth = 1.0});
   factory _HomeMapLabelParameter.fromJson(Map<String, dynamic> json) => _$HomeMapLabelParameterFromJson(json);
 
-@override@JsonKey() final  bool showRegionLabel;
-@override@JsonKey() final  bool showCityLabel;
+@override@JsonKey(defaultValue: true) final  bool showRegionLabel;
+@override@JsonKey(defaultValue: true) final  bool showCityLabel;
 @override@JsonKey() final  double regionLabelMinZoom;
 @override@JsonKey() final  double cityLabelMinZoom;
 @override@JsonKey() final  double regionTextSize;
@@ -259,7 +259,7 @@ abstract mixin class _$HomeMapLabelParameterCopyWith<$Res> implements $HomeMapLa
   factory _$HomeMapLabelParameterCopyWith(_HomeMapLabelParameter value, $Res Function(_HomeMapLabelParameter) _then) = __$HomeMapLabelParameterCopyWithImpl;
 @override @useResult
 $Res call({
- bool showRegionLabel, bool showCityLabel, double regionLabelMinZoom, double cityLabelMinZoom, double regionTextSize, double cityTextSize, double textHaloWidth
+@JsonKey(defaultValue: true) bool showRegionLabel,@JsonKey(defaultValue: true) bool showCityLabel, double regionLabelMinZoom, double cityLabelMinZoom, double regionTextSize, double cityTextSize, double textHaloWidth
 });
 
 

--- a/app/lib/feature/home/data/model/home_map_label_parameter.g.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.g.dart
@@ -17,11 +17,11 @@ _HomeMapLabelParameter _$HomeMapLabelParameterFromJson(
     final val = _HomeMapLabelParameter(
       showRegionLabel: $checkedConvert(
         'show_region_label',
-        (v) => v as bool? ?? false,
+        (v) => v as bool? ?? true,
       ),
       showCityLabel: $checkedConvert(
         'show_city_label',
-        (v) => v as bool? ?? false,
+        (v) => v as bool? ?? true,
       ),
       regionLabelMinZoom: $checkedConvert(
         'region_label_min_zoom',

--- a/app/lib/feature/home/data/model/home_map_label_parameter.g.dart
+++ b/app/lib/feature/home/data/model/home_map_label_parameter.g.dart
@@ -17,11 +17,11 @@ _HomeMapLabelParameter _$HomeMapLabelParameterFromJson(
     final val = _HomeMapLabelParameter(
       showRegionLabel: $checkedConvert(
         'show_region_label',
-        (v) => v as bool? ?? true,
+        (v) => v as bool? ?? false,
       ),
       showCityLabel: $checkedConvert(
         'show_city_label',
-        (v) => v as bool? ?? true,
+        (v) => v as bool? ?? false,
       ),
       regionLabelMinZoom: $checkedConvert(
         'region_label_min_zoom',

--- a/app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.dart
+++ b/app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.dart
@@ -9,6 +9,10 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'home_map_label_parameter_notifier.g.dart';
 
 const _default = HomeMapLabelParameter();
+const _legacyFallback = HomeMapLabelParameter(
+  showRegionLabel: true,
+  showCityLabel: true,
+);
 
 @Riverpod(keepAlive: true)
 class HomeMapLabelParameterNotifier extends _$HomeMapLabelParameterNotifier {
@@ -34,7 +38,7 @@ class HomeMapLabelParameterNotifier extends _$HomeMapLabelParameterNotifier {
         exception,
         stackTrace,
       );
-      return _default;
+      return _legacyFallback;
     }
   }
 

--- a/app/test/feature/home/data/model/home_map_label_parameter_test.dart
+++ b/app/test/feature/home/data/model/home_map_label_parameter_test.dart
@@ -1,0 +1,13 @@
+import 'package:eqmonitor/feature/home/data/model/home_map_label_parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('disables both home map labels by default', () {
+    const parameter = HomeMapLabelParameter();
+
+    expect(parameter.showRegionLabel, isFalse);
+    expect(parameter.showCityLabel, isFalse);
+    expect(parameter.regionLabelMinZoom, 5.0);
+    expect(parameter.cityLabelMinZoom, 9.0);
+  });
+}

--- a/app/test/feature/home/data/model/home_map_label_parameter_test.dart
+++ b/app/test/feature/home/data/model/home_map_label_parameter_test.dart
@@ -10,4 +10,11 @@ void main() {
     expect(parameter.regionLabelMinZoom, 5.0);
     expect(parameter.cityLabelMinZoom, 9.0);
   });
+
+  test('keeps legacy label defaults when deserializing missing fields', () {
+    final parameter = HomeMapLabelParameter.fromJson(<String, dynamic>{});
+
+    expect(parameter.showRegionLabel, isTrue);
+    expect(parameter.showCityLabel, isTrue);
+  });
 }

--- a/app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
+++ b/app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
@@ -1,4 +1,3 @@
-import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
 import 'package:eqmonitor/core/provider/log/talker.dart' as talker_lib;
 import 'package:eqmonitor/feature/home/data/notifier/home_map_label_parameter_notifier.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,14 +13,7 @@ void main() {
     SharedPreferences.setMockInitialValues(<String, Object>{
       'home_map_label_parameter': 'not json',
     });
-    final preferences = await SharedPreferences.getInstance();
-    final container = ProviderContainer(
-      overrides: [
-        app_prefs.sharedPreferencesProvider.overrideWithValue(
-          app_prefs.SharedPreferencesAsync(preferences),
-        ),
-      ],
-    );
+    final container = ProviderContainer();
     addTearDown(container.dispose);
 
     final parameter = await container.read(homeMapLabelParameterProvider.future);

--- a/app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
+++ b/app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
@@ -1,0 +1,32 @@
+import 'package:eqmonitor/core/provider/shared_preferences.dart' as app_prefs;
+import 'package:eqmonitor/core/provider/log/talker.dart' as talker_lib;
+import 'package:eqmonitor/feature/home/data/notifier/home_map_label_parameter_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  talker_lib.talker = Talker();
+
+  test('keeps legacy labels enabled when a saved value is malformed', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'home_map_label_parameter': 'not json',
+    });
+    final preferences = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        app_prefs.sharedPreferencesProvider.overrideWithValue(
+          app_prefs.SharedPreferencesAsync(preferences),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final parameter = await container.read(homeMapLabelParameterProvider.future);
+
+    expect(parameter.showRegionLabel, isTrue);
+    expect(parameter.showCityLabel, isTrue);
+  });
+}

--- a/app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
+++ b/app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
@@ -16,7 +16,9 @@ void main() {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
-    final parameter = await container.read(homeMapLabelParameterProvider.future);
+    final parameter = await container.read(
+      homeMapLabelParameterProvider.future,
+    );
 
     expect(parameter.showRegionLabel, isTrue);
     expect(parameter.showCityLabel, isTrue);

--- a/docs/knowledge/20260722_analyzer_plugin_worktree.md
+++ b/docs/knowledge/20260722_analyzer_plugin_worktree.md
@@ -1,0 +1,18 @@
+# Analyzer plugin path in Git worktrees
+
+## Symptom
+
+Running `mise exec -- dart analyze` can stop before source diagnostics with an
+analyzer-plugin setup error for `app/tools/eqmonitor_custom_lints`.
+
+## Cause
+
+`app/analysis_options.yaml` references the custom-lint plugin through that
+project-relative path. The path is absent in this worktree, so the analyzer
+cannot resolve the plugin package.
+
+## Recovery
+
+Restore the expected plugin directory or update the analyzer configuration to
+the valid checked-out plugin path, then rerun the intended `dart analyze`
+command. Do not treat this setup failure as a source-level analysis result.

--- a/docs/superpowers/plans/2026-07-22-default-map-labels.md
+++ b/docs/superpowers/plans/2026-07-22-default-map-labels.md
@@ -144,3 +144,71 @@ git add app/lib/feature/home/data/model/home_map_label_parameter.dart \
   app/test/feature/home/data/model/home_map_label_parameter_test.dart
 git commit -m "fix: 旧地図ラベル設定の復元を維持"
 ```
+
+### Task 3: Preserve malformed saved-preference recovery
+
+**Files:**
+- Modify: `app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.dart:11-38`
+- Create: `app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart`
+
+**Interfaces:**
+- Consumes: `homeMapLabelParameterProvider.future` with the
+  `home_map_label_parameter` SharedPreferences value set to invalid JSON.
+- Produces: a recovered `HomeMapLabelParameter` with both label values `true`.
+
+- [ ] **Step 1: Write the failing notifier regression test**
+
+```dart
+test('keeps legacy labels enabled when a saved value is malformed', () async {
+  SharedPreferences.setMockInitialValues(<String, Object>{
+    'home_map_label_parameter': 'not json',
+  });
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+
+  final parameter = await container.read(homeMapLabelParameterProvider.future);
+
+  expect(parameter.showRegionLabel, isTrue);
+  expect(parameter.showCityLabel, isTrue);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `mise exec -- flutter test app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart`
+
+Expected: FAIL because the current catch path returns the new-user default
+with both labels disabled.
+
+- [ ] **Step 3: Restore only the legacy error fallback**
+
+```dart
+const _default = HomeMapLabelParameter();
+const _legacyFallback = HomeMapLabelParameter(
+  showRegionLabel: true,
+  showCityLabel: true,
+);
+```
+
+Return `_legacyFallback` only from the JSON error `catch` path. Keep missing
+preference handling (`jsonString == null`) returning `_default`.
+
+- [ ] **Step 4: Run focused validation**
+
+Run:
+
+```bash
+mise exec -- flutter test app/test/feature/home/data/model/home_map_label_parameter_test.dart app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
+mise exec -- dart analyze app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.dart app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
+```
+
+Expected: both test files pass; report any analyzer setup failure unrelated to
+the change with its exact configuration error.
+
+- [ ] **Step 5: Commit the repair**
+
+```bash
+git add app/lib/feature/home/data/notifier/home_map_label_parameter_notifier.dart \
+  app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart
+git commit -m "fix: 破損した地図ラベル設定の復元を維持"
+```

--- a/docs/superpowers/plans/2026-07-22-default-map-labels.md
+++ b/docs/superpowers/plans/2026-07-22-default-map-labels.md
@@ -1,0 +1,87 @@
+# Default Map Labels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Disable home-map region and city labels for users without a saved preference.
+
+**Architecture:** The immutable `HomeMapLabelParameter` model is the single source of default values. Its existing notifier returns this model only when the shared-preferences value is absent or invalid, so changing the model defaults preserves all stored user preferences.
+
+**Tech Stack:** Flutter, Dart, Freezed, json_serializable, flutter_test.
+
+## Global Constraints
+
+- Set both `showRegionLabel` and `showCityLabel` defaults to `false`.
+- Do not alter the shared-preferences key, deserialization behavior, or saved preferences.
+- Regenerate checked-in Freezed and JSON files with `mise exec -- dart run build_runner build --delete-conflicting-outputs`.
+- Run Flutter/Dart commands through `mise exec --`.
+
+---
+
+### Task 1: Disable the default home-map labels
+
+**Files:**
+- Modify: `app/lib/feature/home/data/model/home_map_label_parameter.dart:8-16`
+- Modify: `app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart` (generated)
+- Modify: `app/lib/feature/home/data/model/home_map_label_parameter.g.dart` (generated if changed)
+- Create: `app/test/feature/home/data/model/home_map_label_parameter_test.dart`
+
+**Interfaces:**
+- Consumes: `const HomeMapLabelParameter()`.
+- Produces: defaults where `showRegionLabel == false` and `showCityLabel == false`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:eqmonitor/feature/home/data/model/home_map_label_parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('disables both home map labels by default', () {
+    const parameter = HomeMapLabelParameter();
+
+    expect(parameter.showRegionLabel, isFalse);
+    expect(parameter.showCityLabel, isFalse);
+    expect(parameter.regionLabelMinZoom, 5.0);
+    expect(parameter.cityLabelMinZoom, 9.0);
+  });
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `mise exec -- flutter test test/feature/home/data/model/home_map_label_parameter_test.dart`
+
+Expected: FAIL because the current defaults are `true`.
+
+- [ ] **Step 3: Implement the minimal default change and regenerate code**
+
+```dart
+const factory HomeMapLabelParameter({
+  @Default(false) bool showRegionLabel,
+  @Default(false) bool showCityLabel,
+  // Existing numeric defaults unchanged.
+}) = _HomeMapLabelParameter;
+```
+
+Run: `mise exec -- dart run build_runner build --delete-conflicting-outputs`
+
+- [ ] **Step 4: Run focused validation**
+
+Run:
+
+```bash
+mise exec -- flutter test test/feature/home/data/model/home_map_label_parameter_test.dart
+mise exec -- dart analyze lib/feature/home/data/model/home_map_label_parameter.dart test/feature/home/data/model/home_map_label_parameter_test.dart
+```
+
+Expected: both commands exit with status 0.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add app/lib/feature/home/data/model/home_map_label_parameter.dart \
+  app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart \
+  app/lib/feature/home/data/model/home_map_label_parameter.g.dart \
+  app/test/feature/home/data/model/home_map_label_parameter_test.dart
+git commit -m "fix: 地図ラベルの初期表示を無効化"
+```

--- a/docs/superpowers/plans/2026-07-22-default-map-labels.md
+++ b/docs/superpowers/plans/2026-07-22-default-map-labels.md
@@ -85,3 +85,62 @@ git add app/lib/feature/home/data/model/home_map_label_parameter.dart \
   app/test/feature/home/data/model/home_map_label_parameter_test.dart
 git commit -m "fix: 地図ラベルの初期表示を無効化"
 ```
+
+### Task 2: Preserve legacy partial preference deserialization
+
+**Files:**
+- Modify: `app/lib/feature/home/data/model/home_map_label_parameter.dart:8-12`
+- Modify: `app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart` (generated)
+- Modify: `app/lib/feature/home/data/model/home_map_label_parameter.g.dart` (generated)
+- Modify: `app/test/feature/home/data/model/home_map_label_parameter_test.dart`
+
+**Interfaces:**
+- Consumes: `const HomeMapLabelParameter()` and `HomeMapLabelParameter.fromJson(Map<String, dynamic>)`.
+- Produces: constructor defaults of `false`, while JSON that omits either legacy label field restores it as `true`.
+
+- [ ] **Step 1: Extend the failing regression test**
+
+```dart
+test('keeps legacy label defaults when deserializing missing fields', () {
+  final parameter = HomeMapLabelParameter.fromJson(<String, dynamic>{});
+
+  expect(parameter.showRegionLabel, isTrue);
+  expect(parameter.showCityLabel, isTrue);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `mise exec -- flutter test app/test/feature/home/data/model/home_map_label_parameter_test.dart`
+
+Expected: FAIL because the current generated JSON defaults deserialize omitted label fields as `false`.
+
+- [ ] **Step 3: Preserve the JSON defaults and regenerate code**
+
+```dart
+@JsonKey(defaultValue: true) @Default(false) bool showRegionLabel,
+@JsonKey(defaultValue: true) @Default(false) bool showCityLabel,
+```
+
+Run: `mise exec -- dart run build_runner build --delete-conflicting-outputs`
+
+- [ ] **Step 4: Run focused validation**
+
+Run:
+
+```bash
+mise exec -- flutter test app/test/feature/home/data/model/home_map_label_parameter_test.dart
+mise exec -- dart analyze app/lib/feature/home/data/model/home_map_label_parameter.dart app/test/feature/home/data/model/home_map_label_parameter_test.dart
+```
+
+Expected: the focused test exits with status 0; report any analyzer failure unrelated to this change with its exact configuration error.
+
+- [ ] **Step 5: Commit the repair**
+
+```bash
+git add app/lib/feature/home/data/model/home_map_label_parameter.dart \
+  app/lib/feature/home/data/model/home_map_label_parameter.freezed.dart \
+  app/lib/feature/home/data/model/home_map_label_parameter.g.dart \
+  app/test/feature/home/data/model/home_map_label_parameter_test.dart
+git commit -m "fix: 旧地図ラベル設定の復元を維持"
+```

--- a/docs/superpowers/plans/2026-07-22-default-map-labels.md
+++ b/docs/superpowers/plans/2026-07-22-default-map-labels.md
@@ -4,7 +4,7 @@
 
 **Goal:** Disable home-map region and city labels for users without a saved preference.
 
-**Architecture:** The immutable `HomeMapLabelParameter` model is the single source of default values. Its existing notifier returns this model only when the shared-preferences value is absent or invalid, so changing the model defaults preserves all stored user preferences.
+**Architecture:** The immutable `HomeMapLabelParameter` model is the single source of new-user defaults: an absent shared-preferences value returns its `false`/`false` defaults. A malformed saved value deliberately recovers to the legacy `true`/`true` setting, while valid stored preferences are preserved.
 
 **Tech Stack:** Flutter, Dart, Freezed, json_serializable, flutter_test.
 

--- a/docs/superpowers/specs/2026-07-22-default-map-labels-design.md
+++ b/docs/superpowers/specs/2026-07-22-default-map-labels-design.md
@@ -1,0 +1,20 @@
+# Default Map Labels Design
+
+## Goal
+
+Disable region and city labels by default on the home map.
+
+## Scope
+
+`HomeMapLabelParameter` supplies the defaults used when no saved map-label
+preference exists. Change only its `showRegionLabel` and `showCityLabel`
+defaults from `true` to `false`.
+
+Previously saved preferences remain unchanged because they are deserialized
+from the existing shared-preferences value.
+
+## Validation
+
+Add a model test that verifies a newly constructed parameter disables both
+label types while retaining the existing numeric defaults. Run the focused
+test and static analysis for the touched files.


### PR DESCRIPTION
## 概要

ホーム地図の地域・市区町村ラベルを、新規ユーザーでは初期表示しないようにしました。

## 変更内容

- `HomeMapLabelParameter` の新規既定値を両方 `false` に変更
- 既存の部分保存 JSON で欠落したラベル項目は従来どおり `true` として復元
- 破損した既存保存値も従来どおりラベル有効状態へ復旧
- モデル・notifier の回帰テスト、設計／実装計画、worktree analyzer 設定の知見を追加

## 検証

- `mise exec -- flutter test app/test/feature/home/data/model/home_map_label_parameter_test.dart app/test/feature/home/data/notifier/home_map_label_parameter_notifier_test.dart`
- `mise exec -- dart format --set-exit-if-changed ...`
- `git diff --check origin/develop...HEAD`

`dart analyze` は既存の `app/tools/eqmonitor_custom_lints` 不在により analyzer plugin の初期化前に停止します。今回の変更に起因する診断ではありません。
