### PR TITLE
feat: 設定画面に Asset Pack バージョン表示と Asset Pack デバッグ画面を追加

### DIFF
--- a/app/lib/core/router/router.dart
+++ b/app/lib/core/router/router.dart
@@ -44,6 +44,7 @@ import 'package:eqmonitor/feature/settings/children/application_info/privacy_pol
 import 'package:eqmonitor/feature/settings/children/application_info/term_of_service_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/api_endpoint_selector/http_api_endpoint_selector_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/app_group/debug_app_group_page.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/asset_pack/asset_pack_debug_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/debug_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/device/debug_device_admin_page.dart';
 import 'package:eqmonitor/feature/settings/children/config/debug/earthquake_history/debug_earthquake_history_card_page.dart';
@@ -386,6 +387,7 @@ class TalkerRoute extends GoRouteData with $TalkerRoute {
         TypedGoRoute<DebugDeviceSettingsRoute>(path: 'device-settings'),
         TypedGoRoute<DebugNavigationRoute>(path: 'navigation'),
         TypedGoRoute<DebugAppGroupRoute>(path: 'app-group'),
+        TypedGoRoute<AssetPackDebugRoute>(path: 'asset-pack'),
         TypedGoRoute<DebugSharedPreferencesRoute>(path: 'shared-preferences'),
         TypedGoRoute<DebugSecureStorageRoute>(path: 'secure-storage'),
         TypedGoRoute<DebugHttpCacheRoute>(path: 'http-cache'),
@@ -712,6 +714,15 @@ class DebugAppGroupRoute extends GoRouteData with $DebugAppGroupRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const DebugAppGroupPage();
+  }
+}
+
+class AssetPackDebugRoute extends GoRouteData with $AssetPackDebugRoute {
+  const AssetPackDebugRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const AssetPackDebugPage();
   }
 }
 

--- a/app/lib/core/router/router.g.dart
+++ b/app/lib/core/router/router.g.dart
@@ -643,6 +643,10 @@ RouteBase get $settingsRoute => GoRouteData.$route(
           factory: $DebugAppGroupRoute._fromState,
         ),
         GoRouteData.$route(
+          path: 'asset-pack',
+          factory: $AssetPackDebugRoute._fromState,
+        ),
+        GoRouteData.$route(
           path: 'shared-preferences',
           factory: $DebugSharedPreferencesRoute._fromState,
         ),
@@ -1415,6 +1419,27 @@ mixin $DebugAppGroupRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/settings/debug/app-group');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $AssetPackDebugRoute on GoRouteData {
+  static AssetPackDebugRoute _fromState(GoRouterState state) =>
+      const AssetPackDebugRoute();
+
+  @override
+  String get location => GoRouteData.$location('/settings/debug/asset-pack');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/app/lib/feature/asset_pack/data/notifier/asset_pack_manifest_provider.dart
+++ b/app/lib/feature/asset_pack/data/notifier/asset_pack_manifest_provider.dart
@@ -1,0 +1,17 @@
+import 'package:eqmonitor/feature/asset_pack/data/model/asset_pack_manifest.dart';
+import 'package:eqmonitor/feature/asset_pack/data/repository/asset_pack_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'asset_pack_manifest_provider.g.dart';
+
+/// Reads the Asset Pack `manifest.json` via [AssetPackRepository].
+///
+/// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when
+/// the pack is not downloaded yet or is missing/corrupt — callers such as the
+/// settings footer should treat that as an informational "未取得" state rather
+/// than a hard error.
+@riverpod
+Future<AssetPackManifest> assetPackManifest(Ref ref) async {
+  final repository = ref.watch(assetPackRepositoryProvider);
+  return repository.readManifest();
+}

