### PR TITLE
feat: 地震履歴詳細画面に電文コメント・データソースを表示

### DIFF
--- a/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
+++ b/app/lib/feature/earthquake_history/ui/earthquake_history_details_page.dart
@@ -128,6 +128,10 @@ class _LoadedContent extends HookConsumerWidget {
 
     final designSystem = context.designSystem;
 
+    final telegramCommentLines = selectTelegramCommentLines(
+      earthquake.telegramComments,
+    );
+
     return Scaffold(
       body: Stack(
         children: [
@@ -200,6 +204,35 @@ class _LoadedContent extends HookConsumerWidget {
                               const Duration(hours: 24))
                         const AdBanner(),
                       NearbyEarthquakeCard(earthquake: earthquake),
+                      if (telegramCommentLines.isNotEmpty ||
+                          earthquake.dataSources.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          child: Text.rich(
+                            TextSpan(
+                              children: [
+                                for (final line in telegramCommentLines)
+                                  TextSpan(text: '$line\n'),
+                                TextSpan(
+                                  text:
+                                      'データソース: ${earthquake.dataSources.map((e) => switch (e) {
+                                        EarthquakeDataSource.jmaDisasterInformationXml => '気象庁災害情報XML',
+                                        EarthquakeDataSource.jmaIntensityDatabase => '気象庁震度データベース',
+                                      }).join(', ')}',
+                                ),
+                              ],
+                            ),
+                            style: Theme.of(context).textTheme.bodySmall!
+                                .copyWith(
+                                  color:
+                                      designSystem.colorTheme.onSurfaceVariant,
+                                  fontSize: 11,
+                                ),
+                          ),
+                        ),
                       _TelegramListButton(eventId: earthquake.eventId),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- 地震履歴詳細画面のシートに電文コメント（固定付加文・自由付加文）とデータソース情報を表示
- 既存の `selectTelegramCommentLines` 関数を活用し、`NearbyEarthquakeCard` と `_TelegramListButton` の間に `Text.rich` ウィジェットを追加
- スタイル: `bodySmall`, `onSurfaceVariant`, fontSize 11

## Test plan
- [x] 既存テスト 200/200 パス (`flutter test test/feature/earthquake_history/`)
- [ ] 実機/シミュレータで地震詳細画面を開き、電文コメントとデータソースが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)