### PR TITLE
fix: betaタグから外部テスト配布を起動

### DIFF
--- a/.github/workflows/create-beta-release.yaml
+++ b/.github/workflows/create-beta-release.yaml
@@ -10,6 +10,11 @@ on:
         description: "Beta version override (e.g. v3.1.0-beta.1). Empty for auto-detect."
         required: false
         type: string
+      repair_existing_release:
+        description: "Sanitize an existing beta release instead of creating one"
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -44,6 +49,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # https://github.com/jdx/mise-action
+      - name: Install Mise dependencies
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+          install_args: "python"
+
       - name: Configure git for tagging
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -55,8 +67,14 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version || '' }}
           PR_TITLE: ${{ github.event.issue.title || '' }}
+          REPAIR_EXISTING_RELEASE: ${{ inputs.repair_existing_release || false }}
         run: |
           set -euo pipefail
+
+          if [ "$REPAIR_EXISTING_RELEASE" = "true" ] && [ -z "$INPUT_VERSION" ]; then
+            echo "::error::version is required when repairing an existing release"
+            exit 1
+          fi
 
           if [ -n "$INPUT_VERSION" ]; then
             echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
@@ -81,6 +99,7 @@ jobs:
           echo "version=v${BASE_VERSION}-beta.${NEXT}" >> "$GITHUB_OUTPUT"
 
       - name: Create beta tag
+        if: ${{ !inputs.repair_existing_release }}
         env:
           BETA_VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -88,14 +107,40 @@ jobs:
           git push origin "$BETA_VERSION"
 
       - name: Create GitHub pre-release
+        if: ${{ !inputs.repair_existing_release }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BETA_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$BETA_VERSION" \
+            -f target_commitish=develop \
+            --jq .body \
+            > release-notes.raw.md
+          mise exec -- python3 scripts/release/sanitize_release_notes.py \
+            < release-notes.raw.md \
+            > release-notes.md
           gh release create "$BETA_VERSION" \
             --prerelease \
-            --generate-notes \
+            --notes-file release-notes.md \
             --target develop
+
+      - name: Repair existing GitHub pre-release
+        if: ${{ inputs.repair_existing_release }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BETA_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release view "$BETA_VERSION" \
+            --json body \
+            --jq .body \
+            > release-notes.raw.md
+          mise exec -- python3 scripts/release/sanitize_release_notes.py \
+            < release-notes.raw.md \
+            > release-notes.md
+          gh release edit "$BETA_VERSION" --notes-file release-notes.md
 
       - name: Add reaction to comment
         if: github.event_name == 'issue_comment'

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - develop
+    tags:
+      - "v*-beta.*"
   workflow_dispatch:
     inputs:
       ios:
@@ -41,43 +43,19 @@ jobs:
       deploy-ios: ${{ steps.define-environment-matrix.outputs.deploy-ios }}
       deploy-android: ${{ steps.define-environment-matrix.outputs.deploy-android }}
       deploy-ios-external: ${{ steps.define-environment-matrix.outputs.deploy-ios-external }}
+      android-track: ${{ steps.define-environment-matrix.outputs.android-track }}
     steps:
       - name: Decide which app to deploy
         id: define-environment-matrix
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
           COMMITS_JSON: ${{ toJSON(github.event.commits) }}
-        run: |
-          platforms=()
-          external="false"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.ios }}" = "true" ]; then
-              platforms+=("ios")
-            fi
-            if [ "${{ inputs.android }}" = "true" ]; then
-              platforms+=("android")
-            fi
-            if [ "${{ inputs.external }}" = "true" ]; then
-              external="true"
-            fi
-          elif [ "${{ github.event_name }}" = "push" ]; then
-              # [release only] タグがない場合は全プラットフォームをデプロイ
-              echo "commit message does not contain [release only platform], deploy all platforms"
-              platforms+=("ios" "android")
-              # push に含まれる全コミットのメッセージに [external] があれば外部配布
-              if printf '%s' "$COMMITS_JSON" | grep -qF '[external]'; then
-                external="true"
-              fi
-          else
-            echo "Unknown event name: ${{ github.event_name }}"
-            exit 1
-          fi
-
-          echo "デプロイするプラットフォーム: ${platforms[*]}"
-          for platform in "${platforms[@]}"; do
-            echo "deploy-${platform}=true" >> "$GITHUB_OUTPUT"
-          done
-          echo "外部配布(external): ${external}"
-          echo "deploy-ios-external=${external}" >> "$GITHUB_OUTPUT"
+          INPUT_IOS: ${{ inputs.ios || false }}
+          INPUT_ANDROID: ${{ inputs.android || false }}
+          INPUT_EXTERNAL: ${{ inputs.external || false }}
+        run: scripts/ci/resolve_deploy_app_policy.sh >> "$GITHUB_OUTPUT"
 
   build-ios:
     name: Build iOS
@@ -107,6 +85,7 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          cache: false
           install_args: "flutter xcbeautify"
 
       - name: Set environment variables
@@ -287,6 +266,7 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          cache: false
           install_args: "xcbeautify yq node pnpm"
 
       - name: Set environment variables
@@ -365,6 +345,7 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          cache: false
           install_args: "firebase yq"
 
       - name: Set environment variables
@@ -452,6 +433,7 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          cache: false
           install_args: "flutter java uv python pipx:codemagic-cli-tools"
 
       - name: Set environment variables
@@ -549,6 +531,7 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          cache: false
           install_args: "firebase yq"
 
       - name: Set environment variables
@@ -611,7 +594,9 @@ jobs:
 
   deploy-android-google-play:
     name: Deploy Android (Google Play)
-    needs: build-android
+    needs:
+      - build-android
+      - define-matrix
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
@@ -654,6 +639,7 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
+          cache: false
           install_args: "github:YumNumm/google-play-cli yq"
 
       - name: Set environment variables
@@ -704,10 +690,11 @@ jobs:
       - name: Upload AAB to Google Play
         env:
           RELEASE_NAME: ${{ steps.output_release_version.outputs.release_version }}
+          GOOGLE_PLAY_TRACK: ${{ needs.define-matrix.outputs.android-track }}
         run: |
           google-play-cli bundles publish \
             --bundle app.aab \
