### PR TITLE
fix: 配布ポリシー実行前にcheckoutする

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -45,6 +45,12 @@ jobs:
       deploy-ios-external: ${{ steps.define-environment-matrix.outputs.deploy-ios-external }}
       android-track: ${{ steps.define-environment-matrix.outputs.android-track }}
     steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Decide which app to deploy
         id: define-environment-matrix
         env:

--- a/docs/knowledge/20260725_beta_release_deployment.md
+++ b/docs/knowledge/20260725_beta_release_deployment.md
@@ -31,6 +31,22 @@ Google Play `external` が失敗しても `internal` へフォールバックし
 通常の `develop` pushと手動実行ではAndroidの `internal` trackを維持する。
 `develop` pushの `[external]` は従来どおりiOSのTestFlight外部配布だけを有効にする。
 
+## リポジトリ内スクリプトをjobで実行する
+
+GitHub-hosted runnerのworkspaceは、job開始時点ではリポジトリのファイルを含まない。
+`scripts/ci/resolve_deploy_app_policy.sh` のようなリポジトリ内スクリプトを実行する
+jobは、そのstepより前に `actions/checkout` を置く。
+
+checkoutを省略すると、スクリプトがコミット済みで実行権限を持っていても次のように
+失敗する。
+
+```text
+scripts/ci/resolve_deploy_app_policy.sh: No such file or directory
+```
+
+workflow変更後は、stepの存在だけでなくcheckoutがスクリプト実行より前にあることを
+focused testで確認する。
+
 ## GitHub Deploymentsで実配布を確認する
 
 タグとReleaseの存在だけでは、アプリが配布された証拠にならない。

--- a/docs/superpowers/plans/2026-07-25-beta-release-deployment.md
+++ b/docs/superpowers/plans/2026-07-25-beta-release-deployment.md
@@ -366,3 +366,62 @@ Expected: clean branch containing only the design, plan, sanitizer, focused test
 - [ ] **Step 5: Create the pull request after all implementation is verified**
 
 Open a draft PR from `fix/beta-release-deployment` to `develop`. Include root cause, beta distribution destinations, Release Notes sanitization boundary, repair instructions, and exact verification commands/results. Do not claim that the live stores or current Release were updated until the merged workflow is dispatched and GitHub Deployments/store results are verified.
+
+### Task 5: Checkout repository before resolving deployment policy
+
+**Files:**
+- Modify: `.github/workflows/deploy-app.yaml`
+- Modify: `scripts/ci/test_resolve_deploy_app_policy.sh`
+- Modify: `docs/knowledge/20260725_beta_release_deployment.md`
+
+**Interfaces:**
+- Consumes: repository contents checked out at the workflow run ref.
+- Produces: an executable `scripts/ci/resolve_deploy_app_policy.sh` in the
+  `define-matrix` runner workspace before the policy step starts.
+
+- [x] **Step 1: Add a failing workflow contract test**
+
+Parse `.jobs.define-matrix.steps` using `mise exec -- yq`. Resolve the index of
+the `actions/checkout` step and the index of the step invoking
+`resolve_deploy_app_policy.sh`; fail unless both exist and checkout comes first.
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+```bash
+mise exec -- bash scripts/ci/test_resolve_deploy_app_policy.sh
+```
+
+Expected: FAIL because `define-matrix` invokes the repository script without a
+checkout step.
+
+- [x] **Step 3: Add the minimal checkout step**
+
+Add the pinned repository checkout action before `Decide which app to deploy`:
+
+```yaml
+- name: Checkout
+  uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  with:
+    persist-credentials: false
+```
+
+- [x] **Step 4: Record the runner workspace requirement**
+
+Add the failure mode and the rule that repository scripts require checkout to
+`docs/knowledge/20260725_beta_release_deployment.md`.
+
+- [x] **Step 5: Run focused and workflow verification**
+
+```bash
+mise exec -- bash scripts/ci/test_resolve_deploy_app_policy.sh
+mise exec -- actionlint .github/workflows/*.yaml
+git --no-pager diff --check
+```
+
+Expected: all commands exit 0 without warnings.
+
+- [ ] **Step 6: Commit, push, and open the draft PR**
+
+Stage only the workflow, test, design, plan, and knowledge files. Commit with
+`fix: 配布ポリシー実行前にcheckoutする`, push the existing branch, then open a
+draft PR targeting `develop`.

