### PR TITLE
fix: resolve realtime discriminator refs

### DIFF
--- a/packages/eqmonitor_api/bin/generate.dart
+++ b/packages/eqmonitor_api/bin/generate.dart
@@ -305,11 +305,16 @@ void _generateRealtimeEventEnvelope({
         final type = _singleEnumValue(
           properties[discriminatorKey],
           '$schemaName.$discriminatorKey',
+          schemas,
         );
         final operationValue = properties['operation'];
         final operation = operationValue == null
             ? null
-            : _singleEnumValue(operationValue, '$schemaName.operation');
+            : _singleEnumValue(
+                operationValue,
+                '$schemaName.operation',
+                schemas,
+              );
         return (
           schemaName: schemaName,
           type: type,
@@ -402,11 +407,30 @@ void _generateRealtimeEventEnvelope({
   stdout.writeln('  generated: ${output.path}');
 }
 
-String _singleEnumValue(Object? value, String path) {
-  if (value is! Map<String, dynamic>) {
+String _singleEnumValue(
+  Object? value,
+  String path,
+  Map<String, dynamic> schemas,
+) {
+  var resolved = value;
+  final visitedRefs = <String>{};
+  while (resolved is Map<String, dynamic>) {
+    final ref = resolved[r'$ref'];
+    if (ref is! String) {
+      break;
+    }
+    const componentPrefix = '#/components/schemas/';
+    if (!ref.startsWith(componentPrefix) || !visitedRefs.add(ref)) {
+      throw FormatException(
+        'Realtime discriminator reference is invalid: $path',
+      );
+    }
+    resolved = schemas[ref.substring(componentPrefix.length)];
+  }
+  if (resolved is! Map<String, dynamic>) {
     throw FormatException('Realtime discriminator property is invalid: $path');
   }
-  final enumValues = value['enum'];
+  final enumValues = resolved['enum'];
   if (enumValues is! List ||
       enumValues.length != 1 ||
       enumValues.single is! String) {


### PR DESCRIPTION
## Summary

- resolve local OpenAPI component refs when reading realtime `type` and `operation` discriminator values
- detect invalid or cyclic discriminator refs
- preserve support for the existing inline enum representation

## Why

The backend now gives each realtime discriminator field an explicit component ref so generated Dart types use stable names such as `RealtimeTsunamiDeletePayloadType` instead of positional names such as `Type4`.

## Validation

Validated together with the backend OpenAPI change using the full `packages/eqmonitor_api/bin/generate.dart` flow:

- `swagger_parser` completed successfully
- realtime dispatcher generation completed successfully
- generated payload fields use the explicit realtime discriminator type names
- no `Type2`–`Type5` or `Operation2` model files
- remaining dynamic detection: 0
- `dart format --output=none --set-exit-if-changed packages/eqmonitor_api/bin/generate.dart`
- `git diff --check`

No new tests were added, per request.