-            --track "internal" \
+            --track "$GOOGLE_PLAY_TRACK" \
             --release-notes="$(cat release-notes.json)" \
             --release-name "$RELEASE_NAME" \
             --package-name "net.yumnumm.eqmonitor"

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -686,6 +686,15 @@ jobs:
         with:
           workload_identity_provider: ${{ env.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: actions-eqmonitor-appdistro@eqmonitor-main.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Ensure Google Play track exists
+        if: ${{ needs.define-matrix.outputs.android-track == 'external' }}
+        env:
+          GOOGLE_PLAY_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          PACKAGE_NAME: net.yumnumm.eqmonitor
+          TRACK_NAME: ${{ needs.define-matrix.outputs.android-track }}
+        run: scripts/release/ensure_google_play_track.sh
 
       - name: Upload AAB to Google Play
         env:

--- a/docs/knowledge/20260725_beta_release_deployment.md
+++ b/docs/knowledge/20260725_beta_release_deployment.md
@@ -1,0 +1,91 @@
+# beta Releaseの外部配布とGitHub Deployment確認
+
+## `/beta` から外部配布までの流れ
+
+Release PRへ `/beta` とコメントすると、`Create Beta Release` がGitHub Appの
+installation tokenで `v<version>-beta.<number>` タグをpushする。
+
+`Deploy App` は `v*-beta.*` のtag pushを監視し、betaでは次を配布する。
+
+- iOS
+  - App Store Connectへアップロード
+  - Firebase App Distributionへ配布
+  - TestFlight外部グループへ公開
+- Android
+  - Firebase App Distributionへ配布
+  - Google Playの `external` クローズドテストトラックへ公開
+
+Google Play `external` が失敗しても `internal` へフォールバックしない。失敗は
+該当jobとGitHub Deployment Statusのfailureとして扱う。
+
+通常の `develop` pushと手動実行ではAndroidの `internal` trackを維持する。
+`develop` pushの `[external]` は従来どおりiOSのTestFlight外部配布だけを有効にする。
+
+## GitHub Deploymentsで実配布を確認する
+
+タグとReleaseの存在だけでは、アプリが配布された証拠にならない。
+GitHub Deploymentsをbetaタグで絞り込む。
+
+```bash
+gh api --method GET \
+  repos/YumNumm/EQMonitor/deployments \
+  -f ref=v3.0.0-beta.2 \
+  --jq '.[] | {id, environment, ref, sha, created_at, statuses_url}'
+```
+
+各deploymentの最新statusを確認する。
+
+```bash
+gh api --method GET \
+  repos/YumNumm/EQMonitor/deployments/DEPLOYMENT_ID/statuses \
+  --jq '.[0] | {state, description, environment, log_url, created_at}'
+```
+
+少なくとも `EQMonitor-iOS` と `EQMonitor-Android` のdeploymentがbetaタグをrefに
+持つことを確認する。同じEnvironmentを使うApp Store/Google PlayとFirebaseの
+各jobにより、同じEnvironment名のdeploymentが複数作成される場合がある。
+
+Deploymentがsuccessでも、ストア側の処理完了とは限らない。次も確認する。
+
+- App Store Connectでビルド処理が完了していること
+- TestFlight外部グループへビルドが割り当てられていること
+- Firebase App DistributionのiOS/Android releaseが存在すること
+- Google Play `external` trackに対象version codeが存在すること
+
+## Release Notesの `@` を安全に扱う
+
+GitHubの自動生成Release Notesは、PRタイトルやコミットメッセージ中の `@foo` も
+ユーザーメンションとして解釈する。これにより、実際の作者ではないユーザーが
+Contributorsへ表示されることがある。
+
+`Create Beta Release` は自動生成本文を
+`scripts/release/sanitize_release_notes.py` に通す。変更項目のタイトル部分だけ、
+すべての `@` を表示が同じになるHTML entity `&#64;` へ変換する。
+
+```text
+* fix: @Default(ja) by @YumNumm in ...
+```
+
+は次になる。
+
+```text
+* fix: &#64;Default(ja) by @YumNumm in ...
+```
+
+正式な `by @YumNumm` とNew Contributorsのメンションは変更しない。
+
+## 既存beta Release本文を修復する
+
+修正済みworkflowが `develop` に入った後、次を実行する。
+
+```bash
+gh workflow run create-beta-release.yaml \
+  --ref develop \
+  -f version=v3.0.0-beta.1 \
+  -f repair_existing_release=true
+```
+
+修復モードは既存Release本文を取得して同じサニタイズを適用する。新しいタグや
+Releaseは作成しない。`version` 未指定、Release不在、API失敗時はjobをfailureにする。
+
+実行後はRelease本文で誤メンションが消え、正式な作者表記が残っていることを確認する。

--- a/docs/knowledge/20260725_beta_release_deployment.md
+++ b/docs/knowledge/20260725_beta_release_deployment.md
@@ -15,6 +15,16 @@ installation tokenで `v<version>-beta.<number>` タグをpushする。
   - Firebase App Distributionへ配布
   - Google Playの `external` クローズドテストトラックへ公開
 
+`google-play-cli 1.0.1` は既存trackの更新だけを行うため、`external` が無い状態で
+直接publishすると失敗する。Google Play公開jobはpublish前に
+`scripts/release/ensure_google_play_track.sh` を実行する。このスクリプトは
+Android Publisher APIのedit内でtrack一覧を確認し、無い場合だけ
+`CLOSED_TESTING` / `DEFAULT` の `external` trackを作成してeditをcommitする。
+
+track作成後、Play Consoleの Testing > Closed testing > External で、外部テスターの
+Google Groupまたはメールリストとフィードバック先を一度設定する。Publishing APIの
+track作成だけではテスターは自動追加されない。
+
 Google Play `external` が失敗しても `internal` へフォールバックしない。失敗は
 該当jobとGitHub Deployment Statusのfailureとして扱う。
 

--- a/docs/superpowers/plans/2026-07-25-beta-release-deployment.md
+++ b/docs/superpowers/plans/2026-07-25-beta-release-deployment.md
@@ -1,0 +1,359 @@
+# Beta Release Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/beta` が作成するbetaタグからiOS/Androidの外部テスト配布とGitHub Deployment記録を開始し、Release Notes内の変更タイトルにある `@` の誤メンションを防ぐ。
+
+**Architecture:** beta tag pushを `Deploy App` の正式トリガーにし、イベントから配布matrixを決めるロジックをテスト可能なshell scriptへ分離する。GitHub生成Release NotesはPython sanitizerを通し、変更タイトルだけを無害化して正式な作者メンションを維持する。
+
+**Tech Stack:** GitHub Actions YAML、Bash、Python 3標準ライブラリ、`unittest`、actionlint、mise
+
+## Global Constraints
+
+- beta tag patternは `v*-beta.*` とする。
+- beta配布先はiOS App Store Connect/Firebase/TestFlight external、Android Firebase/Google Play `external` とする。
+- `develop` pushと手動実行のAndroid trackは `internal` のまま維持する。
+- PRタイトルまたはコミットメッセージ部分のすべての `@` を `&#64;` にする。
+- `by @author` とNew Contributorsの正式な作者メンションは維持する。
+- 外部配布失敗時に内部配布へフォールバックしない。
+- Flutter/Dartコマンドとリポジトリtoolは `mise exec --` 経由で実行する。
+
+---
+
+### Task 1: Release Notes sanitizer
+
+**Files:**
+- Create: `scripts/release/sanitize_release_notes.py`
+- Create: `scripts/release/test_sanitize_release_notes.py`
+
+**Interfaces:**
+- Consumes: UTF-8 Markdown from stdin.
+- Produces: sanitized UTF-8 Markdown on stdout.
+- Produces: `sanitize_release_notes(notes: str) -> str` for focused tests.
+
+- [ ] **Step 1: Write failing tests for title-only escaping**
+
+Add literal fixtures covering ordinary PR titles, `@Default(ja)`, multiple `@`, New Contributors, a direct-commit URL, and a second sanitizer pass:
+
+```python
+class SanitizeReleaseNotesTest(unittest.TestCase):
+    def test_escapes_at_signs_only_in_change_title(self) -> None:
+        notes = (
+            "* fix: @Default(ja) and @example "
+            "by @YumNumm in https://github.com/YumNumm/EQMonitor/pull/1234\n"
+        )
+        self.assertEqual(
+            sanitize_release_notes(notes),
+            "* fix: &#64;Default(ja) and &#64;example "
+            "by @YumNumm in https://github.com/YumNumm/EQMonitor/pull/1234\n",
+        )
+
+    def test_preserves_new_contributor_mentions(self) -> None:
+        notes = (
+            "## New Contributors\n"
+            "* @cursor[bot] made their first contribution in "
+            "https://github.com/YumNumm/EQMonitor/pull/1161\n"
+        )
+        self.assertEqual(sanitize_release_notes(notes), notes)
+
+    def test_is_idempotent(self) -> None:
+        notes = (
+            "* fix: @Default(ja) by @YumNumm in "
+            "https://github.com/YumNumm/EQMonitor/pull/1234\n"
+        )
+        once = sanitize_release_notes(notes)
+        self.assertEqual(sanitize_release_notes(once), once)
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+mise exec -- python3 -m unittest scripts/release/test_sanitize_release_notes.py -v
+```
+
+Expected: FAIL because `sanitize_release_notes.py` does not exist.
+
+- [ ] **Step 3: Implement the minimal line transformer and stdin/stdout CLI**
+
+Use a compiled regex that recognizes only a generated change bullet ending in
+` by @author in https://github.com/.../(pull|commit)/...`. Split the title and suffix,
+replace raw `@` only in the title, and join lines with their original line endings.
+
+```python
+CHANGE_LINE_PATTERN = re.compile(
+    r"^(?P<title>\* .+?)(?P<suffix> by @[A-Za-z0-9](?:[A-Za-z0-9-]*|\[bot\])"
+    r" in https://github\.com/.+/(?:pull|commit)/[^\s]+)$"
+)
+
+
+def sanitize_release_notes(notes: str) -> str:
+    lines = notes.splitlines(keepends=True)
+    return "".join(_sanitize_line(line) for line in lines)
+```
+
+The CLI reads `sys.stdin.read()` and writes the return value with `sys.stdout.write()`.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run the same unittest command. Expected: all sanitizer tests PASS.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add scripts/release/sanitize_release_notes.py scripts/release/test_sanitize_release_notes.py
+git commit -m "fix: Release Notesの誤メンションを防止"
+git push
+```
+
+### Task 2: Deploy App policy resolver
+
+**Files:**
+- Create: `scripts/ci/resolve_deploy_app_policy.sh`
+- Create: `scripts/ci/test_resolve_deploy_app_policy.sh`
+- Modify: `.github/workflows/deploy-app.yaml`
+
+**Interfaces:**
+- Consumes env: `EVENT_NAME`, `REF_TYPE`, `REF_NAME`, `COMMITS_JSON`, `INPUT_IOS`, `INPUT_ANDROID`, `INPUT_EXTERNAL`.
+- Produces to stdout: GitHub output lines `deploy-ios`, `deploy-android`, `deploy-ios-external`, `android-track`.
+- `deploy-app.yaml` appends stdout to `$GITHUB_OUTPUT`.
+
+- [ ] **Step 1: Write failing executable policy tests**
+
+The test invokes the real resolver with controlled environment variables and compares exact output files. Cover:
+
+```text
+beta tag push:
+deploy-ios=true
+deploy-android=true
+deploy-ios-external=true
+android-track=external
+
+develop push without [external]:
+deploy-ios=true
+deploy-android=true
+deploy-ios-external=false
+android-track=internal
+
+workflow_dispatch ios=false android=true external=true:
+deploy-android=true
+deploy-ios-external=true
+android-track=internal
+```
+
+Also assert that an unsupported push ref exits non-zero.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+mise exec -- bash scripts/ci/test_resolve_deploy_app_policy.sh
+```
+
+Expected: FAIL because the resolver does not exist.
+
+- [ ] **Step 3: Implement the minimal resolver**
+
+Use `set -euo pipefail` and explicit branches:
+
+```bash
+if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+  # preserve boolean inputs; android-track=internal
+elif [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "tag" && "$REF_NAME" == v*-beta.* ]]; then
+  # both platforms; external=true; android-track=external
+elif [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "branch" && "$REF_NAME" == "develop" ]]; then
+  # both platforms; existing [external] check; android-track=internal
+else
+  echo "Unsupported deployment event/ref" >&2
+  exit 1
+fi
+```
+
+Emit only enabled platform keys, always emit `deploy-ios-external` and `android-track`.
+
+- [ ] **Step 4: Run policy tests and verify GREEN**
+
+Run the same Bash test command. Expected: all cases PASS.
+
+- [ ] **Step 5: Wire the resolver and beta trigger into Deploy App**
+
+Modify `on.push`:
+
+```yaml
+push:
+  branches:
+    - develop
+  tags:
+    - "v*-beta.*"
+```
+
+Add `android-track` to `define-matrix.outputs`. Replace inline decision logic with the resolver, passing:
+
+```yaml
+env:
+  EVENT_NAME: ${{ github.event_name }}
+  REF_TYPE: ${{ github.ref_type }}
+  REF_NAME: ${{ github.ref_name }}
+  COMMITS_JSON: ${{ toJSON(github.event.commits) }}
+  INPUT_IOS: ${{ inputs.ios || false }}
+  INPUT_ANDROID: ${{ inputs.android || false }}
+  INPUT_EXTERNAL: ${{ inputs.external || false }}
+run: scripts/ci/resolve_deploy_app_policy.sh >> "$GITHUB_OUTPUT"
+```
+
+Set Google Play's track from the output:
+
+```yaml
+env:
+  RELEASE_NAME: ${{ steps.output_release_version.outputs.release_version }}
+  GOOGLE_PLAY_TRACK: ${{ needs.define-matrix.outputs.android-track }}
+```
+
+Add `define-matrix` to `deploy-android-google-play.needs`, then use
+`--track "$GOOGLE_PLAY_TRACK"`.
+
+- [ ] **Step 6: Run focused tests and actionlint**
+
+```bash
+mise exec -- bash scripts/ci/test_resolve_deploy_app_policy.sh
+mise exec -- actionlint .github/workflows/*.yaml
+```
+
+Expected: both commands exit 0 without warnings.
+
+- [ ] **Step 7: Commit and push**
+
+```bash
+git add scripts/ci/resolve_deploy_app_policy.sh scripts/ci/test_resolve_deploy_app_policy.sh .github/workflows/deploy-app.yaml
+git commit -m "fix: betaタグから外部テスト配布を起動"
+git push
+```
+
+### Task 3: Beta release creation and existing release repair
+
+**Files:**
+- Modify: `.github/workflows/create-beta-release.yaml`
+- Create: `scripts/ci/test_create_beta_release_workflow.sh`
+
+**Interfaces:**
+- Consumes workflow input: `version: string`, `repair_existing_release: boolean`.
+- Consumes: `scripts/release/sanitize_release_notes.py` from Task 1.
+- Produces: new sanitized prerelease in normal mode, edited release body in repair mode.
+
+- [ ] **Step 1: Write a failing workflow contract test**
+
+Use `mise exec -- yq` to parse the workflow as data. Assert observable wiring contracts:
+
+- `workflow_dispatch.inputs.repair_existing_release.type == "boolean"`.
+- normal create-tag and create-release steps have conditions excluding repair mode.
+- repair step condition requires repair mode.
+- create and repair commands both pipe notes through `sanitize_release_notes.py`.
+- release creation uses `--notes-file`, not `--generate-notes`.
+
+- [ ] **Step 2: Run contract test and verify RED**
+
+```bash
+mise exec -- bash scripts/ci/test_create_beta_release_workflow.sh
+```
+
+Expected: FAIL because `repair_existing_release` and sanitizer wiring are absent.
+
+- [ ] **Step 3: Add repair input and conditional steps**
+
+Add:
+
+```yaml
+repair_existing_release:
+  description: "Sanitize an existing beta release instead of creating one"
+  required: false
+  default: false
+  type: boolean
+```
+
+Normal mode:
+
+1. Generate notes with `gh api --method POST repos/${{ github.repository }}/releases/generate-notes` using `tag_name` and `target_commitish=develop`.
+2. Pipe the body through `mise exec -- python3 scripts/release/sanitize_release_notes.py`.
+3. Create prerelease with `gh release create --notes-file`.
+
+Repair mode:
+
+1. Require non-empty `inputs.version`.
+2. Fetch body using `gh release view "$BETA_VERSION" --json body --jq .body`.
+3. Sanitize and edit with `gh release edit "$BETA_VERSION" --notes-file`.
+4. Skip tag creation and new release creation.
+
+Install Python through the existing mise configuration before invoking the sanitizer if the ubuntu-slim runner does not expose it through mise.
+
+- [ ] **Step 4: Run contract test, sanitizer tests, and actionlint**
+
+```bash
+mise exec -- bash scripts/ci/test_create_beta_release_workflow.sh
+mise exec -- python3 -m unittest scripts/release/test_sanitize_release_notes.py -v
+mise exec -- actionlint .github/workflows/*.yaml
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add .github/workflows/create-beta-release.yaml scripts/ci/test_create_beta_release_workflow.sh
+git commit -m "fix: betaリリース生成と既存本文修復を安全化"
+git push
+```
+
+### Task 4: Operational knowledge and final verification
+
+**Files:**
+- Create: `docs/knowledge/20260725_beta_release_deployment.md`
+
+**Interfaces:**
+- Documents exact commands and expected GitHub Deployment/store states.
+
+- [ ] **Step 1: Record the durable release workflow knowledge**
+
+Document:
+
+- `/beta` → GitHub App tag push → `Deploy App` sequence.
+- beta store destinations and the `external` Android track.
+- GitHub Deployments REST checks filtered by beta tag.
+- how to dispatch repair mode for `v3.0.0-beta.1`.
+- why title/message `@` is escaped while author `@` remains.
+- no fixed-value or internal-track fallback on external publication failure.
+
+- [ ] **Step 2: Run the complete verification suite**
+
+```bash
+mise exec -- python3 -m unittest scripts/release/test_sanitize_release_notes.py -v
+mise exec -- bash scripts/ci/test_resolve_deploy_app_policy.sh
+mise exec -- bash scripts/ci/test_create_beta_release_workflow.sh
+mise exec -- actionlint .github/workflows/*.yaml
+git --no-pager diff --check
+```
+
+Expected: all commands exit 0; no warnings or whitespace errors.
+
+- [ ] **Step 3: Commit and push knowledge**
+
+```bash
+git add docs/knowledge/20260725_beta_release_deployment.md
+git commit -m "docs: beta外部配布の運用手順を記録"
+git push
+```
+
+- [ ] **Step 4: Review final branch scope**
+
+```bash
+git --no-pager status --short --branch
+git --no-pager diff origin/develop...HEAD --stat
+git --no-pager log --oneline origin/develop..HEAD
+```
+
+Expected: clean branch containing only the design, plan, sanitizer, focused tests, two workflows, policy resolver, and knowledge document.
+
+- [ ] **Step 5: Create the pull request after all implementation is verified**
+
+Open a draft PR from `fix/beta-release-deployment` to `develop`. Include root cause, beta distribution destinations, Release Notes sanitization boundary, repair instructions, and exact verification commands/results. Do not claim that the live stores or current Release were updated until the merged workflow is dispatched and GitHub Deployments/store results are verified.

--- a/docs/superpowers/plans/2026-07-25-beta-release-deployment.md
+++ b/docs/superpowers/plans/2026-07-25-beta-release-deployment.md
@@ -214,6 +214,15 @@ env:
 Add `define-matrix` to `deploy-android-google-play.needs`, then use
 `--track "$GOOGLE_PLAY_TRACK"`.
 
+`google-play-cli 1.0.1` はtrack作成を行わないため、PR前レビューで次の境界を追加する。
+
+- `scripts/release/ensure_google_play_track.sh` はAndroid Publisher APIでeditを作り、
+  `external` が無い場合だけ `CLOSED_TESTING` / `DEFAULT` trackを作成・commitする。
+- `scripts/ci/test_ensure_google_play_track.sh` はfake curlで未作成時のcreate/commitと
+  作成済み時の再作成抑止を検証する。
+- Google認証actionは `token_format: access_token` を出力し、external公開時だけ
+  ensure scriptへ渡す。
+
 - [ ] **Step 6: Run focused tests and actionlint**
 
 ```bash

--- a/docs/superpowers/specs/2026-07-25-beta-release-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-25-beta-release-deployment-design.md
@@ -1,0 +1,118 @@
+# Beta Release Deployment Design
+
+## 背景
+
+Release PR のコメントに `/beta` を投稿すると、`Create Beta Release` は
+betaタグとGitHub prereleaseを作成する。しかし `Deploy App` は `develop`
+ブランチへのpushと手動実行だけを監視しているため、betaタグ作成後にアプリの
+ビルド・配布が開始されず、betaタグに対応するGitHub Deploymentも作成されない。
+
+また、GitHubの自動生成Release NotesはPRタイトル中の `@` をメンションとして
+解釈する。`@Default(ja)` を含む過去のPRタイトルにより、実際の作者ではない
+`default` ユーザーがReleaseのContributorsに表示された。
+
+## 成功条件
+
+- `/beta` が作成した `v<version>-beta.<number>` タグで `Deploy App` が起動する。
+- betaタグではiOSとAndroidをビルドし、次の配布を行う。
+  - iOS: App Store Connect、Firebase App Distribution、TestFlight外部グループ
+  - Android: Firebase App Distribution、Google Playの `external` テストトラック
+- Environmentを参照する各配布ジョブにより、betaタグをrefとするGitHub
+  DeploymentとDeployment Statusが記録される。
+- 通常の `develop` pushと手動実行の既存配布動作を維持する。
+- Release NotesのPRタイトルまたはコミットメッセージ部分に含まれるすべての
+  `@` は、見た目を保ったままGitHubメンションとして解釈されない。
+- GitHubが生成する正式な作者表記（`by @user`）とNew Contributorsのメンションは
+  維持する。
+- 既存の `v3.0.0-beta.1` Release本文にも同じサニタイズを適用できる。
+
+## 設計
+
+### 1. betaタグをデプロイトリガーにする
+
+`deploy-app.yaml` の `push` に `v*-beta.*` のtag filterを追加する。
+タグpushはデプロイ対象の不変なrefをそのままワークフローへ渡せるため、
+`workflow_run` で「最新タグ」を再探索する方式や、巨大なワークフロー全体を
+`workflow_call` 化する方式より競合が少なく、変更範囲も小さい。
+
+`define-matrix` はpushの種類を明示的に分ける。
+
+- betaタグ: iOS/Androidを有効化、iOS externalを有効化、Android trackを
+  `external` にする。
+- `develop` push: 現在と同じくiOS/Androidを有効化する。iOS externalは既存の
+  `[external]` 判定を維持し、Android trackは `internal` のままにする。
+- `workflow_dispatch`: 現在の入力を維持し、Android trackは `internal` とする。
+
+AndroidのGoogle Play公開ジョブはmatrixが出力するtrack名を受け取り、固定値の
+`internal` の代わりに使用する。`external` はGoogle Playのクローズドテスト用
+トラックとして最初の公開時に作成する。
+
+各deploy jobには既に `EQMonitor-iOS` または `EQMonitor-Android` Environmentが
+設定されている。したがって追加のDeployments API呼び出しは行わず、GitHub
+Actionsが作成するDeploymentを正とする。
+
+### 2. Release Notesを作成前にサニタイズする
+
+`gh release create --generate-notes` を直接使わず、GitHub Release APIで生成した
+本文をファイルへ保存し、専用スクリプトでサニタイズしてから
+`gh release create --notes-file` に渡す。
+
+生成ノートの変更項目は次の形を持つ。
+
+```text
+* <PR title or commit message> by @author in <URL>
+```
+
+スクリプトは、末尾の ` by @author in <URL>` を正式な作者suffixとして分離する。
+そのsuffixより前にあるすべての `@` をHTML entity `&#64;` に変換し、表示上の
+`@` を維持しながらメンション通知とContributorsへの誤集計を防ぐ。suffix、
+New Contributors、Full Changelogなど、変更項目タイトル以外の行は変更しない。
+作者suffixとして厳密に識別できない行は、正式メンションを誤って壊さないため
+変更しない。
+
+変換は冪等にし、既に `&#64;` になった箇所を再変換しない。
+
+### 3. 既存Releaseの修復
+
+`Create Beta Release` の `workflow_dispatch` に既存Release修復用のboolean入力を
+追加する。修復時は必須の `version` で指定したRelease本文を取得し、同じ
+サニタイズスクリプトを適用して `gh release edit --notes-file` で更新する。
+タグ作成とRelease新規作成は実行しない。
+
+`v3.0.0-beta.1` は修正後のワークフローを手動実行して修復する。version未指定、
+Release不在、API失敗のいずれもjobを失敗させ、成功扱いにはしない。
+
+## エラー処理と安全性
+
+- betaタグのpatternに一致しないタグではデプロイを起動しない。
+- tag、生成ノート、Release作成のいずれかが失敗した場合、`Create Beta Release`を
+  failureにして成功リアクションを付けない。タグpushで非同期に起動する
+  `Deploy App` の成否は別runとGitHub Deployment Statusで判定し、PRコメントの
+  リアクションをデプロイ成功の意味には使わない。
+- ストア公開のいずれかが失敗した場合、対応するdeploy jobとGitHub Deployment
+  Statusをfailureにする。
+- Google Play `external` 公開失敗時に `internal` へフォールバックしない。
+- サニタイズで行構造を識別できない場合、推測で作者メンションを書き換えない。
+- 現在の `develop` pushおよび手動デプロイの配布先をbeta対応の副作用で変えない。
+
+## テスト
+
+リポジトリ内のfixtureとテストスクリプトで次を検証する。
+
+1. `deploy-app.yaml` がbetaタグを監視する。
+2. betaタグではiOS externalが有効になり、Android trackが `external` になる。
+3. `develop` pushと手動実行ではAndroid trackが `internal` のままである。
+4. `@Default(ja)`、`@foo`、複数の `@` を含む変更タイトルが `&#64;` へ変換される。
+5. `by @YumNumm` とNew Contributorsの正式メンションは保持される。
+6. サニタイズを2回適用しても結果が変わらない。
+7. 既存Release修復モードでは新しいタグを作らない。
+
+加えて `mise exec -- actionlint .github/workflows/*.yaml` と、追加したfocused testを
+実行する。実際のストア公開はローカルテストでは行わず、修正後のbetaでActions
+run、GitHub Deployments、TestFlight、Firebase、Google Play `external` の状態を
+確認する。
+
+## 運用知識
+
+betaタグと外部配布の関係、GitHub Deploymentの確認方法、Release Notes内の
+メンション安全化を `docs/knowledge/20260725_beta_release_deployment.md` に記録する。

--- a/scripts/ci/fixtures/fake_google_play_curl.sh
+++ b/scripts/ci/fixtures/fake_google_play_curl.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=${!#}
+printf '%s\n' "$*" >> "$FAKE_CURL_LOG"
+
+case "$url" in
+  */edits)
+    printf '{"id":"edit-1"}\n'
+    ;;
+  */edits/edit-1/tracks)
+    if [[ "$*" == *'--request GET'* ]]; then
+      if [[ "$FAKE_TRACK_EXISTS" == "true" ]]; then
+        printf '{"tracks":[{"track":"external"}]}\n'
+      else
+        printf '{"tracks":[]}\n'
+      fi
+    else
+      printf '{"track":"external"}\n'
+    fi
+    ;;
+  */edits/edit-1:commit)
+    printf '{"id":"edit-1","expiryTimeSeconds":"0"}\n'
+    ;;
+  */edits/edit-1)
+    printf '{}\n'
+    ;;
+  *)
+    echo "unexpected URL: $url" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/ci/resolve_deploy_app_policy.sh
+++ b/scripts/ci/resolve_deploy_app_policy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${REF_TYPE:?REF_TYPE is required}"
+: "${REF_NAME:?REF_NAME is required}"
+: "${COMMITS_JSON:?COMMITS_JSON is required}"
+: "${INPUT_IOS:?INPUT_IOS is required}"
+: "${INPUT_ANDROID:?INPUT_ANDROID is required}"
+: "${INPUT_EXTERNAL:?INPUT_EXTERNAL is required}"
+
+platforms=()
+ios_external=false
+android_track=internal
+
+if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+  if [[ "$INPUT_IOS" == "true" ]]; then
+    platforms+=(ios)
+  fi
+  if [[ "$INPUT_ANDROID" == "true" ]]; then
+    platforms+=(android)
+  fi
+  ios_external=$INPUT_EXTERNAL
+elif [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "tag" && "$REF_NAME" == v*-beta.* ]]; then
+  platforms+=(ios android)
+  ios_external=true
+  android_track=external
+elif [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "branch" && "$REF_NAME" == "develop" ]]; then
+  platforms+=(ios android)
+  if grep -qF '[external]' <<< "$COMMITS_JSON"; then
+    ios_external=true
+  fi
+else
+  echo "Unsupported deployment event/ref: $EVENT_NAME $REF_TYPE $REF_NAME" >&2
+  exit 1
+fi
+
+for platform in "${platforms[@]}"; do
+  echo "deploy-$platform=true"
+done
+echo "deploy-ios-external=$ios_external"
+echo "android-track=$android_track"