--- a/app/lib/feature/asset_pack/data/notifier/asset_pack_manifest_provider.g.dart
+++ b/app/lib/feature/asset_pack/data/notifier/asset_pack_manifest_provider.g.dart
@@ -1,0 +1,72 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'asset_pack_manifest_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Reads the Asset Pack `manifest.json` via [AssetPackRepository].
+///
+/// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when
+/// the pack is not downloaded yet or is missing/corrupt — callers such as the
+/// settings footer should treat that as an informational "未取得" state rather
+/// than a hard error.
+
+@ProviderFor(assetPackManifest)
+final assetPackManifestProvider = AssetPackManifestProvider._();
+
+/// Reads the Asset Pack `manifest.json` via [AssetPackRepository].
+///
+/// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when
+/// the pack is not downloaded yet or is missing/corrupt — callers such as the
+/// settings footer should treat that as an informational "未取得" state rather
+/// than a hard error.
+
+final class AssetPackManifestProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AssetPackManifest>,
+          AssetPackManifest,
+          FutureOr<AssetPackManifest>
+        >
+    with
+        $FutureModifier<AssetPackManifest>,
+        $FutureProvider<AssetPackManifest> {
+  /// Reads the Asset Pack `manifest.json` via [AssetPackRepository].
+  ///
+  /// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when
+  /// the pack is not downloaded yet or is missing/corrupt — callers such as the
+  /// settings footer should treat that as an informational "未取得" state rather
+  /// than a hard error.
+  AssetPackManifestProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'assetPackManifestProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$assetPackManifestHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<AssetPackManifest> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<AssetPackManifest> create(Ref ref) {
+    return assetPackManifest(ref);
+  }
+}
+
+String _$assetPackManifestHash() => r'88fbb99e869be3f9ddf568374bcea80cd097f00d';

