### PR TITLE
fix: private Asset Pack Release の認証付きダウンロード

### DIFF
--- a/.github/workflows/upload-asset-pack.yaml
+++ b/.github/workflows/upload-asset-pack.yaml
@@ -79,6 +79,20 @@ jobs:
         with:
           persist-credentials: false
 
+      # private な YumNumm/eqmonitor-backend Release から zip を取るため。
+      # 無認証 curl は 404 になる（browser_download_url でも private は要認証）。
+      # https://github.com/actions/create-github-app-token
+      - name: Generate GitHub App token (eqmonitor-backend contents:read)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.EQMONITOR_GITHUB_APP_ID }}
+          private-key: ${{ secrets.EQMONITOR_GITHUB_APP_PRIVATE_KEY }}
+          owner: YumNumm
+          repositories: |
+            eqmonitor-backend
+          permission-contents: read
+
       - name: Resolve trigger inputs
         id: resolve-inputs
         env:
@@ -112,8 +126,27 @@ jobs:
 
       - name: Download Asset Pack zip
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PACK_VERSION: ${{ steps.resolve-inputs.outputs.pack_version }}
           ARTIFACT_URL: ${{ steps.resolve-inputs.outputs.artifact_url }}
-        run: curl -fL --retry 3 -o asset-pack.zip "$ARTIFACT_URL"
+        run: |
+          set -euo pipefail
+          # Release tag / 資産名は backend の release-asset-pack.yaml と揃える。
+          # artifact_url は検証・フォールバック用に残す（タグ取得が失敗した場合）。
+          if gh release download "asset-pack-v${PACK_VERSION}" \
+            --repo YumNumm/eqmonitor-backend \
+            --pattern "asset-pack-v${PACK_VERSION}.zip" \
+            --output asset-pack.zip; then
+            echo "downloaded via gh release download (asset-pack-v${PACK_VERSION})"
+          else
+            echo "::warning::gh release download failed; falling back to authenticated curl on artifact_url"
+            curl -fL --retry 3 \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/octet-stream" \
+              -o asset-pack.zip \
+              "$ARTIFACT_URL"
+          fi
+          test -s asset-pack.zip
 
       - name: Verify checksum, unpack, and assert layout
         env:

--- a/docs/asset-pack-cd.md
+++ b/docs/asset-pack-cd.md
@@ -15,11 +15,18 @@ workflow can also be run manually via `workflow_dispatch` with the same
 `pack_version` / `artifact_url` / `sha256` (no `manifest_url` input — the
 manifest is read from inside the downloaded zip, not fetched separately).
 
+**Private Release download:** `eqmonitor-backend` is private, so the zip must
+be fetched with authentication. `download-and-verify` issues a GitHub App
+token (`vars.EQMONITOR_GITHUB_APP_ID` / `secrets.EQMONITOR_GITHUB_APP_PRIVATE_KEY`,
+`repositories: eqmonitor-backend`, `permission-contents: read` — same App as
+integration tests) and uses `gh release download`. Unauthenticated `curl` of
+`artifact_url` returns 404.
+
 ## What the workflow automates today
 
 | Stage | Automated? | Notes |
 |---|---|---|
-| Download + sha256 verify + structure assert + `pack_version` match | Yes | `tool/asset_pack/verify_zip.sh`, shared by all three downstream jobs via an uploaded artifact |
+| Download + sha256 verify + structure assert + `pack_version` match | Yes | GitHub App token（`eqmonitor-backend` `contents:read`）で private Release を `gh release download`（失敗時は認証付き curl）。`tool/asset_pack/verify_zip.sh` で検証し、3 ジョブ共通 Artifact へ |
 | macOS native bundling sync (`app/assets/platform/`) | Yes, via PR | Replaces the directory's contents with the pack's `manifest.json` / `map/all.pmtiles` / `parameters/*.json` |
 | macOS Xcode folder-reference registration check | Check only, no auto-fix | Fails loudly until a separate task registers `app/assets/platform` as a Bundle Resources folder reference in `app/macos/Runner.xcodeproj` |
 | Android Play Asset Delivery module sync (`app/android/assetpacks/eqmonitor_assets/src/main/assets/`) | Yes, via PR | Requires the module to already exist (a separate task creates `app/android/assetpacks/eqmonitor_assets/`); fails loudly (`test -d` guard) until it does |


### PR DESCRIPTION
## Summary
- `upload-asset-pack.yaml` の Download が private な `eqmonitor-backend` Release に対して無認証 `curl` していたため 404 で失敗していた
- Integration Test と同様に GitHub App トークン（`eqmonitor-backend` `contents:read`）を発行し、`gh release download`（失敗時は認証付き curl）で取得するよう修正
- `docs/asset-pack-cd.md` に前提を追記

## Test plan
- [ ] Actions で `Upload Asset Pack` を `workflow_dispatch` 再実行（`pack_version=0.0.0` 等、既存 Release）
- [ ] `Download & verify Asset Pack` が zip 取得・sha256 検証まで成功すること
- [ ] iOS ジョブは ASC 初回セットアップ未完了なら `check-exists` で意図どおり失敗してよい（本 PR の範囲外）