--- a/scripts/ci/test_create_beta_release_workflow.sh
+++ b/scripts/ci/test_create_beta_release_workflow.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+WORKFLOW="$ROOT_DIR/.github/workflows/create-beta-release.yaml"
+
+assert_equal() {
+  local expected=$1
+  local actual=$2
+  local description=$3
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$description: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local value=$1
+  local expected=$2
+  local description=$3
+  if [[ "$value" != *"$expected"* ]]; then
+    echo "$description: '$expected' was not found" >&2
+    exit 1
+  fi
+}
+
+repair_type=$(mise exec -- yq -r \
+  '.on.workflow_dispatch.inputs.repair_existing_release.type' "$WORKFLOW")
+assert_equal boolean "$repair_type" "repair input type"
+
+create_tag_condition=$(mise exec -- yq -r \
+  '.jobs.create-beta.steps[] | select(.name == "Create beta tag") | .if' "$WORKFLOW")
+assert_contains "$create_tag_condition" '!inputs.repair_existing_release' \
+  "create tag repair guard"
+
+create_release_condition=$(mise exec -- yq -r \
+  '.jobs.create-beta.steps[] | select(.name == "Create GitHub pre-release") | .if' "$WORKFLOW")
+assert_contains "$create_release_condition" '!inputs.repair_existing_release' \
+  "create release repair guard"
+
+create_release_command=$(mise exec -- yq -r \
+  '.jobs.create-beta.steps[] | select(.name == "Create GitHub pre-release") | .run' "$WORKFLOW")
+assert_contains "$create_release_command" 'sanitize_release_notes.py' \
+  "create release sanitizer"
+assert_contains "$create_release_command" '--notes-file' \
+  "create release notes file"
+if [[ "$create_release_command" == *'--generate-notes'* ]]; then
+  echo "create release must not use --generate-notes" >&2
+  exit 1
+fi
+
+repair_condition=$(mise exec -- yq -r \
+  '.jobs.create-beta.steps[] | select(.name == "Repair existing GitHub pre-release") | .if' "$WORKFLOW")
+assert_contains "$repair_condition" 'inputs.repair_existing_release' \
+  "repair mode condition"
+
+repair_command=$(mise exec -- yq -r \
+  '.jobs.create-beta.steps[] | select(.name == "Repair existing GitHub pre-release") | .run' "$WORKFLOW")
+assert_contains "$repair_command" 'sanitize_release_notes.py' \
+  "repair release sanitizer"
+assert_contains "$repair_command" 'gh release edit' \
+  "repair release edit"
+
+echo "create beta release workflow tests passed"