--- a/docs/superpowers/specs/2026-07-25-beta-release-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-25-beta-release-deployment-design.md
@@ -43,6 +43,11 @@ betaタグとGitHub prereleaseを作成する。しかし `Deploy App` は `deve
   `[external]` 判定を維持し、Android trackは `internal` のままにする。
 - `workflow_dispatch`: 現在の入力を維持し、Android trackは `internal` とする。
 
+配布ポリシーはリポジトリ内のshell scriptとして実行するため、`define-matrix` は
+resolver実行前に `actions/checkout` で対象refを取得する。checkoutを省略すると、
+GitHub-hosted runnerのworkspaceに `scripts/ci/resolve_deploy_app_policy.sh` が存在せず、
+ポリシー判定前にjobが失敗する。
+
 AndroidのGoogle Play公開ジョブはmatrixが出力するtrack名を受け取り、固定値の
 `internal` の代わりに使用する。`external` はGoogle Playのクローズドテスト用
 トラックとして最初の公開時に作成する。
@@ -102,10 +107,11 @@ Release不在、API失敗のいずれもjobを失敗させ、成功扱いには�
 1. `deploy-app.yaml` がbetaタグを監視する。
 2. betaタグではiOS externalが有効になり、Android trackが `external` になる。
 3. `develop` pushと手動実行ではAndroid trackが `internal` のままである。
-4. `@Default(ja)`、`@foo`、複数の `@` を含む変更タイトルが `&#64;` へ変換される。
-5. `by @YumNumm` とNew Contributorsの正式メンションは保持される。
-6. サニタイズを2回適用しても結果が変わらない。
-7. 既存Release修復モードでは新しいタグを作らない。
+4. `define-matrix` はresolver実行前にリポジトリをcheckoutする。
+5. `@Default(ja)`、`@foo`、複数の `@` を含む変更タイトルが `&#64;` へ変換される。
+6. `by @YumNumm` とNew Contributorsの正式メンションは保持される。
+7. サニタイズを2回適用しても結果が変わらない。
+8. 既存Release修復モードでは新しいタグを作らない。
 
 加えて `mise exec -- actionlint .github/workflows/*.yaml` と、追加したfocused testを
 実行する。実際のストア公開はローカルテストでは行わず、修正後のbetaでActions

--- a/scripts/ci/test_resolve_deploy_app_policy.sh
+++ b/scripts/ci/test_resolve_deploy_app_policy.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
 RESOLVER="$SCRIPT_DIR/resolve_deploy_app_policy.sh"
+WORKFLOW="$ROOT_DIR/.github/workflows/deploy-app.yaml"
 TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
 
@@ -77,5 +79,17 @@ fi
 
 grep -Fx "Unsupported deployment event/ref: push tag v3.0.0" \
   "$TEST_DIR/unsupported.stderr"
+
+checkout_index=$(mise exec -- yq -r \
+  '.jobs.define-matrix.steps | to_entries | map(select(.value.uses == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1")) | .[0].key // ""' \
+  "$WORKFLOW")
+resolver_index=$(mise exec -- yq -r \
+  '.jobs.define-matrix.steps | to_entries | map(select((.value.run // "") | contains("scripts/ci/resolve_deploy_app_policy.sh"))) | .[0].key // ""' \
+  "$WORKFLOW")
+
+if [[ -z "$checkout_index" || -z "$resolver_index" || "$checkout_index" -ge "$resolver_index" ]]; then
+  echo "define-matrix must checkout the repository before invoking the deploy policy resolver" >&2
+  exit 1
+fi
 
 echo "deploy app policy tests passed"


### PR DESCRIPTION
## 概要

`Deploy App / Define Matrix` がリポジトリ内の配布ポリシースクリプトを実行する前に、対象refをcheckoutするよう修正します。

## Root cause

`define-matrix` jobは `scripts/ci/resolve_deploy_app_policy.sh` を直接実行していましたが、`actions/checkout` がありませんでした。GitHub-hosted runnerのworkspaceにリポジトリファイルが存在しないため、次のエラーでポリシー判定前に失敗していました。

```text
scripts/ci/resolve_deploy_app_policy.sh: No such file or directory
```

## 変更内容

- `define-matrix` のresolver実行前に、commit SHAで固定した `actions/checkout` を追加
- checkoutが存在し、resolverより前に実行されることをYAML契約テストで検証
- GitHub Actionsでリポジトリ内スクリプトを実行する際のcheckout要件を設計・運用knowledgeへ記録

## 検証

- `mise exec -- python3 -m unittest scripts/release/test_sanitize_release_notes.py -v`
- `mise exec -- bash scripts/ci/test_resolve_deploy_app_policy.sh`
- `mise exec -- bash scripts/ci/test_create_beta_release_workflow.sh`
- `mise exec -- bash scripts/ci/test_ensure_google_play_track.sh`
- `mise exec -- actionlint .github/workflows/*.yaml`
- `git --no-pager diff --check`

すべて成功しています。