--- a/app/lib/feature/settings/children/config/debug/asset_pack/asset_pack_debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/asset_pack/asset_pack_debug_page.dart
@@ -1,0 +1,202 @@
+import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
+import 'package:eqmonitor/core/gen/fonts.gen.dart';
+import 'package:eqmonitor/core/util/byte_size_formatter.dart';
+import 'package:eqmonitor/feature/asset_pack/data/repository/asset_pack_repository.dart';
+import 'package:eqmonitor/feature/settings/children/config/debug/asset_pack/asset_pack_debug_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class AssetPackDebugPage extends ConsumerWidget {
+  const AssetPackDebugPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final infoAsync = ref.watch(assetPackDebugInfoProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Asset Pack'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: '再読込',
+            onPressed: () =>
+                ref.invalidate(assetPackDebugInfoProvider),
+          ),
+        ],
+      ),
+      body: Theme(
+        data: Theme.of(context).copyWith(visualDensity: .compact),
+        child: ListTileTheme(
+          dense: true,
+          child: switch (infoAsync) {
+            AsyncLoading() => const Center(child: CircularProgressIndicator()),
+            AsyncError(:final error) => _NotReady(error: error),
+            AsyncData(:final value) => _AssetPackDebugContent(info: value),
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _NotReady extends StatelessWidget {
+  const _NotReady({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = error is AssetPackNotReadyException
+        ? (error as AssetPackNotReadyException).message
+        : error.toString();
+    return ListView(
+      children: [
+        const ListTile(
+          leading: Icon(Icons.download_for_offline_outlined),
+          title: Text('Asset Pack 未取得'),
+          subtitle: Text('Pack がダウンロードされていないか、破損しています'),
+        ),
+        ListTile(
+          title: const Text('詳細'),
+          subtitle: Text(
+            message,
+            style: const TextStyle(fontFamily: FontFamily.googleSansCode),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AssetPackDebugContent extends StatelessWidget {
+  const _AssetPackDebugContent({required this.info});
+
+  final AssetPackDebugInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    final manifest = info.manifest;
+    return ListView(
+      children: [
+        _CopyableTile(
+          leading: const Icon(Icons.inventory_2_outlined),
+          title: 'pack_version',
+          value: manifest.packVersion,
+        ),
+        _CopyableTile(
+          leading: const Icon(Icons.schema_outlined),
+          title: 'schema_version',
+          value: '${manifest.schemaVersion}',
+        ),
+        _CopyableTile(
+          leading: const Icon(Icons.schedule),
+          title: 'generated_at',
+          value: manifest.generatedAt,
+        ),
+        _CopyableTile(
+          leading: const Icon(Icons.folder_outlined),
+          title: 'pack root',
+          value: info.packRoot,
+        ),
+        const Divider(),
+        ListTile(
+          title: Text(
+            'Assets (${info.assets.length})',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+        ),
+        for (final status in info.assets) _AssetTile(status: status),
+      ],
+    );
+  }
+}
+
+class _AssetTile extends StatelessWidget {
+  const _AssetTile({required this.status});
+
+  final AssetPackAssetFileStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final item = status.item;
+    const formatter = ByteSizeFormatter();
+    final colorTheme = context.designSystem.colorTheme;
+
+    final String fileState;
+    final Color fileStateColor;
+    if (!status.exists) {
+      fileState = 'ファイルなし';
+      fileStateColor = colorTheme.error;
+    } else if (!status.sizeMatches) {
+      fileState =
+          'サイズ不一致 (期待 ${formatter.format(item.sizeBytes)} / '
+          '実際 ${formatter.format(status.actualSizeBytes ?? 0)})';
+      fileStateColor = colorTheme.error;
+    } else {
+      fileState = 'OK';
+      fileStateColor = colorTheme.onSurface.withValues(alpha: 0.7);
+    }
+
+    return ListTile(
+      isThreeLine: true,
+      leading: Icon(
+        status.exists && status.sizeMatches
+            ? Icons.check_circle_outline
+            : Icons.error_outline,
+        color: fileStateColor,
+      ),
+      title: Text(item.id.name),
+      subtitle: Text(
+        'path: ${item.path}\n'
+        'size: ${formatter.format(item.sizeBytes)} (${item.sizeBytes} B)  '
+        '[$fileState]\n'
+        'source_version: ${item.sourceVersion}  '
+        'updated: ${item.sourceUpdatedAt ?? '-'}\n'
+        'sha256: ${item.sha256.substring(0, 16)}…',
+        style: const TextStyle(fontFamily: FontFamily.googleSansCode),
+      ),
+      onLongPress: () async {
+        await Clipboard.setData(ClipboardData(text: item.sha256));
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('${item.id.name} の sha256 をコピーしました')),
+          );
+        }
+      },
+    );
+  }
+}
+
+class _CopyableTile extends StatelessWidget {
+  const _CopyableTile({
+    required this.title,
+    required this.value,
+    this.leading,
+  });
+
+  final String title;
+  final String value;
+  final Widget? leading;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: leading,
+      title: Text(title),
+      subtitle: Text(
+        value,
+        style: const TextStyle(fontFamily: FontFamily.googleSansCode),
+      ),
+      onTap: () async {
+        await Clipboard.setData(ClipboardData(text: value));
+        if (context.mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('$title をコピーしました')));
+        }
+      },
+    );
+  }
+}

--- a/app/lib/feature/settings/children/config/debug/asset_pack/asset_pack_debug_provider.dart
+++ b/app/lib/feature/settings/children/config/debug/asset_pack/asset_pack_debug_provider.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:assets_util/assets_util.dart';
+import 'package:eqmonitor/feature/asset_pack/data/model/asset_pack_manifest.dart';
+import 'package:eqmonitor/feature/asset_pack/data/repository/asset_pack_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'asset_pack_debug_provider.g.dart';
+
+/// On-device status of a single Asset Pack asset, comparing the manifest entry
+/// against the actual file on disk.
+class AssetPackAssetFileStatus {
+  const AssetPackAssetFileStatus({
+    required this.item,
+    required this.absolutePath,
+    required this.exists,
+    required this.actualSizeBytes,
+  });
+
+  final AssetPackManifestItem item;
+  final String absolutePath;
+  final bool exists;
+
+  /// Actual byte length on disk, or `null` when the file is missing.
+  final int? actualSizeBytes;
+
+  /// Whether the on-device file matches the manifest's `size_bytes`.
+  bool get sizeMatches => exists && actualSizeBytes == item.sizeBytes;
+}
+
+/// Aggregated Asset Pack state for the debug page: the resolved pack root, the
+/// parsed manifest, and per-asset on-device file status.
+class AssetPackDebugInfo {
+  const AssetPackDebugInfo({
+    required this.packRoot,
+    required this.manifest,
+    required this.assets,
+  });
+
+  final String packRoot;
+  final AssetPackManifest manifest;
+  final List<AssetPackAssetFileStatus> assets;
+}
+
+/// Builds [AssetPackDebugInfo] for the Asset Pack debug page.
+///
+/// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when the
+/// pack is unavailable; the debug page renders the exception message in that
+/// case rather than treating it as a fatal error.
+@riverpod
+Future<AssetPackDebugInfo> assetPackDebugInfo(Ref ref) async {
+  final packRoot = await AssetsUtil.resolvePackRoot();
+  final repository = ref.watch(assetPackRepositoryProvider);
+  final manifest = await repository.readManifest();
+
+  final assets = <AssetPackAssetFileStatus>[];
+  for (final item in manifest.assets) {
+    final file = File('$packRoot/${item.path}');
+    final exists = file.existsSync();
+    assets.add(
+      AssetPackAssetFileStatus(
+        item: item,
+        absolutePath: file.path,
+        exists: exists,
+        actualSizeBytes: exists ? await file.length() : null,
+      ),
+    );
+  }
+
+  return AssetPackDebugInfo(
+    packRoot: packRoot,
+    manifest: manifest,
+    assets: assets,
+  );
+}

--- a/app/lib/feature/settings/children/config/debug/asset_pack/asset_pack_debug_provider.g.dart
+++ b/app/lib/feature/settings/children/config/debug/asset_pack/asset_pack_debug_provider.g.dart
@@ -1,0 +1,70 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'asset_pack_debug_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Builds [AssetPackDebugInfo] for the Asset Pack debug page.
+///
+/// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when the
+/// pack is unavailable; the debug page renders the exception message in that
+/// case rather than treating it as a fatal error.
+
+@ProviderFor(assetPackDebugInfo)
+final assetPackDebugInfoProvider = AssetPackDebugInfoProvider._();
+
+/// Builds [AssetPackDebugInfo] for the Asset Pack debug page.
+///
+/// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when the
+/// pack is unavailable; the debug page renders the exception message in that
+/// case rather than treating it as a fatal error.
+
+final class AssetPackDebugInfoProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AssetPackDebugInfo>,
+          AssetPackDebugInfo,
+          FutureOr<AssetPackDebugInfo>
+        >
+    with
+        $FutureModifier<AssetPackDebugInfo>,
+        $FutureProvider<AssetPackDebugInfo> {
+  /// Builds [AssetPackDebugInfo] for the Asset Pack debug page.
+  ///
+  /// Errors with [AssetPackNotReadyException] (surfaced as `AsyncError`) when the
+  /// pack is unavailable; the debug page renders the exception message in that
+  /// case rather than treating it as a fatal error.
+  AssetPackDebugInfoProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'assetPackDebugInfoProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$assetPackDebugInfoHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<AssetPackDebugInfo> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<AssetPackDebugInfo> create(Ref ref) {
+    return assetPackDebugInfo(ref);
+  }
+}
+
+String _$assetPackDebugInfoHash() =>
+    r'0f0cb1f10f28cfc414f70b0f11642ca46a2a7b16';

--- a/app/lib/feature/settings/children/config/debug/debug_page.dart
+++ b/app/lib/feature/settings/children/config/debug/debug_page.dart
@@ -135,6 +135,13 @@ class _DebugWidget extends ConsumerWidget {
                 onTap: () => const DebugAppGroupRoute().push<void>(context),
               ),
             ListTile(
+              title: const Text('Asset Pack'),
+              subtitle: const Text('Pack バージョン・アセットの整合性を確認'),
+              leading: const Icon(Icons.inventory_2_outlined),
+              onTap: () async =>
+                  const AssetPackDebugRoute().push<void>(context),
+            ),
+            ListTile(
               title: const Text('SharedPreferences'),
               subtitle: const Text('保存されている Key-Value の一覧・編集'),
               leading: const Icon(Icons.data_object),

--- a/app/lib/feature/settings/settings_page.dart
+++ b/app/lib/feature/settings/settings_page.dart
@@ -9,6 +9,7 @@ import 'package:eqmonitor/core/provider/package_info.dart';
 import 'package:eqmonitor/core/router/router.dart';
 import 'package:eqmonitor/feature/ads/data/notifier/ads_opt_out_notifier.dart';
 import 'package:eqmonitor/feature/ads/ui/component/ad_banner.dart';
+import 'package:eqmonitor/feature/asset_pack/data/notifier/asset_pack_manifest_provider.dart';
 import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_enabled_notifier.dart';
 import 'package:eqmonitor/feature/eew/data/notifier/eew_warning_overlay_simulation_notifier.dart';
 import 'package:eqmonitor/feature/settings/component/settings_section_header.dart';
@@ -181,6 +182,7 @@ class SettingsPage extends ConsumerWidget {
                     ),
                   ),
                 ),