--- a/scripts/ci/test_ensure_google_play_track.sh
+++ b/scripts/ci/test_ensure_google_play_track.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+ENSURE_TRACK="$ROOT_DIR/scripts/release/ensure_google_play_track.sh"
+WORKFLOW="$ROOT_DIR/.github/workflows/deploy-app.yaml"
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR/bin"
+ln -s "$ROOT_DIR/scripts/ci/fixtures/fake_google_play_curl.sh" \
+  "$TEST_DIR/bin/curl"
+
+run_ensure_track() {
+  local track_exists=$1
+  local log_file=$2
+  PATH="$TEST_DIR/bin:$PATH" \
+    FAKE_CURL_LOG="$log_file" \
+    FAKE_TRACK_EXISTS="$track_exists" \
+    GOOGLE_PLAY_ACCESS_TOKEN=test-token \
+    PACKAGE_NAME=net.yumnumm.eqmonitor \
+    TRACK_NAME=external \
+    "$ENSURE_TRACK"
+}
+
+missing_log="$TEST_DIR/missing.log"
+run_ensure_track false "$missing_log"
+grep -F -- '--request POST' "$missing_log" | grep -F '/tracks'
+grep -F -- '"type":"CLOSED_TESTING"' "$missing_log"
+grep -F -- '/edits/edit-1:commit' "$missing_log"
+if grep -F -- '--request DELETE' "$missing_log"; then
+  echo "missing track edit must not be deleted before commit" >&2
+  exit 1
+fi
+
+existing_log="$TEST_DIR/existing.log"
+run_ensure_track true "$existing_log"
+grep -F -- '--request DELETE' "$existing_log"
+if grep -F -- '"type":"CLOSED_TESTING"' "$existing_log"; then
+  echo "existing track must not be created again" >&2
+  exit 1
+fi
+if grep -F -- '/edits/edit-1:commit' "$existing_log"; then
+  echo "unchanged edit must not be committed" >&2
+  exit 1
+fi
+
+token_format=$(mise exec -- yq -r \
+  '.jobs.deploy-android-google-play.steps[] | select(.id == "auth") | .with.token_format' \
+  "$WORKFLOW")
+if [[ "$token_format" != "access_token" ]]; then
+  echo "Google Play auth must expose an access token" >&2
+  exit 1
+fi
+
+ensure_condition=$(mise exec -- yq -r \
+  '.jobs.deploy-android-google-play.steps[] | select(.name == "Ensure Google Play track exists") | .if' \
+  "$WORKFLOW")
+if [[ "$ensure_condition" != *"android-track == 'external'"* ]]; then
+  echo "ensure track step must run only for external track" >&2
+  exit 1
+fi
+
+ensure_command=$(mise exec -- yq -r \
+  '.jobs.deploy-android-google-play.steps[] | select(.name == "Ensure Google Play track exists") | .run' \
+  "$WORKFLOW")
+if [[ "$ensure_command" != *'ensure_google_play_track.sh'* ]]; then
+  echo "Deploy App must invoke the track creation script" >&2
+  exit 1
+fi
+
+echo "ensure Google Play track tests passed"

