### PR TITLE
feat: アプリ使用中の緊急地震速報警報overlayを追加

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -33,6 +33,7 @@ class App extends HookConsumerWidget {
       themeMode: theme.value,
       routerConfig: routerConfig,
       builder: (context, child) => EewWarningOverlayHost(
+        backButtonDispatcher: routerConfig.backButtonDispatcher,
         child: DebugLauncher(child: child ?? const SizedBox.shrink()),
       ),
       theme: buildTheme(colorSet: lightColorSet, brightness: Brightness.light),

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:eqmonitor/core/theme/build_theme.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/core/theme/theme_provider.dart';
 import 'package:eqmonitor/feature/debug/launcher/debug_launcher.dart';
+import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_host.dart';
 import 'package:eqmonitor/feature/start/ui/component/forced_update_dialog.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -20,30 +21,34 @@ class App extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = ref.watch(themeModeProvider);
     final routerConfig = ref.watch(goRouterProvider);
-    final lightColorSet = ref.watch(colorSetForBrightnessProvider(Brightness.light));
-    final darkColorSet = ref.watch(colorSetForBrightnessProvider(Brightness.dark));
+    final lightColorSet = ref.watch(
+      colorSetForBrightnessProvider(Brightness.light),
+    );
+    final darkColorSet = ref.watch(
+      colorSetForBrightnessProvider(Brightness.dark),
+    );
 
     final app = MaterialApp.router(
       title: 'EQMonitor',
       themeMode: theme.value,
       routerConfig: routerConfig,
-      builder: (context, child) =>
-          DebugLauncher(child: child ?? const SizedBox.shrink()),
+      builder: (context, child) => EewWarningOverlayHost(
+        child: DebugLauncher(child: child ?? const SizedBox.shrink()),
+      ),
       theme: buildTheme(colorSet: lightColorSet, brightness: Brightness.light),
-      darkTheme: buildTheme(colorSet: darkColorSet, brightness: Brightness.dark),
+      darkTheme: buildTheme(
+        colorSet: darkColorSet,
+        brightness: Brightness.dark,
+      ),
       localizationsDelegates: const [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: const [
-        Locale('ja', 'JP'),
-      ],
+      supportedLocales: const [Locale('ja', 'JP')],
     );
     final buildConfig = ref.watch(buildConfigProvider);
-    Widget result = ForcedUpdateWrapper(
-      child: app,
-    );
+    Widget result = ForcedUpdateWrapper(child: app);
 
     if (!kDebugMode && buildConfig.isBetaTesting) {
       result = Directionality(

--- a/app/lib/core/data/preferences/shared/shared_preferences_key.dart
+++ b/app/lib/core/data/preferences/shared/shared_preferences_key.dart
@@ -46,7 +46,8 @@ enum SharedPreferencesKey {
   bglDebugNotifyRegion('bgl_debug_region'),
   bglDebugNotifyPrefecture('bgl_debug_prefecture'),
   bglDebugNotifyApiUpdate('bgl_debug_api_update'),
-  feedLastReadPublishedAt('feed_last_read_published_at');
+  feedLastReadPublishedAt('feed_last_read_published_at'),
+  eewWarningOverlayEnabled('eew_warning_overlay_enabled');
 
   const SharedPreferencesKey(this.key);
   final String key;

--- a/app/lib/feature/eew/data/logic/eew_warning_arrival_classifier.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_arrival_classifier.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+
+class EewWarningArrivalClassifier {
+  EewWarningArrivalState classify({
+    required EewWarningOverlayCandidate candidate,
+    required DateTime now,
+  }) {
+    final localForecast = candidate.localForecastRegion;
+    if (localForecast?.isArrived == true) {
+      return EewWarningArrivalState.arrived;
+    }
+    final arrivalTime = localForecast?.arrivalTime;
+    if (arrivalTime == null) {
+      return EewWarningArrivalState.unknown;
+    }
+    return arrivalTime.isAfter(now)
+        ? EewWarningArrivalState.unarrived
+        : EewWarningArrivalState.arrived;
+  }
+}

--- a/app/lib/feature/eew/data/logic/eew_warning_arrival_classifier.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_arrival_classifier.dart
@@ -1,5 +1,12 @@
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_arrival_classifier.g.dart';
+
+@riverpod
+EewWarningArrivalClassifier eewWarningArrivalClassifier(Ref ref) =>
+    EewWarningArrivalClassifier();
 
 class EewWarningArrivalClassifier {
   EewWarningArrivalState classify({

--- a/app/lib/feature/eew/data/logic/eew_warning_arrival_classifier.g.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_arrival_classifier.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_arrival_classifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningArrivalClassifier)
+final eewWarningArrivalClassifierProvider =
+    EewWarningArrivalClassifierProvider._();
+
+final class EewWarningArrivalClassifierProvider
+    extends
+        $FunctionalProvider<
+          EewWarningArrivalClassifier,
+          EewWarningArrivalClassifier,
+          EewWarningArrivalClassifier
+        >
+    with $Provider<EewWarningArrivalClassifier> {
+  EewWarningArrivalClassifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningArrivalClassifierProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningArrivalClassifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningArrivalClassifier> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningArrivalClassifier create(Ref ref) {
+    return eewWarningArrivalClassifier(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningArrivalClassifier value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningArrivalClassifier>(value),
+    );
+  }
+}
+
+String _$eewWarningArrivalClassifierHash() =>
+    r'c237e8ff3dfdc8540a5a548e567b1c1272dabc28';

--- a/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart
@@ -1,0 +1,45 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+
+class EewWarningCandidateSelector {
+  List<EewWarningOverlayCandidate> select({
+    required List<EewTelegramItem> aliveEews,
+    required String warningAreaCode,
+    required String warningAreaName,
+    required String? forecastAreaCode,
+    required String? forecastAreaName,
+  }) {
+    final candidates = <EewWarningOverlayCandidate>[];
+    for (final event in aliveEews) {
+      final hasCurrentWarning = event.warning?.regions.any(
+        (region) => region.code == warningAreaCode && region.hadWarning,
+      );
+      if (event.isWarning != true ||
+          event.isCanceled ||
+          hasCurrentWarning != true) {
+        continue;
+      }
+
+      EewForecastRegionInfo? localForecastRegion;
+      if (forecastAreaCode != null) {
+        for (final region in event.forecastIntensity?.regions ?? const []) {
+          if (region.code == forecastAreaCode) {
+            localForecastRegion = region;
+            break;
+          }
+        }
+      }
+
+      candidates.add(
+        EewWarningOverlayCandidate(
+          event: event,
+          warningAreaCode: warningAreaCode,
+          warningAreaName: warningAreaName,
+          forecastAreaName: forecastAreaName,
+          localForecastRegion: localForecastRegion,
+        ),
+      );
+    }
+    return candidates;
+  }
+}

--- a/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.dart
@@ -1,5 +1,12 @@
 import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_candidate_selector.g.dart';
+
+@riverpod
+EewWarningCandidateSelector eewWarningCandidateSelector(Ref ref) =>
+    EewWarningCandidateSelector();
 
 class EewWarningCandidateSelector {
   List<EewWarningOverlayCandidate> select({

--- a/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.g.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_candidate_selector.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_candidate_selector.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningCandidateSelector)
+final eewWarningCandidateSelectorProvider =
+    EewWarningCandidateSelectorProvider._();
+
+final class EewWarningCandidateSelectorProvider
+    extends
+        $FunctionalProvider<
+          EewWarningCandidateSelector,
+          EewWarningCandidateSelector,
+          EewWarningCandidateSelector
+        >
+    with $Provider<EewWarningCandidateSelector> {
+  EewWarningCandidateSelectorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningCandidateSelectorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningCandidateSelectorHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningCandidateSelector> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningCandidateSelector create(Ref ref) {
+    return eewWarningCandidateSelector(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningCandidateSelector value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningCandidateSelector>(value),
+    );
+  }
+}
+
+String _$eewWarningCandidateSelectorHash() =>
+    r'e6e8079371518935b9b350a09d09095dc3c7565a';

--- a/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
@@ -1,0 +1,88 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_arrival_classifier.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_representative_selector.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+
+class EewWarningDisplayModelBuilder {
+  EewWarningOverlayDisplayModel? build({
+    required List<EewWarningOverlayCandidate> candidates,
+    required DateTime now,
+  }) {
+    final representativeSelector = EewWarningRepresentativeSelector();
+    final representative = representativeSelector.select(
+      candidates: candidates,
+      now: now,
+    );
+    if (representative == null) {
+      return null;
+    }
+
+    final sortedCandidates = [...candidates]
+      ..sort(
+        (left, right) =>
+            representativeSelector.compare(left: left, right: right, now: now),
+      );
+
+    final zoneNamesByCode = <String, String>{};
+    for (final candidate in sortedCandidates) {
+      for (final zone in candidate.event.warning?.zones ?? const []) {
+        if (zone.hadWarning) {
+          zoneNamesByCode.putIfAbsent(zone.code, () => zone.name);
+        }
+      }
+    }
+    final zoneCodes = zoneNamesByCode.keys.toList()..sort();
+    final combinedZoneNames = zoneCodes
+        .map((code) => zoneNamesByCode[code])
+        .whereType<String>()
+        .join(' ');
+
+    final event = representative.event;
+    final hypocenter = event.hypocenter;
+    final isLevelMethod =
+        event.accuracy?.epicenter == 1 && event.originTime == null;
+    final preferredHypocenterName =
+        hypocenter?.detailedName ?? hypocenter?.name;
+    final visibleHypocenterName =
+        event.isPlum ||
+            isLevelMethod ||
+            preferredHypocenterName == null ||
+            preferredHypocenterName.isEmpty
+        ? null
+        : preferredHypocenterName;
+    final arrivalState = EewWarningArrivalClassifier().classify(
+      candidate: representative,
+      now: now,
+    );
+    final localForecast = representative.localForecastRegion;
+
+    return EewWarningOverlayDisplayModel(
+      source: EewWarningOverlaySource.real,
+      eventIds: sortedCandidates
+          .map((candidate) => candidate.event.eventId)
+          .toList(),
+      representativeEventId: event.eventId,
+      serialNo: event.serialNo,
+      alertCount: candidates.length,
+      reportLabel: '緊急地震速報（警報） 第${event.serialNo}報',
+      hypocenterHeadline: visibleHypocenterName == null
+          ? null
+          : '$visibleHypocenterNameで地震',
+      strongMotionHeadline: combinedZoneNames.isEmpty
+          ? '強い揺れに警戒'
+          : '$combinedZoneNamesで強い揺れ',
+      currentRegionName:
+          representative.forecastAreaName ?? representative.warningAreaName,
+      localIntensity: localForecast?.intensity ?? JmaIntensity.unknown,
+      localIntensityIsOver: localForecast?.intensityIsOver ?? false,
+      arrivalState: arrivalState,
+      secondsUntilArrival: arrivalState == EewWarningArrivalState.unarrived
+          ? localForecast?.arrivalTime?.difference(now).inSeconds
+          : null,
+      hypocenterName: hypocenter?.name,
+      magnitude: hypocenter?.magnitude,
+      depth: hypocenter?.depth,
+    );
+  }
+}

--- a/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.dart
@@ -3,14 +3,35 @@ import 'package:eqmonitor/feature/eew/data/logic/eew_warning_arrival_classifier.
 import 'package:eqmonitor/feature/eew/data/logic/eew_warning_representative_selector.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_display_model_builder.g.dart';
+
+@riverpod
+EewWarningDisplayModelBuilder eewWarningDisplayModelBuilder(Ref ref) =>
+    EewWarningDisplayModelBuilder(
+      arrivalClassifier: ref.watch(eewWarningArrivalClassifierProvider),
+      representativeSelector: ref.watch(
+        eewWarningRepresentativeSelectorProvider,
+      ),
+    );
 
 class EewWarningDisplayModelBuilder {
+  EewWarningDisplayModelBuilder({
+    EewWarningArrivalClassifier? arrivalClassifier,
+    EewWarningRepresentativeSelector? representativeSelector,
+  }) : _arrivalClassifier = arrivalClassifier ?? EewWarningArrivalClassifier(),
+       _representativeSelector =
+           representativeSelector ?? EewWarningRepresentativeSelector();
+
+  final EewWarningArrivalClassifier _arrivalClassifier;
+  final EewWarningRepresentativeSelector _representativeSelector;
+
   EewWarningOverlayDisplayModel? build({
     required List<EewWarningOverlayCandidate> candidates,
     required DateTime now,
   }) {
-    final representativeSelector = EewWarningRepresentativeSelector();
-    final representative = representativeSelector.select(
+    final representative = _representativeSelector.select(
       candidates: candidates,
       now: now,
     );
@@ -21,7 +42,7 @@ class EewWarningDisplayModelBuilder {
     final sortedCandidates = [...candidates]
       ..sort(
         (left, right) =>
-            representativeSelector.compare(left: left, right: right, now: now),
+            _representativeSelector.compare(left: left, right: right, now: now),
       );
 
     final zoneNamesByCode = <String, String>{};
@@ -51,7 +72,7 @@ class EewWarningDisplayModelBuilder {
             preferredHypocenterName.isEmpty
         ? null
         : preferredHypocenterName;
-    final arrivalState = EewWarningArrivalClassifier().classify(
+    final arrivalState = _arrivalClassifier.classify(
       candidate: representative,
       now: now,
     );

--- a/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.g.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_display_model_builder.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_display_model_builder.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningDisplayModelBuilder)
+final eewWarningDisplayModelBuilderProvider =
+    EewWarningDisplayModelBuilderProvider._();
+
+final class EewWarningDisplayModelBuilderProvider
+    extends
+        $FunctionalProvider<
+          EewWarningDisplayModelBuilder,
+          EewWarningDisplayModelBuilder,
+          EewWarningDisplayModelBuilder
+        >
+    with $Provider<EewWarningDisplayModelBuilder> {
+  EewWarningDisplayModelBuilderProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningDisplayModelBuilderProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningDisplayModelBuilderHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningDisplayModelBuilder> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningDisplayModelBuilder create(Ref ref) {
+    return eewWarningDisplayModelBuilder(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningDisplayModelBuilder value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningDisplayModelBuilder>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$eewWarningDisplayModelBuilderHash() =>
+    r'5717db48bba4b73ceffa34cac8bcea47af903829';

--- a/app/lib/feature/eew/data/logic/eew_warning_representative_selector.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_representative_selector.dart
@@ -1,8 +1,23 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/eew/data/logic/eew_warning_arrival_classifier.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_representative_selector.g.dart';
+
+@riverpod
+EewWarningRepresentativeSelector eewWarningRepresentativeSelector(Ref ref) =>
+    EewWarningRepresentativeSelector(
+      arrivalClassifier: ref.watch(eewWarningArrivalClassifierProvider),
+    );
 
 class EewWarningRepresentativeSelector {
+  EewWarningRepresentativeSelector({
+    EewWarningArrivalClassifier? arrivalClassifier,
+  }) : _arrivalClassifier = arrivalClassifier ?? EewWarningArrivalClassifier();
+
+  final EewWarningArrivalClassifier _arrivalClassifier;
+
   EewWarningOverlayCandidate? select({
     required List<EewWarningOverlayCandidate> candidates,
     required DateTime now,
@@ -20,11 +35,12 @@ class EewWarningRepresentativeSelector {
     required EewWarningOverlayCandidate right,
     required DateTime now,
   }) {
-    final classifier = EewWarningArrivalClassifier();
-    final arrivalComparison = classifier
+    final arrivalComparison = _arrivalClassifier
         .classify(candidate: left, now: now)
         .index
-        .compareTo(classifier.classify(candidate: right, now: now).index);
+        .compareTo(
+          _arrivalClassifier.classify(candidate: right, now: now).index,
+        );
     if (arrivalComparison != 0) {
       return arrivalComparison;
     }

--- a/app/lib/feature/eew/data/logic/eew_warning_representative_selector.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_representative_selector.dart
@@ -1,0 +1,49 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_arrival_classifier.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+
+class EewWarningRepresentativeSelector {
+  EewWarningOverlayCandidate? select({
+    required List<EewWarningOverlayCandidate> candidates,
+    required DateTime now,
+  }) {
+    if (candidates.isEmpty) {
+      return null;
+    }
+    final sorted = [...candidates]
+      ..sort((left, right) => compare(left: left, right: right, now: now));
+    return sorted.first;
+  }
+
+  int compare({
+    required EewWarningOverlayCandidate left,
+    required EewWarningOverlayCandidate right,
+    required DateTime now,
+  }) {
+    final classifier = EewWarningArrivalClassifier();
+    final arrivalComparison = classifier
+        .classify(candidate: left, now: now)
+        .index
+        .compareTo(classifier.classify(candidate: right, now: now).index);
+    if (arrivalComparison != 0) {
+      return arrivalComparison;
+    }
+    final intensityComparison =
+        (right.localForecastRegion?.intensity ?? JmaIntensity.unknown)
+            .orderIndex
+            .compareTo(
+              (left.localForecastRegion?.intensity ?? JmaIntensity.unknown)
+                  .orderIndex,
+            );
+    if (intensityComparison != 0) {
+      return intensityComparison;
+    }
+    final reportTimeComparison = right.event.reportTime.compareTo(
+      left.event.reportTime,
+    );
+    if (reportTimeComparison != 0) {
+      return reportTimeComparison;
+    }
+    return left.event.eventId.compareTo(right.event.eventId);
+  }
+}

--- a/app/lib/feature/eew/data/logic/eew_warning_representative_selector.g.dart
+++ b/app/lib/feature/eew/data/logic/eew_warning_representative_selector.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_representative_selector.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningRepresentativeSelector)
+final eewWarningRepresentativeSelectorProvider =
+    EewWarningRepresentativeSelectorProvider._();
+
+final class EewWarningRepresentativeSelectorProvider
+    extends
+        $FunctionalProvider<
+          EewWarningRepresentativeSelector,
+          EewWarningRepresentativeSelector,
+          EewWarningRepresentativeSelector
+        >
+    with $Provider<EewWarningRepresentativeSelector> {
+  EewWarningRepresentativeSelectorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningRepresentativeSelectorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningRepresentativeSelectorHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningRepresentativeSelector> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningRepresentativeSelector create(Ref ref) {
+    return eewWarningRepresentativeSelector(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningRepresentativeSelector value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningRepresentativeSelector>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$eewWarningRepresentativeSelectorHash() =>
+    r'23ae79c3cd22e4984fd40b01cb6d909ce6150f3f';

--- a/app/lib/feature/eew/data/model/eew_warning_overlay_candidate.dart
+++ b/app/lib/feature/eew/data/model/eew_warning_overlay_candidate.dart
@@ -1,0 +1,15 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'eew_warning_overlay_candidate.freezed.dart';
+
+@Freezed(toJson: false)
+abstract class EewWarningOverlayCandidate with _$EewWarningOverlayCandidate {
+  const factory EewWarningOverlayCandidate({
+    required EewTelegramItem event,
+    required String warningAreaCode,
+    required String warningAreaName,
+    required String? forecastAreaName,
+    required EewForecastRegionInfo? localForecastRegion,
+  }) = _EewWarningOverlayCandidate;
+}

--- a/app/lib/feature/eew/data/model/eew_warning_overlay_candidate.freezed.dart
+++ b/app/lib/feature/eew/data/model/eew_warning_overlay_candidate.freezed.dart
@@ -1,0 +1,325 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'eew_warning_overlay_candidate.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EewWarningOverlayCandidate {
+
+ EewTelegramItem get event; String get warningAreaCode; String get warningAreaName; String? get forecastAreaName; EewForecastRegionInfo? get localForecastRegion;
+/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EewWarningOverlayCandidateCopyWith<EewWarningOverlayCandidate> get copyWith => _$EewWarningOverlayCandidateCopyWithImpl<EewWarningOverlayCandidate>(this as EewWarningOverlayCandidate, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningOverlayCandidate&&(identical(other.event, event) || other.event == event)&&(identical(other.warningAreaCode, warningAreaCode) || other.warningAreaCode == warningAreaCode)&&(identical(other.warningAreaName, warningAreaName) || other.warningAreaName == warningAreaName)&&(identical(other.forecastAreaName, forecastAreaName) || other.forecastAreaName == forecastAreaName)&&(identical(other.localForecastRegion, localForecastRegion) || other.localForecastRegion == localForecastRegion));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,event,warningAreaCode,warningAreaName,forecastAreaName,localForecastRegion);
+
+@override
+String toString() {
+  return 'EewWarningOverlayCandidate(event: $event, warningAreaCode: $warningAreaCode, warningAreaName: $warningAreaName, forecastAreaName: $forecastAreaName, localForecastRegion: $localForecastRegion)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EewWarningOverlayCandidateCopyWith<$Res>  {
+  factory $EewWarningOverlayCandidateCopyWith(EewWarningOverlayCandidate value, $Res Function(EewWarningOverlayCandidate) _then) = _$EewWarningOverlayCandidateCopyWithImpl;
+@useResult
+$Res call({
+ EewTelegramItem event, String warningAreaCode, String warningAreaName, String? forecastAreaName, EewForecastRegionInfo? localForecastRegion
+});
+
+
+$EewTelegramItemCopyWith<$Res> get event;$EewForecastRegionInfoCopyWith<$Res>? get localForecastRegion;
+
+}
+/// @nodoc
+class _$EewWarningOverlayCandidateCopyWithImpl<$Res>
+    implements $EewWarningOverlayCandidateCopyWith<$Res> {
+  _$EewWarningOverlayCandidateCopyWithImpl(this._self, this._then);
+
+  final EewWarningOverlayCandidate _self;
+  final $Res Function(EewWarningOverlayCandidate) _then;
+
+/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? event = null,Object? warningAreaCode = null,Object? warningAreaName = null,Object? forecastAreaName = freezed,Object? localForecastRegion = freezed,}) {
+  return _then(_self.copyWith(
+event: null == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
+as EewTelegramItem,warningAreaCode: null == warningAreaCode ? _self.warningAreaCode : warningAreaCode // ignore: cast_nullable_to_non_nullable
+as String,warningAreaName: null == warningAreaName ? _self.warningAreaName : warningAreaName // ignore: cast_nullable_to_non_nullable
+as String,forecastAreaName: freezed == forecastAreaName ? _self.forecastAreaName : forecastAreaName // ignore: cast_nullable_to_non_nullable
+as String?,localForecastRegion: freezed == localForecastRegion ? _self.localForecastRegion : localForecastRegion // ignore: cast_nullable_to_non_nullable
+as EewForecastRegionInfo?,
+  ));
+}
+/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EewTelegramItemCopyWith<$Res> get event {
+
+  return $EewTelegramItemCopyWith<$Res>(_self.event, (value) {
+    return _then(_self.copyWith(event: value));
+  });
+}/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EewForecastRegionInfoCopyWith<$Res>? get localForecastRegion {
+    if (_self.localForecastRegion == null) {
+    return null;
+  }
+
+  return $EewForecastRegionInfoCopyWith<$Res>(_self.localForecastRegion!, (value) {
+    return _then(_self.copyWith(localForecastRegion: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EewWarningOverlayCandidate].
+extension EewWarningOverlayCandidatePatterns on EewWarningOverlayCandidate {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EewWarningOverlayCandidate value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayCandidate() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EewWarningOverlayCandidate value)  $default,){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayCandidate():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EewWarningOverlayCandidate value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayCandidate() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( EewTelegramItem event,  String warningAreaCode,  String warningAreaName,  String? forecastAreaName,  EewForecastRegionInfo? localForecastRegion)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayCandidate() when $default != null:
+return $default(_that.event,_that.warningAreaCode,_that.warningAreaName,_that.forecastAreaName,_that.localForecastRegion);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( EewTelegramItem event,  String warningAreaCode,  String warningAreaName,  String? forecastAreaName,  EewForecastRegionInfo? localForecastRegion)  $default,) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayCandidate():
+return $default(_that.event,_that.warningAreaCode,_that.warningAreaName,_that.forecastAreaName,_that.localForecastRegion);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( EewTelegramItem event,  String warningAreaCode,  String warningAreaName,  String? forecastAreaName,  EewForecastRegionInfo? localForecastRegion)?  $default,) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayCandidate() when $default != null:
+return $default(_that.event,_that.warningAreaCode,_that.warningAreaName,_that.forecastAreaName,_that.localForecastRegion);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EewWarningOverlayCandidate implements EewWarningOverlayCandidate {
+  const _EewWarningOverlayCandidate({required this.event, required this.warningAreaCode, required this.warningAreaName, required this.forecastAreaName, required this.localForecastRegion});
+
+
+@override final  EewTelegramItem event;
+@override final  String warningAreaCode;
+@override final  String warningAreaName;
+@override final  String? forecastAreaName;
+@override final  EewForecastRegionInfo? localForecastRegion;
+
+/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EewWarningOverlayCandidateCopyWith<_EewWarningOverlayCandidate> get copyWith => __$EewWarningOverlayCandidateCopyWithImpl<_EewWarningOverlayCandidate>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningOverlayCandidate&&(identical(other.event, event) || other.event == event)&&(identical(other.warningAreaCode, warningAreaCode) || other.warningAreaCode == warningAreaCode)&&(identical(other.warningAreaName, warningAreaName) || other.warningAreaName == warningAreaName)&&(identical(other.forecastAreaName, forecastAreaName) || other.forecastAreaName == forecastAreaName)&&(identical(other.localForecastRegion, localForecastRegion) || other.localForecastRegion == localForecastRegion));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,event,warningAreaCode,warningAreaName,forecastAreaName,localForecastRegion);
+
+@override
+String toString() {
+  return 'EewWarningOverlayCandidate(event: $event, warningAreaCode: $warningAreaCode, warningAreaName: $warningAreaName, forecastAreaName: $forecastAreaName, localForecastRegion: $localForecastRegion)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EewWarningOverlayCandidateCopyWith<$Res> implements $EewWarningOverlayCandidateCopyWith<$Res> {
+  factory _$EewWarningOverlayCandidateCopyWith(_EewWarningOverlayCandidate value, $Res Function(_EewWarningOverlayCandidate) _then) = __$EewWarningOverlayCandidateCopyWithImpl;
+@override @useResult
+$Res call({
+ EewTelegramItem event, String warningAreaCode, String warningAreaName, String? forecastAreaName, EewForecastRegionInfo? localForecastRegion
+});
+
+
+@override $EewTelegramItemCopyWith<$Res> get event;@override $EewForecastRegionInfoCopyWith<$Res>? get localForecastRegion;
+
+}
+/// @nodoc
+class __$EewWarningOverlayCandidateCopyWithImpl<$Res>
+    implements _$EewWarningOverlayCandidateCopyWith<$Res> {
+  __$EewWarningOverlayCandidateCopyWithImpl(this._self, this._then);
+
+  final _EewWarningOverlayCandidate _self;
+  final $Res Function(_EewWarningOverlayCandidate) _then;
+
+/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? event = null,Object? warningAreaCode = null,Object? warningAreaName = null,Object? forecastAreaName = freezed,Object? localForecastRegion = freezed,}) {
+  return _then(_EewWarningOverlayCandidate(
+event: null == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
+as EewTelegramItem,warningAreaCode: null == warningAreaCode ? _self.warningAreaCode : warningAreaCode // ignore: cast_nullable_to_non_nullable
+as String,warningAreaName: null == warningAreaName ? _self.warningAreaName : warningAreaName // ignore: cast_nullable_to_non_nullable
+as String,forecastAreaName: freezed == forecastAreaName ? _self.forecastAreaName : forecastAreaName // ignore: cast_nullable_to_non_nullable
+as String?,localForecastRegion: freezed == localForecastRegion ? _self.localForecastRegion : localForecastRegion // ignore: cast_nullable_to_non_nullable
+as EewForecastRegionInfo?,
+  ));
+}
+
+/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EewTelegramItemCopyWith<$Res> get event {
+
+  return $EewTelegramItemCopyWith<$Res>(_self.event, (value) {
+    return _then(_self.copyWith(event: value));
+  });
+}/// Create a copy of EewWarningOverlayCandidate
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EewForecastRegionInfoCopyWith<$Res>? get localForecastRegion {
+    if (_self.localForecastRegion == null) {
+    return null;
+  }
+
+  return $EewForecastRegionInfoCopyWith<$Res>(_self.localForecastRegion!, (value) {
+    return _then(_self.copyWith(localForecastRegion: value));
+  });
+}
+}
+
+// dart format on

--- a/app/lib/feature/eew/data/model/eew_warning_overlay_display_model.dart
+++ b/app/lib/feature/eew/data/model/eew_warning_overlay_display_model.dart
@@ -1,0 +1,31 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'eew_warning_overlay_display_model.freezed.dart';
+
+enum EewWarningOverlaySource { real, simulation }
+
+enum EewWarningArrivalState { unarrived, unknown, arrived }
+
+@Freezed(toJson: false)
+abstract class EewWarningOverlayDisplayModel
+    with _$EewWarningOverlayDisplayModel {
+  const factory EewWarningOverlayDisplayModel({
+    required EewWarningOverlaySource source,
+    required List<String> eventIds,
+    required String representativeEventId,
+    required int serialNo,
+    required int alertCount,
+    required String reportLabel,
+    required String? hypocenterHeadline,
+    required String strongMotionHeadline,
+    required String currentRegionName,
+    required JmaIntensity localIntensity,
+    required bool localIntensityIsOver,
+    required EewWarningArrivalState arrivalState,
+    required int? secondsUntilArrival,
+    required String? hypocenterName,
+    required double? magnitude,
+    required int? depth,
+  }) = _EewWarningOverlayDisplayModel;
+}

--- a/app/lib/feature/eew/data/model/eew_warning_overlay_display_model.freezed.dart
+++ b/app/lib/feature/eew/data/model/eew_warning_overlay_display_model.freezed.dart
@@ -1,0 +1,322 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'eew_warning_overlay_display_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EewWarningOverlayDisplayModel {
+
+ EewWarningOverlaySource get source; List<String> get eventIds; String get representativeEventId; int get serialNo; int get alertCount; String get reportLabel; String? get hypocenterHeadline; String get strongMotionHeadline; String get currentRegionName; JmaIntensity get localIntensity; bool get localIntensityIsOver; EewWarningArrivalState get arrivalState; int? get secondsUntilArrival; String? get hypocenterName; double? get magnitude; int? get depth;
+/// Create a copy of EewWarningOverlayDisplayModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EewWarningOverlayDisplayModelCopyWith<EewWarningOverlayDisplayModel> get copyWith => _$EewWarningOverlayDisplayModelCopyWithImpl<EewWarningOverlayDisplayModel>(this as EewWarningOverlayDisplayModel, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningOverlayDisplayModel&&(identical(other.source, source) || other.source == source)&&const DeepCollectionEquality().equals(other.eventIds, eventIds)&&(identical(other.representativeEventId, representativeEventId) || other.representativeEventId == representativeEventId)&&(identical(other.serialNo, serialNo) || other.serialNo == serialNo)&&(identical(other.alertCount, alertCount) || other.alertCount == alertCount)&&(identical(other.reportLabel, reportLabel) || other.reportLabel == reportLabel)&&(identical(other.hypocenterHeadline, hypocenterHeadline) || other.hypocenterHeadline == hypocenterHeadline)&&(identical(other.strongMotionHeadline, strongMotionHeadline) || other.strongMotionHeadline == strongMotionHeadline)&&(identical(other.currentRegionName, currentRegionName) || other.currentRegionName == currentRegionName)&&(identical(other.localIntensity, localIntensity) || other.localIntensity == localIntensity)&&(identical(other.localIntensityIsOver, localIntensityIsOver) || other.localIntensityIsOver == localIntensityIsOver)&&(identical(other.arrivalState, arrivalState) || other.arrivalState == arrivalState)&&(identical(other.secondsUntilArrival, secondsUntilArrival) || other.secondsUntilArrival == secondsUntilArrival)&&(identical(other.hypocenterName, hypocenterName) || other.hypocenterName == hypocenterName)&&(identical(other.magnitude, magnitude) || other.magnitude == magnitude)&&(identical(other.depth, depth) || other.depth == depth));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,source,const DeepCollectionEquality().hash(eventIds),representativeEventId,serialNo,alertCount,reportLabel,hypocenterHeadline,strongMotionHeadline,currentRegionName,localIntensity,localIntensityIsOver,arrivalState,secondsUntilArrival,hypocenterName,magnitude,depth);
+
+@override
+String toString() {
+  return 'EewWarningOverlayDisplayModel(source: $source, eventIds: $eventIds, representativeEventId: $representativeEventId, serialNo: $serialNo, alertCount: $alertCount, reportLabel: $reportLabel, hypocenterHeadline: $hypocenterHeadline, strongMotionHeadline: $strongMotionHeadline, currentRegionName: $currentRegionName, localIntensity: $localIntensity, localIntensityIsOver: $localIntensityIsOver, arrivalState: $arrivalState, secondsUntilArrival: $secondsUntilArrival, hypocenterName: $hypocenterName, magnitude: $magnitude, depth: $depth)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EewWarningOverlayDisplayModelCopyWith<$Res>  {
+  factory $EewWarningOverlayDisplayModelCopyWith(EewWarningOverlayDisplayModel value, $Res Function(EewWarningOverlayDisplayModel) _then) = _$EewWarningOverlayDisplayModelCopyWithImpl;
+@useResult
+$Res call({
+ EewWarningOverlaySource source, List<String> eventIds, String representativeEventId, int serialNo, int alertCount, String reportLabel, String? hypocenterHeadline, String strongMotionHeadline, String currentRegionName, JmaIntensity localIntensity, bool localIntensityIsOver, EewWarningArrivalState arrivalState, int? secondsUntilArrival, String? hypocenterName, double? magnitude, int? depth
+});
+
+
+
+
+}
+/// @nodoc
+class _$EewWarningOverlayDisplayModelCopyWithImpl<$Res>
+    implements $EewWarningOverlayDisplayModelCopyWith<$Res> {
+  _$EewWarningOverlayDisplayModelCopyWithImpl(this._self, this._then);
+
+  final EewWarningOverlayDisplayModel _self;
+  final $Res Function(EewWarningOverlayDisplayModel) _then;
+
+/// Create a copy of EewWarningOverlayDisplayModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? source = null,Object? eventIds = null,Object? representativeEventId = null,Object? serialNo = null,Object? alertCount = null,Object? reportLabel = null,Object? hypocenterHeadline = freezed,Object? strongMotionHeadline = null,Object? currentRegionName = null,Object? localIntensity = null,Object? localIntensityIsOver = null,Object? arrivalState = null,Object? secondsUntilArrival = freezed,Object? hypocenterName = freezed,Object? magnitude = freezed,Object? depth = freezed,}) {
+  return _then(_self.copyWith(
+source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as EewWarningOverlaySource,eventIds: null == eventIds ? _self.eventIds : eventIds // ignore: cast_nullable_to_non_nullable
+as List<String>,representativeEventId: null == representativeEventId ? _self.representativeEventId : representativeEventId // ignore: cast_nullable_to_non_nullable
+as String,serialNo: null == serialNo ? _self.serialNo : serialNo // ignore: cast_nullable_to_non_nullable
+as int,alertCount: null == alertCount ? _self.alertCount : alertCount // ignore: cast_nullable_to_non_nullable
+as int,reportLabel: null == reportLabel ? _self.reportLabel : reportLabel // ignore: cast_nullable_to_non_nullable
+as String,hypocenterHeadline: freezed == hypocenterHeadline ? _self.hypocenterHeadline : hypocenterHeadline // ignore: cast_nullable_to_non_nullable
+as String?,strongMotionHeadline: null == strongMotionHeadline ? _self.strongMotionHeadline : strongMotionHeadline // ignore: cast_nullable_to_non_nullable
+as String,currentRegionName: null == currentRegionName ? _self.currentRegionName : currentRegionName // ignore: cast_nullable_to_non_nullable
+as String,localIntensity: null == localIntensity ? _self.localIntensity : localIntensity // ignore: cast_nullable_to_non_nullable
+as JmaIntensity,localIntensityIsOver: null == localIntensityIsOver ? _self.localIntensityIsOver : localIntensityIsOver // ignore: cast_nullable_to_non_nullable
+as bool,arrivalState: null == arrivalState ? _self.arrivalState : arrivalState // ignore: cast_nullable_to_non_nullable
+as EewWarningArrivalState,secondsUntilArrival: freezed == secondsUntilArrival ? _self.secondsUntilArrival : secondsUntilArrival // ignore: cast_nullable_to_non_nullable
+as int?,hypocenterName: freezed == hypocenterName ? _self.hypocenterName : hypocenterName // ignore: cast_nullable_to_non_nullable
+as String?,magnitude: freezed == magnitude ? _self.magnitude : magnitude // ignore: cast_nullable_to_non_nullable
+as double?,depth: freezed == depth ? _self.depth : depth // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EewWarningOverlayDisplayModel].
+extension EewWarningOverlayDisplayModelPatterns on EewWarningOverlayDisplayModel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EewWarningOverlayDisplayModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayDisplayModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EewWarningOverlayDisplayModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayDisplayModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EewWarningOverlayDisplayModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayDisplayModel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( EewWarningOverlaySource source,  List<String> eventIds,  String representativeEventId,  int serialNo,  int alertCount,  String reportLabel,  String? hypocenterHeadline,  String strongMotionHeadline,  String currentRegionName,  JmaIntensity localIntensity,  bool localIntensityIsOver,  EewWarningArrivalState arrivalState,  int? secondsUntilArrival,  String? hypocenterName,  double? magnitude,  int? depth)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayDisplayModel() when $default != null:
+return $default(_that.source,_that.eventIds,_that.representativeEventId,_that.serialNo,_that.alertCount,_that.reportLabel,_that.hypocenterHeadline,_that.strongMotionHeadline,_that.currentRegionName,_that.localIntensity,_that.localIntensityIsOver,_that.arrivalState,_that.secondsUntilArrival,_that.hypocenterName,_that.magnitude,_that.depth);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( EewWarningOverlaySource source,  List<String> eventIds,  String representativeEventId,  int serialNo,  int alertCount,  String reportLabel,  String? hypocenterHeadline,  String strongMotionHeadline,  String currentRegionName,  JmaIntensity localIntensity,  bool localIntensityIsOver,  EewWarningArrivalState arrivalState,  int? secondsUntilArrival,  String? hypocenterName,  double? magnitude,  int? depth)  $default,) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayDisplayModel():
+return $default(_that.source,_that.eventIds,_that.representativeEventId,_that.serialNo,_that.alertCount,_that.reportLabel,_that.hypocenterHeadline,_that.strongMotionHeadline,_that.currentRegionName,_that.localIntensity,_that.localIntensityIsOver,_that.arrivalState,_that.secondsUntilArrival,_that.hypocenterName,_that.magnitude,_that.depth);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( EewWarningOverlaySource source,  List<String> eventIds,  String representativeEventId,  int serialNo,  int alertCount,  String reportLabel,  String? hypocenterHeadline,  String strongMotionHeadline,  String currentRegionName,  JmaIntensity localIntensity,  bool localIntensityIsOver,  EewWarningArrivalState arrivalState,  int? secondsUntilArrival,  String? hypocenterName,  double? magnitude,  int? depth)?  $default,) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayDisplayModel() when $default != null:
+return $default(_that.source,_that.eventIds,_that.representativeEventId,_that.serialNo,_that.alertCount,_that.reportLabel,_that.hypocenterHeadline,_that.strongMotionHeadline,_that.currentRegionName,_that.localIntensity,_that.localIntensityIsOver,_that.arrivalState,_that.secondsUntilArrival,_that.hypocenterName,_that.magnitude,_that.depth);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EewWarningOverlayDisplayModel implements EewWarningOverlayDisplayModel {
+  const _EewWarningOverlayDisplayModel({required this.source, required final  List<String> eventIds, required this.representativeEventId, required this.serialNo, required this.alertCount, required this.reportLabel, required this.hypocenterHeadline, required this.strongMotionHeadline, required this.currentRegionName, required this.localIntensity, required this.localIntensityIsOver, required this.arrivalState, required this.secondsUntilArrival, required this.hypocenterName, required this.magnitude, required this.depth}): _eventIds = eventIds;
+
+
+@override final  EewWarningOverlaySource source;
+ final  List<String> _eventIds;
+@override List<String> get eventIds {
+  if (_eventIds is EqualUnmodifiableListView) return _eventIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_eventIds);
+}
+
+@override final  String representativeEventId;
+@override final  int serialNo;
+@override final  int alertCount;
+@override final  String reportLabel;
+@override final  String? hypocenterHeadline;
+@override final  String strongMotionHeadline;
+@override final  String currentRegionName;
+@override final  JmaIntensity localIntensity;
+@override final  bool localIntensityIsOver;
+@override final  EewWarningArrivalState arrivalState;
+@override final  int? secondsUntilArrival;
+@override final  String? hypocenterName;
+@override final  double? magnitude;
+@override final  int? depth;
+
+/// Create a copy of EewWarningOverlayDisplayModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EewWarningOverlayDisplayModelCopyWith<_EewWarningOverlayDisplayModel> get copyWith => __$EewWarningOverlayDisplayModelCopyWithImpl<_EewWarningOverlayDisplayModel>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningOverlayDisplayModel&&(identical(other.source, source) || other.source == source)&&const DeepCollectionEquality().equals(other._eventIds, _eventIds)&&(identical(other.representativeEventId, representativeEventId) || other.representativeEventId == representativeEventId)&&(identical(other.serialNo, serialNo) || other.serialNo == serialNo)&&(identical(other.alertCount, alertCount) || other.alertCount == alertCount)&&(identical(other.reportLabel, reportLabel) || other.reportLabel == reportLabel)&&(identical(other.hypocenterHeadline, hypocenterHeadline) || other.hypocenterHeadline == hypocenterHeadline)&&(identical(other.strongMotionHeadline, strongMotionHeadline) || other.strongMotionHeadline == strongMotionHeadline)&&(identical(other.currentRegionName, currentRegionName) || other.currentRegionName == currentRegionName)&&(identical(other.localIntensity, localIntensity) || other.localIntensity == localIntensity)&&(identical(other.localIntensityIsOver, localIntensityIsOver) || other.localIntensityIsOver == localIntensityIsOver)&&(identical(other.arrivalState, arrivalState) || other.arrivalState == arrivalState)&&(identical(other.secondsUntilArrival, secondsUntilArrival) || other.secondsUntilArrival == secondsUntilArrival)&&(identical(other.hypocenterName, hypocenterName) || other.hypocenterName == hypocenterName)&&(identical(other.magnitude, magnitude) || other.magnitude == magnitude)&&(identical(other.depth, depth) || other.depth == depth));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,source,const DeepCollectionEquality().hash(_eventIds),representativeEventId,serialNo,alertCount,reportLabel,hypocenterHeadline,strongMotionHeadline,currentRegionName,localIntensity,localIntensityIsOver,arrivalState,secondsUntilArrival,hypocenterName,magnitude,depth);
+
+@override
+String toString() {
+  return 'EewWarningOverlayDisplayModel(source: $source, eventIds: $eventIds, representativeEventId: $representativeEventId, serialNo: $serialNo, alertCount: $alertCount, reportLabel: $reportLabel, hypocenterHeadline: $hypocenterHeadline, strongMotionHeadline: $strongMotionHeadline, currentRegionName: $currentRegionName, localIntensity: $localIntensity, localIntensityIsOver: $localIntensityIsOver, arrivalState: $arrivalState, secondsUntilArrival: $secondsUntilArrival, hypocenterName: $hypocenterName, magnitude: $magnitude, depth: $depth)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EewWarningOverlayDisplayModelCopyWith<$Res> implements $EewWarningOverlayDisplayModelCopyWith<$Res> {
+  factory _$EewWarningOverlayDisplayModelCopyWith(_EewWarningOverlayDisplayModel value, $Res Function(_EewWarningOverlayDisplayModel) _then) = __$EewWarningOverlayDisplayModelCopyWithImpl;
+@override @useResult
+$Res call({
+ EewWarningOverlaySource source, List<String> eventIds, String representativeEventId, int serialNo, int alertCount, String reportLabel, String? hypocenterHeadline, String strongMotionHeadline, String currentRegionName, JmaIntensity localIntensity, bool localIntensityIsOver, EewWarningArrivalState arrivalState, int? secondsUntilArrival, String? hypocenterName, double? magnitude, int? depth
+});
+
+
+
+
+}
+/// @nodoc
+class __$EewWarningOverlayDisplayModelCopyWithImpl<$Res>
+    implements _$EewWarningOverlayDisplayModelCopyWith<$Res> {
+  __$EewWarningOverlayDisplayModelCopyWithImpl(this._self, this._then);
+
+  final _EewWarningOverlayDisplayModel _self;
+  final $Res Function(_EewWarningOverlayDisplayModel) _then;
+
+/// Create a copy of EewWarningOverlayDisplayModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? source = null,Object? eventIds = null,Object? representativeEventId = null,Object? serialNo = null,Object? alertCount = null,Object? reportLabel = null,Object? hypocenterHeadline = freezed,Object? strongMotionHeadline = null,Object? currentRegionName = null,Object? localIntensity = null,Object? localIntensityIsOver = null,Object? arrivalState = null,Object? secondsUntilArrival = freezed,Object? hypocenterName = freezed,Object? magnitude = freezed,Object? depth = freezed,}) {
+  return _then(_EewWarningOverlayDisplayModel(
+source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as EewWarningOverlaySource,eventIds: null == eventIds ? _self._eventIds : eventIds // ignore: cast_nullable_to_non_nullable
+as List<String>,representativeEventId: null == representativeEventId ? _self.representativeEventId : representativeEventId // ignore: cast_nullable_to_non_nullable
+as String,serialNo: null == serialNo ? _self.serialNo : serialNo // ignore: cast_nullable_to_non_nullable
+as int,alertCount: null == alertCount ? _self.alertCount : alertCount // ignore: cast_nullable_to_non_nullable
+as int,reportLabel: null == reportLabel ? _self.reportLabel : reportLabel // ignore: cast_nullable_to_non_nullable
+as String,hypocenterHeadline: freezed == hypocenterHeadline ? _self.hypocenterHeadline : hypocenterHeadline // ignore: cast_nullable_to_non_nullable
+as String?,strongMotionHeadline: null == strongMotionHeadline ? _self.strongMotionHeadline : strongMotionHeadline // ignore: cast_nullable_to_non_nullable
+as String,currentRegionName: null == currentRegionName ? _self.currentRegionName : currentRegionName // ignore: cast_nullable_to_non_nullable
+as String,localIntensity: null == localIntensity ? _self.localIntensity : localIntensity // ignore: cast_nullable_to_non_nullable
+as JmaIntensity,localIntensityIsOver: null == localIntensityIsOver ? _self.localIntensityIsOver : localIntensityIsOver // ignore: cast_nullable_to_non_nullable
+as bool,arrivalState: null == arrivalState ? _self.arrivalState : arrivalState // ignore: cast_nullable_to_non_nullable
+as EewWarningArrivalState,secondsUntilArrival: freezed == secondsUntilArrival ? _self.secondsUntilArrival : secondsUntilArrival // ignore: cast_nullable_to_non_nullable
+as int?,hypocenterName: freezed == hypocenterName ? _self.hypocenterName : hypocenterName // ignore: cast_nullable_to_non_nullable
+as String?,magnitude: freezed == magnitude ? _self.magnitude : magnitude // ignore: cast_nullable_to_non_nullable
+as double?,depth: freezed == depth ? _self.depth : depth // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/feature/eew/data/model/eew_warning_overlay_state.dart
+++ b/app/lib/feature/eew/data/model/eew_warning_overlay_state.dart
@@ -1,0 +1,17 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'eew_warning_overlay_state.freezed.dart';
+
+enum EewWarningOverlayMode { hidden, fullscreen, minimized }
+
+@Freezed(toJson: false)
+abstract class EewWarningOverlayState with _$EewWarningOverlayState {
+  const factory EewWarningOverlayState({
+    @Default(EewWarningOverlayMode.hidden) EewWarningOverlayMode mode,
+    EewWarningOverlayDisplayModel? displayModel,
+    @Default(<String>{}) Set<String> seenEventIds,
+    @Default(<String>{}) Set<String> dismissedEventIds,
+    @Default(false) bool simulationSessionActive,
+  }) = _EewWarningOverlayState;
+}

--- a/app/lib/feature/eew/data/model/eew_warning_overlay_state.freezed.dart
+++ b/app/lib/feature/eew/data/model/eew_warning_overlay_state.freezed.dart
@@ -1,0 +1,319 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'eew_warning_overlay_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EewWarningOverlayState {
+
+ EewWarningOverlayMode get mode; EewWarningOverlayDisplayModel? get displayModel; Set<String> get seenEventIds; Set<String> get dismissedEventIds; bool get simulationSessionActive;
+/// Create a copy of EewWarningOverlayState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EewWarningOverlayStateCopyWith<EewWarningOverlayState> get copyWith => _$EewWarningOverlayStateCopyWithImpl<EewWarningOverlayState>(this as EewWarningOverlayState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EewWarningOverlayState&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.displayModel, displayModel) || other.displayModel == displayModel)&&const DeepCollectionEquality().equals(other.seenEventIds, seenEventIds)&&const DeepCollectionEquality().equals(other.dismissedEventIds, dismissedEventIds)&&(identical(other.simulationSessionActive, simulationSessionActive) || other.simulationSessionActive == simulationSessionActive));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,mode,displayModel,const DeepCollectionEquality().hash(seenEventIds),const DeepCollectionEquality().hash(dismissedEventIds),simulationSessionActive);
+
+@override
+String toString() {
+  return 'EewWarningOverlayState(mode: $mode, displayModel: $displayModel, seenEventIds: $seenEventIds, dismissedEventIds: $dismissedEventIds, simulationSessionActive: $simulationSessionActive)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EewWarningOverlayStateCopyWith<$Res>  {
+  factory $EewWarningOverlayStateCopyWith(EewWarningOverlayState value, $Res Function(EewWarningOverlayState) _then) = _$EewWarningOverlayStateCopyWithImpl;
+@useResult
+$Res call({
+ EewWarningOverlayMode mode, EewWarningOverlayDisplayModel? displayModel, Set<String> seenEventIds, Set<String> dismissedEventIds, bool simulationSessionActive
+});
+
+
+$EewWarningOverlayDisplayModelCopyWith<$Res>? get displayModel;
+
+}
+/// @nodoc
+class _$EewWarningOverlayStateCopyWithImpl<$Res>
+    implements $EewWarningOverlayStateCopyWith<$Res> {
+  _$EewWarningOverlayStateCopyWithImpl(this._self, this._then);
+
+  final EewWarningOverlayState _self;
+  final $Res Function(EewWarningOverlayState) _then;
+
+/// Create a copy of EewWarningOverlayState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? mode = null,Object? displayModel = freezed,Object? seenEventIds = null,Object? dismissedEventIds = null,Object? simulationSessionActive = null,}) {
+  return _then(_self.copyWith(
+mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as EewWarningOverlayMode,displayModel: freezed == displayModel ? _self.displayModel : displayModel // ignore: cast_nullable_to_non_nullable
+as EewWarningOverlayDisplayModel?,seenEventIds: null == seenEventIds ? _self.seenEventIds : seenEventIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,dismissedEventIds: null == dismissedEventIds ? _self.dismissedEventIds : dismissedEventIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,simulationSessionActive: null == simulationSessionActive ? _self.simulationSessionActive : simulationSessionActive // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+/// Create a copy of EewWarningOverlayState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EewWarningOverlayDisplayModelCopyWith<$Res>? get displayModel {
+    if (_self.displayModel == null) {
+    return null;
+  }
+
+  return $EewWarningOverlayDisplayModelCopyWith<$Res>(_self.displayModel!, (value) {
+    return _then(_self.copyWith(displayModel: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [EewWarningOverlayState].
+extension EewWarningOverlayStatePatterns on EewWarningOverlayState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EewWarningOverlayState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EewWarningOverlayState value)  $default,){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EewWarningOverlayState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EewWarningOverlayState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( EewWarningOverlayMode mode,  EewWarningOverlayDisplayModel? displayModel,  Set<String> seenEventIds,  Set<String> dismissedEventIds,  bool simulationSessionActive)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayState() when $default != null:
+return $default(_that.mode,_that.displayModel,_that.seenEventIds,_that.dismissedEventIds,_that.simulationSessionActive);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( EewWarningOverlayMode mode,  EewWarningOverlayDisplayModel? displayModel,  Set<String> seenEventIds,  Set<String> dismissedEventIds,  bool simulationSessionActive)  $default,) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayState():
+return $default(_that.mode,_that.displayModel,_that.seenEventIds,_that.dismissedEventIds,_that.simulationSessionActive);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( EewWarningOverlayMode mode,  EewWarningOverlayDisplayModel? displayModel,  Set<String> seenEventIds,  Set<String> dismissedEventIds,  bool simulationSessionActive)?  $default,) {final _that = this;
+switch (_that) {
+case _EewWarningOverlayState() when $default != null:
+return $default(_that.mode,_that.displayModel,_that.seenEventIds,_that.dismissedEventIds,_that.simulationSessionActive);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _EewWarningOverlayState implements EewWarningOverlayState {
+  const _EewWarningOverlayState({this.mode = EewWarningOverlayMode.hidden, this.displayModel, final  Set<String> seenEventIds = const <String>{}, final  Set<String> dismissedEventIds = const <String>{}, this.simulationSessionActive = false}): _seenEventIds = seenEventIds,_dismissedEventIds = dismissedEventIds;
+
+
+@override@JsonKey() final  EewWarningOverlayMode mode;
+@override final  EewWarningOverlayDisplayModel? displayModel;
+ final  Set<String> _seenEventIds;
+@override@JsonKey() Set<String> get seenEventIds {
+  if (_seenEventIds is EqualUnmodifiableSetView) return _seenEventIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableSetView(_seenEventIds);
+}
+
+ final  Set<String> _dismissedEventIds;
+@override@JsonKey() Set<String> get dismissedEventIds {
+  if (_dismissedEventIds is EqualUnmodifiableSetView) return _dismissedEventIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableSetView(_dismissedEventIds);
+}
+
+@override@JsonKey() final  bool simulationSessionActive;
+
+/// Create a copy of EewWarningOverlayState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EewWarningOverlayStateCopyWith<_EewWarningOverlayState> get copyWith => __$EewWarningOverlayStateCopyWithImpl<_EewWarningOverlayState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EewWarningOverlayState&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.displayModel, displayModel) || other.displayModel == displayModel)&&const DeepCollectionEquality().equals(other._seenEventIds, _seenEventIds)&&const DeepCollectionEquality().equals(other._dismissedEventIds, _dismissedEventIds)&&(identical(other.simulationSessionActive, simulationSessionActive) || other.simulationSessionActive == simulationSessionActive));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,mode,displayModel,const DeepCollectionEquality().hash(_seenEventIds),const DeepCollectionEquality().hash(_dismissedEventIds),simulationSessionActive);
+
+@override
+String toString() {
+  return 'EewWarningOverlayState(mode: $mode, displayModel: $displayModel, seenEventIds: $seenEventIds, dismissedEventIds: $dismissedEventIds, simulationSessionActive: $simulationSessionActive)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EewWarningOverlayStateCopyWith<$Res> implements $EewWarningOverlayStateCopyWith<$Res> {
+  factory _$EewWarningOverlayStateCopyWith(_EewWarningOverlayState value, $Res Function(_EewWarningOverlayState) _then) = __$EewWarningOverlayStateCopyWithImpl;
+@override @useResult
+$Res call({
+ EewWarningOverlayMode mode, EewWarningOverlayDisplayModel? displayModel, Set<String> seenEventIds, Set<String> dismissedEventIds, bool simulationSessionActive
+});
+
+
+@override $EewWarningOverlayDisplayModelCopyWith<$Res>? get displayModel;
+
+}
+/// @nodoc
+class __$EewWarningOverlayStateCopyWithImpl<$Res>
+    implements _$EewWarningOverlayStateCopyWith<$Res> {
+  __$EewWarningOverlayStateCopyWithImpl(this._self, this._then);
+
+  final _EewWarningOverlayState _self;
+  final $Res Function(_EewWarningOverlayState) _then;
+
+/// Create a copy of EewWarningOverlayState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? mode = null,Object? displayModel = freezed,Object? seenEventIds = null,Object? dismissedEventIds = null,Object? simulationSessionActive = null,}) {
+  return _then(_EewWarningOverlayState(
+mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as EewWarningOverlayMode,displayModel: freezed == displayModel ? _self.displayModel : displayModel // ignore: cast_nullable_to_non_nullable
+as EewWarningOverlayDisplayModel?,seenEventIds: null == seenEventIds ? _self._seenEventIds : seenEventIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,dismissedEventIds: null == dismissedEventIds ? _self._dismissedEventIds : dismissedEventIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,simulationSessionActive: null == simulationSessionActive ? _self.simulationSessionActive : simulationSessionActive // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+/// Create a copy of EewWarningOverlayState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EewWarningOverlayDisplayModelCopyWith<$Res>? get displayModel {
+    if (_self.displayModel == null) {
+    return null;
+  }
+
+  return $EewWarningOverlayDisplayModelCopyWith<$Res>(_self.displayModel!, (value) {
+    return _then(_self.copyWith(displayModel: value));
+  });
+}
+}
+
+// dart format on

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.dart
@@ -1,0 +1,30 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_data_source.dart';
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_overlay_enabled_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class EewWarningOverlayEnabled extends _$EewWarningOverlayEnabled {
+  @override
+  Future<bool> build() async {
+    final dataSource = await ref.watch(
+      sharedPreferencesDataSourceProvider.future,
+    );
+    return await dataSource.getBool(
+          key: SharedPreferencesKey.eewWarningOverlayEnabled,
+        ) ??
+        true;
+  }
+
+  Future<void> set({required bool value}) async {
+    final dataSource = await ref.read(
+      sharedPreferencesDataSourceProvider.future,
+    );
+    await dataSource.setBool(
+      key: SharedPreferencesKey.eewWarningOverlayEnabled,
+      value: value,
+    );
+    state = AsyncData(value);
+  }
+}

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.g.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_enabled_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EewWarningOverlayEnabled)
+final eewWarningOverlayEnabledProvider = EewWarningOverlayEnabledProvider._();
+
+final class EewWarningOverlayEnabledProvider
+    extends $AsyncNotifierProvider<EewWarningOverlayEnabled, bool> {
+  EewWarningOverlayEnabledProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlayEnabledProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningOverlayEnabledHash();
+
+  @$internal
+  @override
+  EewWarningOverlayEnabled create() => EewWarningOverlayEnabled();
+}
+
+String _$eewWarningOverlayEnabledHash() =>
+    r'e377f9a5c0708a322831b29d6bd27c022b821cda';
+
+abstract class _$EewWarningOverlayEnabled extends $AsyncNotifier<bool> {
+  FutureOr<bool> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<bool>, bool>,
+              AsyncValue<bool>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.dart
@@ -1,0 +1,238 @@
+import 'package:eqmonitor/core/provider/app_lifecycle.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_state.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_effective_display_provider.dart';
+import 'package:eqmonitor/feature/eew/data/service/eew_warning_overlay_scheduler.dart';
+import 'package:eqmonitor/feature/eew/data/service/eew_warning_overlay_vibration_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_overlay_notifier.g.dart';
+
+const eewWarningOverlayFullscreenDuration = Duration(seconds: 10);
+
+@riverpod
+class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
+  EewWarningOverlayScheduledTask? _scheduledTask;
+  EewWarningOverlayScheduledTask? _initializationTask;
+  late EewWarningOverlayScheduler _scheduler;
+  late EewWarningOverlayVibrationService _vibrationService;
+  var _transitionEpoch = 0;
+  var _vibrationEpoch = 0;
+  var _alertActive = false;
+
+  @override
+  EewWarningOverlayState build() {
+    _scheduler = ref.read(eewWarningOverlaySchedulerProvider);
+    _vibrationService = ref.read(eewWarningOverlayVibrationServiceProvider);
+    ref
+      ..listen(eewWarningOverlayEffectiveDisplayProvider, (
+        previous,
+        next,
+      ) async {
+        await handleDisplayChange(next);
+      })
+      ..listen(appLifecycleProvider, (previous, next) async {
+        await handleLifecycleChange(next);
+      })
+      ..onDispose(() async {
+        _transitionEpoch += 1;
+        _initializationTask?.cancel();
+        cancelScheduledTask();
+        await cancelVibration();
+      });
+    final initialDisplay = ref.read(eewWarningOverlayEffectiveDisplayProvider);
+    if (initialDisplay != null &&
+        ref.read(appLifecycleProvider) == AppLifecycleState.resumed) {
+      _initializationTask = _scheduler.schedule(
+        delay: Duration.zero,
+        callback: () async {
+          _initializationTask = null;
+          if (_transitionEpoch == 0) {
+            await handleDisplayChange(initialDisplay);
+          }
+        },
+      );
+    }
+    return const EewWarningOverlayState();
+  }
+
+  Future<void> handleDisplayChange(EewWarningOverlayDisplayModel? model) async {
+    final transition = ++_transitionEpoch;
+    if (model == null) {
+      await hide();
+      return;
+    }
+    if (ref.read(appLifecycleProvider) != AppLifecycleState.resumed) {
+      await retainWhileBackgrounded(model: model);
+      return;
+    }
+    if (model.source == EewWarningOverlaySource.simulation) {
+      await handleSimulation(model: model, transition: transition);
+      return;
+    }
+    await handleReal(model: model, transition: transition);
+  }
+
+  Future<void> handleLifecycleChange(AppLifecycleState lifecycle) async {
+    _transitionEpoch += 1;
+    if (lifecycle != AppLifecycleState.resumed) {
+      await minimizeForBackground();
+      return;
+    }
+    await handleDisplayChange(
+      ref.read(eewWarningOverlayEffectiveDisplayProvider),
+    );
+  }
+
+  Future<void> handleReal({
+    required EewWarningOverlayDisplayModel model,
+    required int transition,
+  }) async {
+    final eventIds = model.eventIds.toSet();
+    final activeIds = eventIds.difference(state.dismissedEventIds);
+    if (activeIds.isEmpty) {
+      await hide();
+      return;
+    }
+    final newIds = eventIds.difference(state.seenEventIds);
+    if (newIds.isNotEmpty) {
+      final next = state.copyWith(
+        displayModel: model,
+        seenEventIds: {...state.seenEventIds, ...eventIds},
+        simulationSessionActive: false,
+      );
+      await beginFullscreen(next: next, transition: transition);
+      return;
+    }
+    state = state.copyWith(
+      mode: state.mode == EewWarningOverlayMode.hidden
+          ? EewWarningOverlayMode.minimized
+          : state.mode,
+      displayModel: model,
+      simulationSessionActive: false,
+    );
+  }
+
+  Future<void> handleSimulation({
+    required EewWarningOverlayDisplayModel model,
+    required int transition,
+  }) async {
+    if (state.simulationSessionActive) {
+      state = state.copyWith(displayModel: model);
+      return;
+    }
+    final next = state.copyWith(
+      displayModel: model,
+      simulationSessionActive: true,
+    );
+    await beginFullscreen(next: next, transition: transition);
+  }
+
+  Future<void> retainWhileBackgrounded({
+    required EewWarningOverlayDisplayModel model,
+  }) async {
+    state = state.copyWith(
+      mode: state.mode == EewWarningOverlayMode.fullscreen
+          ? EewWarningOverlayMode.minimized
+          : state.mode,
+      displayModel: model,
+      simulationSessionActive:
+          model.source == EewWarningOverlaySource.simulation
+          ? state.simulationSessionActive
+          : false,
+    );
+    await cancelVibration();
+  }
+
+  Future<void> minimizeForBackground() async {
+    cancelScheduledTask();
+    state = state.copyWith(
+      mode: state.mode == EewWarningOverlayMode.fullscreen
+          ? EewWarningOverlayMode.minimized
+          : state.mode,
+    );
+    await cancelVibration();
+  }
+
+  Future<void> beginFullscreen({
+    required EewWarningOverlayState next,
+    required int transition,
+  }) async {
+    cancelScheduledTask();
+    final cancellation = cancelVibration();
+    state = next.copyWith(mode: EewWarningOverlayMode.fullscreen);
+    _scheduledTask = _scheduler.schedule(
+      delay: eewWarningOverlayFullscreenDuration,
+      callback: minimize,
+    );
+    _alertActive = true;
+    final vibration = ++_vibrationEpoch;
+    await cancellation;
+    if (transition != _transitionEpoch || !ref.mounted) {
+      return;
+    }
+    await _vibrationService.start();
+    if (vibration != _vibrationEpoch || !ref.mounted) {
+      await _vibrationService.cancel();
+    }
+  }
+
+  Future<void> minimize() async {
+    _transitionEpoch += 1;
+    cancelScheduledTask();
+    if (state.displayModel != null) {
+      state = state.copyWith(mode: EewWarningOverlayMode.minimized);
+    }
+    await cancelVibration();
+  }
+
+  void expand() {
+    _transitionEpoch += 1;
+    cancelScheduledTask();
+    if (state.mode == EewWarningOverlayMode.minimized &&
+        state.displayModel != null) {
+      state = state.copyWith(mode: EewWarningOverlayMode.fullscreen);
+    }
+  }
+
+  Future<void> close() async {
+    _transitionEpoch += 1;
+    final model = state.displayModel;
+    if (model?.source == EewWarningOverlaySource.simulation) {
+      ref.read(eewWarningOverlaySimulationProvider.notifier).stop();
+    }
+    final dismissed = model?.source == EewWarningOverlaySource.real
+        ? {...state.dismissedEventIds, ...?model?.eventIds}
+        : state.dismissedEventIds;
+    await hide(dismissedEventIds: dismissed);
+  }
+
+  Future<void> hide({Set<String>? dismissedEventIds}) async {
+    cancelScheduledTask();
+    state = state.copyWith(
+      mode: EewWarningOverlayMode.hidden,
+      displayModel: null,
+      dismissedEventIds: dismissedEventIds ?? state.dismissedEventIds,
+      simulationSessionActive: false,
+    );
+    await cancelVibration();
+  }
+
+  void cancelScheduledTask() {
+    _scheduledTask?.cancel();
+    _scheduledTask = null;
+  }
+
+  Future<void> cancelVibration() async {
+    _vibrationEpoch += 1;
+    if (!_alertActive) {
+      return;
+    }
+    _alertActive = false;
+    await _vibrationService.cancel();
+  }
+}
+
+final eewWarningOverlayNotifierProvider = eewWarningOverlayProvider;

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.dart
@@ -18,9 +18,10 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
   EewWarningOverlayScheduledTask? _initializationTask;
   late EewWarningOverlayScheduler _scheduler;
   late EewWarningOverlayVibrationService _vibrationService;
-  var _transitionEpoch = 0;
-  var _vibrationEpoch = 0;
-  var _alertActive = false;
+  var _displayEpoch = 0;
+  var _alertGeneration = 0;
+  var _vibrationActive = false;
+  Future<void> _vibrationQueue = Future.value();
 
   @override
   EewWarningOverlayState build() {
@@ -37,10 +38,10 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
         await handleLifecycleChange(next);
       })
       ..onDispose(() async {
-        _transitionEpoch += 1;
+        _displayEpoch += 1;
         _initializationTask?.cancel();
         cancelScheduledTask();
-        await cancelVibration();
+        await stopVibration();
       });
     final initialDisplay = ref.read(eewWarningOverlayEffectiveDisplayProvider);
     if (initialDisplay != null &&
@@ -49,7 +50,7 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
         delay: Duration.zero,
         callback: () async {
           _initializationTask = null;
-          if (_transitionEpoch == 0) {
+          if (_displayEpoch == 0) {
             await handleDisplayChange(initialDisplay);
           }
         },
@@ -59,7 +60,7 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
   }
 
   Future<void> handleDisplayChange(EewWarningOverlayDisplayModel? model) async {
-    final transition = ++_transitionEpoch;
+    _displayEpoch += 1;
     if (model == null) {
       await hide();
       return;
@@ -69,14 +70,14 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
       return;
     }
     if (model.source == EewWarningOverlaySource.simulation) {
-      await handleSimulation(model: model, transition: transition);
+      await handleSimulation(model: model);
       return;
     }
-    await handleReal(model: model, transition: transition);
+    await handleReal(model: model);
   }
 
   Future<void> handleLifecycleChange(AppLifecycleState lifecycle) async {
-    _transitionEpoch += 1;
+    _displayEpoch += 1;
     if (lifecycle != AppLifecycleState.resumed) {
       await minimizeForBackground();
       return;
@@ -88,8 +89,8 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
 
   Future<void> handleReal({
     required EewWarningOverlayDisplayModel model,
-    required int transition,
   }) async {
+    final previousSource = state.displayModel?.source;
     final eventIds = model.eventIds.toSet();
     final activeIds = eventIds.difference(state.dismissedEventIds);
     if (activeIds.isEmpty) {
@@ -103,7 +104,17 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
         seenEventIds: {...state.seenEventIds, ...eventIds},
         simulationSessionActive: false,
       );
-      await beginFullscreen(next: next, transition: transition);
+      await beginFullscreen(next: next);
+      return;
+    }
+    if (previousSource == EewWarningOverlaySource.simulation) {
+      cancelScheduledTask();
+      state = state.copyWith(
+        mode: EewWarningOverlayMode.minimized,
+        displayModel: model,
+        simulationSessionActive: false,
+      );
+      await stopVibration();
       return;
     }
     state = state.copyWith(
@@ -117,7 +128,6 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
 
   Future<void> handleSimulation({
     required EewWarningOverlayDisplayModel model,
-    required int transition,
   }) async {
     if (state.simulationSessionActive) {
       state = state.copyWith(displayModel: model);
@@ -127,7 +137,7 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
       displayModel: model,
       simulationSessionActive: true,
     );
-    await beginFullscreen(next: next, transition: transition);
+    await beginFullscreen(next: next);
   }
 
   Future<void> retainWhileBackgrounded({
@@ -143,7 +153,7 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
           ? state.simulationSessionActive
           : false,
     );
-    await cancelVibration();
+    await stopVibration();
   }
 
   Future<void> minimizeForBackground() async {
@@ -153,43 +163,31 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
           ? EewWarningOverlayMode.minimized
           : state.mode,
     );
-    await cancelVibration();
+    await stopVibration();
   }
 
-  Future<void> beginFullscreen({
-    required EewWarningOverlayState next,
-    required int transition,
-  }) async {
+  Future<void> beginFullscreen({required EewWarningOverlayState next}) async {
     cancelScheduledTask();
-    final cancellation = cancelVibration();
     state = next.copyWith(mode: EewWarningOverlayMode.fullscreen);
     _scheduledTask = _scheduler.schedule(
       delay: eewWarningOverlayFullscreenDuration,
       callback: minimize,
     );
-    _alertActive = true;
-    final vibration = ++_vibrationEpoch;
-    await cancellation;
-    if (transition != _transitionEpoch || !ref.mounted) {
-      return;
-    }
-    await _vibrationService.start();
-    if (vibration != _vibrationEpoch || !ref.mounted) {
-      await _vibrationService.cancel();
-    }
+    final generation = ++_alertGeneration;
+    await startVibration(generation: generation);
   }
 
   Future<void> minimize() async {
-    _transitionEpoch += 1;
+    _displayEpoch += 1;
     cancelScheduledTask();
     if (state.displayModel != null) {
       state = state.copyWith(mode: EewWarningOverlayMode.minimized);
     }
-    await cancelVibration();
+    await stopVibration();
   }
 
   void expand() {
-    _transitionEpoch += 1;
+    _displayEpoch += 1;
     cancelScheduledTask();
     if (state.mode == EewWarningOverlayMode.minimized &&
         state.displayModel != null) {
@@ -198,7 +196,7 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
   }
 
   Future<void> close() async {
-    _transitionEpoch += 1;
+    _displayEpoch += 1;
     final model = state.displayModel;
     if (model?.source == EewWarningOverlaySource.simulation) {
       ref.read(eewWarningOverlaySimulationProvider.notifier).stop();
@@ -217,7 +215,7 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
       dismissedEventIds: dismissedEventIds ?? state.dismissedEventIds,
       simulationSessionActive: false,
     );
-    await cancelVibration();
+    await stopVibration();
   }
 
   void cancelScheduledTask() {
@@ -225,13 +223,40 @@ class EewWarningOverlayNotifier extends _$EewWarningOverlayNotifier {
     _scheduledTask = null;
   }
 
-  Future<void> cancelVibration() async {
-    _vibrationEpoch += 1;
-    if (!_alertActive) {
-      return;
-    }
-    _alertActive = false;
-    await _vibrationService.cancel();
+  Future<void> startVibration({required int generation}) {
+    final operation = _vibrationQueue.then((_) async {
+      if (_vibrationActive) {
+        _vibrationActive = false;
+        await _vibrationService.cancel();
+      }
+      if (generation != _alertGeneration || !ref.mounted) {
+        return;
+      }
+      final started = await _vibrationService.start();
+      if (generation == _alertGeneration && ref.mounted) {
+        _vibrationActive = started;
+        return;
+      }
+      if (started) {
+        await _vibrationService.cancel();
+      }
+      _vibrationActive = false;
+    });
+    _vibrationQueue = operation;
+    return operation;
+  }
+
+  Future<void> stopVibration() {
+    _alertGeneration += 1;
+    final operation = _vibrationQueue.then((_) async {
+      if (!_vibrationActive) {
+        return;
+      }
+      _vibrationActive = false;
+      await _vibrationService.cancel();
+    });
+    _vibrationQueue = operation;
+    return operation;
   }
 }
 

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.g.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.g.dart
@@ -45,7 +45,7 @@ final class EewWarningOverlayNotifierProvider
 }
 
 String _$eewWarningOverlayNotifierHash() =>
-    r'df44c1d01355aff5e7619c9db6b04d697587937e';
+    r'137eeea0239a552ac2dc4519eaf1cd07c60ac907';
 
 abstract class _$EewWarningOverlayNotifier
     extends $Notifier<EewWarningOverlayState> {

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.g.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_notifier.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EewWarningOverlayNotifier)
+final eewWarningOverlayProvider = EewWarningOverlayNotifierProvider._();
+
+final class EewWarningOverlayNotifierProvider
+    extends
+        $NotifierProvider<EewWarningOverlayNotifier, EewWarningOverlayState> {
+  EewWarningOverlayNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlayProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningOverlayNotifierHash();
+
+  @$internal
+  @override
+  EewWarningOverlayNotifier create() => EewWarningOverlayNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningOverlayState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningOverlayState>(value),
+    );
+  }
+}
+
+String _$eewWarningOverlayNotifierHash() =>
+    r'df44c1d01355aff5e7619c9db6b04d697587937e';
+
+abstract class _$EewWarningOverlayNotifier
+    extends $Notifier<EewWarningOverlayState> {
+  EewWarningOverlayState build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref as $Ref<EewWarningOverlayState, EewWarningOverlayState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<EewWarningOverlayState, EewWarningOverlayState>,
+              EewWarningOverlayState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart
@@ -1,0 +1,47 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_display_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_overlay_simulation_notifier.g.dart';
+
+@riverpod
+class EewWarningOverlaySimulation extends _$EewWarningOverlaySimulation {
+  @override
+  EewWarningOverlayDisplayModel? build() {
+    ref.listen(eewWarningOverlayDisplayProvider, (_, real) {
+      if (real != null) {
+        state = null;
+      }
+    });
+    return null;
+  }
+
+  void start() {
+    if (ref.read(eewWarningOverlayDisplayProvider) != null) {
+      return;
+    }
+    state = const EewWarningOverlayDisplayModel(
+      source: EewWarningOverlaySource.simulation,
+      eventIds: ['eew-warning-overlay-simulation'],
+      representativeEventId: 'eew-warning-overlay-simulation',
+      serialNo: 1,
+      alertCount: 1,
+      reportLabel: '訓練／シミュレーション',
+      hypocenterHeadline: 'テスト震源で地震',
+      strongMotionHeadline: 'テスト地域で強い揺れ',
+      currentRegionName: 'テスト地域',
+      localIntensity: JmaIntensity.sixLower,
+      localIntensityIsOver: false,
+      arrivalState: EewWarningArrivalState.unarrived,
+      secondsUntilArrival: 10,
+      hypocenterName: 'テスト震源',
+      magnitude: null,
+      depth: null,
+    );
+  }
+
+  void stop() {
+    state = null;
+  }
+}

--- a/app/lib/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.g.dart
+++ b/app/lib/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.g.dart
@@ -1,0 +1,81 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_simulation_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(EewWarningOverlaySimulation)
+final eewWarningOverlaySimulationProvider =
+    EewWarningOverlaySimulationProvider._();
+
+final class EewWarningOverlaySimulationProvider
+    extends
+        $NotifierProvider<
+          EewWarningOverlaySimulation,
+          EewWarningOverlayDisplayModel?
+        > {
+  EewWarningOverlaySimulationProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlaySimulationProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningOverlaySimulationHash();
+
+  @$internal
+  @override
+  EewWarningOverlaySimulation create() => EewWarningOverlaySimulation();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningOverlayDisplayModel? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningOverlayDisplayModel?>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$eewWarningOverlaySimulationHash() =>
+    r'40a3810f42241ec519f80046f87d6853aab518ae';
+
+abstract class _$EewWarningOverlaySimulation
+    extends $Notifier<EewWarningOverlayDisplayModel?> {
+  EewWarningOverlayDisplayModel? build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              EewWarningOverlayDisplayModel?,
+              EewWarningOverlayDisplayModel?
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                EewWarningOverlayDisplayModel?,
+                EewWarningOverlayDisplayModel?
+              >,
+              EewWarningOverlayDisplayModel?,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/app/lib/feature/eew/data/provider/eew_warning_overlay_candidate_provider.dart
+++ b/app/lib/feature/eew/data/provider/eew_warning_overlay_candidate_provider.dart
@@ -1,0 +1,76 @@
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_candidate_selector.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.dart';
+import 'package:eqmonitor/feature/location/data/location.dart';
+import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
+import 'package:lat_lng/lat_lng.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_overlay_candidate_provider.g.dart';
+
+@riverpod
+List<EewWarningOverlayCandidate> eewWarningOverlayCandidates(Ref ref) {
+  if (!ref.watch(isRealtimeModeProvider)) {
+    return const [];
+  }
+  final enabled = ref.watch(eewWarningOverlayEnabledProvider);
+  final isEnabled = switch (enabled) {
+    AsyncData(value: true) when !enabled.isLoading && !enabled.hasError => true,
+    _ => false,
+  };
+  if (!isEnabled) {
+    return const [];
+  }
+  final aliveEews = ref.watch(eewAliveTelegramProvider);
+  if (aliveEews == null) {
+    return const [];
+  }
+  final positionState = ref.watch(locationStreamProvider);
+  final position = switch (positionState) {
+    AsyncData(:final value)
+        when !positionState.isLoading && !positionState.hasError =>
+      value,
+    _ => null,
+  };
+  if (position == null) {
+    return const [];
+  }
+
+  final latLng = LatLng(position.latitude, position.longitude);
+  final warningAreaState = ref.watch(
+    jmaMapAreaForecastLocalEewInsideProvider(latLng),
+  );
+  final warningArea = switch (warningAreaState) {
+    AsyncData(:final value)
+        when !warningAreaState.isLoading && !warningAreaState.hasError =>
+      value,
+    _ => null,
+  };
+  final warningAreaProperty = warningArea?.property;
+  if (warningAreaProperty == null) {
+    return const [];
+  }
+
+  final forecastAreaState = ref.watch(
+    jmaMapAreaForecastLocalEInsideProvider(latLng),
+  );
+  final forecastArea = switch (forecastAreaState) {
+    AsyncData(:final value)
+        when !forecastAreaState.isLoading && !forecastAreaState.hasError =>
+      value,
+    _ => null,
+  };
+  final forecastAreaProperty = forecastArea?.property;
+
+  return ref
+      .watch(eewWarningCandidateSelectorProvider)
+      .select(
+        aliveEews: aliveEews,
+        warningAreaCode: warningAreaProperty.code,
+        warningAreaName: warningAreaProperty.name,
+        forecastAreaCode: forecastAreaProperty?.code,
+        forecastAreaName: forecastAreaProperty?.name,
+      );
+}

--- a/app/lib/feature/eew/data/provider/eew_warning_overlay_candidate_provider.g.dart
+++ b/app/lib/feature/eew/data/provider/eew_warning_overlay_candidate_provider.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_candidate_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningOverlayCandidates)
+final eewWarningOverlayCandidatesProvider =
+    EewWarningOverlayCandidatesProvider._();
+
+final class EewWarningOverlayCandidatesProvider
+    extends
+        $FunctionalProvider<
+          List<EewWarningOverlayCandidate>,
+          List<EewWarningOverlayCandidate>,
+          List<EewWarningOverlayCandidate>
+        >
+    with $Provider<List<EewWarningOverlayCandidate>> {
+  EewWarningOverlayCandidatesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlayCandidatesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningOverlayCandidatesHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<EewWarningOverlayCandidate>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<EewWarningOverlayCandidate> create(Ref ref) {
+    return eewWarningOverlayCandidates(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<EewWarningOverlayCandidate> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<EewWarningOverlayCandidate>>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$eewWarningOverlayCandidatesHash() =>
+    r'7fde071e4259f7977018f0ece36009d998b4039b';

--- a/app/lib/feature/eew/data/provider/eew_warning_overlay_display_provider.dart
+++ b/app/lib/feature/eew/data/provider/eew_warning_overlay_display_provider.dart
@@ -1,0 +1,21 @@
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/core/provider/time_ticker.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_display_model_builder.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_candidate_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_overlay_display_provider.g.dart';
+
+@riverpod
+EewWarningOverlayDisplayModel? eewWarningOverlayDisplay(Ref ref) {
+  final candidates = ref.watch(eewWarningOverlayCandidatesProvider);
+  if (candidates.isEmpty) {
+    return null;
+  }
+  final ticker = ref.watch(timeTickerProvider());
+  final now = ticker.value ?? ref.read(appClockProvider.notifier).now();
+  return ref
+      .watch(eewWarningDisplayModelBuilderProvider)
+      .build(candidates: candidates, now: now.toUtc());
+}

--- a/app/lib/feature/eew/data/provider/eew_warning_overlay_display_provider.g.dart
+++ b/app/lib/feature/eew/data/provider/eew_warning_overlay_display_provider.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_display_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningOverlayDisplay)
+final eewWarningOverlayDisplayProvider = EewWarningOverlayDisplayProvider._();
+
+final class EewWarningOverlayDisplayProvider
+    extends
+        $FunctionalProvider<
+          EewWarningOverlayDisplayModel?,
+          EewWarningOverlayDisplayModel?,
+          EewWarningOverlayDisplayModel?
+        >
+    with $Provider<EewWarningOverlayDisplayModel?> {
+  EewWarningOverlayDisplayProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlayDisplayProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningOverlayDisplayHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningOverlayDisplayModel?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningOverlayDisplayModel? create(Ref ref) {
+    return eewWarningOverlayDisplay(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningOverlayDisplayModel? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningOverlayDisplayModel?>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$eewWarningOverlayDisplayHash() =>
+    r'4d36d5f249e7b462447e724d3dc6ea0eae8405ff';

--- a/app/lib/feature/eew/data/provider/eew_warning_overlay_effective_display_provider.dart
+++ b/app/lib/feature/eew/data/provider/eew_warning_overlay_effective_display_provider.dart
@@ -1,0 +1,13 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_display_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_overlay_effective_display_provider.g.dart';
+
+@riverpod
+EewWarningOverlayDisplayModel? eewWarningOverlayEffectiveDisplay(Ref ref) {
+  final real = ref.watch(eewWarningOverlayDisplayProvider);
+  final simulation = ref.watch(eewWarningOverlaySimulationProvider);
+  return real ?? simulation;
+}

--- a/app/lib/feature/eew/data/provider/eew_warning_overlay_effective_display_provider.g.dart
+++ b/app/lib/feature/eew/data/provider/eew_warning_overlay_effective_display_provider.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_effective_display_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningOverlayEffectiveDisplay)
+final eewWarningOverlayEffectiveDisplayProvider =
+    EewWarningOverlayEffectiveDisplayProvider._();
+
+final class EewWarningOverlayEffectiveDisplayProvider
+    extends
+        $FunctionalProvider<
+          EewWarningOverlayDisplayModel?,
+          EewWarningOverlayDisplayModel?,
+          EewWarningOverlayDisplayModel?
+        >
+    with $Provider<EewWarningOverlayDisplayModel?> {
+  EewWarningOverlayEffectiveDisplayProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlayEffectiveDisplayProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$eewWarningOverlayEffectiveDisplayHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningOverlayDisplayModel?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningOverlayDisplayModel? create(Ref ref) {
+    return eewWarningOverlayEffectiveDisplay(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningOverlayDisplayModel? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningOverlayDisplayModel?>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$eewWarningOverlayEffectiveDisplayHash() =>
+    r'490186e205c7ccbf9e47412855a9be7779537277';

--- a/app/lib/feature/eew/data/service/eew_warning_overlay_scheduler.dart
+++ b/app/lib/feature/eew/data/service/eew_warning_overlay_scheduler.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'eew_warning_overlay_scheduler.g.dart';
+
+abstract interface class EewWarningOverlayScheduledTask {
+  void cancel();
+}
+
+abstract interface class EewWarningOverlayScheduler {
+  EewWarningOverlayScheduledTask schedule({
+    required Duration delay,
+    required Future<void> Function() callback,
+  });
+}
+
+class TimerEewWarningOverlayScheduledTask
+    implements EewWarningOverlayScheduledTask {
+  const TimerEewWarningOverlayScheduledTask({required Timer timer})
+    : _timer = timer;
+
+  final Timer _timer;
+
+  @override
+  void cancel() => _timer.cancel();
+}
+
+class TimerEewWarningOverlayScheduler implements EewWarningOverlayScheduler {
+  const TimerEewWarningOverlayScheduler();
+
+  @override
+  EewWarningOverlayScheduledTask schedule({
+    required Duration delay,
+    required Future<void> Function() callback,
+  }) => TimerEewWarningOverlayScheduledTask(
+    timer: Timer(delay, () async => callback()),
+  );
+}
+
+@riverpod
+EewWarningOverlayScheduler eewWarningOverlayScheduler(Ref ref) =>
+    const TimerEewWarningOverlayScheduler();

--- a/app/lib/feature/eew/data/service/eew_warning_overlay_scheduler.g.dart
+++ b/app/lib/feature/eew/data/service/eew_warning_overlay_scheduler.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_scheduler.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningOverlayScheduler)
+final eewWarningOverlaySchedulerProvider =
+    EewWarningOverlaySchedulerProvider._();
+
+final class EewWarningOverlaySchedulerProvider
+    extends
+        $FunctionalProvider<
+          EewWarningOverlayScheduler,
+          EewWarningOverlayScheduler,
+          EewWarningOverlayScheduler
+        >
+    with $Provider<EewWarningOverlayScheduler> {
+  EewWarningOverlaySchedulerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlaySchedulerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$eewWarningOverlaySchedulerHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningOverlayScheduler> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningOverlayScheduler create(Ref ref) {
+    return eewWarningOverlayScheduler(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningOverlayScheduler value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningOverlayScheduler>(value),
+    );
+  }
+}
+
+String _$eewWarningOverlaySchedulerHash() =>
+    r'f1385754f1a975e1189da481b4339ff61d665fb1';

--- a/app/lib/feature/eew/data/service/eew_warning_overlay_vibration_service.dart
+++ b/app/lib/feature/eew/data/service/eew_warning_overlay_vibration_service.dart
@@ -72,22 +72,24 @@ class EewWarningOverlayVibrationService {
   final EewWarningOverlayVibrationGateway _gateway;
   final Talker _talker;
 
-  Future<void> start() async {
+  Future<bool> start() async {
     try {
       if (!await _gateway.hasVibrator()) {
-        return;
+        return false;
       }
       if (await _gateway.hasCustomVibrationsSupport()) {
         await _gateway.vibrate(pattern: eewWarningOverlayVibrationPattern);
       } else {
         await _gateway.vibrateOnce(durationMs: 700);
       }
+      return true;
     } on Object catch (error, stackTrace) {
       _talker.error(
         '[EEW warning overlay] vibration start failed',
         error,
         stackTrace,
       );
+      return false;
     }
   }
 

--- a/app/lib/feature/eew/data/service/eew_warning_overlay_vibration_service.dart
+++ b/app/lib/feature/eew/data/service/eew_warning_overlay_vibration_service.dart
@@ -1,0 +1,112 @@
+import 'package:eqmonitor/core/provider/log/talker.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+import 'package:vibration/vibration.dart';
+
+part 'eew_warning_overlay_vibration_service.g.dart';
+
+const eewWarningOverlayVibrationPattern = <int>[
+  0,
+  700,
+  300,
+  700,
+  300,
+  700,
+  300,
+  700,
+  300,
+  700,
+  300,
+  700,
+  300,
+  700,
+  300,
+  700,
+  300,
+  700,
+  300,
+  700,
+];
+
+abstract interface class EewWarningOverlayVibrationGateway {
+  Future<bool> hasVibrator();
+
+  Future<bool> hasCustomVibrationsSupport();
+
+  Future<void> vibrate({required List<int> pattern});
+
+  Future<void> vibrateOnce({required int durationMs});
+
+  Future<void> cancel();
+}
+
+class VibrationPackageGateway implements EewWarningOverlayVibrationGateway {
+  const VibrationPackageGateway();
+
+  @override
+  Future<bool> hasVibrator() => Vibration.hasVibrator();
+
+  @override
+  Future<bool> hasCustomVibrationsSupport() =>
+      Vibration.hasCustomVibrationsSupport();
+
+  @override
+  Future<void> vibrate({required List<int> pattern}) =>
+      Vibration.vibrate(pattern: pattern);
+
+  @override
+  Future<void> vibrateOnce({required int durationMs}) =>
+      Vibration.vibrate(duration: durationMs);
+
+  @override
+  Future<void> cancel() => Vibration.cancel();
+}
+
+class EewWarningOverlayVibrationService {
+  const EewWarningOverlayVibrationService({
+    required EewWarningOverlayVibrationGateway gateway,
+    required Talker talker,
+  }) : _gateway = gateway,
+       _talker = talker;
+
+  final EewWarningOverlayVibrationGateway _gateway;
+  final Talker _talker;
+
+  Future<void> start() async {
+    try {
+      if (!await _gateway.hasVibrator()) {
+        return;
+      }
+      if (await _gateway.hasCustomVibrationsSupport()) {
+        await _gateway.vibrate(pattern: eewWarningOverlayVibrationPattern);
+      } else {
+        await _gateway.vibrateOnce(durationMs: 700);
+      }
+    } on Object catch (error, stackTrace) {
+      _talker.error(
+        '[EEW warning overlay] vibration start failed',
+        error,
+        stackTrace,
+      );
+    }
+  }
+
+  Future<void> cancel() async {
+    try {
+      await _gateway.cancel();
+    } on Object catch (error, stackTrace) {
+      _talker.error(
+        '[EEW warning overlay] vibration cancel failed',
+        error,
+        stackTrace,
+      );
+    }
+  }
+}
+
+@riverpod
+EewWarningOverlayVibrationService eewWarningOverlayVibrationService(Ref ref) =>
+    EewWarningOverlayVibrationService(
+      gateway: const VibrationPackageGateway(),
+      talker: talker,
+    );

--- a/app/lib/feature/eew/data/service/eew_warning_overlay_vibration_service.g.dart
+++ b/app/lib/feature/eew/data/service/eew_warning_overlay_vibration_service.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'eew_warning_overlay_vibration_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(eewWarningOverlayVibrationService)
+final eewWarningOverlayVibrationServiceProvider =
+    EewWarningOverlayVibrationServiceProvider._();
+
+final class EewWarningOverlayVibrationServiceProvider
+    extends
+        $FunctionalProvider<
+          EewWarningOverlayVibrationService,
+          EewWarningOverlayVibrationService,
+          EewWarningOverlayVibrationService
+        >
+    with $Provider<EewWarningOverlayVibrationService> {
+  EewWarningOverlayVibrationServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'eewWarningOverlayVibrationServiceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() =>
+      _$eewWarningOverlayVibrationServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<EewWarningOverlayVibrationService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  EewWarningOverlayVibrationService create(Ref ref) {
+    return eewWarningOverlayVibrationService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(EewWarningOverlayVibrationService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<EewWarningOverlayVibrationService>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$eewWarningOverlayVibrationServiceHash() =>
+    r'e14fdbd8ba8d99ff1804afcd19011aeebf5c9aaf';

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_banner.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_banner.dart
@@ -3,6 +3,7 @@ import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_mod
 import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_top_stripe.dart';
 import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart';
 import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_label_formatter.dart';
 import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_banner.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_banner.dart
@@ -1,7 +1,8 @@
-import 'package:eqmonitor/core/component/decoration/warning_stripe_decoration.dart';
 import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_top_stripe.dart';
 import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart';
 import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
 import 'package:flutter/material.dart';
 
@@ -25,7 +26,14 @@ class EewWarningOverlayBanner extends StatelessWidget {
       state: displayModel.arrivalState,
       secondsUntilArrival: displayModel.secondsUntilArrival,
     );
-    final intensityQualifier = displayModel.localIntensityIsOver ? '以上' : '';
+    final intensityText = formatEewWarningOverlayIntensity(
+      intensity: displayModel.localIntensity,
+      isOver: displayModel.localIntensityIsOver,
+    );
+    final bannerLabel = formatEewWarningOverlayBannerLabel(
+      source: displayModel.source,
+      reportLabel: displayModel.reportLabel,
+    );
     final headline = displayModel.hypocenterHeadline == null
         ? displayModel.strongMotionHeadline
         : '${displayModel.hypocenterHeadline}\n${displayModel.strongMotionHeadline}';
@@ -37,12 +45,9 @@ class EewWarningOverlayBanner extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const WarningStripeDecoration(
-            colors: [Colors.red, Colors.black],
-            height: 10,
-          ),
+          const EewWarningOverlayTopStripe(),
           SafeArea(
-            top: true,
+            top: false,
             bottom: false,
             child: InkWell(
               onTap: onExpand,
@@ -51,10 +56,12 @@ class EewWarningOverlayBanner extends StatelessWidget {
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    JmaIntensityIcon(
-                      intensity: displayModel.localIntensity,
-                      type: IntensityIconType.filled,
-                      size: 52,
+                    ExcludeSemantics(
+                      child: JmaIntensityIcon(
+                        intensity: displayModel.localIntensity,
+                        type: IntensityIconType.filled,
+                        size: 52,
+                      ),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
@@ -63,7 +70,7 @@ class EewWarningOverlayBanner extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            '緊急地震速報（警報）',
+                            bannerLabel,
                             style: theme.textTheme.labelLarge?.copyWith(
                               color: colorScheme.onErrorContainer,
                               fontWeight: FontWeight.w800,
@@ -84,7 +91,7 @@ class EewWarningOverlayBanner extends StatelessWidget {
                             runSpacing: 2,
                             children: [
                               Text(
-                                '予想震度${displayModel.localIntensity.label}$intensityQualifier',
+                                '予想震度$intensityText',
                                 style: theme.textTheme.bodyMedium?.copyWith(
                                   color: colorScheme.onErrorContainer,
                                   fontWeight: FontWeight.w700,

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_banner.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_banner.dart
@@ -1,0 +1,121 @@
+import 'package:eqmonitor/core/component/decoration/warning_stripe_decoration.dart';
+import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart';
+import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
+import 'package:flutter/material.dart';
+
+class EewWarningOverlayBanner extends StatelessWidget {
+  const EewWarningOverlayBanner({
+    required this.displayModel,
+    required this.onExpand,
+    required this.onClose,
+    super.key,
+  });
+
+  final EewWarningOverlayDisplayModel displayModel;
+  final VoidCallback onExpand;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final arrivalText = formatEewWarningOverlayArrival(
+      state: displayModel.arrivalState,
+      secondsUntilArrival: displayModel.secondsUntilArrival,
+    );
+    final intensityQualifier = displayModel.localIntensityIsOver ? '以上' : '';
+    final headline = displayModel.hypocenterHeadline == null
+        ? displayModel.strongMotionHeadline
+        : '${displayModel.hypocenterHeadline}\n${displayModel.strongMotionHeadline}';
+
+    return Material(
+      color: colorScheme.errorContainer,
+      elevation: 8,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const WarningStripeDecoration(
+            colors: [Colors.red, Colors.black],
+            height: 10,
+          ),
+          SafeArea(
+            top: true,
+            bottom: false,
+            child: InkWell(
+              onTap: onExpand,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 10, 4, 12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    JmaIntensityIcon(
+                      intensity: displayModel.localIntensity,
+                      type: IntensityIconType.filled,
+                      size: 52,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '緊急地震速報（警報）',
+                            style: theme.textTheme.labelLarge?.copyWith(
+                              color: colorScheme.onErrorContainer,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            headline,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              color: colorScheme.onErrorContainer,
+                              fontWeight: FontWeight.w800,
+                              height: 1.2,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Wrap(
+                            spacing: 12,
+                            runSpacing: 2,
+                            children: [
+                              Text(
+                                '予想震度${displayModel.localIntensity.label}$intensityQualifier',
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: colorScheme.onErrorContainer,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              if (arrivalText case final text?)
+                                Text(
+                                  text,
+                                  style: theme.textTheme.bodyMedium?.copyWith(
+                                    color: colorScheme.onErrorContainer,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: onClose,
+                      color: colorScheme.onErrorContainer,
+                      tooltip: '警報表示を閉じる',
+                      icon: const Icon(Icons.close),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart
@@ -3,6 +3,7 @@ import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_mod
 import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_top_stripe.dart';
 import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart';
 import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_label_formatter.dart';
 import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
 import 'package:flutter/material.dart';
 
@@ -42,7 +43,9 @@ class EewWarningOverlayFullscreen extends StatelessWidget {
 
     return BlockSemantics(
       child: Semantics(
-        label: '緊急地震速報警報',
+        label: formatEewWarningOverlaySemanticsLabel(
+          source: displayModel.source,
+        ),
         scopesRoute: true,
         explicitChildNodes: true,
         child: SizedBox.expand(

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart
@@ -1,7 +1,8 @@
-import 'package:eqmonitor/core/component/decoration/warning_stripe_decoration.dart';
 import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_top_stripe.dart';
 import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart';
 import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
 import 'package:flutter/material.dart';
 
@@ -25,7 +26,10 @@ class EewWarningOverlayFullscreen extends StatelessWidget {
       state: displayModel.arrivalState,
       secondsUntilArrival: displayModel.secondsUntilArrival,
     );
-    final intensityQualifier = displayModel.localIntensityIsOver ? '以上' : '';
+    final intensityText = formatEewWarningOverlayIntensity(
+      intensity: displayModel.localIntensity,
+      isOver: displayModel.localIntensityIsOver,
+    );
     final magnitudeText = switch (displayModel.magnitude) {
       null => '不明',
       final double magnitude => 'M${magnitude.toStringAsFixed(1)}',
@@ -36,100 +40,100 @@ class EewWarningOverlayFullscreen extends StatelessWidget {
       final int depth => '${depth}km',
     };
 
-    return Semantics(
-      label: '緊急地震速報警報',
-      scopesRoute: true,
-      explicitChildNodes: true,
-      child: SizedBox.expand(
-        child: Material(
-          color: colorScheme.errorContainer,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const WarningStripeDecoration(
-                colors: [Colors.red, Colors.black],
-                height: 10,
-              ),
-              Expanded(
-                child: SafeArea(
-                  top: true,
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Expanded(
-                          child: ListView(
-                            children: [
-                              Text(
-                                displayModel.reportLabel,
-                                style: theme.textTheme.titleMedium?.copyWith(
-                                  color: colorScheme.onErrorContainer,
-                                  fontWeight: FontWeight.w700,
-                                ),
-                              ),
-                              const SizedBox(height: 24),
-                              _EewWarningHeadline(displayModel: displayModel),
-                              const SizedBox(height: 28),
-                              _EewWarningLocalIntensity(
-                                displayModel: displayModel,
-                                arrivalText: arrivalText,
-                                intensityQualifier: intensityQualifier,
-                              ),
-                              const SizedBox(height: 24),
-                              _EewWarningDetails(
-                                displayModel: displayModel,
-                                magnitudeText: magnitudeText,
-                                depthText: depthText,
-                              ),
-                              if (displayModel.alertCount > 1) ...[
-                                const SizedBox(height: 16),
+    return BlockSemantics(
+      child: Semantics(
+        label: '緊急地震速報警報',
+        scopesRoute: true,
+        explicitChildNodes: true,
+        child: SizedBox.expand(
+          child: Material(
+            color: colorScheme.errorContainer,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const EewWarningOverlayTopStripe(),
+                Expanded(
+                  child: SafeArea(
+                    top: false,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            child: ListView(
+                              children: [
                                 Text(
-                                  '${displayModel.alertCount}件の警報から代表表示',
-                                  style: theme.textTheme.bodyMedium?.copyWith(
+                                  displayModel.reportLabel,
+                                  style: theme.textTheme.titleMedium?.copyWith(
                                     color: colorScheme.onErrorContainer,
+                                    fontWeight: FontWeight.w700,
                                   ),
                                 ),
+                                const SizedBox(height: 24),
+                                _EewWarningHeadline(displayModel: displayModel),
+                                const SizedBox(height: 28),
+                                _EewWarningLocalIntensity(
+                                  displayModel: displayModel,
+                                  arrivalText: arrivalText,
+                                  intensityText: intensityText,
+                                ),
+                                const SizedBox(height: 24),
+                                _EewWarningDetails(
+                                  displayModel: displayModel,
+                                  magnitudeText: magnitudeText,
+                                  depthText: depthText,
+                                ),
+                                if (displayModel.alertCount > 1) ...[
+                                  const SizedBox(height: 16),
+                                  Text(
+                                    '${displayModel.alertCount}件の警報から代表表示',
+                                    style: theme.textTheme.bodyMedium?.copyWith(
+                                      color: colorScheme.onErrorContainer,
+                                    ),
+                                  ),
+                                ],
                               ],
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: OutlinedButton.icon(
+                                  onPressed: onMinimize,
+                                  style: OutlinedButton.styleFrom(
+                                    foregroundColor:
+                                        colorScheme.onErrorContainer,
+                                    side: BorderSide(
+                                      color: colorScheme.onErrorContainer,
+                                    ),
+                                  ),
+                                  icon: const Icon(Icons.keyboard_arrow_down),
+                                  label: const Text('最小化'),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: FilledButton.icon(
+                                  onPressed: onClose,
+                                  style: FilledButton.styleFrom(
+                                    backgroundColor: colorScheme.error,
+                                    foregroundColor: colorScheme.onError,
+                                  ),
+                                  icon: const Icon(Icons.close),
+                                  label: const Text('閉じる'),
+                                ),
+                              ),
                             ],
                           ),
-                        ),
-                        const SizedBox(height: 12),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: OutlinedButton.icon(
-                                onPressed: onMinimize,
-                                style: OutlinedButton.styleFrom(
-                                  foregroundColor: colorScheme.onErrorContainer,
-                                  side: BorderSide(
-                                    color: colorScheme.onErrorContainer,
-                                  ),
-                                ),
-                                icon: const Icon(Icons.keyboard_arrow_down),
-                                label: const Text('最小化'),
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: FilledButton.icon(
-                                onPressed: onClose,
-                                style: FilledButton.styleFrom(
-                                  backgroundColor: colorScheme.error,
-                                  foregroundColor: colorScheme.onError,
-                                ),
-                                icon: const Icon(Icons.close),
-                                label: const Text('閉じる'),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -167,12 +171,12 @@ class _EewWarningLocalIntensity extends StatelessWidget {
   const _EewWarningLocalIntensity({
     required this.displayModel,
     required this.arrivalText,
-    required this.intensityQualifier,
+    required this.intensityText,
   });
 
   final EewWarningOverlayDisplayModel displayModel;
   final String? arrivalText;
-  final String intensityQualifier;
+  final String intensityText;
 
   @override
   Widget build(BuildContext context) {
@@ -184,10 +188,12 @@ class _EewWarningLocalIntensity extends StatelessWidget {
       runSpacing: 16,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        JmaIntensityIcon(
-          intensity: displayModel.localIntensity,
-          type: IntensityIconType.filled,
-          size: 104,
+        ExcludeSemantics(
+          child: JmaIntensityIcon(
+            intensity: displayModel.localIntensity,
+            type: IntensityIconType.filled,
+            size: 104,
+          ),
         ),
         Column(
           mainAxisSize: MainAxisSize.min,
@@ -198,7 +204,7 @@ class _EewWarningLocalIntensity extends StatelessWidget {
               style: theme.textTheme.titleMedium?.copyWith(color: color),
             ),
             Text(
-              '震度${displayModel.localIntensity.label}$intensityQualifier',
+              '震度$intensityText',
               style: theme.textTheme.headlineSmall?.copyWith(
                 color: color,
                 fontWeight: FontWeight.w800,

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart
@@ -1,0 +1,300 @@
+import 'package:eqmonitor/core/component/decoration/warning_stripe_decoration.dart';
+import 'package:eqmonitor/core/component/intenisty/jma_intensity_icon.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart';
+import 'package:eqmonitor/feature/map/features/icon/data/model/intensity_icon.dart';
+import 'package:flutter/material.dart';
+
+class EewWarningOverlayFullscreen extends StatelessWidget {
+  const EewWarningOverlayFullscreen({
+    required this.displayModel,
+    required this.onMinimize,
+    required this.onClose,
+    super.key,
+  });
+
+  final EewWarningOverlayDisplayModel displayModel;
+  final VoidCallback onMinimize;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final arrivalText = formatEewWarningOverlayArrival(
+      state: displayModel.arrivalState,
+      secondsUntilArrival: displayModel.secondsUntilArrival,
+    );
+    final intensityQualifier = displayModel.localIntensityIsOver ? '以上' : '';
+    final magnitudeText = switch (displayModel.magnitude) {
+      null => '不明',
+      final double magnitude => 'M${magnitude.toStringAsFixed(1)}',
+    };
+    final depthText = switch (displayModel.depth) {
+      null => '不明',
+      0 => 'ごく浅い',
+      final int depth => '${depth}km',
+    };
+
+    return Semantics(
+      label: '緊急地震速報警報',
+      scopesRoute: true,
+      explicitChildNodes: true,
+      child: SizedBox.expand(
+        child: Material(
+          color: colorScheme.errorContainer,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const WarningStripeDecoration(
+                colors: [Colors.red, Colors.black],
+                height: 10,
+              ),
+              Expanded(
+                child: SafeArea(
+                  top: true,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Expanded(
+                          child: ListView(
+                            children: [
+                              Text(
+                                displayModel.reportLabel,
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  color: colorScheme.onErrorContainer,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              const SizedBox(height: 24),
+                              _EewWarningHeadline(displayModel: displayModel),
+                              const SizedBox(height: 28),
+                              _EewWarningLocalIntensity(
+                                displayModel: displayModel,
+                                arrivalText: arrivalText,
+                                intensityQualifier: intensityQualifier,
+                              ),
+                              const SizedBox(height: 24),
+                              _EewWarningDetails(
+                                displayModel: displayModel,
+                                magnitudeText: magnitudeText,
+                                depthText: depthText,
+                              ),
+                              if (displayModel.alertCount > 1) ...[
+                                const SizedBox(height: 16),
+                                Text(
+                                  '${displayModel.alertCount}件の警報から代表表示',
+                                  style: theme.textTheme.bodyMedium?.copyWith(
+                                    color: colorScheme.onErrorContainer,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: OutlinedButton.icon(
+                                onPressed: onMinimize,
+                                style: OutlinedButton.styleFrom(
+                                  foregroundColor: colorScheme.onErrorContainer,
+                                  side: BorderSide(
+                                    color: colorScheme.onErrorContainer,
+                                  ),
+                                ),
+                                icon: const Icon(Icons.keyboard_arrow_down),
+                                label: const Text('最小化'),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: FilledButton.icon(
+                                onPressed: onClose,
+                                style: FilledButton.styleFrom(
+                                  backgroundColor: colorScheme.error,
+                                  foregroundColor: colorScheme.onError,
+                                ),
+                                icon: const Icon(Icons.close),
+                                label: const Text('閉じる'),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EewWarningHeadline extends StatelessWidget {
+  const _EewWarningHeadline({required this.displayModel});
+
+  final EewWarningOverlayDisplayModel displayModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.onErrorContainer;
+    final headlineStyle = theme.textTheme.headlineMedium?.copyWith(
+      color: color,
+      fontWeight: FontWeight.w900,
+      height: 1.25,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (displayModel.hypocenterHeadline case final headline?)
+          Text(headline, style: headlineStyle),
+        Text(displayModel.strongMotionHeadline, style: headlineStyle),
+      ],
+    );
+  }
+}
+
+class _EewWarningLocalIntensity extends StatelessWidget {
+  const _EewWarningLocalIntensity({
+    required this.displayModel,
+    required this.arrivalText,
+    required this.intensityQualifier,
+  });
+
+  final EewWarningOverlayDisplayModel displayModel;
+  final String? arrivalText;
+  final String intensityQualifier;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.onErrorContainer;
+
+    return Wrap(
+      spacing: 20,
+      runSpacing: 16,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        JmaIntensityIcon(
+          intensity: displayModel.localIntensity,
+          type: IntensityIconType.filled,
+          size: 104,
+        ),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '現在地の予想震度',
+              style: theme.textTheme.titleMedium?.copyWith(color: color),
+            ),
+            Text(
+              '震度${displayModel.localIntensity.label}$intensityQualifier',
+              style: theme.textTheme.headlineSmall?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            if (arrivalText case final text?)
+              Text(
+                text,
+                style: theme.textTheme.titleLarge?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _EewWarningDetails extends StatelessWidget {
+  const _EewWarningDetails({
+    required this.displayModel,
+    required this.magnitudeText,
+    required this.depthText,
+  });
+
+  final EewWarningOverlayDisplayModel displayModel;
+  final String magnitudeText;
+  final String depthText;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.82),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _EewWarningDetailRow(
+              label: '現在地域',
+              value: displayModel.currentRegionName,
+            ),
+            const SizedBox(height: 10),
+            _EewWarningDetailRow(
+              label: '震源',
+              value: displayModel.hypocenterName ?? '不明',
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 24,
+              runSpacing: 8,
+              children: [
+                _EewWarningDetailRow(label: 'マグニチュード', value: magnitudeText),
+                _EewWarningDetailRow(label: '深さ', value: depthText),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EewWarningDetailRow extends StatelessWidget {
+  const _EewWarningDetailRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: '$label：',
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          TextSpan(
+            text: value,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurface,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_host.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_host.dart
@@ -1,0 +1,63 @@
+import 'package:eqmonitor/core/provider/app_lifecycle.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_state.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_notifier.dart';
+import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_banner.dart';
+import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class EewWarningOverlayHost extends ConsumerWidget {
+  const EewWarningOverlayHost({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final lifecycle = ref.watch(appLifecycleProvider);
+    final state = ref.watch(eewWarningOverlayNotifierProvider);
+    final displayModel = state.displayModel;
+
+    if (lifecycle != AppLifecycleState.resumed ||
+        state.mode == EewWarningOverlayMode.hidden ||
+        displayModel == null) {
+      return child;
+    }
+
+    final notifier = ref.read(eewWarningOverlayNotifierProvider.notifier);
+    final overlay = switch (state.mode) {
+      EewWarningOverlayMode.fullscreen => EewWarningOverlayFullscreen(
+        displayModel: displayModel,
+        onMinimize: () async {
+          await notifier.minimize();
+        },
+        onClose: () async {
+          await notifier.close();
+        },
+      ),
+      EewWarningOverlayMode.minimized => Align(
+        alignment: Alignment.topCenter,
+        child: SizedBox(
+          width: double.infinity,
+          child: EewWarningOverlayBanner(
+            displayModel: displayModel,
+            onExpand: notifier.expand,
+            onClose: () async {
+              await notifier.close();
+            },
+          ),
+        ),
+      ),
+      EewWarningOverlayMode.hidden => const SizedBox.shrink(),
+    };
+
+    return PopScope<Object?>(
+      canPop: state.mode != EewWarningOverlayMode.fullscreen,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (!didPop && state.mode == EewWarningOverlayMode.fullscreen) {
+          await notifier.minimize();
+        }
+      },
+      child: Stack(fit: StackFit.expand, children: [child, overlay]),
+    );
+  }
+}

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_host.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_host.dart
@@ -3,19 +3,49 @@ import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_state.dart'
 import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_notifier.dart';
 import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_banner.dart';
 import 'package:eqmonitor/feature/eew/ui/components/eew_warning_overlay_fullscreen.dart';
+import 'package:eqmonitor/feature/eew/ui/controller/eew_warning_overlay_back_dispatcher_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class EewWarningOverlayHost extends ConsumerWidget {
-  const EewWarningOverlayHost({required this.child, super.key});
+class EewWarningOverlayHost extends HookConsumerWidget {
+  const EewWarningOverlayHost({
+    required this.child,
+    required this.backButtonDispatcher,
+    super.key,
+  });
 
   final Widget child;
+  final BackButtonDispatcher backButtonDispatcher;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final lifecycle = ref.watch(appLifecycleProvider);
     final state = ref.watch(eewWarningOverlayNotifierProvider);
     final displayModel = state.displayModel;
+    final shouldInterceptBack =
+        lifecycle == AppLifecycleState.resumed &&
+        state.mode == EewWarningOverlayMode.fullscreen &&
+        displayModel != null;
+    final backDispatcherController = useMemoized(
+      () => EewWarningOverlayBackDispatcherController(
+        parent: backButtonDispatcher,
+        onFullscreenBack: () async {
+          await ref.read(eewWarningOverlayNotifierProvider.notifier).minimize();
+        },
+      ),
+      [backButtonDispatcher],
+    );
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        backDispatcherController.attach();
+      });
+      return backDispatcherController.dispose;
+    }, [backDispatcherController]);
+    useEffect(() {
+      backDispatcherController.update(shouldIntercept: shouldInterceptBack);
+      return null;
+    }, [backDispatcherController, shouldInterceptBack]);
 
     if (lifecycle != AppLifecycleState.resumed ||
         state.mode == EewWarningOverlayMode.hidden ||
@@ -50,14 +80,6 @@ class EewWarningOverlayHost extends ConsumerWidget {
       EewWarningOverlayMode.hidden => const SizedBox.shrink(),
     };
 
-    return PopScope<Object?>(
-      canPop: state.mode != EewWarningOverlayMode.fullscreen,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (!didPop && state.mode == EewWarningOverlayMode.fullscreen) {
-          await notifier.minimize();
-        }
-      },
-      child: Stack(fit: StackFit.expand, children: [child, overlay]),
-    );
+    return Stack(fit: StackFit.expand, children: [child, overlay]);
   }
 }

--- a/app/lib/feature/eew/ui/components/eew_warning_overlay_top_stripe.dart
+++ b/app/lib/feature/eew/ui/components/eew_warning_overlay_top_stripe.dart
@@ -1,0 +1,14 @@
+import 'package:eqmonitor/core/component/decoration/warning_stripe_decoration.dart';
+import 'package:flutter/material.dart';
+
+const eewWarningOverlayStripeHeight = 10.0;
+
+class EewWarningOverlayTopStripe extends StatelessWidget {
+  const EewWarningOverlayTopStripe({super.key});
+
+  @override
+  Widget build(BuildContext context) => WarningStripeDecoration(
+    colors: const [Colors.red, Colors.black],
+    height: MediaQuery.paddingOf(context).top + eewWarningOverlayStripeHeight,
+  );
+}

--- a/app/lib/feature/eew/ui/controller/eew_warning_overlay_back_dispatcher_controller.dart
+++ b/app/lib/feature/eew/ui/controller/eew_warning_overlay_back_dispatcher_controller.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/widgets.dart';
+
+class EewWarningOverlayBackDispatcherController {
+  EewWarningOverlayBackDispatcherController({
+    required BackButtonDispatcher parent,
+    required Future<void> Function() onFullscreenBack,
+  }) : _parent = parent,
+       _dispatcher = parent.createChildBackButtonDispatcher() {
+    _callback = () async {
+      if (!_shouldIntercept || _isDisposed) {
+        return false;
+      }
+      await onFullscreenBack();
+      return true;
+    };
+  }
+
+  final BackButtonDispatcher _parent;
+  final ChildBackButtonDispatcher _dispatcher;
+  late final ValueGetter<Future<bool>> _callback;
+  var _isAttached = false;
+  var _isDisposed = false;
+  var _shouldIntercept = false;
+
+  void attach() {
+    if (_isAttached || _isDisposed) {
+      return;
+    }
+    _dispatcher.addCallback(_callback);
+    _isAttached = true;
+    if (_shouldIntercept) {
+      _dispatcher.takePriority();
+    }
+  }
+
+  void update({required bool shouldIntercept}) {
+    _shouldIntercept = shouldIntercept;
+    if (!_isAttached || _isDisposed) {
+      return;
+    }
+    if (shouldIntercept) {
+      _dispatcher.takePriority();
+    } else {
+      _parent.forget(_dispatcher);
+    }
+  }
+
+  void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    if (_isAttached) {
+      _dispatcher.removeCallback(_callback);
+      _isAttached = false;
+    }
+  }
+}

--- a/app/lib/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart
+++ b/app/lib/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart
@@ -1,0 +1,10 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+
+String? formatEewWarningOverlayArrival({
+  required EewWarningArrivalState state,
+  required int? secondsUntilArrival,
+}) => switch ((state, secondsUntilArrival)) {
+  (EewWarningArrivalState.unarrived, final int seconds) => 'あと約${seconds}秒',
+  (EewWarningArrivalState.arrived, _) => '到達と推定',
+  _ => null,
+};

--- a/app/lib/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart
+++ b/app/lib/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart
@@ -1,0 +1,35 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+
+String formatEewWarningOverlayIntensity({
+  required JmaIntensity intensity,
+  required bool isOver,
+}) {
+  final value = switch (intensity) {
+    JmaIntensity.unknown => '不明',
+    JmaIntensity.zero => '0',
+    JmaIntensity.one => '1',
+    JmaIntensity.two => '2',
+    JmaIntensity.three => '3',
+    JmaIntensity.four => '4',
+    JmaIntensity.fiveUnknown => '5弱以上',
+    JmaIntensity.fiveLower => '5弱',
+    JmaIntensity.fiveUpper => '5強',
+    JmaIntensity.sixUnknown => '6弱以上',
+    JmaIntensity.sixLower => '6弱',
+    JmaIntensity.sixUpper => '6強',
+    JmaIntensity.seven => '7',
+  };
+  if (!isOver || intensity == JmaIntensity.unknown || value.endsWith('以上')) {
+    return value;
+  }
+  return '$value以上';
+}
+
+String formatEewWarningOverlayBannerLabel({
+  required EewWarningOverlaySource source,
+  required String reportLabel,
+}) => switch (source) {
+  EewWarningOverlaySource.real => '緊急地震速報（警報）',
+  EewWarningOverlaySource.simulation => reportLabel,
+};

--- a/app/lib/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart
+++ b/app/lib/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart
@@ -1,5 +1,4 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
-import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
 
 String formatEewWarningOverlayIntensity({
   required JmaIntensity intensity,
@@ -25,11 +24,3 @@ String formatEewWarningOverlayIntensity({
   }
   return '$value以上';
 }
-
-String formatEewWarningOverlayBannerLabel({
-  required EewWarningOverlaySource source,
-  required String reportLabel,
-}) => switch (source) {
-  EewWarningOverlaySource.real => '緊急地震速報（警報）',
-  EewWarningOverlaySource.simulation => reportLabel,
-};

--- a/app/lib/feature/eew/ui/formatter/eew_warning_overlay_label_formatter.dart
+++ b/app/lib/feature/eew/ui/formatter/eew_warning_overlay_label_formatter.dart
@@ -1,0 +1,16 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+
+String formatEewWarningOverlayBannerLabel({
+  required EewWarningOverlaySource source,
+  required String reportLabel,
+}) => switch (source) {
+  EewWarningOverlaySource.real => '緊急地震速報（警報）',
+  EewWarningOverlaySource.simulation => reportLabel,
+};
+
+String formatEewWarningOverlaySemanticsLabel({
+  required EewWarningOverlaySource source,
+}) => switch (source) {
+  EewWarningOverlaySource.real => '緊急地震速報警報',
+  EewWarningOverlaySource.simulation => '訓練／シミュレーションの緊急地震速報',
+};

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -9,6 +9,8 @@ import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/ads/data/notifier/ads_opt_out_notifier.dart';
 import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
 import 'package:eqmonitor/feature/settings/data/contact/contact_action.dart';
 import 'package:eqmonitor/feature/settings/features/debug/debug_provider.dart';
@@ -62,6 +64,27 @@ class SettingsPage extends ConsumerWidget {
                   leading: const Icon(Icons.notifications_outlined),
                   onTap: () async =>
                       const NotificationSettingsRoute().push<void>(context),
+                ),
+                AppSwitchListTile(
+                  title: 'アプリ使用中の緊急地震速報警報',
+                  subtitle: '現在地が警報対象になった時に全画面で知らせます',
+                  value:
+                      ref.watch(eewWarningOverlayEnabledProvider).value ?? true,
+                  onChanged: (value) async {
+                    await ref
+                        .read(eewWarningOverlayEnabledProvider.notifier)
+                        .set(value: value);
+                  },
+                ),
+                ListTile(
+                  leading: const Icon(Icons.play_arrow),
+                  title: const Text('警報画面をシミュレーション'),
+                  subtitle: const Text('固定の訓練データで表示と振動を確認します'),
+                  onTap: () {
+                    ref
+                        .read(eewWarningOverlaySimulationProvider.notifier)
+                        .start();
+                  },
                 ),
                 ListTile(
                   title: const Text('表示設定'),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -182,6 +182,7 @@ dependencies:
   flutter_inappwebview: ^6.2.0-beta.3
   assets_util:
     path: ../packages/assets_util
+  vibration: ^3.2.0
 
 dev_dependencies:
   build_runner: ^2.11.1

--- a/app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart
+++ b/app/test/feature/eew/data/logic/eew_warning_candidate_selector_test.dart
@@ -1,0 +1,128 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_candidate_selector.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final selector = EewWarningCandidateSelector();
+
+  test('現在のwarning regionにhadWarningがある警報だけを返す', () {
+    final result = selector.select(
+      aliveEews: [
+        warningEew(eventId: 'eligible', warningRegionCode: '100'),
+        warningEew(eventId: 'other', warningRegionCode: '200'),
+        warningEew(
+          eventId: 'previous-only',
+          warningRegionCode: '100',
+          hadWarning: false,
+        ),
+        warningEew(
+          eventId: 'forecast',
+          warningRegionCode: '100',
+          isWarning: false,
+        ),
+        warningEew(
+          eventId: 'canceled',
+          warningRegionCode: '100',
+          isCanceled: true,
+        ),
+      ],
+      warningAreaCode: '100',
+      warningAreaName: '石狩地方北部',
+      forecastAreaCode: '100',
+      forecastAreaName: '石狩地方北部',
+    );
+
+    expect(result.map((candidate) => candidate.event.eventId), ['eligible']);
+  });
+
+  test('forecast area codeで現在地震度と到達情報を関連付ける', () {
+    final arrival = DateTime.utc(2026, 7, 25, 12, 0, 10);
+    final result = selector
+        .select(
+          aliveEews: [
+            warningEew(
+              eventId: 'event',
+              warningRegionCode: '100',
+              forecastRegionCode: '100',
+              intensity: JmaIntensity.sixLower,
+              arrivalTime: arrival,
+            ),
+          ],
+          warningAreaCode: '100',
+          warningAreaName: '石狩地方北部',
+          forecastAreaCode: '100',
+          forecastAreaName: '石狩地方北部',
+        )
+        .single;
+
+    expect(result.localForecastRegion?.intensity, JmaIntensity.sixLower);
+    expect(result.localForecastRegion?.arrivalTime, arrival);
+  });
+
+  test('forecast area未解決でも対象警報は候補に残す', () {
+    final result = selector
+        .select(
+          aliveEews: [warningEew(eventId: 'event', warningRegionCode: '100')],
+          warningAreaCode: '100',
+          warningAreaName: '石狩地方北部',
+          forecastAreaCode: null,
+          forecastAreaName: null,
+        )
+        .single;
+
+    expect(result.localForecastRegion, isNull);
+  });
+}
+
+EewTelegramItem warningEew({
+  required String eventId,
+  bool? isWarning = true,
+  bool isCanceled = false,
+  String warningRegionCode = '100',
+  bool hadWarning = true,
+  String forecastRegionCode = '999',
+  JmaIntensity intensity = JmaIntensity.fiveLower,
+  DateTime? arrivalTime,
+  bool isArrived = false,
+}) => EewTelegramItem(
+  eventId: eventId,
+  status: TelegramStatus.normal,
+  infoType: TelegramInfoType.publication,
+  serialNo: 1,
+  isCanceled: isCanceled,
+  isLastInfo: false,
+  reportTime: DateTime.utc(2026, 7, 25, 11, 59),
+  isPlum: false,
+  isWarning: isWarning,
+  arrivalTime: DateTime.utc(2026, 7, 25, 12, 30),
+  forecastIntensity: EewForecastIntensityInfo(
+    regions: [
+      EewForecastRegionInfo(
+        code: forecastRegionCode,
+        name: '予報区',
+        isPlum: false,
+        isWarning: true,
+        intensity: intensity,
+        intensityIsOver: false,
+        arrivalTime: arrivalTime,
+        isArrived: isArrived,
+      ),
+    ],
+  ),
+  warning: EewWarningInfo(
+    regions: [
+      EewWarningZoneInfo(
+        code: warningRegionCode,
+        name: '警報地域',
+        hadWarning: hadWarning,
+      ),
+    ],
+    zones: [
+      EewWarningZoneInfo(code: '9910', name: '北海道', hadWarning: hadWarning),
+    ],
+    prefectures: const [],
+  ),
+);

--- a/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
+++ b/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
@@ -39,29 +39,77 @@ void main() {
     );
   });
 
-  test('代表は到達区分 震度 reportTime eventIdの辞書順で決まる', () {
-    final selected = EewWarningRepresentativeSelector().select(
+  final representativeCases = [
+    (
+      name: '到達区分は未到達を不明より優先する',
       candidates: [
-        candidate(eventId: 'd', intensity: JmaIntensity.seven, isArrived: true),
-        candidate(eventId: 'c', intensity: JmaIntensity.fiveLower),
+        candidate(eventId: 'unknown'),
+        candidate(
+          eventId: 'unarrived',
+          arrivalTime: now.add(const Duration(seconds: 10)),
+        ),
+      ],
+      expectedEventId: 'unarrived',
+    ),
+    (
+      name: '到達区分が同じなら震度の高い候補を優先する',
+      candidates: [
+        candidate(
+          eventId: 'lower',
+          intensity: JmaIntensity.fiveUpper,
+          arrivalTime: now.add(const Duration(seconds: 10)),
+        ),
+        candidate(
+          eventId: 'higher',
+          intensity: JmaIntensity.sixLower,
+          arrivalTime: now.add(const Duration(seconds: 10)),
+        ),
+      ],
+      expectedEventId: 'higher',
+    ),
+    (
+      name: '到達区分と震度が同じなら新しいreportTimeを優先する',
+      candidates: [
+        candidate(
+          eventId: 'older',
+          arrivalTime: now.add(const Duration(seconds: 10)),
+          reportTime: now.subtract(const Duration(seconds: 1)),
+        ),
+        candidate(
+          eventId: 'newer',
+          arrivalTime: now.add(const Duration(seconds: 10)),
+          reportTime: now,
+        ),
+      ],
+      expectedEventId: 'newer',
+    ),
+    (
+      name: '前三条件が同じならeventIdの辞書順を優先する',
+      candidates: [
         candidate(
           eventId: 'b',
-          intensity: JmaIntensity.sixLower,
           arrivalTime: now.add(const Duration(seconds: 10)),
           reportTime: now,
         ),
         candidate(
           eventId: 'a',
-          intensity: JmaIntensity.sixLower,
           arrivalTime: now.add(const Duration(seconds: 10)),
           reportTime: now,
         ),
       ],
-      now: now,
-    );
+      expectedEventId: 'a',
+    ),
+  ];
+  for (final testCase in representativeCases) {
+    test(testCase.name, () {
+      final selected = EewWarningRepresentativeSelector().select(
+        candidates: testCase.candidates,
+        now: now,
+      );
 
-    expect(selected?.event.eventId, 'a');
-  });
+      expect(selected?.event.eventId, testCase.expectedEventId);
+    });
+  }
 
   test('実警報表示を構造化データから集約する', () {
     final model = EewWarningDisplayModelBuilder().build(

--- a/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
+++ b/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
@@ -52,6 +52,14 @@ void main() {
       expectedEventId: 'unarrived',
     ),
     (
+      name: '到達区分は不明を到達済みより優先する',
+      candidates: [
+        candidate(eventId: 'unknown'),
+        candidate(eventId: 'arrived', isArrived: true),
+      ],
+      expectedEventId: 'unknown',
+    ),
+    (
       name: '到達区分が同じなら震度の高い候補を優先する',
       candidates: [
         candidate(

--- a/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
+++ b/app/test/feature/eew/data/logic/eew_warning_display_model_builder_test.dart
@@ -1,0 +1,230 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_arrival_classifier.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_candidate_selector.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_display_model_builder.dart';
+import 'package:eqmonitor/feature/eew/data/logic/eew_warning_representative_selector.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 7, 25, 12);
+
+  test('到達区分を未到達 不明 到達済みの順に分類する', () {
+    final classifier = EewWarningArrivalClassifier();
+    expect(
+      classifier.classify(
+        candidate: candidate(arrivalTime: now.add(const Duration(seconds: 5))),
+        now: now,
+      ),
+      EewWarningArrivalState.unarrived,
+    );
+    expect(
+      classifier.classify(candidate: candidate(), now: now),
+      EewWarningArrivalState.unknown,
+    );
+    expect(
+      classifier.classify(candidate: candidate(isArrived: true), now: now),
+      EewWarningArrivalState.arrived,
+    );
+    expect(
+      classifier.classify(
+        candidate: candidate(arrivalTime: now),
+        now: now,
+      ),
+      EewWarningArrivalState.arrived,
+    );
+  });
+
+  test('代表は到達区分 震度 reportTime eventIdの辞書順で決まる', () {
+    final selected = EewWarningRepresentativeSelector().select(
+      candidates: [
+        candidate(eventId: 'd', intensity: JmaIntensity.seven, isArrived: true),
+        candidate(eventId: 'c', intensity: JmaIntensity.fiveLower),
+        candidate(
+          eventId: 'b',
+          intensity: JmaIntensity.sixLower,
+          arrivalTime: now.add(const Duration(seconds: 10)),
+          reportTime: now,
+        ),
+        candidate(
+          eventId: 'a',
+          intensity: JmaIntensity.sixLower,
+          arrivalTime: now.add(const Duration(seconds: 10)),
+          reportTime: now,
+        ),
+      ],
+      now: now,
+    );
+
+    expect(selected?.event.eventId, 'a');
+  });
+
+  test('実警報表示を構造化データから集約する', () {
+    final model = EewWarningDisplayModelBuilder().build(
+      candidates: [
+        candidate(
+          eventId: 'b',
+          serialNo: 3,
+          detailedHypocenterName: 'テスト震源詳細',
+          warningZones: const [('9920', '東北'), ('9910', '北海道')],
+          intensity: JmaIntensity.sixLower,
+          arrivalTime: now.add(const Duration(seconds: 10)),
+        ),
+        candidate(
+          eventId: 'c',
+          warningZones: const [('9920', '東北'), ('9931', '関東')],
+          intensity: JmaIntensity.fiveUpper,
+        ),
+      ],
+      now: now,
+    );
+
+    expect(model?.source, EewWarningOverlaySource.real);
+    expect(model?.representativeEventId, 'b');
+    expect(model?.eventIds, ['b', 'c']);
+    expect(model?.alertCount, 2);
+    expect(model?.reportLabel, '緊急地震速報（警報） 第3報');
+    expect(model?.hypocenterHeadline, 'テスト震源詳細で地震');
+    expect(model?.strongMotionHeadline, '北海道 東北 関東で強い揺れ');
+    expect(model?.currentRegionName, '現在地予報区');
+    expect(model?.localIntensity, JmaIntensity.sixLower);
+    expect(model?.localIntensityIsOver, isFalse);
+    expect(model?.arrivalState, EewWarningArrivalState.unarrived);
+    expect(model?.secondsUntilArrival, 10);
+    expect(model?.hypocenterName, 'テスト震源');
+    expect(model?.magnitude, 6.2);
+    expect(model?.depth, 30);
+  });
+
+  test('PLUM法とレベル法では震源見出しを表示しない', () {
+    final builder = EewWarningDisplayModelBuilder();
+    final plumCandidate = candidate(isPlum: true);
+    final levelCandidate = candidate(isLevelMethod: true);
+
+    expect(
+      builder.build(candidates: [plumCandidate], now: now)?.hypocenterHeadline,
+      isNull,
+    );
+    expect(
+      builder.build(candidates: [levelCandidate], now: now)?.hypocenterHeadline,
+      isNull,
+    );
+  });
+
+  test('警報zoneがなければ汎用警戒見出しを使う', () {
+    final noZoneCandidate = candidate(warningZones: const []);
+
+    expect(
+      EewWarningDisplayModelBuilder()
+          .build(candidates: [noZoneCandidate], now: now)
+          ?.strongMotionHeadline,
+      '強い揺れに警戒',
+    );
+  });
+
+  test('候補が空なら表示しない', () {
+    expect(
+      EewWarningDisplayModelBuilder().build(candidates: const [], now: now),
+      isNull,
+    );
+  });
+
+  test('現在地予報が不明なら不明な局地情報と警報地域名を使う', () {
+    final model = EewWarningDisplayModelBuilder().build(
+      candidates: [candidate(hasLocalForecast: false)],
+      now: now,
+    );
+
+    expect(model?.currentRegionName, '石狩地方北部');
+    expect(model?.localIntensity, JmaIntensity.unknown);
+    expect(model?.localIntensityIsOver, isFalse);
+    expect(model?.arrivalState, EewWarningArrivalState.unknown);
+    expect(model?.secondsUntilArrival, isNull);
+  });
+}
+
+EewWarningOverlayCandidate candidate({
+  String eventId = 'event',
+  int serialNo = 1,
+  DateTime? reportTime,
+  bool isPlum = false,
+  bool isLevelMethod = false,
+  String? detailedHypocenterName,
+  List<(String, String)> warningZones = const [('9910', '北海道')],
+  JmaIntensity intensity = JmaIntensity.fiveLower,
+  DateTime? arrivalTime,
+  bool isArrived = false,
+  bool hasLocalForecast = true,
+}) {
+  final event = EewTelegramItem(
+    eventId: eventId,
+    status: TelegramStatus.normal,
+    infoType: TelegramInfoType.publication,
+    serialNo: serialNo,
+    isCanceled: false,
+    isLastInfo: false,
+    reportTime: reportTime ?? DateTime.utc(2026, 7, 25, 11, 59),
+    isPlum: isPlum,
+    isWarning: true,
+    originTime: isLevelMethod ? null : DateTime.utc(2026, 7, 25, 11, 58),
+    accuracy: EewAccuracyInfo(
+      epicenter: isLevelMethod ? 1 : 4,
+      hypocenter: 4,
+      depth: 4,
+      magnitudeCalculation: 5,
+      numberOfMagnitudeCalculation: 5,
+    ),
+    hypocenter: EewHypocenterInfo(
+      code: '001',
+      name: 'テスト震源',
+      detailedName: detailedHypocenterName,
+      magnitude: 6.2,
+      depth: 30,
+    ),
+    forecastIntensity: EewForecastIntensityInfo(
+      regions: hasLocalForecast
+          ? [
+              EewForecastRegionInfo(
+                code: '100',
+                name: '現在地予報区',
+                isPlum: false,
+                isWarning: true,
+                intensity: intensity,
+                intensityIsOver: false,
+                arrivalTime: arrivalTime,
+                isArrived: isArrived,
+              ),
+            ]
+          : const [],
+    ),
+    warning: EewWarningInfo(
+      zones: warningZones
+          .map(
+            (zone) => EewWarningZoneInfo(
+              code: zone.$1,
+              name: zone.$2,
+              hadWarning: true,
+            ),
+          )
+          .toList(),
+      prefectures: const [],
+      regions: const [
+        EewWarningZoneInfo(code: '100', name: '石狩地方北部', hadWarning: true),
+      ],
+    ),
+  );
+
+  return EewWarningCandidateSelector()
+      .select(
+        aliveEews: [event],
+        warningAreaCode: '100',
+        warningAreaName: '石狩地方北部',
+        forecastAreaCode: hasLocalForecast ? '100' : null,
+        forecastAreaName: hasLocalForecast ? '現在地予報区' : null,
+      )
+      .single;
+}

--- a/app/test/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier_test.dart
+++ b/app/test/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier_test.dart
@@ -1,0 +1,53 @@
+import 'package:eqmonitor/core/data/preferences/shared/shared_preferences_key.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('EewWarningOverlayEnabled', () {
+    test('未設定ならtrueを返す', () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        await container.read(eewWarningOverlayEnabledProvider.future),
+        isTrue,
+      );
+    });
+
+    test('保存済みfalseを復元する', () async {
+      SharedPreferences.setMockInitialValues({
+        SharedPreferencesKey.eewWarningOverlayEnabled.key: false,
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        await container.read(eewWarningOverlayEnabledProvider.future),
+        isFalse,
+      );
+    });
+
+    test('setは状態とSharedPreferencesを更新する', () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await container.read(eewWarningOverlayEnabledProvider.future);
+
+      await container
+          .read(eewWarningOverlayEnabledProvider.notifier)
+          .set(value: false);
+
+      expect(container.read(eewWarningOverlayEnabledProvider).value, isFalse);
+      final preferences = await SharedPreferences.getInstance();
+      expect(
+        preferences.getBool(SharedPreferencesKey.eewWarningOverlayEnabled.key),
+        isFalse,
+      );
+    });
+  });
+}

--- a/app/test/feature/eew/data/notifier/eew_warning_overlay_notifier_test.dart
+++ b/app/test/feature/eew/data/notifier/eew_warning_overlay_notifier_test.dart
@@ -82,16 +82,27 @@ final class FakeScheduler implements EewWarningOverlayScheduler {
 }
 
 final class FakeVibrationGateway implements EewWarningOverlayVibrationGateway {
-  FakeVibrationGateway({this.startBarrier});
+  FakeVibrationGateway({
+    this.startBarriers = const [],
+    this.cancelBarriers = const [],
+    this.hasVibratorResult = true,
+  });
 
-  final Completer<void>? startBarrier;
+  final List<Completer<void>?> startBarriers;
+  final List<Completer<void>?> cancelBarriers;
+  final bool hasVibratorResult;
   int startCalls = 0;
   int cancelCalls = 0;
+  int hasVibratorCalls = 0;
+  bool isVibrating = false;
 
   @override
   Future<bool> hasVibrator() async {
-    await startBarrier?.future;
-    return true;
+    final index = hasVibratorCalls++;
+    if (index < startBarriers.length) {
+      await startBarriers[index]?.future;
+    }
+    return hasVibratorResult;
   }
 
   @override
@@ -100,16 +111,23 @@ final class FakeVibrationGateway implements EewWarningOverlayVibrationGateway {
   @override
   Future<void> vibrate({required List<int> pattern}) async {
     startCalls += 1;
+    isVibrating = true;
   }
 
   @override
   Future<void> vibrateOnce({required int durationMs}) async {
     startCalls += 1;
+    isVibrating = true;
   }
 
   @override
   Future<void> cancel() async {
+    final index = cancelCalls;
+    if (index < cancelBarriers.length) {
+      await cancelBarriers[index]?.future;
+    }
     cancelCalls += 1;
+    isVibrating = false;
   }
 }
 
@@ -262,7 +280,7 @@ void main() {
   test('振動開始中の同一eventId更新も振動を途中停止しない', () async {
     final startBarrier = Completer<void>();
     final context = createContext(
-      vibrationGateway: FakeVibrationGateway(startBarrier: startBarrier),
+      vibrationGateway: FakeVibrationGateway(startBarriers: [startBarrier]),
     );
     addTearDown(context.container.dispose);
 
@@ -277,6 +295,70 @@ void main() {
     expect(context.state.displayModel?.serialNo, 2);
     expect(context.vibration.startCalls, 1);
     expect(context.vibration.cancelCalls, 0);
+  });
+
+  test('known実警報がsimulationをpreemptすると最小化して警報動作を止める', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+    await context.publishReal(null);
+    context.container
+        .read(eewWarningOverlaySimulationProvider.notifier)
+        .start();
+    await context.settle();
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.vibration.isVibrating, isTrue);
+
+    await context.publishReal(display(eventIds: ['A'], serialNo: 2));
+
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
+    expect(context.state.displayModel?.source, EewWarningOverlaySource.real);
+    expect(context.scheduler.activeTaskCount, 0);
+    expect(context.vibration.isVibrating, isFalse);
+  });
+
+  test('新規Bのcancel待機中の同一内容更新はBの振動開始を中止しない', () async {
+    final cancelBarrier = Completer<void>();
+    final context = createContext(
+      vibrationGateway: FakeVibrationGateway(cancelBarriers: [cancelBarrier]),
+    );
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+
+    context.real.publish(display(eventIds: ['A', 'B']));
+    await Future<void>.delayed(Duration.zero);
+    context.real.publish(display(eventIds: ['A', 'B'], serialNo: 2));
+    await context.container.pump();
+    expect(context.state.displayModel?.serialNo, 2);
+    cancelBarrier.complete();
+    await context.settle();
+
+    expect(context.vibration.startCalls, 2);
+    expect(context.vibration.isVibrating, isTrue);
+  });
+
+  test('古いAのstart完了は後から開始したBの振動を停止しない', () async {
+    final oldStartBarrier = Completer<void>();
+    final context = createContext(
+      vibrationGateway: FakeVibrationGateway(
+        startBarriers: [oldStartBarrier, null],
+      ),
+    );
+    addTearDown(context.container.dispose);
+
+    context.real.publish(display(eventIds: ['A']));
+    await Future<void>.delayed(Duration.zero);
+    context.real.publish(display(eventIds: ['A', 'B']));
+    await context.container.pump();
+    await Future<void>.delayed(Duration.zero);
+    expect(context.vibration.startCalls, 0);
+    expect(context.vibration.isVibrating, isFalse);
+
+    oldStartBarrier.complete();
+    await context.settle();
+
+    expect(context.vibration.startCalls, 2);
+    expect(context.vibration.isVibrating, isTrue);
   });
 
   test('closeは有効群をdismissし新規Cだけ再開条件にする', () async {
@@ -468,5 +550,19 @@ void main() {
 
     expect(context.scheduler.activeTaskCount, 0);
     expect(context.vibration.cancelCalls, 1);
+  });
+
+  test('非対応端末では未開始の振動を停止対象として保持しない', () async {
+    final context = createContext(
+      vibrationGateway: FakeVibrationGateway(hasVibratorResult: false),
+    );
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+
+    await context.scheduler.elapse(const Duration(seconds: 10));
+
+    expect(context.vibration.startCalls, 0);
+    expect(context.vibration.cancelCalls, 0);
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
   });
 }

--- a/app/test/feature/eew/data/notifier/eew_warning_overlay_notifier_test.dart
+++ b/app/test/feature/eew/data/notifier/eew_warning_overlay_notifier_test.dart
@@ -1,0 +1,472 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/provider/app_lifecycle.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_state.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_display_provider.dart';
+import 'package:eqmonitor/feature/eew/data/service/eew_warning_overlay_scheduler.dart';
+import 'package:eqmonitor/feature/eew/data/service/eew_warning_overlay_vibration_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+
+final mutableRealDisplayProvider =
+    NotifierProvider<MutableRealDisplay, EewWarningOverlayDisplayModel?>(
+      MutableRealDisplay.new,
+    );
+
+final class MutableRealDisplay
+    extends Notifier<EewWarningOverlayDisplayModel?> {
+  MutableRealDisplay([this.initial]);
+
+  final EewWarningOverlayDisplayModel? initial;
+
+  @override
+  EewWarningOverlayDisplayModel? build() => initial;
+
+  void publish(EewWarningOverlayDisplayModel? model) => state = model;
+}
+
+final class MutableAppLifecycle extends AppLifecycle {
+  MutableAppLifecycle({this.initial = AppLifecycleState.resumed});
+
+  final AppLifecycleState initial;
+
+  @override
+  AppLifecycleState build() => initial;
+
+  void publish(AppLifecycleState value) => state = value;
+}
+
+final class FakeScheduledTask implements EewWarningOverlayScheduledTask {
+  FakeScheduledTask({required this.delay, required this.callback});
+
+  final Duration delay;
+  final Future<void> Function() callback;
+  bool isCancelled = false;
+  bool hasRun = false;
+
+  @override
+  void cancel() => isCancelled = true;
+}
+
+final class FakeScheduler implements EewWarningOverlayScheduler {
+  final tasks = <FakeScheduledTask>[];
+
+  int get activeTaskCount =>
+      tasks.where((task) => !task.isCancelled && !task.hasRun).length;
+
+  @override
+  EewWarningOverlayScheduledTask schedule({
+    required Duration delay,
+    required Future<void> Function() callback,
+  }) {
+    final task = FakeScheduledTask(delay: delay, callback: callback);
+    tasks.add(task);
+    return task;
+  }
+
+  Future<void> elapse(Duration duration) async {
+    final due = tasks.where(
+      (task) => !task.isCancelled && !task.hasRun && task.delay <= duration,
+    );
+    for (final task in due.toList(growable: false)) {
+      task.hasRun = true;
+      await task.callback();
+    }
+  }
+}
+
+final class FakeVibrationGateway implements EewWarningOverlayVibrationGateway {
+  FakeVibrationGateway({this.startBarrier});
+
+  final Completer<void>? startBarrier;
+  int startCalls = 0;
+  int cancelCalls = 0;
+
+  @override
+  Future<bool> hasVibrator() async {
+    await startBarrier?.future;
+    return true;
+  }
+
+  @override
+  Future<bool> hasCustomVibrationsSupport() async => true;
+
+  @override
+  Future<void> vibrate({required List<int> pattern}) async {
+    startCalls += 1;
+  }
+
+  @override
+  Future<void> vibrateOnce({required int durationMs}) async {
+    startCalls += 1;
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls += 1;
+  }
+}
+
+final class TestContext {
+  TestContext({
+    required this.container,
+    required this.real,
+    required this.lifecycle,
+    required this.scheduler,
+    required this.vibration,
+  });
+
+  final ProviderContainer container;
+  final MutableRealDisplay real;
+  final MutableAppLifecycle lifecycle;
+  final FakeScheduler scheduler;
+  final FakeVibrationGateway vibration;
+
+  EewWarningOverlayState get state =>
+      container.read(eewWarningOverlayNotifierProvider);
+
+  Future<void> publishReal(EewWarningOverlayDisplayModel? model) async {
+    real.publish(model);
+    await container.pump();
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> publishLifecycle(AppLifecycleState value) async {
+    lifecycle.publish(value);
+    await container.pump();
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> settle() async {
+    await scheduler.elapse(Duration.zero);
+    await container.pump();
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+TestContext createContext({
+  AppLifecycleState lifecycleState = AppLifecycleState.resumed,
+  EewWarningOverlayDisplayModel? initialDisplay,
+  FakeVibrationGateway? vibrationGateway,
+}) {
+  final real = MutableRealDisplay(initialDisplay);
+  final lifecycle = MutableAppLifecycle(initial: lifecycleState);
+  final scheduler = FakeScheduler();
+  final vibration = vibrationGateway ?? FakeVibrationGateway();
+  final container = ProviderContainer(
+    overrides: [
+      mutableRealDisplayProvider.overrideWith(() => real),
+      eewWarningOverlayDisplayProvider.overrideWith(
+        (ref) => ref.watch(mutableRealDisplayProvider),
+      ),
+      appLifecycleProvider.overrideWith(() => lifecycle),
+      eewWarningOverlaySchedulerProvider.overrideWithValue(scheduler),
+      eewWarningOverlayVibrationServiceProvider.overrideWithValue(
+        EewWarningOverlayVibrationService(gateway: vibration, talker: Talker()),
+      ),
+    ],
+  );
+  container.listen(
+    eewWarningOverlayNotifierProvider,
+    (_, _) {},
+    fireImmediately: true,
+  );
+  return TestContext(
+    container: container,
+    real: real,
+    lifecycle: lifecycle,
+    scheduler: scheduler,
+    vibration: vibration,
+  );
+}
+
+EewWarningOverlayDisplayModel display({
+  required List<String> eventIds,
+  int serialNo = 1,
+}) => EewWarningOverlayDisplayModel(
+  source: EewWarningOverlaySource.real,
+  eventIds: eventIds,
+  representativeEventId: eventIds.first,
+  serialNo: serialNo,
+  alertCount: eventIds.length,
+  reportLabel: '第$serialNo報',
+  hypocenterHeadline: 'テスト震源で地震',
+  strongMotionHeadline: 'テスト地域で強い揺れ',
+  currentRegionName: 'テスト地域',
+  localIntensity: JmaIntensity.sixLower,
+  localIntensityIsOver: false,
+  arrivalState: EewWarningArrivalState.unarrived,
+  secondsUntilArrival: 10,
+  hypocenterName: 'テスト震源',
+  magnitude: 6,
+  depth: 10,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('新しい実警報は全画面と振動を開始し10秒後に最小化する', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    await context.publishReal(display(eventIds: ['A']));
+
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.state.seenEventIds, {'A'});
+    expect(context.vibration.startCalls, 1);
+    expect(context.scheduler.activeTaskCount, 1);
+
+    await context.scheduler.elapse(const Duration(seconds: 10));
+
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
+    expect(context.vibration.cancelCalls, 1);
+  });
+
+  test('provider構築前から有効な実警報も初回購読時に通知する', () async {
+    final context = createContext(initialDisplay: display(eventIds: ['A']));
+    addTearDown(context.container.dispose);
+    await context.settle();
+
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.state.seenEventIds, {'A'});
+    expect(context.vibration.startCalls, 1);
+  });
+
+  test('同一eventIdの内容更新では再通知せず新しいeventId追加時だけ再通知する', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+
+    await context.publishReal(display(eventIds: ['A'], serialNo: 2));
+
+    expect(context.state.displayModel?.serialNo, 2);
+    expect(context.vibration.startCalls, 1);
+    expect(context.vibration.cancelCalls, 0);
+    expect(context.scheduler.tasks, hasLength(1));
+
+    await context.publishReal(display(eventIds: ['A', 'B']));
+
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.state.seenEventIds, {'A', 'B'});
+    expect(context.vibration.startCalls, 2);
+    expect(context.scheduler.tasks, hasLength(2));
+  });
+
+  test('振動開始中の同一eventId更新も振動を途中停止しない', () async {
+    final startBarrier = Completer<void>();
+    final context = createContext(
+      vibrationGateway: FakeVibrationGateway(startBarrier: startBarrier),
+    );
+    addTearDown(context.container.dispose);
+
+    context.real.publish(display(eventIds: ['A']));
+    await Future<void>.delayed(Duration.zero);
+    context.real.publish(display(eventIds: ['A'], serialNo: 2));
+    await context.container.pump();
+    expect(context.state.displayModel?.serialNo, 2);
+    startBarrier.complete();
+    await context.settle();
+
+    expect(context.state.displayModel?.serialNo, 2);
+    expect(context.vibration.startCalls, 1);
+    expect(context.vibration.cancelCalls, 0);
+  });
+
+  test('closeは有効群をdismissし新規Cだけ再開条件にする', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A', 'B']));
+
+    await context.container
+        .read(eewWarningOverlayNotifierProvider.notifier)
+        .close();
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    expect(context.state.dismissedEventIds, {'A', 'B'});
+
+    await context.publishReal(display(eventIds: ['A', 'B'], serialNo: 2));
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+
+    await context.publishReal(display(eventIds: ['A', 'B', 'C']));
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.vibration.startCalls, 2);
+
+    await context.publishReal(display(eventIds: ['A', 'B']));
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    expect(context.state.displayModel, isNull);
+  });
+
+  test('手動最小化と再展開はtimerと振動を再開しない', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+    final notifier = context.container.read(
+      eewWarningOverlayNotifierProvider.notifier,
+    );
+
+    await notifier.minimize();
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
+    expect(context.scheduler.activeTaskCount, 0);
+
+    notifier.expand();
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.vibration.startCalls, 1);
+    expect(context.scheduler.tasks, hasLength(1));
+
+    await context.scheduler.elapse(const Duration(seconds: 10));
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+  });
+
+  test('対象消失でhiddenになり既知eventIdの再進入は最小表示にする', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+
+    await context.publishReal(null);
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    expect(context.state.displayModel, isNull);
+
+    await context.publishReal(display(eventIds: ['A'], serialNo: 2));
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
+    expect(context.state.displayModel?.serialNo, 2);
+    expect(context.vibration.startCalls, 1);
+  });
+
+  test('設定無効相当で実警報がeffectiveから消えてもsimulationは表示できる', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+
+    context.container
+        .read(eewWarningOverlaySimulationProvider.notifier)
+        .start();
+    await context.settle();
+
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(
+      context.state.displayModel?.source,
+      EewWarningOverlaySource.simulation,
+    );
+  });
+
+  test('simulationのcloseはsessionとsourceを停止する', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    context.container
+        .read(eewWarningOverlaySimulationProvider.notifier)
+        .start();
+    await context.settle();
+
+    await context.container
+        .read(eewWarningOverlayNotifierProvider.notifier)
+        .close();
+    await context.settle();
+
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    expect(context.state.simulationSessionActive, isFalse);
+    expect(context.container.read(eewWarningOverlaySimulationProvider), isNull);
+  });
+
+  test('実警報preemption後はsimulationを新しいsessionとして再実行できる', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    final simulation = context.container.read(
+      eewWarningOverlaySimulationProvider.notifier,
+    );
+    simulation.start();
+    await context.settle();
+    expect(context.vibration.startCalls, 1);
+
+    await context.publishReal(display(eventIds: ['A']));
+    expect(context.state.displayModel?.source, EewWarningOverlaySource.real);
+    expect(context.vibration.startCalls, 2);
+
+    await context.publishReal(null);
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    simulation.start();
+    await context.settle();
+
+    expect(
+      context.state.displayModel?.source,
+      EewWarningOverlaySource.simulation,
+    );
+    expect(context.state.simulationSessionActive, isTrue);
+    expect(context.vibration.startCalls, 3);
+  });
+
+  test('background中の新eventIdはseenにせずresume時に初めて通知する', () async {
+    final context = createContext(lifecycleState: AppLifecycleState.paused);
+    addTearDown(context.container.dispose);
+
+    await context.publishReal(display(eventIds: ['A']));
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    expect(context.state.seenEventIds, isEmpty);
+    expect(context.vibration.startCalls, 0);
+
+    await context.publishLifecycle(AppLifecycleState.resumed);
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.state.seenEventIds, {'A'});
+    expect(context.vibration.startCalls, 1);
+  });
+
+  test('foregroundで既知のAにbackgroundでBが加わるとresume時に再通知する', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+    await context.publishLifecycle(AppLifecycleState.paused);
+
+    await context.publishReal(display(eventIds: ['A', 'B']));
+    expect(context.state.seenEventIds, {'A'});
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
+
+    await context.publishLifecycle(AppLifecycleState.resumed);
+    expect(context.state.seenEventIds, {'A', 'B'});
+    expect(context.state.mode, EewWarningOverlayMode.fullscreen);
+    expect(context.vibration.startCalls, 2);
+  });
+
+  test('background中に消えた新eventIdはresumeしても通知しない', () async {
+    final context = createContext(lifecycleState: AppLifecycleState.paused);
+    addTearDown(context.container.dispose);
+
+    await context.publishReal(display(eventIds: ['A']));
+    await context.publishReal(null);
+    await context.publishLifecycle(AppLifecycleState.resumed);
+
+    expect(context.state.mode, EewWarningOverlayMode.hidden);
+    expect(context.state.seenEventIds, isEmpty);
+    expect(context.vibration.startCalls, 0);
+  });
+
+  test('非resumed遷移は全画面を最小化してtimerと振動を止める', () async {
+    final context = createContext();
+    addTearDown(context.container.dispose);
+    await context.publishReal(display(eventIds: ['A']));
+
+    await context.publishLifecycle(AppLifecycleState.inactive);
+
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
+    expect(context.scheduler.activeTaskCount, 0);
+    expect(context.vibration.cancelCalls, 1);
+
+    await context.publishLifecycle(AppLifecycleState.resumed);
+    expect(context.state.mode, EewWarningOverlayMode.minimized);
+    expect(context.vibration.startCalls, 1);
+  });
+
+  test('provider破棄時はtimerと振動を停止する', () async {
+    final context = createContext();
+    await context.publishReal(display(eventIds: ['A']));
+
+    context.container.dispose();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(context.scheduler.activeTaskCount, 0);
+    expect(context.vibration.cancelCalls, 1);
+  });
+}

--- a/app/test/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier_test.dart
+++ b/app/test/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier_test.dart
@@ -1,0 +1,147 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_display_provider.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_effective_display_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final mutableRealDisplayProvider =
+    NotifierProvider<MutableRealDisplay, EewWarningOverlayDisplayModel?>(
+      MutableRealDisplay.new,
+    );
+
+final class MutableRealDisplay
+    extends Notifier<EewWarningOverlayDisplayModel?> {
+  MutableRealDisplay([this.initial]);
+
+  final EewWarningOverlayDisplayModel? initial;
+
+  @override
+  EewWarningOverlayDisplayModel? build() => initial;
+
+  void publish(EewWarningOverlayDisplayModel? model) => state = model;
+}
+
+ProviderContainer simulationContainer({
+  EewWarningOverlayDisplayModel? real,
+  MutableRealDisplay? realNotifier,
+}) => ProviderContainer(
+  overrides: [
+    mutableRealDisplayProvider.overrideWith(
+      () => realNotifier ?? MutableRealDisplay(real),
+    ),
+    eewWarningOverlayDisplayProvider.overrideWith(
+      (ref) => ref.watch(mutableRealDisplayProvider),
+    ),
+  ],
+);
+
+EewWarningOverlayDisplayModel realDisplayModel({required String eventId}) =>
+    EewWarningOverlayDisplayModel(
+      source: EewWarningOverlaySource.real,
+      eventIds: [eventId],
+      representativeEventId: eventId,
+      serialNo: 1,
+      alertCount: 1,
+      reportLabel: '第1報',
+      hypocenterHeadline: '実震源で地震',
+      strongMotionHeadline: '実地域で強い揺れ',
+      currentRegionName: '実地域',
+      localIntensity: JmaIntensity.fiveLower,
+      localIntensityIsOver: false,
+      arrivalState: EewWarningArrivalState.unknown,
+      secondsUntilArrival: null,
+      hypocenterName: '実震源',
+      magnitude: 5,
+      depth: 10,
+    );
+
+void main() {
+  test('startは設定に依存しない固定訓練モデルを公開する', () {
+    final container = simulationContainer(real: null);
+    addTearDown(container.dispose);
+
+    container.read(eewWarningOverlaySimulationProvider.notifier).start();
+    final model = container.read(eewWarningOverlaySimulationProvider);
+
+    expect(
+      model,
+      const EewWarningOverlayDisplayModel(
+        source: EewWarningOverlaySource.simulation,
+        eventIds: ['eew-warning-overlay-simulation'],
+        representativeEventId: 'eew-warning-overlay-simulation',
+        serialNo: 1,
+        alertCount: 1,
+        reportLabel: '訓練／シミュレーション',
+        hypocenterHeadline: 'テスト震源で地震',
+        strongMotionHeadline: 'テスト地域で強い揺れ',
+        currentRegionName: 'テスト地域',
+        localIntensity: JmaIntensity.sixLower,
+        localIntensityIsOver: false,
+        arrivalState: EewWarningArrivalState.unarrived,
+        secondsUntilArrival: 10,
+        hypocenterName: 'テスト震源',
+        magnitude: null,
+        depth: null,
+      ),
+    );
+  });
+
+  test('stopは訓練モデルを消す', () {
+    final container = simulationContainer(real: null);
+    addTearDown(container.dispose);
+    final notifier = container.read(
+      eewWarningOverlaySimulationProvider.notifier,
+    );
+
+    notifier.start();
+    notifier.stop();
+
+    expect(container.read(eewWarningOverlaySimulationProvider), isNull);
+  });
+
+  test('実警報が訓練を破棄し終了後も訓練へ戻らない', () async {
+    final real = MutableRealDisplay();
+    final container = simulationContainer(realNotifier: real);
+    addTearDown(container.dispose);
+    final effectiveSubscription = container.listen(
+      eewWarningOverlayEffectiveDisplayProvider,
+      (_, _) {},
+    );
+    addTearDown(effectiveSubscription.close);
+
+    container.read(eewWarningOverlaySimulationProvider.notifier).start();
+    expect(
+      container.read(eewWarningOverlayEffectiveDisplayProvider)?.source,
+      EewWarningOverlaySource.simulation,
+    );
+
+    real.publish(realDisplayModel(eventId: 'real-event'));
+    await container.pump();
+    expect(
+      container.read(eewWarningOverlayEffectiveDisplayProvider)?.source,
+      EewWarningOverlaySource.real,
+    );
+    expect(container.read(eewWarningOverlaySimulationProvider), isNull);
+
+    real.publish(null);
+    await container.pump();
+    expect(container.read(eewWarningOverlayEffectiveDisplayProvider), isNull);
+  });
+
+  test('実警報中のstartは訓練を開始しない', () {
+    final container = simulationContainer(
+      real: realDisplayModel(eventId: 'real-event'),
+    );
+    addTearDown(container.dispose);
+
+    container.read(eewWarningOverlaySimulationProvider.notifier).start();
+
+    expect(container.read(eewWarningOverlaySimulationProvider), isNull);
+    expect(
+      container.read(eewWarningOverlayEffectiveDisplayProvider)?.source,
+      EewWarningOverlaySource.real,
+    );
+  });
+}

--- a/app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart
+++ b/app/test/feature/eew/data/provider/eew_warning_overlay_candidate_provider_test.dart
@@ -1,0 +1,373 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/core/provider/clock/app_clock.dart';
+import 'package:eqmonitor/feature/eew/data/eew_alive_telegram.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_candidate_provider.dart';
+import 'package:eqmonitor/feature/location/data/location.dart';
+import 'package:eqmonitor/feature/location/data/model/map_data_item.dart';
+import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lat_lng/lat_lng.dart';
+
+class _StubEewAliveTelegram extends EewAliveTelegram {
+  _StubEewAliveTelegram(this.value);
+
+  final List<EewTelegramItem>? value;
+
+  @override
+  List<EewTelegramItem>? build() => value;
+}
+
+class _StubEewWarningOverlayEnabled extends EewWarningOverlayEnabled {
+  _StubEewWarningOverlayEnabled(this.value);
+
+  final Future<bool> value;
+
+  @override
+  Future<bool> build() => value;
+}
+
+Position _position() => Position(
+  latitude: 35.681,
+  longitude: 139.767,
+  timestamp: DateTime.utc(2026),
+  accuracy: 0,
+  altitude: 0,
+  altitudeAccuracy: 0,
+  heading: 0,
+  headingAccuracy: 0,
+  speed: 0,
+  speedAccuracy: 0,
+);
+
+MapDataItem _mapItem({
+  required String code,
+  required String name,
+  bool hasProperty = true,
+}) => MapDataItem(
+  property: hasProperty
+      ? MapDataProperty(code: code, name: name, nameKana: '')
+      : null,
+);
+
+EewTelegramItem _warningEew({
+  bool? isWarning = true,
+  bool isCanceled = false,
+  bool hadWarning = true,
+  String warningRegionCode = '100',
+  String forecastRegionCode = '200',
+  JmaIntensity intensity = JmaIntensity.sixUpper,
+}) => EewTelegramItem(
+  eventId: 'event',
+  status: TelegramStatus.normal,
+  infoType: TelegramInfoType.publication,
+  serialNo: 1,
+  isCanceled: isCanceled,
+  isLastInfo: false,
+  reportTime: DateTime.utc(2026, 7, 25, 11, 59),
+  isPlum: false,
+  isWarning: isWarning,
+  forecastIntensity: EewForecastIntensityInfo(
+    regions: [
+      EewForecastRegionInfo(
+        code: forecastRegionCode,
+        name: '予報区',
+        isPlum: false,
+        isWarning: true,
+        intensity: intensity,
+        intensityIsOver: false,
+      ),
+    ],
+  ),
+  warning: EewWarningInfo(
+    zones: const [],
+    prefectures: const [],
+    regions: [
+      EewWarningZoneInfo(
+        code: warningRegionCode,
+        name: '警報地域',
+        hadWarning: hadWarning,
+      ),
+    ],
+  ),
+);
+
+ProviderContainer _container({
+  bool realtime = true,
+  Future<bool>? enabled,
+  List<EewTelegramItem>? alive,
+  Stream<Position>? positions,
+  Future<MapDataItem?>? warningArea,
+  Future<MapDataItem?>? forecastArea,
+  Future<MapDataItem?> Function()? forecastAreaBuilder,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      isRealtimeModeProvider.overrideWithValue(realtime),
+      eewWarningOverlayEnabledProvider.overrideWith(
+        () => _StubEewWarningOverlayEnabled(enabled ?? Future.value(true)),
+      ),
+      eewAliveTelegramProvider.overrideWith(() => _StubEewAliveTelegram(alive)),
+      locationStreamProvider.overrideWith(
+        (ref) => positions ?? Stream.value(_position()),
+      ),
+      jmaMapAreaForecastLocalEewInsideProvider.overrideWith(
+        (ref, latLng) =>
+            warningArea ?? Future.value(_mapItem(code: '100', name: '警報判定区域')),
+      ),
+      jmaMapAreaForecastLocalEInsideProvider.overrideWith(
+        (ref, latLng) =>
+            forecastAreaBuilder?.call() ??
+            forecastArea ??
+            Future.value(_mapItem(code: '200', name: '震度予報区域')),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Future<List<EewWarningOverlayCandidate>> _waitForCandidates(
+  ProviderContainer container,
+) async {
+  final completer = Completer<List<EewWarningOverlayCandidate>>();
+  final subscription = container.listen(eewWarningOverlayCandidatesProvider, (
+    _,
+    next,
+  ) {
+    if (!completer.isCompleted &&
+        next.isNotEmpty &&
+        next.first.localForecastRegion != null) {
+      completer.complete(next);
+    }
+  }, fireImmediately: true);
+  addTearDown(subscription.close);
+  return completer.future;
+}
+
+Future<List<EewWarningOverlayCandidate>> _candidatesFor({
+  bool realtime = true,
+  Future<bool>? enabled,
+  List<EewTelegramItem>? alive,
+  Stream<Position>? positions,
+  Future<MapDataItem?>? warningArea,
+  Future<MapDataItem?>? forecastArea,
+}) async {
+  final container = _container(
+    realtime: realtime,
+    enabled: enabled,
+    alive: alive,
+    positions: positions,
+    warningArea: warningArea,
+    forecastArea: forecastArea,
+  );
+  final subscription = container.listen(
+    eewWarningOverlayCandidatesProvider,
+    (_, _) {},
+  );
+  addTearDown(subscription.close);
+  for (var i = 0; i < 6; i++) {
+    await container.pump();
+  }
+  return container.read(eewWarningOverlayCandidatesProvider);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('LocalEewで対象判定しLocalEで現在地予想を引く', () async {
+    final container = _container(alive: [_warningEew()]);
+
+    final value = await _waitForCandidates(container);
+
+    expect(value, hasLength(1));
+    expect(value.single.warningAreaName, '警報判定区域');
+    expect(value.single.localForecastRegion?.intensity, JmaIntensity.sixUpper);
+  });
+
+  test('前提条件を満たさない警報を候補から除外する', () async {
+    expect(
+      await _candidatesFor(realtime: false, alive: [_warningEew()]),
+      isEmpty,
+    );
+    expect(
+      await _candidatesFor(
+        enabled: Future.value(false),
+        alive: [_warningEew()],
+      ),
+      isEmpty,
+    );
+    expect(await _candidatesFor(), isEmpty);
+    expect(
+      await _candidatesFor(
+        alive: [_warningEew()],
+        positions: const Stream.empty(),
+      ),
+      isEmpty,
+    );
+    expect(
+      await _candidatesFor(alive: [_warningEew()], warningArea: Future.value()),
+      isEmpty,
+    );
+    expect(
+      await _candidatesFor(
+        alive: [_warningEew()],
+        warningArea: Future.value(
+          _mapItem(code: '100', name: '警報判定区域', hasProperty: false),
+        ),
+      ),
+      isEmpty,
+    );
+    expect(
+      await _candidatesFor(alive: [_warningEew(isCanceled: true)]),
+      isEmpty,
+    );
+    expect(
+      await _candidatesFor(alive: [_warningEew(isWarning: false)]),
+      isEmpty,
+    );
+    expect(
+      await _candidatesFor(alive: [_warningEew(hadWarning: false)]),
+      isEmpty,
+    );
+  });
+
+  test('設定の未解決中は候補を返さない', () async {
+    expect(
+      await _candidatesFor(
+        enabled: Completer<bool>().future,
+        alive: [_warningEew()],
+      ),
+      isEmpty,
+    );
+  });
+
+  test('位置情報が解決済みからloadingまたはerrorになると候補を消す', () async {
+    final positions = StreamController<Position>.broadcast();
+    addTearDown(positions.close);
+    final container = _container(
+      alive: [_warningEew()],
+      positions: positions.stream,
+    );
+    final subscription = container.listen(
+      eewWarningOverlayCandidatesProvider,
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+
+    await container.pump();
+    await container.pump();
+    positions.add(_position());
+    for (var i = 0; i < 6; i++) {
+      await container.pump();
+    }
+    expect(container.read(eewWarningOverlayCandidatesProvider), hasLength(1));
+
+    container.invalidate(locationStreamProvider);
+    await container.pump();
+    expect(container.read(eewWarningOverlayCandidatesProvider), isEmpty);
+
+    positions.addError(StateError('location failed'));
+    await container.pump();
+    expect(container.read(eewWarningOverlayCandidatesProvider), isEmpty);
+  });
+
+  test('警報区域が解決済みからloadingまたはerrorになると候補を消す', () async {
+    var warningArea = Future<MapDataItem?>.value(
+      _mapItem(code: '100', name: '警報判定区域'),
+    );
+    final position = _position();
+    final latLng = LatLng(position.latitude, position.longitude);
+    final container = ProviderContainer(
+      overrides: [
+        isRealtimeModeProvider.overrideWithValue(true),
+        eewWarningOverlayEnabledProvider.overrideWith(
+          () => _StubEewWarningOverlayEnabled(Future.value(true)),
+        ),
+        eewAliveTelegramProvider.overrideWith(
+          () => _StubEewAliveTelegram([_warningEew()]),
+        ),
+        locationStreamProvider.overrideWith((ref) => Stream.value(position)),
+        jmaMapAreaForecastLocalEewInsideProvider.overrideWith(
+          (ref, latLng) => warningArea,
+        ),
+        jmaMapAreaForecastLocalEInsideProvider.overrideWith(
+          (ref, latLng) async => _mapItem(code: '200', name: '震度予報区域'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      eewWarningOverlayCandidatesProvider,
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+    for (var i = 0; i < 6; i++) {
+      await container.pump();
+    }
+    expect(container.read(eewWarningOverlayCandidatesProvider), hasLength(1));
+
+    warningArea = Completer<MapDataItem?>().future;
+    container.invalidate(jmaMapAreaForecastLocalEewInsideProvider(latLng));
+    await container.pump();
+    expect(container.read(eewWarningOverlayCandidatesProvider), isEmpty);
+
+    final errorArea = Completer<MapDataItem?>();
+    warningArea = errorArea.future;
+    container.invalidate(jmaMapAreaForecastLocalEewInsideProvider(latLng));
+    await container.pump();
+    errorArea.completeError(StateError('area failed'));
+    await container.pump();
+    expect(container.read(eewWarningOverlayCandidatesProvider), isEmpty);
+  });
+
+  test('予報区域がloadingまたはerrorでも候補を残し局地情報を不明にする', () async {
+    var forecastArea = Future<MapDataItem?>.value(
+      _mapItem(code: '200', name: '震度予報区域'),
+    );
+    final position = _position();
+    final latLng = LatLng(position.latitude, position.longitude);
+    final container = _container(
+      alive: [_warningEew()],
+      positions: Stream.value(position),
+      forecastAreaBuilder: () => forecastArea,
+    );
+    final subscription = container.listen(
+      eewWarningOverlayCandidatesProvider,
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+    final initial = await _waitForCandidates(container);
+    expect(
+      initial.single.localForecastRegion,
+      isNotNull,
+    );
+
+    forecastArea = Completer<MapDataItem?>().future;
+    container.invalidate(jmaMapAreaForecastLocalEInsideProvider(latLng));
+    await container.pump();
+    var value = container.read(eewWarningOverlayCandidatesProvider);
+    expect(value, hasLength(1));
+    expect(value.single.localForecastRegion, isNull);
+    expect(value.single.forecastAreaName, isNull);
+
+    final errorArea = Completer<MapDataItem?>();
+    forecastArea = errorArea.future;
+    container.invalidate(jmaMapAreaForecastLocalEInsideProvider(latLng));
+    await container.pump();
+    errorArea.completeError(StateError('forecast area failed'));
+    await container.pump();
+    value = container.read(eewWarningOverlayCandidatesProvider);
+    expect(value, hasLength(1));
+    expect(value.single.localForecastRegion, isNull);
+    expect(value.single.forecastAreaName, isNull);
+  });
+}

--- a/app/test/feature/eew/data/provider/eew_warning_overlay_display_provider_test.dart
+++ b/app/test/feature/eew/data/provider/eew_warning_overlay_display_provider_test.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_info_type.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/core/provider/time_ticker.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_telegram_item.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_candidate.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_candidate_provider.dart';
+import 'package:eqmonitor/feature/eew/data/provider/eew_warning_overlay_display_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+EewWarningOverlayCandidate _candidate() => EewWarningOverlayCandidate(
+  event: EewTelegramItem(
+    eventId: 'event',
+    status: TelegramStatus.normal,
+    infoType: TelegramInfoType.publication,
+    serialNo: 1,
+    isCanceled: false,
+    isLastInfo: false,
+    reportTime: DateTime.utc(2026, 7, 25, 11, 59),
+    isPlum: false,
+    isWarning: true,
+    warning: const EewWarningInfo(zones: [], prefectures: [], regions: []),
+  ),
+  warningAreaCode: '100',
+  warningAreaName: '警報判定区域',
+  forecastAreaName: '震度予報区域',
+  localForecastRegion: EewForecastRegionInfo(
+    code: '200',
+    name: '震度予報区域',
+    isPlum: false,
+    isWarning: true,
+    intensity: JmaIntensity.sixUpper,
+    intensityIsOver: false,
+    arrivalTime: DateTime.utc(2026, 7, 25, 12, 0, 10),
+  ),
+);
+
+void main() {
+  test('ticker更新で到達秒数と代表を再計算する', () async {
+    final ticker = StreamController<DateTime>.broadcast();
+    addTearDown(ticker.close);
+    final container = ProviderContainer(
+      overrides: [
+        eewWarningOverlayCandidatesProvider.overrideWithValue([_candidate()]),
+        timeTickerProvider().overrideWith((ref) => ticker.stream),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      eewWarningOverlayDisplayProvider,
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+
+    ticker.add(DateTime.utc(2026, 7, 25, 12));
+    await container.pump();
+    expect(
+      container.read(eewWarningOverlayDisplayProvider)?.secondsUntilArrival,
+      10,
+    );
+
+    ticker.add(DateTime.utc(2026, 7, 25, 12, 0, 10));
+    await container.pump();
+    expect(
+      container.read(eewWarningOverlayDisplayProvider)?.arrivalState,
+      EewWarningArrivalState.arrived,
+    );
+  });
+
+  test('候補が空なら表示しない', () {
+    final container = ProviderContainer(
+      overrides: [
+        eewWarningOverlayCandidatesProvider.overrideWithValue(const []),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(eewWarningOverlayDisplayProvider), isNull);
+  });
+}

--- a/app/test/feature/eew/data/service/eew_warning_overlay_vibration_service_test.dart
+++ b/app/test/feature/eew/data/service/eew_warning_overlay_vibration_service_test.dart
@@ -1,0 +1,166 @@
+import 'package:eqmonitor/feature/eew/data/service/eew_warning_overlay_vibration_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+
+void main() {
+  test('custom vibration starts the finite requested pulse pattern', () async {
+    final gateway = _FakeVibrationGateway(
+      hasVibratorResult: true,
+      hasCustomVibrationsSupportResult: true,
+    );
+    final service = EewWarningOverlayVibrationService(
+      gateway: gateway,
+      talker: Talker(),
+    );
+
+    await service.start();
+
+    expect(gateway.pattern, eewWarningOverlayVibrationPattern);
+    expect(gateway.vibrateCalls, 1);
+    expect(gateway.vibrateOnceCalls, 0);
+    expect(eewWarningOverlayVibrationPattern, const <int>[
+      0,
+      700,
+      300,
+      700,
+      300,
+      700,
+      300,
+      700,
+      300,
+      700,
+      300,
+      700,
+      300,
+      700,
+      300,
+      700,
+      300,
+      700,
+      300,
+      700,
+    ]);
+    expect(eewWarningOverlayVibrationPattern.reduce((a, b) => a + b), 9700);
+  });
+
+  test(
+    'device without custom support uses one finite fallback pulse',
+    () async {
+      final gateway = _FakeVibrationGateway(
+        hasVibratorResult: true,
+        hasCustomVibrationsSupportResult: false,
+      );
+
+      await EewWarningOverlayVibrationService(
+        gateway: gateway,
+        talker: Talker(),
+      ).start();
+
+      expect(gateway.vibrateCalls, 0);
+      expect(gateway.vibrateOnceCalls, 1);
+      expect(gateway.durationMs, 700);
+    },
+  );
+
+  test('unsupported device is ignored', () async {
+    final gateway = _FakeVibrationGateway(hasVibratorResult: false);
+
+    await EewWarningOverlayVibrationService(
+      gateway: gateway,
+      talker: Talker(),
+    ).start();
+
+    expect(gateway.vibrateCalls, 0);
+    expect(gateway.vibrateOnceCalls, 0);
+  });
+
+  test('plugin errors from start and cancel do not escape', () async {
+    final gateway = _FakeVibrationGateway(
+      hasVibratorResult: true,
+      error: StateError('disabled'),
+    );
+    final service = EewWarningOverlayVibrationService(
+      gateway: gateway,
+      talker: Talker(),
+    );
+
+    await expectLater(service.start(), completes);
+    await expectLater(service.cancel(), completes);
+  });
+
+  test('cancel delegates to the gateway', () async {
+    final gateway = _FakeVibrationGateway(hasVibratorResult: true);
+
+    await EewWarningOverlayVibrationService(
+      gateway: gateway,
+      talker: Talker(),
+    ).cancel();
+
+    expect(gateway.cancelCalls, 1);
+  });
+}
+
+final class _FakeVibrationGateway implements EewWarningOverlayVibrationGateway {
+  _FakeVibrationGateway({
+    required this.hasVibratorResult,
+    this.hasCustomVibrationsSupportResult = false,
+    this.error,
+  });
+
+  final bool hasVibratorResult;
+  final bool hasCustomVibrationsSupportResult;
+  final Object? error;
+
+  int vibrateCalls = 0;
+  int vibrateOnceCalls = 0;
+  int cancelCalls = 0;
+  List<int>? pattern;
+  int? durationMs;
+
+  @override
+  Future<bool> hasCustomVibrationsSupport() async {
+    final configuredError = error;
+    if (configuredError != null) {
+      throw configuredError;
+    }
+    return hasCustomVibrationsSupportResult;
+  }
+
+  @override
+  Future<bool> hasVibrator() async {
+    final configuredError = error;
+    if (configuredError != null) {
+      throw configuredError;
+    }
+    return hasVibratorResult;
+  }
+
+  @override
+  Future<void> vibrate({required List<int> pattern}) async {
+    final configuredError = error;
+    if (configuredError != null) {
+      throw configuredError;
+    }
+    vibrateCalls += 1;
+    this.pattern = pattern;
+  }
+
+  @override
+  Future<void> vibrateOnce({required int durationMs}) async {
+    final configuredError = error;
+    if (configuredError != null) {
+      throw configuredError;
+    }
+    vibrateOnceCalls += 1;
+    this.durationMs = durationMs;
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls += 1;
+    final configuredError = error;
+    if (configuredError != null) {
+      throw configuredError;
+    }
+  }
+}

--- a/app/test/feature/eew/data/service/eew_warning_overlay_vibration_service_test.dart
+++ b/app/test/feature/eew/data/service/eew_warning_overlay_vibration_service_test.dart
@@ -13,8 +13,9 @@ void main() {
       talker: Talker(),
     );
 
-    await service.start();
+    final started = await service.start();
 
+    expect(started, isTrue);
     expect(gateway.pattern, eewWarningOverlayVibrationPattern);
     expect(gateway.vibrateCalls, 1);
     expect(gateway.vibrateOnceCalls, 0);
@@ -51,11 +52,12 @@ void main() {
         hasCustomVibrationsSupportResult: false,
       );
 
-      await EewWarningOverlayVibrationService(
+      final started = await EewWarningOverlayVibrationService(
         gateway: gateway,
         talker: Talker(),
       ).start();
 
+      expect(started, isTrue);
       expect(gateway.vibrateCalls, 0);
       expect(gateway.vibrateOnceCalls, 1);
       expect(gateway.durationMs, 700);
@@ -65,11 +67,12 @@ void main() {
   test('unsupported device is ignored', () async {
     final gateway = _FakeVibrationGateway(hasVibratorResult: false);
 
-    await EewWarningOverlayVibrationService(
+    final started = await EewWarningOverlayVibrationService(
       gateway: gateway,
       talker: Talker(),
     ).start();
 
+    expect(started, isFalse);
     expect(gateway.vibrateCalls, 0);
     expect(gateway.vibrateOnceCalls, 0);
   });
@@ -84,7 +87,7 @@ void main() {
       talker: Talker(),
     );
 
-    await expectLater(service.start(), completes);
+    expect(await service.start(), isFalse);
     await expectLater(service.cancel(), completes);
   });
 

--- a/app/test/feature/eew/ui/controller/eew_warning_overlay_back_dispatcher_controller_test.dart
+++ b/app/test/feature/eew/ui/controller/eew_warning_overlay_back_dispatcher_controller_test.dart
@@ -1,0 +1,94 @@
+import 'package:eqmonitor/feature/eew/ui/controller/eew_warning_overlay_back_dispatcher_controller.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('fullscreen back is handled after minimizing the overlay', () async {
+    final parent = _FakeBackButtonDispatcher();
+    var delegatedCalls = 0;
+    parent.addCallback(() async {
+      delegatedCalls += 1;
+      return false;
+    });
+    var minimizeCalls = 0;
+    final controller = EewWarningOverlayBackDispatcherController(
+      parent: parent,
+      onFullscreenBack: () async {
+        minimizeCalls += 1;
+      },
+    )..update(shouldIntercept: true);
+    addTearDown(controller.dispose);
+
+    controller.attach();
+
+    expect(await parent.invokeCallback(Future.value(false)), isTrue);
+    expect(minimizeCalls, 1);
+    expect(delegatedCalls, 0);
+  });
+
+  test('non-fullscreen back delegates to the router dispatcher', () async {
+    final parent = _FakeBackButtonDispatcher();
+    var delegatedCalls = 0;
+    parent.addCallback(() async {
+      delegatedCalls += 1;
+      return false;
+    });
+    var minimizeCalls = 0;
+    final controller = EewWarningOverlayBackDispatcherController(
+      parent: parent,
+      onFullscreenBack: () async {
+        minimizeCalls += 1;
+      },
+    )..attach();
+    addTearDown(controller.dispose);
+
+    controller
+      ..update(shouldIntercept: true)
+      ..update(shouldIntercept: false);
+
+    expect(await parent.invokeCallback(Future.value(false)), isFalse);
+    expect(minimizeCalls, 0);
+    expect(delegatedCalls, 1);
+  });
+
+  test('dispose releases the old router when dispatcher changes', () async {
+    final oldParent = _FakeBackButtonDispatcher();
+    var oldDelegatedCalls = 0;
+    oldParent.addCallback(() async {
+      oldDelegatedCalls += 1;
+      return false;
+    });
+    var minimizeCalls = 0;
+    final oldController =
+        EewWarningOverlayBackDispatcherController(
+            parent: oldParent,
+            onFullscreenBack: () async {
+              minimizeCalls += 1;
+            },
+          )
+          ..attach()
+          ..update(shouldIntercept: true);
+
+    oldController.dispose();
+
+    final newParent = _FakeBackButtonDispatcher()
+      ..addCallback(() async => false);
+    final newController =
+        EewWarningOverlayBackDispatcherController(
+            parent: newParent,
+            onFullscreenBack: () async {
+              minimizeCalls += 1;
+            },
+          )
+          ..attach()
+          ..update(shouldIntercept: true);
+    addTearDown(newController.dispose);
+
+    expect(await oldParent.invokeCallback(Future.value(false)), isFalse);
+    expect(oldDelegatedCalls, 1);
+    expect(await newParent.invokeCallback(Future.value(false)), isTrue);
+    expect(minimizeCalls, 1);
+  });
+}
+
+class _FakeBackButtonDispatcher extends BackButtonDispatcher {}

--- a/app/test/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter_test.dart
+++ b/app/test/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter_test.dart
@@ -1,0 +1,39 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_arrival_formatter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('arrival text distinguishes future, arrived, and unknown', () {
+    expect(
+      formatEewWarningOverlayArrival(
+        state: EewWarningArrivalState.unarrived,
+        secondsUntilArrival: 10,
+      ),
+      'あと約10秒',
+    );
+    expect(
+      formatEewWarningOverlayArrival(
+        state: EewWarningArrivalState.arrived,
+        secondsUntilArrival: null,
+      ),
+      '到達と推定',
+    );
+    expect(
+      formatEewWarningOverlayArrival(
+        state: EewWarningArrivalState.unknown,
+        secondsUntilArrival: null,
+      ),
+      isNull,
+    );
+  });
+
+  test('unarrived without remaining seconds stays unknown', () {
+    expect(
+      formatEewWarningOverlayArrival(
+        state: EewWarningArrivalState.unarrived,
+        secondsUntilArrival: null,
+      ),
+      isNull,
+    );
+  });
+}

--- a/app/test/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter_test.dart
+++ b/app/test/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter_test.dart
@@ -1,0 +1,88 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('formats split JMA intensities with Japanese suffixes', () {
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.fiveLower,
+        isOver: false,
+      ),
+      '5弱',
+    );
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.fiveUpper,
+        isOver: false,
+      ),
+      '5強',
+    );
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.sixLower,
+        isOver: false,
+      ),
+      '6弱',
+    );
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.sixUpper,
+        isOver: false,
+      ),
+      '6強',
+    );
+  });
+
+  test('formats unknown and over values without duplicated qualifiers', () {
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.unknown,
+        isOver: true,
+      ),
+      '不明',
+    );
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.fiveUnknown,
+        isOver: true,
+      ),
+      '5弱以上',
+    );
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.sixLower,
+        isOver: true,
+      ),
+      '6弱以上',
+    );
+  });
+
+  test('fixed simulation intensity copy is 6弱', () {
+    expect(
+      formatEewWarningOverlayIntensity(
+        intensity: JmaIntensity.sixLower,
+        isOver: false,
+      ),
+      '6弱',
+    );
+  });
+
+  test('banner label keeps simulation identity', () {
+    expect(
+      formatEewWarningOverlayBannerLabel(
+        source: EewWarningOverlaySource.simulation,
+        reportLabel: '訓練／シミュレーション',
+      ),
+      '訓練／シミュレーション',
+    );
+    expect(
+      formatEewWarningOverlayBannerLabel(
+        source: EewWarningOverlaySource.real,
+        reportLabel: '緊急地震速報（警報） 第3報',
+      ),
+      '緊急地震速報（警報）',
+    );
+  });
+}

--- a/app/test/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter_test.dart
+++ b/app/test/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter_test.dart
@@ -1,6 +1,7 @@
 import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
 import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_intensity_formatter.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_label_formatter.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/app/test/feature/eew/ui/formatter/eew_warning_overlay_label_formatter_test.dart
+++ b/app/test/feature/eew/ui/formatter/eew_warning_overlay_label_formatter_test.dart
@@ -1,0 +1,20 @@
+import 'package:eqmonitor/feature/eew/data/model/eew_warning_overlay_display_model.dart';
+import 'package:eqmonitor/feature/eew/ui/formatter/eew_warning_overlay_label_formatter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('fullscreen semantics identifies real and simulation sources', () {
+    expect(
+      formatEewWarningOverlaySemanticsLabel(
+        source: EewWarningOverlaySource.real,
+      ),
+      '緊急地震速報警報',
+    );
+    expect(
+      formatEewWarningOverlaySemanticsLabel(
+        source: EewWarningOverlaySource.simulation,
+      ),
+      '訓練／シミュレーションの緊急地震速報',
+    );
+  });
+}

--- a/docs/knowledge/20260725_eew_warning_overlay_vibration.md
+++ b/docs/knowledge/20260725_eew_warning_overlay_vibration.md
@@ -1,0 +1,27 @@
+# EEW警報overlayの端末振動
+
+## 実装上の前提
+
+- Android は `app/android/app/src/main/AndroidManifest.xml` に
+  `android.permission.VIBRATE` が既に宣言されている。重複追加しない。
+- iOS の端末振動には `Info.plist` の usage description は不要である。
+- OS設定、端末能力、plugin呼び出しの失敗で振動できなくても、警報UIの表示は
+  継続する。振動serviceは例外をtalkerへ記録し、呼び出し元へ送出しない。
+- custom pattern対応端末では、700msの振動を10回、間に300msの停止を9回入れる。
+  patternは9700msで有限に終了させ、停止処理の失敗時も無期限に振動させない。
+- custom pattern非対応端末では700msの振動を1回だけ実行する。
+
+## 実機確認
+
+接続端末を確認し、アプリを実機起動する。
+
+```bash
+cd app
+mise exec -- flutter devices
+mise exec -- flutter run -d <device-id>
+```
+
+設定画面のEEW警報overlayシミュレーションを開始し、振動開始を確認する。
+全画面の閉じる操作、手動最小化、10秒経過、アプリのbackground移行の各操作で
+振動が停止することも確認する。iOS Simulatorなど振動非対応環境では、UIが継続し
+talkerに失敗が記録されてもアプリが終了しないことを確認する。

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2515,6 +2515,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  vibration:
+    dependency: transitive
+    description:
+      name: vibration
+      sha256: c6c25eb7acadfd231925a60004736443cbf63f1eb5740d6dd83a1bc09cf00f6d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  vibration_platform_interface:
+    dependency: transitive
+    description:
+      name: vibration_platform_interface
+      sha256: "258c273268f8aa40c88d29741137c536874a738779b92ddb8aa32ed093721ec5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   video_player:
     dependency: transitive
     description:


### PR DESCRIPTION
## 概要

アプリ使用中に現在地が緊急地震速報（警報）の対象になった場合、全画面overlayと有限のバイブレーションで通知する仕組みを追加します。

## 変更内容

- 現在地のLocalEew警報対象判定と、LocalEによる予想震度・主要動到達情報の関連付け
- 複数の有効な警報から「主要動未到達、不明、到達済み」「予想震度」「発表時刻」の順で代表表示を選択
- 新規eventIdの全画面表示、10秒後の最小化、手動最小化・閉じる・再展開
- 同一eventIdの再通知抑止と、複数eventIdをまとめて閉じる状態制御
- foreground限定の表示、background遷移時の振動・timer停止、復帰時の未処理eventId判定
- 700ms振動と300ms停止を組み合わせた有限9700msパターンと、非対応端末・plugin例外の安全な処理
- SafeArea外まで続く赤黒ストライプ、全画面表示、最小化バナー、訓練表示とaccessibility対応
- 既定有効の設定toggleと、設定無効時にも利用できる固定simulation
- Android backによる全画面からの最小化

## 影響

- OS通知やbackground overlay、音声、安全行動案内は追加しません。
- 実警報はアプリがforegroundかつrealtimeで、現在地が警報対象の場合だけ表示します。
- `vibration 3.2.0`を追加します。Androidの`VIBRATE`権限は既存宣言を利用します。

## 検証

- `mise exec -- flutter test test/feature/eew` — 117 tests passed
- `mise exec -- flutter test test/feature/settings/features/notification_settings/notification_preset_notifier_test.dart` — 2 tests passed
- 設定済みanalyzer pluginを有効にした計画対象の`dart analyze` — No issues found
- `git diff --check 5d04581f8..HEAD` — passed
- subagentによるtask別レビューとPlan 1 / Plan 2横断レビュー — findingsなし

ユーザー指定によりWidget testは追加していません。Android/iOS端末・SDKがこの実行環境にないため、SafeArea、200% text scale、画面回転、back gesture、物理振動の実機受け入れ確認は未実施です。