+                const _AssetPackVersionInformation(),
                 if (isDebugEnabled ?? false) ...[
                   Center(
                     child: Text(
@@ -203,6 +205,38 @@ class SettingsPage extends ConsumerWidget {
           ),
           const AdBanner(),
         ],
+      ),
+    );
+  }
+}
+
+class _AssetPackVersionInformation extends ConsumerWidget {
+  const _AssetPackVersionInformation();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final manifestAsync = ref.watch(assetPackManifestProvider);
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    final text = switch (manifestAsync) {
+      AsyncData(:final value) => 'Asset Pack v${value.packVersion}',
+      AsyncError() => 'Asset Pack: 未取得',
+      _ => 'Asset Pack: 確認中…',
+    };
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Text(
+          text,
+          style: textTheme.bodySmall!.copyWith(
+            color: context.designSystem.colorTheme.onSurface.withValues(
+              alpha: 0.8,
+            ),
+          ),
+          textAlign: TextAlign.center,
+        ),
       ),
     );
   }

--- a/app/test/feature/asset_pack/asset_pack_manifest_provider_test.dart
+++ b/app/test/feature/asset_pack/asset_pack_manifest_provider_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:eqmonitor/feature/asset_pack/data/model/asset_pack_manifest.dart';
+import 'package:eqmonitor/feature/asset_pack/data/notifier/asset_pack_manifest_provider.dart';
+import 'package:eqmonitor/feature/asset_pack/data/repository/asset_pack_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+Map<String, Object?> _validManifestJson() => {
+  'pack_version': '1.2.3',
+  'schema_version': 1,
+  'generated_at': '2026-07-18T09:00:00+09:00',
+  'assets': [
+    {
+      'id': 'JMA_CODE_TABLE',
+      'kind': 'json',
+      'path': 'parameters/jma_code_table.json',
+      'schema_version': 1,
+      'source_version': '20260623',
+      'source_updated_at': null,
+      'source_urls': <String>[],
+      'sha256': 'b' * 64,
+      'size_bytes': 2,
+    },
+  ],
+};
+
+/// Builds the provider inside [container] and waits for it to leave the
+/// loading state, returning the settled [AsyncValue]. The [container] must
+/// keep the provider alive (autodispose would otherwise cut the build short).
+Future<AsyncValue<AssetPackManifest>> _settle(ProviderContainer container) {
+  final completer = Completer<AsyncValue<AssetPackManifest>>();
+  final sub = container.listen<AsyncValue<AssetPackManifest>>(
+    assetPackManifestProvider,
+    (_, next) {
+      if ((next.hasValue || next.hasError) && !completer.isCompleted) {
+        completer.complete(next);
+      }
+    },
+    fireImmediately: true,
+  );
+  return completer.future.whenComplete(sub.close);
+}
+
+void main() {
+  group('assetPackManifestProvider', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('asset_pack_provider');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('pack ready: exposes the manifest pack_version', () async {
+      await File(
+        '${tempDir.path}/manifest.json',
+      ).writeAsString(jsonEncode(_validManifestJson()));
+
+      final container = ProviderContainer(
+        overrides: [
+          assetPackRepositoryProvider.overrideWithValue(
+            AssetPackRepository(resolvePackRoot: () async => tempDir.path),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await _settle(container);
+      expect(result.requireValue.packVersion, '1.2.3');
+    });
+
+    test(
+      'pack not ready: surfaces AssetPackNotReadyException as AsyncError',
+      () async {
+        final container = ProviderContainer(
+          overrides: [
+            assetPackRepositoryProvider.overrideWithValue(
+              AssetPackRepository(
+                resolvePackRoot: () async =>
+                    throw const AssetPackNotReadyException('not downloaded'),
+              ),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final result = await _settle(container);
+        expect(result.hasError, isTrue);
+        expect(result.error, isA<AssetPackNotReadyException>());
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 概要

#1551 (Asset Pack 移行) の follow-up です。

- **設定画面の最下部**("Powered by Flutter" の直下)に、インストール済み Asset Pack のバージョンをフッタースタイルで表示します。状態に応じて `Asset Pack v1.2.3` / `未取得` / `確認中…` を表示
- **デバッグメニューに「Asset Pack」ページを追加** (`/settings/debug/asset-pack`):
  - manifest 情報 (pack_version / schema_version / generated_at) と pack root パス
  - アセットごとの id / path / サイズ / source_version / sha256 (長押しコピー可)
  - **実ファイルの存在・サイズを manifest と照合し、不一致をマーク**
  - 再読込アクション (provider invalidate)
  - Pack 未取得時は AssetPackNotReadyException の内容を表示

## 変更内容

- 新規 provider: `assetPackManifestProvider` (フッター用) / `assetPackDebugProvider` (照合付き詳細)
- 全て追加のみ (+613 行)。既存画面への変更は settings_page のフッター追加と debug メニューのタイル追加のみ

## テスト

- provider 単体テスト (pack ready → バージョン文字列 / not-ready → フォールバック) + 既存 asset_pack / settings テスト: 25/25 green
- 変更ファイルへの targeted `dart analyze` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)