--- a/scripts/ci/test_resolve_deploy_app_policy.sh
+++ b/scripts/ci/test_resolve_deploy_app_policy.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+RESOLVER="$SCRIPT_DIR/resolve_deploy_app_policy.sh"
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+assert_policy() {
+  local name=$1
+  local expected=$2
+  shift 2
+  local actual="$TEST_DIR/$name.actual"
+  local expected_file="$TEST_DIR/$name.expected"
+
+  env "$@" "$RESOLVER" > "$actual"
+  printf '%s' "$expected" > "$expected_file"
+  diff -u "$expected_file" "$actual"
+}
+
+assert_policy \
+  beta-tag \
+  $'deploy-ios=true\ndeploy-android=true\ndeploy-ios-external=true\nandroid-track=external\n' \
+  EVENT_NAME=push \
+  REF_TYPE=tag \
+  REF_NAME=v3.0.0-beta.2 \
+  COMMITS_JSON='[]' \
+  INPUT_IOS=false \
+  INPUT_ANDROID=false \
+  INPUT_EXTERNAL=false
+
+assert_policy \
+  develop \
+  $'deploy-ios=true\ndeploy-android=true\ndeploy-ios-external=false\nandroid-track=internal\n' \
+  EVENT_NAME=push \
+  REF_TYPE=branch \
+  REF_NAME=develop \
+  COMMITS_JSON='[{"message":"fix: ordinary push"}]' \
+  INPUT_IOS=false \
+  INPUT_ANDROID=false \
+  INPUT_EXTERNAL=false
+
+assert_policy \
+  develop-external \
+  $'deploy-ios=true\ndeploy-android=true\ndeploy-ios-external=true\nandroid-track=internal\n' \
+  EVENT_NAME=push \
+  REF_TYPE=branch \
+  REF_NAME=develop \
+  COMMITS_JSON='[{"message":"feat: distribute [external]"}]' \
+  INPUT_IOS=false \
+  INPUT_ANDROID=false \
+  INPUT_EXTERNAL=false
+
+assert_policy \
+  workflow-dispatch \
+  $'deploy-android=true\ndeploy-ios-external=true\nandroid-track=internal\n' \
+  EVENT_NAME=workflow_dispatch \
+  REF_TYPE=branch \
+  REF_NAME=develop \
+  COMMITS_JSON='[]' \
+  INPUT_IOS=false \
+  INPUT_ANDROID=true \
+  INPUT_EXTERNAL=true
+
+if env \
+  EVENT_NAME=push \
+  REF_TYPE=tag \
+  REF_NAME=v3.0.0 \
+  COMMITS_JSON='[]' \
+  INPUT_IOS=false \
+  INPUT_ANDROID=false \
+  INPUT_EXTERNAL=false \
+  "$RESOLVER" > "$TEST_DIR/unsupported.stdout" 2> "$TEST_DIR/unsupported.stderr"; then
+  echo "unsupported ref unexpectedly succeeded" >&2
+  exit 1
+fi
+
+grep -Fx "Unsupported deployment event/ref: push tag v3.0.0" \
+  "$TEST_DIR/unsupported.stderr"
+
+echo "deploy app policy tests passed"

--- a/scripts/release/ensure_google_play_track.sh
+++ b/scripts/release/ensure_google_play_track.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GOOGLE_PLAY_ACCESS_TOKEN:?GOOGLE_PLAY_ACCESS_TOKEN is required}"
+: "${PACKAGE_NAME:?PACKAGE_NAME is required}"
+: "${TRACK_NAME:?TRACK_NAME is required}"
+
+api_root=https://androidpublisher.googleapis.com/androidpublisher/v3
+edits_url="$api_root/applications/$PACKAGE_NAME/edits"
+authorization="Authorization: Bearer $GOOGLE_PLAY_ACCESS_TOKEN"
+edit_id=
+edit_open=false
+
+cleanup_edit() {
+  if [[ "$edit_open" == "true" ]]; then
+    curl \
+      --fail-with-body \
+      --silent \
+      --show-error \
+      --request DELETE \
+      --header "$authorization" \
+      "$edits_url/$edit_id" \
+      > /dev/null
+  fi
+}
+trap cleanup_edit EXIT
+
+edit_response=$(curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --request POST \
+  --header "$authorization" \
+  --header 'Content-Type: application/json' \
+  --data '{}' \
+  "$edits_url")
+edit_id=$(jq -er '.id' <<< "$edit_response")
+edit_open=true
+
+tracks_response=$(curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --request GET \
+  --header "$authorization" \
+  "$edits_url/$edit_id/tracks")
+
+if jq -e --arg track "$TRACK_NAME" \
+  'any((.tracks // [])[]; .track == $track)' \
+  > /dev/null <<< "$tracks_response"; then
+  cleanup_edit
+  edit_open=false
+  echo "Google Play track already exists: $TRACK_NAME"
+  exit 0
+fi
+
+track_config=$(jq -nc \
+  --arg track "$TRACK_NAME" \
+  '{track: $track, type: "CLOSED_TESTING", formFactor: "DEFAULT"}')
+curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --request POST \
+  --header "$authorization" \
+  --header 'Content-Type: application/json' \
+  --data "$track_config" \
+  "$edits_url/$edit_id/tracks" \
+  > /dev/null
+curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --request POST \
+  --header "$authorization" \
+  "$edits_url/$edit_id:commit" \
+  > /dev/null
+edit_open=false
+
+echo "Created Google Play closed testing track: $TRACK_NAME"

--- a/scripts/release/sanitize_release_notes.py
+++ b/scripts/release/sanitize_release_notes.py
@@ -1,0 +1,26 @@
+import re
+import sys
+
+
+CHANGE_LINE_PATTERN = re.compile(
+    r"^(?P<title>\* .+?)(?P<suffix> by @[A-Za-z0-9-]+(?:\[bot\])? in "
+    r"https://github\.com/[^/\s]+/[^/\s]+/(?:pull|commit)/[^\s]+)$"
+)
+
+
+def sanitize_release_notes(notes: str) -> str:
+    return "".join(_sanitize_line(line) for line in notes.splitlines(keepends=True))
+
+
+def _sanitize_line(line: str) -> str:
+    content = line.rstrip("\r\n")
+    line_ending = line[len(content) :]
+    match = CHANGE_LINE_PATTERN.fullmatch(content)
+    if match is None:
+        return line
+    title = match.group("title").replace("@", "&#64;")
+    return f'{title}{match.group("suffix")}{line_ending}'
+
+
+if __name__ == "__main__":
+    sys.stdout.write(sanitize_release_notes(sys.stdin.read()))

--- a/scripts/release/test_sanitize_release_notes.py
+++ b/scripts/release/test_sanitize_release_notes.py
@@ -1,0 +1,57 @@
+import unittest
+
+from scripts.release.sanitize_release_notes import sanitize_release_notes
+
+
+class SanitizeReleaseNotesTest(unittest.TestCase):
+    def test_escapes_at_signs_only_in_pull_request_title(self) -> None:
+        notes = (
+            "* fix: @Default(ja) and @example by @YumNumm in "
+            "https://github.com/YumNumm/EQMonitor/pull/1234\n"
+        )
+
+        self.assertEqual(
+            sanitize_release_notes(notes),
+            "* fix: &#64;Default(ja) and &#64;example by @YumNumm in "
+            "https://github.com/YumNumm/EQMonitor/pull/1234\n",
+        )
+
+    def test_escapes_at_sign_in_direct_commit_message(self) -> None:
+        notes = (
+            "* fix: avoid @mention by @dependabot[bot] in "
+            "https://github.com/YumNumm/EQMonitor/commit/abc123"
+        )
+
+        self.assertEqual(
+            sanitize_release_notes(notes),
+            "* fix: avoid &#64;mention by @dependabot[bot] in "
+            "https://github.com/YumNumm/EQMonitor/commit/abc123",
+        )
+
+    def test_preserves_new_contributor_mentions(self) -> None:
+        notes = (
+            "## New Contributors\n"
+            "* @cursor[bot] made their first contribution in "
+            "https://github.com/YumNumm/EQMonitor/pull/1161\n"
+        )
+
+        self.assertEqual(sanitize_release_notes(notes), notes)
+
+    def test_preserves_unrecognized_bullet(self) -> None:
+        notes = "* contact @team when publishing\n"
+
+        self.assertEqual(sanitize_release_notes(notes), notes)
+
+    def test_is_idempotent(self) -> None:
+        notes = (
+            "* fix: @Default(ja) by @YumNumm in "
+            "https://github.com/YumNumm/EQMonitor/pull/1234\n"
+        )
+
+        once = sanitize_release_notes(notes)
+
+        self.assertEqual(sanitize_release_notes(once), once)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

`/beta` がbetaタグとprereleaseだけを作成し、実際のアプリ配布やGitHub Deploymentを起動していなかった問題を修正します。

## Root cause

- `Deploy App` が `develop` pushと手動実行しか監視しておらず、beta tag pushを受け取っていませんでした。
- Release Notesを `--generate-notes` で直接作成していたため、PRタイトル／コミットメッセージ内の `@Default(ja)` などがGitHubメンションとして解釈されていました。
- `google-play-cli 1.0.1` は既存trackの更新のみで、未作成の `external` trackを作成できません。

## 変更内容

- `v*-beta.*` tag pushで `Deploy App` を起動
- betaではiOS App Store Connect/Firebase/TestFlight externalへ配布
- betaではAndroid Firebase/Google Play `external` closed-testing trackへ配布
- Android Publisher APIで `external` trackを存在確認し、未作成時だけ作成
- Environment jobによりbetaタグをrefとするGitHub Deploymentを記録
- Release Notesの変更タイトル内だけ `@` を `&#64;` に変換
- 正式な `by @author` とNew Contributorsメンションは維持
- 既存beta Release本文を修復するworkflow_dispatchモードを追加
- tag公開workflowのmise cacheを無効化し、cache-poisoningを防止
- focused regression testsと運用knowledgeを追加

## 検証

- `mise exec -- python3 -m unittest scripts/release/test_sanitize_release_notes.py -v`
- `mise exec -- bash scripts/ci/test_resolve_deploy_app_policy.sh`
- `mise exec -- bash scripts/ci/test_create_beta_release_workflow.sh`
- `mise exec -- bash scripts/ci/test_ensure_google_play_track.sh`
- `mise exec -- actionlint .github/workflows/*.yaml`
- `mise exec -- shellcheck -S error ...`
- `mise exec -- zizmor .github/workflows/create-beta-release.yaml .github/workflows/deploy-app.yaml`
- `mise exec -- pinact run --check .github/workflows/create-beta-release.yaml .github/workflows/deploy-app.yaml`
- `git --no-pager diff origin/develop...HEAD --check`

すべて成功しています。

## マージ後の作業

1. Play Consoleの Closed testing > External で、外部テスターのGoogle Groupまたはメールリストとフィードバック先を設定する
2. `v3.0.0-beta.1` の誤メンションを修復するため、`Create Beta Release` を `version=v3.0.0-beta.1`, `repair_existing_release=true` で手動実行する
3. 次の `/beta` でActions run、GitHub Deployments、TestFlight、Firebase、Google Play Externalを確認する

このPR自体の作成時点では、ストア配布や既存Release本文の更新は行いません。
