### PR TITLE
Docs: EQMonitor専用Flutter地図レンダラー設計

### DIFF
--- a/docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md
+++ b/docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md
@@ -5,8 +5,11 @@
 - `packages/eqmonitor_map`はEQMonitor専用とする。
 - 初期対象はiOS/Android、北固定・真上視点とする。
 - Flutter Sceneで地物、Flutter `TextPainter`でラベルを描画する。
-- ラベルアンカーはPMTiles生成時に専用Pointレイヤーへ格納する。
+- ラベルの地理anchorはPMTiles生成時に専用Pointレイヤーへ1点だけ格納し、right/left/up/downのscreen placementはrendererが実測文字サイズとDPRから生成する。
+- label schema、backend生成器、producerのglobal validator、digest-bound summary、Asset Pack rolloutをrendererのlabel実装より先に用意する。runtimeはarchive全体をscanしない。
 - 動的描画でGeoJSONを介さない。
+- 新Home rendererは回転を明示的に無効化するが、残存MapLibre surface用の共有`lockBearing`設定/UIは全surface移行まで削除しない。
+- 現在地はapp側で権限とlifecycleを処理し、accuracy、course、pulse、stale、unavailableを表す型付き動的layerとして渡す。
 
 ## 将来互換性
 
@@ -15,19 +18,42 @@
 - Geographic、Mercator、Tile Local、Camera-relative World、Screenを別の型と責務で扱う。
 - GPUへ渡す座標はcamera origin rebasingを行い、高zoomと3Dのfloat精度低下を避ける。
 - bearing、pitch、透視投影、地下表示はfeatureモデルではなくprojection/rendererを拡張する。
+- P/S波の距離はgeodesic meter radiusとして計算し、Mercator平面上の円で近似しない。
 
 ## 宣言と実体
 
-- 公開APIは不変なFreezed `MapNode`ツリーとする。
+- 公開APIは不変かつ原則Freezedの`MapNode`ツリーとする。JSONは明示的な保存・通信DTO/specにだけ要求する。
 - 内部`MapElement`がkeyとnode型でmount/update/unmountを行う。
 - Flutter Widget/Elementの内部APIへ依存しない。
 - GPU/HTTP/Controllerなどの実行時資源をJSONモデルへ混ぜない。
+- hot pathのpacked payload、snapshot、deltaはJSONを要求しないversion付きruntime型とし、Freezedのdeep equalityでgeometryを比較しない。
+- deltaは`baseRevision`/`targetRevision`、重複しない`upserts`/`removals`を持ち、duplicate/stale/gapをatomicに拒否してfull snapshot resyncする。full snapshotは完全なFeature集合で、省略は削除を意味する。
+- renderごとにcamera、viewport、DPR、revision、context generationをimmutable snapshotへ固定する。
+- async処理はelement/source incarnationをawait前後で検証し、GPU resourceはcompletionまたは検証済みframes-in-flight方式でretireする。
+
+## Sourceとresourceの安全境界
+
+- tile cache keyは`sourceInstanceId`、source revision/content digest、Z/X/Y、world wrapを含める。
+- hazard sourceはrevisionを跨いでlast good tileを表示しない。basemapのstale表示も同一revisionに限る。
+- appはAsset Pack manifest trust/size/hashを検証し、path/digest/size/schema/summaryを持つimmutable descriptorだけをpackageへ渡す。packageは`app`へ依存しない。
+- manifest/item schema v1と既存`BASE_MAP_PMTILES`を維持し、新しいversion付きPoint layerを同archiveへ追加する。未知のasset IDは追加しない。
+- remote rangeはstrong ETagまたは`If-Match`可能なimmutable validator、`206`、安定total length、同一validatorを必須とし、`412`/mismatchで全byteを破棄する。validatorなしは上限付き単一full-streamだけを使う。
+- PMTiles/MVTは件数・byte・decode時間をversion付きpolicyで制限し、壊れた入力を空tileへ変換しない。
+- CPU/GPU cacheはaggregate budget、pin、context generation、rebuild原因を観測可能にする。
 
 ## 性能観測
 
 - HUDや性能試験より先に`MapPerformanceSnapshot`と`MapPerformanceEvent`を実装する。
 - tile request、decode、mesh build、GPU upload、cache、label、frameを同じ計測基盤で観測する。
 - Feature単位のScene Nodeを作らず、tile/layer/material単位でbatchする。
+- tile/material batching後もcanonical render orderを保存し、hit testは同じ順序を逆から使う。
+- metricsはbounded・rate-limitedにし、queue待機、実行、GPU submission/completion、current/peak memoryを分離する。
+
+## Flutter Scene gate
+
+- Flutter SDKとFlutter Scene revisionを固定し、adapterの外へFlutter Scene型を漏らさない。
+- foundation前にiOS/Android実機でprocedural mesh、partial update、overlay、dispose、background復帰、context rebuild、resource retirementを検証する。
+- gateを満たせない場合は実装を進めず設計を更新する。
 
 ## 検証コマンド
 

--- a/docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md
+++ b/docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md
@@ -6,10 +6,10 @@
 - 初期対象はiOS/Android、北固定・真上視点とする。
 - Flutter Sceneで地物、Flutter `TextPainter`でラベルを描画する。
 - ラベルの地理anchorはPMTiles生成時に専用Pointレイヤーへ1点だけ格納し、right/left/up/downのscreen placementはrendererが実測文字サイズとDPRから生成する。
-- label schema、backend生成器、producerのglobal validator、digest-bound summary、Asset Pack rolloutをrendererのlabel実装より先に用意する。runtimeはarchive全体をscanしない。
+- label schema、backend生成器、producerのglobal validator、signed sidecarによるdigest-bound summary、Asset Pack rolloutをrendererのlabel実装より先に用意する。runtimeはarchive全体をscanしない。
 - 動的描画でGeoJSONを介さない。
 - 新Home rendererは回転を明示的に無効化するが、残存MapLibre surface用の共有`lockBearing`設定/UIは全surface移行まで削除しない。
-- 現在地はapp側で権限とlifecycleを処理し、accuracy、course、pulse、stale、unavailableを表す型付き動的layerとして渡す。
+- 現在地はapp側で権限とlifecycleを処理し、accuracy、course、pulse、fresh/stale/expired、unavailableを表す型付き動的layerとして渡す。
 
 ## 将来互換性
 
@@ -28,7 +28,9 @@
 - GPU/HTTP/Controllerなどの実行時資源をJSONモデルへ混ぜない。
 - hot pathのpacked payload、snapshot、deltaはJSONを要求しないversion付きruntime型とし、Freezedのdeep equalityでgeometryを比較しない。
 - deltaは`baseRevision`/`targetRevision`、重複しない`upserts`/`removals`を持ち、duplicate/stale/gapをatomicに拒否してfull snapshot resyncする。full snapshotは完全なFeature集合で、省略は削除を意味する。
-- renderごとにcamera、viewport、DPR、revision、context generationをimmutable snapshotへ固定する。
+- full snapshotは全検証後にatomic commitする。低revisionを拒否し、同一revisionはidentity/digest一致時だけno-op、競合時はerrorとする。gap/branch latchはより新しいauthoritative fullのcommitだけで解除し、新しい`sourceInstanceId`も検証済みfull commit後だけ交換する。
+- renderごとに注入clockからwall/monotonic時刻を1回だけcaptureし、camera、viewport、DPR、revision、context generationとともにimmutable snapshotへ固定する。
+- freshnessはload stateと分離し、receipt ageはmonotonic clockで判定する。staleはprovenance/ageを公開し、expired hazard/current locationはanimationを停止して描画せずtyped unavailableへfail closedする。producer時刻の未来skewやexpiryはversion付きpolicyで保守的に検証する。
 - async処理はelement/source incarnationをawait前後で検証し、GPU resourceはcompletionまたは検証済みframes-in-flight方式でretireする。
 
 ## Sourceとresourceの安全境界
@@ -36,8 +38,9 @@
 - tile cache keyは`sourceInstanceId`、source revision/content digest、Z/X/Y、world wrapを含める。
 - hazard sourceはrevisionを跨いでlast good tileを表示しない。basemapのstale表示も同一revisionに限る。
 - appはAsset Pack manifest trust/size/hashを検証し、path/digest/size/schema/summaryを持つimmutable descriptorだけをpackageへ渡す。packageは`app`へ依存しない。
-- manifest/item schema v1と既存`BASE_MAP_PMTILES`を維持し、新しいversion付きPoint layerを同archiveへ追加する。未知のasset IDは追加しない。
-- remote rangeはstrong ETagまたは`If-Match`可能なimmutable validator、`206`、安定total length、同一validatorを必須とし、`412`/mismatchで全byteを破棄する。validatorなしは上限付き単一full-streamだけを使う。
+- manifest/item schema v1と既存`BASE_MAP_PMTILES`を維持し、新しいversion付きPoint layerを同archiveへ追加する。新asset IDは作らず、`<pmtiles basename>.eqmonitor-attestation.v1.json`という決定的なsigned sidecarを隣へ配布し、旧clientには無視させる。
+- sidecar signatureはasset ID、archive SHA-256/size、label schema/summary、source version、発行/失効時刻、sequenceをbindする。app埋め込みtrust root/key ID、rotation/revocation、高水位sequenceによるreplay/rollback拒否を必須とし、missing/unknown/invalid/expired時は新rendererをfail closedする。
+- remoteは`Accept-Encoding: identity`を送り、非identity `Content-Encoding`を拒否する。rangeはstrong ETagまたは`If-Match`可能なimmutable validator、`206`、安定total length、同一validator、`Content-Range`と実body長の完全一致を必須とし、`412`/mismatchで全byteを破棄する。validatorなしはidentity encodingの上限付き単一full-streamだけを使う。
 - PMTiles/MVTは件数・byte・decode時間をversion付きpolicyで制限し、壊れた入力を空tileへ変換しない。
 - CPU/GPU cacheはaggregate budget、pin、context generation、rebuild原因を観測可能にする。
 
@@ -46,7 +49,7 @@
 - HUDや性能試験より先に`MapPerformanceSnapshot`と`MapPerformanceEvent`を実装する。
 - tile request、decode、mesh build、GPU upload、cache、label、frameを同じ計測基盤で観測する。
 - Feature単位のScene Nodeを作らず、tile/layer/material単位でbatchする。
-- tile/material batching後もcanonical render orderを保存し、hit testは同じ順序を逆から使う。
+- canonical `RenderSortKey`だけを描画順の正本とする。全resolved node/specがphaseを明示し、宣言順はphase内だけに適用してv1ではcross-phase interleaveを禁止する。label/leader lineは`labelForeground` phase、hit testは同じkeyの降順とする。
 - metricsはbounded・rate-limitedにし、queue待機、実行、GPU submission/completion、current/peak memoryを分離する。
 
 ## Flutter Scene gate

--- a/docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md
+++ b/docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md
@@ -1,0 +1,41 @@
+# eqmonitor_mapで維持する設計制約
+
+## 初期surface
+
+- `packages/eqmonitor_map`はEQMonitor専用とする。
+- 初期対象はiOS/Android、北固定・真上視点とする。
+- Flutter Sceneで地物、Flutter `TextPainter`でラベルを描画する。
+- ラベルアンカーはPMTiles生成時に専用Pointレイヤーへ格納する。
+- 動的描画でGeoJSONを介さない。
+
+## 将来互換性
+
+- 地理座標は`altitudeMeters`を持ち、2D段階でもZ軸を削除しない。
+- 地表は0、地下震源や断層は負、地上要素は正の高度を使う。
+- Geographic、Mercator、Tile Local、Camera-relative World、Screenを別の型と責務で扱う。
+- GPUへ渡す座標はcamera origin rebasingを行い、高zoomと3Dのfloat精度低下を避ける。
+- bearing、pitch、透視投影、地下表示はfeatureモデルではなくprojection/rendererを拡張する。
+
+## 宣言と実体
+
+- 公開APIは不変なFreezed `MapNode`ツリーとする。
+- 内部`MapElement`がkeyとnode型でmount/update/unmountを行う。
+- Flutter Widget/Elementの内部APIへ依存しない。
+- GPU/HTTP/Controllerなどの実行時資源をJSONモデルへ混ぜない。
+
+## 性能観測
+
+- HUDや性能試験より先に`MapPerformanceSnapshot`と`MapPerformanceEvent`を実装する。
+- tile request、decode、mesh build、GPU upload、cache、label、frameを同じ計測基盤で観測する。
+- Feature単位のScene Nodeを作らず、tile/layer/material単位でbatchする。
+
+## 検証コマンド
+
+Flutter/Dartコマンドは必ず`mise exec --`経由で実行する。
+
+```bash
+cd packages/eqmonitor_map
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+mise exec -- flutter test
+mise exec -- dart analyze
+```

--- a/docs/knowledge/20260802_kevi_map_renderer_reference.md
+++ b/docs/knowledge/20260802_kevi_map_renderer_reference.md
@@ -1,0 +1,36 @@
+# KEVi地図描画から参照する設計知見
+
+## 調査対象
+
+- Repository: `ingen084/KyoshinEewViewerIngen`
+- Commit: `5a2bf513b6b9c93ee06473f70b6d27ee96070b3f`
+- License: MIT, Copyright © 2019 ingen084
+- 固定参照: https://github.com/ingen084/KyoshinEewViewerIngen/tree/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f
+
+KEViはAvaloniaの`CompositionCustomVisual`からSkiaSharpの`SKCanvas`へ順序付きlayerを直接描画する。PMTiles/MVT tile engineではないため、tile選択の正本にはしない。
+
+## 採用するパターン
+
+- `MapControl.cs` / `MapLayer.cs`: UI/render間のstate snapshot、`RefreshRequested`、`NeedPersistentUpdate`をframe schedulingの参考にする。typed dirty reasonはKEViで観測したものではなく、EQMonitor側の強化とする。
+- `MapLayerHost.cs`: 宣言順を描画順、逆順をhit test優先順として同じtreeから導出する。
+- `PointLayoutCache.cs` / `NormalizedPointSet.cs`: array-backed point dataと投影cacheを参考にする。投影済みpointとflat spatial indexをimmutableに共有することはEQMonitor側のpolicyとする。
+- `HoverTracker.cs`: callerが提供するequalityで更新後の要素を照合する。stable Feature IDでhover/selectionを再束縛することはEQMonitor側のpolicyとする。
+- `MapLayerLabelRenderer.cs`: 実測文字サイズに基づくscreen placement候補とleader lineをrenderer policyの参考にする。alternate geographic anchorをKEViへ帰属させない。
+- metricsはopt-inかつrate-limitedにし、frameとnode/layerの両方を観測する。
+
+## 採用しないパターン
+
+- 既定Miller projection、緯度±80°clamp、1回だけのlongitude wrapをWeb Mercator実装へ流用しない。
+- camera変更ごとの全`SKPicture`破棄をGPU mesh/buffer cacheへ流用しない。
+- host lockを保持した全render、exact zoomやarray referenceだけのcache keyを採用しない。
+- 次frame開始時のdisposeをGPU completionとみなさない。
+- dynamic layerを毎frame全再描画せず、typed deltaと部分buffer更新を使う。
+- mutable paintやsetter中心のlayerを、Freezed DTO + reconcilerの公開APIへ持ち込まない。
+
+## EQMonitorでの適用境界
+
+KEViはframe snapshot、ordered layer、array-backed動的点群、screen上のlabel placementの参考とする。EQMonitorのlabel assetは1つの地理anchorだけを持ち、right/left/up/down候補を実測文字サイズとDPRからrendererで生成する。leader lineもrenderer policyであり、assetへalternate anchorやleader line属性を持たせない。
+
+Web Mercator、tile cover、overzoom、world wrap、MVT edge処理、PMTiles range fetchはMapLibreの仕様・実装に従う。KEViの個別EEW P/S波実装を検証済みとは扱わず、本設計のgeodesic P/S波はEQMonitor独自の要件とする。
+
+参照ファイルの固定URLは設計正本`docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md`に記録する。

--- a/docs/knowledge/20260802_kevi_map_renderer_reference.md
+++ b/docs/knowledge/20260802_kevi_map_renderer_reference.md
@@ -12,7 +12,7 @@ KEViはAvaloniaの`CompositionCustomVisual`からSkiaSharpの`SKCanvas`へ順序
 ## 採用するパターン
 
 - `MapControl.cs` / `MapLayer.cs`: UI/render間のstate snapshot、`RefreshRequested`、`NeedPersistentUpdate`をframe schedulingの参考にする。typed dirty reasonはKEViで観測したものではなく、EQMonitor側の強化とする。
-- `MapLayerHost.cs`: 宣言順を描画順、逆順をhit test優先順として同じtreeから導出する。
+- `MapLayerHost.cs`: 同一render phase内の宣言順とその逆順hit testを同じtreeから導出する着想を参考にする。EQMonitorでは全resolved node/specがphaseを明示し、cross-phase orderを含むcanonical `RenderSortKey`だけを描画・hit testの正本とするため、KEViの宣言順をglobal orderとしては採用しない。
 - `PointLayoutCache.cs` / `NormalizedPointSet.cs`: array-backed point dataと投影cacheを参考にする。投影済みpointとflat spatial indexをimmutableに共有することはEQMonitor側のpolicyとする。
 - `HoverTracker.cs`: callerが提供するequalityで更新後の要素を照合する。stable Feature IDでhover/selectionを再束縛することはEQMonitor側のpolicyとする。
 - `MapLayerLabelRenderer.cs`: 実測文字サイズに基づくscreen placement候補とleader lineをrenderer policyの参考にする。alternate geographic anchorをKEViへ帰属させない。
@@ -29,7 +29,7 @@ KEViはAvaloniaの`CompositionCustomVisual`からSkiaSharpの`SKCanvas`へ順序
 
 ## EQMonitorでの適用境界
 
-KEViはframe snapshot、ordered layer、array-backed動的点群、screen上のlabel placementの参考とする。EQMonitorのlabel assetは1つの地理anchorだけを持ち、right/left/up/down候補を実測文字サイズとDPRからrendererで生成する。leader lineもrenderer policyであり、assetへalternate anchorやleader line属性を持たせない。
+KEViはframe snapshot、phase内ordered layer、array-backed動的点群、screen上のlabel placementの参考とする。EQMonitorのlabel assetは1つの地理anchorだけを持ち、right/left/up/down候補を実測文字サイズとDPRからrendererで生成する。採用済みlabelとleader lineは`labelForeground` phaseのcanonical `RenderSortKey`で描画・hit testする。leader lineもrenderer policyであり、assetへalternate anchorやleader line属性を持たせない。
 
 Web Mercator、tile cover、overzoom、world wrap、MVT edge処理、PMTiles range fetchはMapLibreの仕様・実装に従う。KEViの個別EEW P/S波実装を検証済みとは扱わず、本設計のgeodesic P/S波はEQMonitor独自の要件とする。
 

--- a/docs/superpowers/pr-drafts/2026-08-02-eqmonitor-map-01-design.md
+++ b/docs/superpowers/pr-drafts/2026-08-02-eqmonitor-map-01-design.md
@@ -1,0 +1,69 @@
+# Summary
+
+- Base: `develop`
+- Head: `codex/eqmonitor-map-01-design`
+- EQMonitor専用Flutter地図レンダラーの設計正本、package README、運用知見、将来TODOを整備します。
+- 設計成果は8ファイルで、すべてdocumentation-onlyです。このPRではFlutter packageやrendererの実装、既存MapLibre surfaceの変更は行いません。
+
+# Why
+
+緊急地震速報など生命に関わる表示を扱うため、MapLibre Nativeからの段階的な移行に先立ち、描画・データ鮮度・入力検証・GPU resource lifecycle・障害時挙動の契約を固定する必要があります。
+
+特に、Flutter Sceneの成熟度を実機で確認するgate、PMTiles/MVTとAsset Packの信頼境界、動的hazard dataのatomic updateとexpiry、既存MapLibre pathを維持した段階移行を、実装着手前のreview対象として明文化します。
+
+# Scope
+
+- [`docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md`](../specs/2026-08-02-eqmonitor-map-renderer-design.md): 公開境界、座標系、tile pipeline、label、hit test、cache/error、性能観測、移行gate、stacked deliveryを定義します。
+- [`packages/eqmonitor_map/README.md`](../../../packages/eqmonitor_map/README.md): packageの目的、初期スコープ、設計原則、delivery graphを記録します。package自体はまだ作成しません。
+- [`docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md`](../../knowledge/20260802_eqmonitor_map_renderer_constraints.md): 今後の実装で維持する安全・互換性・性能上の制約を記録します。
+- [`docs/knowledge/20260802_kevi_map_renderer_reference.md`](../../knowledge/20260802_kevi_map_renderer_reference.md): KEViから参照した知見と、採用しない境界を固定します。
+- `docs/todo/`の4ファイル: 初期PRに含めないsurface拡張、3D camera、MapLibre surface移行、追加検証を追跡します。
+
+# Architecture / safety highlights
+
+- 公開APIは不変かつ型付きの`MapScene` / `MapNode`ツリーとし、内部の`MapElement` / `MapRenderObject`がkeyとnode型でreconcileします。描画hot pathではGeoJSONやJSON serialization、geometryのdeep equalityを使いません。
+- Flutter Scene型はadapter内へ隔離し、Flutter SDKとFlutter Scene revisionを固定します。foundation実装前にiOS/Android実機spikeを通し、gateを満たせない場合は実装を進めず設計を更新します。
+- PMTiles/MVTはlocal/remoteを問わずuntrustedなbounded inputとして扱います。appがmanifest、archive size/hash、署名済みsidecarを検証したimmutable descriptorだけをpackageへ渡し、missing/unknown/invalid/expiredなattestationでは新rendererをmountしません。
+- remote range取得はidentity encodingとstrong validatorを必須とし、validatorやtotal length、`Content-Range`、body lengthが不一致なら取得済みbyteを破棄します。壊れた入力を空tileや固定値へfallbackしません。
+- 動的sourceは`sourceInstanceId`とrevisionを持ち、full snapshot / deltaを完全検証後にatomic commitします。gapやbranchではdelta受付を止め、より新しいauthoritative full snapshotでのみ復旧します。
+- freshnessはload stateから分離し、注入したmonotonic clockで`fresh` / `stale` / `expired`を評価します。expiredなhazardと現在地はanimationを止めて描画せず、typed unavailableへfail closedします。
+- 描画順とhit test順はphaseを含むcanonical `RenderSortKey`を唯一の正本とし、async continuation、source identity、GPU completion/context generationを分離して古い結果やresourceを再利用しません。
+- Home移行で新rendererの回転gestureは無効化しますが、既存MapLibre pathと共有`lockBearing`設定/UIは全surfaceのparity確認が完了するまで残します。
+
+# KEVi research attribution
+
+設計上の先行調査として、MIT License（Copyright © 2019 ingen084）の[`ingen084/KyoshinEewViewerIngen`](https://github.com/ingen084/KyoshinEewViewerIngen/tree/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f)を固定commit `5a2bf513b6b9c93ee06473f70b6d27ee96070b3f`で参照しています。
+
+UI/render間state snapshot、phase内のordered layer、array-backed point data、実測文字サイズに基づくscreen label placementを参考にします。一方、Web Mercator、tile cover、overzoom、world wrap、MVT/PMTiles処理や、EQMonitor固有のrevision/freshness/fail-closed policyはKEVi由来とせず、Miller projection、全`SKPicture` invalidation、次frameでのGPU resource disposeなども採用しません。
+
+# Stacked follow-ups
+
+先に別repositoryの`eqmonitor-backend`で`B1-label-asset-release`を独立して完了し、後方互換なlabel Point layer、global validator、署名済みsidecar、release fixtureを提供します。これはGit ancestryではなくrelease artifact contractとして依存します。
+
+EQMonitor側はこのDesign PRを起点に、次の順でstackします。
+
+1. `02-scene-spike`: minimal compilable scaffold、adapter prototype、iOS/Android実機gate
+2. `03-foundation`: 型付きモデル、座標、reconciler、frame/render契約、性能観測
+3. `04-tile-pipeline`: verified source、PMTiles/MVT、remote range fixture、worker/cache
+4. `05-label-asset-integration`: backend fixture、sidecar検証、Asset Pack境界
+5. `06-scene-renderer`: Flutter Scene adapter、Fill/Line、GPU lifecycle
+6. `07-labels`: placement、collision、TextPainter overlay、semantics
+7. `08-dynamic-interaction`: atomic delta、camera、現在地、hit test
+8. `09-home-integration`: Home Mapの並行検証と北固定移行
+
+# Validation
+
+- Final subagent reviews: clean（最終指摘なし）
+- Branch hook: 設計成果8ファイルに対して完了
+- Gitleaks: branch上の3コミットを検査済み
+- `git diff --check`: pass
+- Flutter tests: documentation-onlyのため該当なし。Flutter/Dart実装の動作確認は後続stackで実施します。
+
+# Deferred work
+
+- [`450_eqmonitor_map_future_surface.md`](../../todo/450_eqmonitor_map_future_surface.md): Performance HUD、desktop/Web、線上ラベル、汎用package化
+- [`650_eqmonitor_map_3d_camera.md`](../../todo/650_eqmonitor_map_3d_camera.md): bearing/pitch、透視投影、3D地形、地下震源、断層
+- [`780_eqmonitor_map_maplibre_surface_migrations.md`](../../todo/780_eqmonitor_map_maplibre_surface_migrations.md): Home以外を含む全MapLibre surfaceのparity確認と段階移行
+- [`800_eqmonitor_map_deferred_verification.md`](../../todo/800_eqmonitor_map_deferred_verification.md): Widget/Golden test、iOS/Android実機性能・復帰・memory pressure・context rebuild検証
+
+これらは本PRで実装・検証済みという意味ではありません。各後続PRでcompile、生成、format、analyze、対象test、fixture、実機gateをその時点のscopeに合わせて実行します。

--- a/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
+++ b/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
@@ -14,7 +14,7 @@ PMTiles内のMVTと型付き動的データをDart側で解釈し、Fill・Line�
 - Flutter Sceneはadapter境界の内側へ隔離し、FlutterとFlutter Sceneのrevisionを固定する。実装着手前にiOS/Android実機spikeを通す。
 - MapLibre Style JSON互換は持たず、型付きの独自レイヤー定義を使う。
 - ラベルの地理anchorはPMTiles生成時に専用Pointレイヤーへ1点だけ格納する。表示位置候補はrendererが実測文字サイズとDPRからscreen上に生成する。
-- ラベルanchorを含むbase PMTilesは既存Asset Pack manifest/item schema v1と既存asset IDを維持したまま後方互換に拡張し、生成器、release検証器、schema/summary attestationをrendererより先に用意する。
+- ラベルanchorを含むbase PMTilesは既存Asset Pack manifest/item schema v1と既存asset IDを維持したまま後方互換に拡張し、生成器、release検証器、signed sidecarのschema/summary attestationをrendererより先に用意する。
 - 動的更新でGeoJSONを介さない。
 - runtimeの`MapNode`を含む主要データモデルは不変かつ原則Freezedとする。JSONは明示的な保存・通信DTO/specだけに要求する。
 - FlutterのWidget型は使わず、Widget/Elementに似た宣言と実体の分離を採用する。
@@ -90,6 +90,12 @@ Flutter SceneのGeometry/Material、GPU buffer、`TextPainter`、Controller、Re
 
 動的データsourceは`sourceInstanceId`と単調増加する`snapshotRevision`を持つ。full snapshotは`sourceInstanceId`、`snapshotRevision`、重複のない安定Feature IDの完全な集合を持ち、省略されたFeatureは削除済みとみなす。deltaは`sourceInstanceId`、`baseRevision`、`targetRevision`、重複のないFeature IDごとの`upserts`と`removals`を持ち、同じIDを両方へ含めない。
 
+動的・現在地source snapshotは、型付き`observedAtUtc: UtcInstant`、注入`MapClock`で受信時に取得した`receivedAt: MonotonicInstant`、source policy由来の`staleAfter: Duration`、`validUntil: MapValidityDeadline`を必須とする。`MapValidityDeadline`はUTC deadlineと同じclock domainのmonotonic deadlineを持つ。producerがexpiryを持たない場合もappのversion付きpolicyが明示的に決め、rendererの固定値や暗默defaultで補わない。monotonic instantはprocess/clock domainを跨いでserializeしない。
+
+freshnessはload stateと直交する型付き状態`fresh`、`stale`、`expired`として評価する。localな経過時間は`MapFrameSnapshot.monotonicNow - receivedAt`だけで計算し、wall clockの巻き戻りや進みによってfreshへ戻さない。`staleAfter`を超え、かつ`validUntil`前なら`stale`とし、source identity、revision、`observedAtUtc`、receipt ageをUI、semantics、性能eventへ公開する。monotonic deadline到達、clock domain不一致、または保守的なUTC検証で失効した場合は`expired`とする。producerの観測時刻が許容skewを超えて未来、expiryが観測時刻以前、またはUTC expiryが受信時点ですでに過去なら、version付きsource policyに従ってvalidation errorまたは即時`expired`とし、wall clockだけを根拠に有効期間を延長しない。expired hazardは継続animationを停止して描画対象から除外し、fail closedのtyped unavailable stateを公開する。expired current locationも同様に描画しない。
+
+full snapshotは、authoritative full-snapshot channelのidentity/trust、envelope、revision、canonical content digest、Feature ID重複、全Featureの型・時間metadata・semantic/resource limitを完全に検証してcandidate stateを構築した後で、Feature集合・revision・digest・時間metadataを1回でatomic commitする。同一`sourceInstanceId`の低いrevisionはstaleとして拒否する。同一revisionはidentityとdigestが一致するときだけidempotent no-opとし、digestの異なる同一revisionはconflicting-equal errorにする。gap/branch latchは、latch時点より新しいauthoritative full snapshotのcommit成功後だけ解除する。equal no-opや検証失敗では解除しない。新しい`sourceInstanceId`は検証済みfull snapshotのatomic commit成功時にだけ旧sourceを置き換え、失敗時は旧state/latchを保つ。
+
 deltaは全項目を検証してから1回のcommitでatomicに適用する。`targetRevision <= currentRevision`または既適用の`targetRevision`はduplicate/staleとして拒否し、`baseRevision > currentRevision`はgap、`baseRevision < currentRevision`かつtargetが新しい場合は枝分かれしたstale deltaとして拒否する。`targetRevision`は`baseRevision`より大きくなければならない。どの拒否でも既存feature集合とrevisionを変更しない。gapまたは枝分かれを検出したsourceはdelta受付を停止し、full snapshot resyncを要求する。新しい`sourceInstanceId`はfull snapshotからだけ開始する。Feature単位revisionだけで完全性を推論する代替契約は採用せず、削除はdeltaの`removals`、完全性はfull snapshotでのみ表す。
 
 reconcilerはkey、型、revision metadataだけを比較し、geometry collectionのFreezed deep equalityやhashをhot pathで実行しない。描画経路でJSONへの変換は行わない。
@@ -108,13 +114,13 @@ MapElement         mount/update/unmountと実行状態
 MapRenderObject    CPU meshとGPU resource
 ```
 
-`MapNode`は毎回再生成してよい。同じkeyとnode型なら`MapElement`を更新し、異なる場合はunmount後にmountする。ネットワーク取得やGPU操作は宣言の組み立て中に実行せず、command queueをrender tickで適用する。宣言順は描画順の唯一の根拠とし、hit testは同じ解決済み順序を逆から走査する。
+`MapNode`は毎回再生成してよい。同じkeyとnode型なら`MapElement`を更新し、異なる場合はunmount後にmountする。ネットワーク取得やGPU操作は宣言の組み立て中に実行せず、command queueをrender tickで適用する。各drawable node/specはresolve時に明示的な`MapRenderPhase`を必ず持ち、宣言順は同一phase内の順序だけを決める。v1ではphaseを跨ぐinterleaveを許可せず、後述のcanonical `RenderSortKey`だけを描画順とhit test順の正本とする。
 
 設定変更はstyleのみ、filter/source layer、動的feature、source交換に分類し、必要な範囲だけ再構築する。GPU resourceの解放は描画中・実行中のGPU参照を避け、後述のretirement方式で行う。
 
 各`MapElement`とsource mountは再利用されないincarnation tokenとowned cancellation scopeを持つ。network、worker、label、uploadを含む全async継続はawaitの前後でmounted状態とtokenを検証する。command queueはsource内で順序を保証し、同一resourceへの更新はlast-writer-wins、disposeはidempotentかつawait可能にする。古いtokenの結果とエラーはattachmentも通知もしない。
 
-render開始時に、camera、viewport、DPR、source/layer revision、app lifecycle、Flutter Scene context generationを固定したimmutable `MapFrameSnapshot`を作る。各render nodeはdirty reasonと`needsContinuousFrame`を返し、静的nodeは変更時だけ、P/S波など時間依存nodeだけは必要期間中に継続frameを要求する。detach/backgroundではanimation、request、decode、uploadを停止する。
+rendererに`MapClock`を注入し、render開始時の1回のcaptureで`wallNowUtc`と`monotonicNow`を同時に凍結する。immutable `MapFrameSnapshot`はこの両時刻とclock domain、camera、viewport、DPR、source/layer revision、app lifecycle、Flutter Scene context generationを固定する。P/S波、pulse、freshness、expiryを含む全time-dependent nodeはこのsnapshotの時刻だけを使い、nodeごとにclockを再取得しない。各render nodeはdirty reasonと`needsContinuousFrame`を返し、期限内のtime-dependent nodeだけが継続frameを要求する。detach/backgroundではanimation、request、decode、uploadを停止し、resume後は新しいcaptureでfreshness/expiryを再評価してから描画する。
 
 CPU frame終了はGPU完了を意味しない。GPU resourceはFlutter Scene/Flutter GPUのcompletion通知、または実機検証したframes-in-flight世代方式でretireする。context generationが変わったresourceを再利用しない。
 
@@ -173,8 +179,9 @@ PMTiles/MVTはローカルでもremoteでもuntrustedなbounded inputとして�
 
 - Asset Packの取得、platform/release由来のmanifest trust、v1 manifest/item schema、`sizeBytes`、`sha256`の検証はappが所有する。appは検証後のpath、digest、size、semantic schema/summaryを持つimmutable verified source descriptorを`eqmonitor_map`へ渡す。packageは`app`へ依存せず、未検証pathやmanifest repositoryを受け取らない。
 - remoteはHTTPSとallowlist hostを基本とし、redirect回数、cross-host redirect、TLS downgradeをpolicyで制限する。
-- remote range合成はweakでないstrong ETag、またはAPIが提供して`If-Match`に利用できるimmutable digest/versionを最初のresponseで確立できる場合だけ行う。2回目以降の全Range requestへそのvalidatorを`If-Match`で送り、`206`、requested `Content-Range`、安定したarchive total length、同一validatorを必須とする。`412`、validator/total length不一致、validator欠落では、それまでに取得した全byteを破棄してtyped snapshot mismatchにする。
-- strong snapshot identityを得られないremoteはrangeを合成せず、上限付きの単一full-stream downloadだけを許可する。途中byteを別requestと結合しない。
+- remote requestはrange/full-streamとも`Accept-Encoding: identity`を送り、responseの`Content-Encoding`は欠落または`identity`だけを受理する。gzip、brなど非identity表現はarchive offset、size、digestの対象と一致しないためrejectし、透過展開後のbyteを検証対象にしない。
+- remote range合成はweakでないstrong ETag、またはAPIが提供して`If-Match`に利用できるimmutable digest/versionを最初のresponseで確立できる場合だけ行う。2回目以降の全Range requestへそのvalidatorを`If-Match`で送り、`206`、requested `Content-Range`、安定したarchive total length、同一validatorを必須とする。各bodyの実byte長は`Content-Range`のinclusiveなstart/endから得る長さと完全一致させる。`412`、validator/total length不一致、validator欠落、body長不一致では、それまでに取得した全byteを破棄してtyped snapshot mismatchにする。
+- strong snapshot identityを得られないremoteはrangeを合成せず、identity encodingの上限付き単一full-stream downloadだけを許可する。途中byteを別requestと結合しない。
 - archive offsetとlengthはchecked arithmeticで検証し、archive、directory depth/entry、compressed/uncompressed tile bytes、layer、feature、vertex、command、string、triangulation work、decode時間にhard limitを設ける。
 - `eqmonitor-backend`のproducer/release validatorはarchive全体を走査し、global coverage、zoom別feature count、必須ID集合、必須propertyと型、zoom範囲を検証する。検証済みsemantic schema/summaryはarchive SHA-256へ結び付けた署名済み、または同等にtrustedなrelease attestationとして配布する。
 - runtimeではappがmanifest trust、archive size/hash、attestationとdigestの対応を検証し、packageがPMTiles header/metadataとverified descriptorのschema/summaryの整合を検証する。その後は読み込んだ各tileへ件数、ID/property型、zoom、byte/work上限を適用する。runtimeがarchive全体をscanしてglobal coverageや全件数を再検証するとはしない。
@@ -184,13 +191,19 @@ PMTiles/MVTはローカルでもremoteでもuntrustedなbounded inputとして�
 
 初期rolloutでは既存clientを壊さないことを必須とする。manifestと各itemの`schema_version`はv1のまま、asset IDは既存の`BASE_MAP_PMTILES`だけを使い、version付きlabel Point source layerを既存base PMTilesへ追加する。既存clientは未知のsource layerとPMTiles metadataを無視して従来layerを描画できなければならない。新しいasset IDは追加しない。
 
-producerは既存basemap layerの互換性fixtureと新旧client fixtureを通し、global semantic summary/schemaをrelease attestationへ出力する。v1 manifest itemの`sha256`とattestationのarchive digestを一致させることで、新しいlayer schema/summaryを既存asset digestへ結び付ける。manifest/item schemaを変更する方式は、producer先行、旧新consumer共存、store rollout、rollbackを別途実証したrelease sequenceが承認されるまで採用しない。
+attestation carrierはmanifest itemではなく、既存PMTilesのbasenameへ`.eqmonitor-attestation.v1.json`を付けたversion付きsigned sidecarとする。たとえば`base_map.pmtiles`に対して`base_map.pmtiles.eqmonitor-attestation.v1.json`を同じ配布directoryへ置く。新clientは`BASE_MAP_PMTILES`の解決済みURL/pathのpathnameへこのsuffixを付けて明示的に取得し、bounded downloadとatomic write後にPMTilesの隣へ保存してreadbackする。認証query/headerはAsset Pack transport policyに従ってsidecar requestへ引き継ぐ。旧clientはmanifest v1に列挙されないsidecarを要求も解釈もしないため、manifest/item schema v1とasset IDを変更しない。
+
+sidecarは`format`、`version: 1`、`keyId`、JCSでcanonical化するpayload、Ed25519 signatureを持つ。domain-separated signature payloadには少なくとも`assetId: BASE_MAP_PMTILES`、archive SHA-256、archive byte size、label schema versionとschema digest、global semantic summary、producer source version、`issuedAtUtc`、`expiresAtUtc`、単調増加`sequence`を含め、これらの変更を署名なしで許さない。v1 manifest itemの`sha256`/`sizeBytes`、実archiveのdigest/size、sidecar payloadの値はすべて一致しなければならない。
+
+app releaseへversion付きtrust policyとしてroot public keyと許可`keyId`、revoked key ID、asset/sourceごとのminimum sequenceを埋め込む。key rotationは旧新keyの重複信頼期間を設けて先にappを配布し、revokedまたはunknown keyは拒否する。appはasset/sourceごとの最高accept済みsequenceとdigestを永続化し、低いsequenceをrollback、同一sequenceで異なるdigestをconflicting replayとして拒否する。同一sequenceかつ同一digestだけをidempotent readbackとして許可する。意図的なrollbackは、対象sequenceとdigestを明記した新しいapp trust policyまたは、より高いsequenceで再署名したreleaseだけで行う。missing sidecar、unknown format/version/key、invalid/revoked signature、payload/manifest/archive mismatch、expired attestation、replay/rollbackはtyped verification errorにし、新rendererはbase/label sourceをmountせずfail closedでunavailableを表示する。legacy rendererの既存manifest v1 pathは移行期間中この判定と分離する。
+
+producerは既存basemap layerの互換性fixtureと新旧client fixtureを通し、global semantic summary/schemaをrelease attestationへ出力する。`eqmonitor-backend`のB1はsidecar生成・署名、key rotation sample、archive/size/schema/summary/source version/時刻/sequenceのmutation、旧新client fixtureを所有する。EQMonitor PR 05はsidecar discovery/download/readback、署名・unknown/revoked key・expiry、同一sequence replay、rollback拒否、明示的rollback許可、manifest/archiveとのbinding fixtureを所有する。manifest/item schemaを変更する方式は、producer先行、旧新consumer共存、store rollout、rollbackを別途実証したrelease sequenceが承認されるまで採用しない。
 
 ## 描画
 
 Flutter SceneのScene GraphをFeature単位では使用しない。`tile × layer × material`単位でmeshを結合し、GPU bucketを生成する。
 
-描画順は`render phase → 宣言layer order → source order → overscaled tile order → feature order`からなるcanonical `RenderSortKey`で固定する。material batchingはこの順を変えず、同じ連続範囲だけを結合する。hit testも同じkeyを利用する。
+描画順の唯一の権威は`render phase → phase内宣言layer order → source order → overscaled tile order → feature order`からなるcanonical `RenderSortKey`とする。各resolved drawable node/specはversion付き`MapRenderPhase`を明示し、treeのpre-orderをphaseでfilterした値だけを`declarationOrderWithinPhase`へ使う。v1のphase境界を跨ぐ宣言順interleaveは無効であり、batchingやsource traversalから別のglobal順序を導出しない。material batchingは同じkeyの連続範囲だけを結合する。labelとleader lineは常に`labelForeground` phaseへ解決し、collision用priorityとは別にこのkeyを持つ。geometry、icon、採用済みlabelのhit testは同じkeyの降順、すなわち画面上側から走査する。
 
 - Fillは穴付きPolygonをtriangulationする。
 - Fill/LineはMVT extent外bufferをmesh構築とtile edgeのjoinに保持し、最終描画はtile境界へscissorする。ring winding、hole分類、degenerate/invalid ringのreject規則を固定する。
@@ -212,7 +225,7 @@ domain、reconciler、packed meshはFlutter Scene型へ依存させず、`MapSce
 
 PMTilesの専用Pointレイヤーは、Feature geometryとして1つの地理anchor、安定ID、文字列、優先度、zoom範囲を持つ。alternate geographic anchorやleader line属性はMVTへ持たせない。layer IDとproperty型、ID生成規則、zoom policyをversion付きAsset Pack semantic schemaで管理し、生成器・producer validator・fixtureをrendererと同じ契約で検証する。
 
-表示対象tileから候補を収集し、source/layer/安定ID/world wrapで重複を解決した後、地理anchorをscreen座標へ投影する。rendererは`TextPainter`の実測boundsとDPRからright、left、up、downのscreen placement candidateを生成する。候補は優先度、layer order、stable ID、screen placement orderの決定的sort keyでcollision gridへ配置し、画面端補正を行う。既定のright以外へ退避したlabelのleader line要否、長さ、stroke、描画閾値はversion付きrenderer policyで決め、asset schemaへは含めない。
+表示対象tileから候補を収集し、source/layer/安定ID/world wrapで重複を解決した後、地理anchorをscreen座標へ投影する。rendererは`TextPainter`の実測boundsとDPRからright、left、up、downのscreen placement candidateを生成する。候補は優先度、phase内layer order、stable ID、screen placement orderの決定的collision keyで配置し、画面端補正を行う。採用後のlabelとleader lineは`labelForeground`のcanonical `RenderSortKey`だけで描画・hit testする。既定のright以外へ退避したlabelのleader line要否、長さ、stroke、描画閾値はversion付きrenderer policyで決め、asset schemaへは含めない。
 
 `TextPainter`は文字列、text direction、locale、font family/fallback/load generation、weight/features、letter/word spacing、height、color、`TextScaler`、width、max lines、ellipsis、theme generation、DPRを完全なkeyとして、byte/count上限付きLRUでcacheする。font load、theme、locale、text scale、DPR、accessibility変更で対応entryをinvalidateする。カメラ移動時は原則再layoutせず、screen位置とcollisionだけを更新する。
 
@@ -228,12 +241,12 @@ visibility、min/max zoom、filter、fill hole、描画時のline/icon/label bou
 
 ## 現在地
 
-appはpermission、location service、lifecycleを扱い、`CurrentLocationLayerNode`へ`availableFix`または理由付き`unavailable`を渡す。fixはcoordinate、非負の`accuracyMeters`、`capturedAt`、任意のcourse/speedと各値のvalidityを持つ。利用不能時に固定座標や疑似fixへfallbackしない。
+appはpermission、location service、lifecycleを扱い、`CurrentLocationLayerNode`へ`availableFix`または理由付き`unavailable`を渡す。fixはcoordinate、非負の`accuracyMeters`、`observedAtUtc`、`receivedAt`、`staleAfter`、`validUntil`、任意のcourse/speedと各値のvalidityを持つ。利用不能時に固定座標や疑似fixへfallbackしない。
 
 - available fixは現在地点とgeodesic meterのaccuracy radiusを描画する。accuracyが非finite、不正、またはapp policyの信頼上限外ならradiusを描画せず、その理由をobservable stateへ残す。
 - course indicatorは有効なcourseとapp側の信頼判定がある場合に、真北基準の向きで表示する。北固定cameraは地図の回転を止めるだけで、course indicatorを削除する根拠にはしない。
 - pulseはfresh fixだけに使い、`CurrentLocationPolicy`の周期・振幅、app lifecycle、reduced motionに従う。background、stale、reduced motionでは静止表示にする。
-- `now - capturedAt`が設定可能な`staleAfter`を超えたfixはstaleとし、pulseとcourseを止め、point/accuracyをstale styleへ変更し、semanticsとperformance eventへageを公開する。
+- frameの`monotonicNow - receivedAt`が`staleAfter`を超えたfixはstaleとし、pulseとcourseを止め、point/accuracyをstale styleへ変更し、semanticsとperformance eventへprovenanceとreceipt ageを公開する。`validUntil`到達時はexpired unavailableとして全geometryを除去する。
 - unavailableではpoint、accuracy、courseを描画せず、permission denied、service disabled、no fixなどのtyped reasonをappへ通知する。appが適切な案内やretryを表示する。
 
 ## Cacheとエラー
@@ -242,7 +255,7 @@ PMTiles bytes、decoded MVT、CPU mesh、GPU resource、TextPainterをresource o
 
 読み込み中や部分的な取得失敗のfallbackはsource criticalityごとに定義する。basemapは同一source revisionの直前正常tileまたは有効な親tileをprovenanceとage付きで維持できる。event固有・hazard sourceは異なるrevisionのtileを絶対に維持せず、fail closedして利用不可・stale状態を明示する。壊れたPMTiles/MVTを空tileとして扱わず、失敗データをcacheしない。古い処理のcancelはエラーにしない。
 
-エラーはsource identity、TileKey、失敗段階、再試行可能性、provenance、ageを持つFreezed unionとして通知する。集約状態は`ready`、`loading`、`degraded`、`failed`とし、一部basemap tile失敗で動的レイヤーを消さない。同一原因のtile errorは集約key、count、代表sampleを持たせ、rate limitとbounded deliveryで通知する。
+エラーはsource identity、TileKey、失敗段階、再試行可能性、provenance、ageを持つFreezed unionとして通知する。loadの集約状態は`ready`、`loading`、`degraded`、`failed`とし、sourceの`fresh`、`stale`、`expired`とは別々に保持・通知する。一部basemap tile失敗で動的レイヤーを消さない。同一原因のtile errorは集約key、count、代表sampleを持たせ、rate limitとbounded deliveryで通知する。
 
 memory pressureでは非可視・非pin resourceから削除する。background/surface loss/context generation変更ではGPU resourceを破棄し、保持済みCPU mesh、decoded data、または再decodeの順で再構築する。current/peak bytes、pin、eviction/rebuild原因を性能snapshotへ記録する。
 
@@ -259,7 +272,7 @@ HUD、Widget/Golden test、実機性能試験は後続TODOとするが、後か�
 先行実装として、MIT Licenseの[ingen084/KyoshinEewViewerIngen](https://github.com/ingen084/KyoshinEewViewerIngen/tree/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f) commit `5a2bf513b6b9c93ee06473f70b6d27ee96070b3f`を参照した。
 
 - [`MapControl.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.CustomControl/MapControl.cs)と`MapLayer`で観測したUI/render間state snapshot、`RefreshRequested`、`NeedPersistentUpdate`を、`MapFrameSnapshot`とframe schedulingへ反映する。変更種別を表すtyped dirty reasonはEQMonitor側の強化であり、KEVi由来とはしない。
-- [`MapLayerHost.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.Map/Layers/MapLayerHost.cs)の宣言順描画・逆順hit testを、canonical render orderへ反映する。
+- [`MapLayerHost.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.Map/Layers/MapLayerHost.cs)の宣言順描画・逆順hit testをphase内orderの参考にし、cross-phase orderはEQMonitorのcanonical `RenderSortKey`で固定する。
 - [`PointLayoutCache.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.Map/Layers/PointLayoutCache.cs)と[`NormalizedPointSet.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.Map/Layers/NormalizedPointSet.cs)で観測したarray-backed point dataとprojection cacheを参考にする。projection結果とflat spatial indexをimmutableに共有することはEQMonitor側のpolicyである。
 - `HoverTracker`で観測したのはcaller提供のequalityによる再照合である。安定Feature IDによるhover/selection再束縛はEQMonitor側のpolicyとする。
 - [`MapLayerLabelRenderer.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.CustomControl/MapLayerLabelRenderer.cs)の実測文字サイズに基づくscreen placementとleader lineをrenderer policyの参考にする。alternate geographic anchorをKEViへ帰属させず、assetには1つの地理anchorだけを格納する。
@@ -277,8 +290,10 @@ KEViはSkia/Avaloniaの直接描画で、PMTiles/MVT tile engineではない。M
 - extent外buffer geometry、tile edge line、invalid ring、resource limit、malformed/fuzz payload
 - Node/Elementのmount/update/reorder/unmount、同じkeyのremount、await中cancel、source交換、controller dispose
 - full snapshotと`baseRevision`/`targetRevision` deltaのatomic apply、duplicate/stale/gap reject、remove、full resync
-- strong ETag/immutable validator付きrange、`If-Match`、`206`/total length検証、range間でarchiveが変異して`412`またはvalidator不一致になるfixture、validatorなしfull-stream
-- producerのglobal semantic fixtureと、runtimeのdescriptor/metadata整合・bounded per-tile検証
+- full snapshot resyncの低revision、同一revision同一digest no-op、同一revision異digest、malformed full、gap後のequal/新revision、sourceInstanceId交換成功/失敗fixture
+- fake `MapClock`を進めるfresh/stale/expired境界、wall-clock skew、background/resume、source停止、現在地expiryとexpired hazardのanimation停止/fail-closed fixture
+- strong ETag/immutable validator付きrange、`If-Match`、`Accept-Encoding: identity`、非identity `Content-Encoding`拒否、`206`/total length/`Content-Range` body長検証、range間でarchiveが変異して`412`またはvalidator不一致になるfixture、validatorなしidentity full-stream。これらのremote byte fixtureはPR 04で実装する
+- producerのglobal semantic fixtureと、runtimeのdescriptor/metadata整合・bounded per-tile検証。B1でsidecar signing/mutation、PR 05でsignature/readback/replay/rollback fixtureを実装する
 - ラベル重複排除、決定的優先順、right/left/up/down screen placement、衝突、leader line policy、hysteresis、cache invalidation、semantics
 - hit test parity、stale generation破棄、aggregate cache eviction、context generation rebuild
 
@@ -286,7 +301,7 @@ KEViはSkia/Avaloniaの直接描画で、PMTiles/MVT tile engineではない。M
 
 ### Cross-repository prerequisite
 
-`eqmonitor-backend`側で先に`B1-label-asset-release` milestoneを完了する。既存base PMTilesへversion付きlabel Point layerを後方互換に追加するgenerator、archive全体のsemantic validator、digestへ結び付いたtrusted schema/summary attestation、mutation/旧新client fixture、Asset Pack releaseを同repositoryでreview・releaseする。このbranch/PRは`eqmonitor-backend`の既定branchまたは同repository内の先行branchから分岐し、EQMonitor repositoryのbranchやPRを祖先にしない。EQMonitor側はrelease済みartifact digestとattestationをfixtureとして受け取る。
+`eqmonitor-backend`側で先に`B1-label-asset-release` milestoneを完了する。既存base PMTilesへversion付きlabel Point layerを後方互換に追加するgenerator、archive全体のsemantic validator、version付きsidecar生成・署名、署名payload mutation/旧新client fixture、Asset Pack releaseを同repositoryでreview・releaseする。このbranch/PRは`eqmonitor-backend`の既定branchまたは同repository内の先行branchから分岐し、EQMonitor repositoryのbranchやPRを祖先にしない。EQMonitor側はrelease済みartifact digestとattestationをfixtureとして受け取る。
 
 ### EQMonitor repository stacked PRs
 
@@ -295,8 +310,8 @@ EQMonitor側の後続PRは前のEQMonitor PRだけへ依存させ、各stackを�
 1. `01-design`: 設計書、README、知見、将来TODO
 2. `02-scene-spike`: minimalでcompile可能な`packages/eqmonitor_map` scaffoldとexample/harnessを作成し、revision固定、adapter prototype、iOS/Android実機gateを実行
 3. `03-foundation`: モデル、座標、Node/Element、FrameSnapshot、render order、packed mesh/render command契約とfake、性能観測
-4. `04-tile-pipeline`: verified source descriptor、trust policy、PMTiles、MVT、packed worker payload、tile scheduler、cache
-5. `05-label-asset-integration`: backend release fixture、semantic schema/summary contract、app側Asset Pack検証とpackage boundary、旧新client compatibility test
+4. `04-tile-pipeline`: verified source descriptor、trust policy、PMTiles、MVT、identity-encoded remote byte/range fixture、packed worker payload、tile scheduler、cache
+5. `05-label-asset-integration`: backend release fixture、signed sidecar discovery/readback/signature/replay/rollback fixture、semantic schema/summary contract、app側Asset Pack検証とpackage boundary、旧新client compatibility test
 6. `06-scene-renderer`: Flutter Scene adapter、Fill/Line、GPU lifecycleとcontext recovery
 7. `07-labels`: screen placement候補、collision、TextPainter overlay、leader line、semantics
 8. `08-dynamic-interaction`: atomic typed delta、point index、camera、fitBounds、現在地、hit test
@@ -313,10 +328,10 @@ Home Mapの移行matrixをstack内でversion管理する。
 | pan / pinch zoom | min/max zoom、gesture enable、boundsを含め同等 |
 | rotation | 新Home rendererでgestureを明示的に無効化し北固定にする。legacy MapLibre consumer用`lockBearing`設定/UIは維持する |
 | camera | 初期位置、fitBounds、date line、viewport resize、状態復元が同等 |
-| 現在地 | permission/lifecycle/errorをapp側で扱い、accuracy、course、pulse、stale、unavailableの規定を型付き`CurrentLocationLayerNode`で満たす |
+| 現在地 | permission/lifecycle/errorをapp側で扱い、accuracy、course、pulse、fresh/stale/expired、unavailableの規定を型付き`CurrentLocationLayerNode`で満たす |
 | theme / layer | Light/Dark再構築、順序、visibility、loading/errorが同等 |
 | event / interaction | Homeで利用するgesture event、controller、hover/selectionがparity fixtureを通る。別surfaceの`queryLayers` parityはHome gateに含めない |
-| hazard | 観測点、震源、P/S波、区域状態でsource revisionとstale表示規則を満たす |
+| hazard | 観測点、震源、P/S波、区域状態でsource revision、fresh/stale表示、expired fail-closed規則を満たす |
 | platform | label asset新schemaとFlutter Scene lifecycleをiOS/Android実機で検証済み |
 
 ベース地図、ラベル、観測点、震源、P/S波、区域状態、camera、現在地、Homeで実際に使うinteraction、障害時表示がmatrixを満たし、性能観測で継続利用可能と判断できるまでHomeのMapLibre pathを削除しない。その後は`docs/todo/780_eqmonitor_map_maplibre_surface_migrations.md`に従って地図surfaceを一つずつ移行し、全surface完了までMapLibre packageと共有設定を削除しない。

--- a/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
+++ b/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
@@ -1,0 +1,209 @@
+# EQMonitor専用Flutter地図レンダラー設計
+
+## 目的
+
+MapLibre Nativeへの描画依存を段階的に置き換えるため、Flutter SceneをGPU描画基盤とするEQMonitor専用地図パッケージ`packages/eqmonitor_map`を新設する。
+
+PMTiles内のMVTと型付き動的データをDart側で解釈し、Fill・Line・Point・CircleをFlutter Sceneで描画する。ラベルは事前計算済みアンカーを使い、Flutterの`TextPainter`で描画する。
+
+## 確定事項
+
+- 初期対象はiOSとAndroidのみ。
+- 初期カメラは北固定・真上視点とし、bearingとpitchは実装しない。
+- Flutter master channelとFlutter Sceneの利用を許容する。
+- MapLibre Style JSON互換は持たず、型付きの独自レイヤー定義を使う。
+- ラベルアンカーはPMTiles生成時に専用Pointレイヤーへ事前格納する。
+- 動的更新でGeoJSONを介さない。
+- 主要データモデルはFreezedと`json_serializable`へ対応する。
+- FlutterのWidget型は使わず、Widget/Elementに似た宣言と実体の分離を採用する。
+- 性能HUDは後続実装とするが、性能観測基盤は初期実装に含める。
+- 将来の3D、地下震源、断層表示に備え、座標モデルからZ軸を削除しない。
+- 既存MapLibre実装は機能・障害時挙動の同等性を確認するまで残す。
+- 実装は依存順のstacked PRで提供する。
+
+## 対象外
+
+初期実装では次を対象外とする。
+
+- bearing、pitch、透視投影
+- 3D地形、地下震源、断層面
+- Web、macOS、Windows、Linux
+- 線上ラベル
+- 任意のMapLibre Style JSON
+- 汎用地図パッケージとしての公開
+- Performance HUD
+- Widget、Golden、実機性能試験の完成
+
+## 公開API
+
+利用側は不変な`MapScene`を宣言し、`EqmonitorMapView`へ渡す。
+
+```dart
+final scene = MapScene(
+  children: [
+    PmTilesSourceNode(
+      key: const MapNodeKey('base-map'),
+      source: baseMapSource,
+      children: [
+        FillLayerNode(
+          key: const MapNodeKey('countries-fill'),
+          spec: countriesFillSpec,
+        ),
+        LineLayerNode(
+          key: const MapNodeKey('region-line'),
+          spec: regionLineSpec,
+        ),
+        LabelLayerNode(
+          key: const MapNodeKey('city-label'),
+          spec: cityLabelSpec,
+        ),
+      ],
+    ),
+    ObservationPointLayerNode(
+      key: const MapNodeKey('observations'),
+      data: observationSnapshot,
+    ),
+    WaveCircleLayerNode(
+      key: const MapNodeKey('ps-wave'),
+      data: waveSnapshot,
+    ),
+  ],
+);
+
+EqmonitorMapView(controller: controller, scene: scene);
+```
+
+主要公開境界は`EqmonitorMapView`、`EqmonitorMapController`、`MapScene`、各`MapNode`、型付きsource/layer/featureモデルとする。
+
+## モデルと実行時オブジェクト
+
+座標、カメラ、source、layer、feature、ラベル候補、hit test結果、エラー、性能snapshotはFreezedモデルとし、JSONへ変換できるようにする。
+
+Flutter SceneのGeometry/Material、GPU buffer、`TextPainter`、Controller、Repository、HTTP clientなど、状態や外部資源を持つ実行時オブジェクトはモデルに含めず、JSON対応の対象外とする。
+
+動的データは安定したFeature IDとrevisionを持つ。reconcilerはrevisionで更新有無を判定し、変更時だけFeature ID単位の差分を適用する。描画経路でJSONへの変換は行わない。
+
+## 宣言的Nodeツリー
+
+Flutter内部APIへ結合せず、地図専用の軽量reconcilerを実装する。
+
+```text
+MapNode            不変な宣言、Freezed/JSON
+  ↓ keyとnode型でreconcile
+MapElement         mount/update/unmountと実行状態
+  ↓ command queue
+MapRenderObject    CPU meshとGPU resource
+```
+
+`MapNode`は毎回再生成してよい。同じkeyとnode型なら`MapElement`を更新し、異なる場合はunmount後にmountする。ネットワーク取得やGPU操作は宣言の組み立て中に実行せず、command queueをrender tickで適用する。
+
+設定変更はstyleのみ、filter/source layer、動的feature、source交換に分類し、必要な範囲だけ再構築する。GPU resourceの解放は描画中の参照を避けるためframe終了後に行う。
+
+## 座標系
+
+MapLibre Nativeの座標変換を参考に、次の段階を明示する。
+
+```text
+WGS84 Geographic
+  → normalized Web Mercator world
+  → Z/X/Y tile
+  → MVT tile-local extent
+  → camera-relative world
+  → clip
+  → screen
+```
+
+参考: https://maplibre.org/maplibre-native/docs/book/design/coordinate-system.html
+
+地理座標は経度、緯度、`altitudeMeters`を保持する。地表は0、地下は負、地上は正とする。初期描画は正射影でも頂点を常にXYZで扱い、将来の投影変更でfeatureモデルを変更しない。
+
+高zoomや将来の3DでGPU float精度を失わないよう、カメラ中心を原点とするorigin rebasingをrenderer境界で行う。高度からworld Zへの変換はprojection層へ集約し、メートルとMercator単位を混在させない。
+
+## 静的タイルデータフロー
+
+```text
+camera change
+  → TileCoverCalculator
+  → TileScheduler
+  → PmTilesTileRepository
+  → MVT bytes
+  → worker isolateでdecode/geometry/label candidate生成
+  → TransferableTypedData
+  → UI isolateでFlutter Scene Geometryとlabel stateを更新
+```
+
+`TileKey`はsource、Z/X/Y、world wrapを持つ。source zoomは連続camera zoomから決定し、sourceのmin/max zoomで制限する。max zoom超過時は親タイルをoverscaleする。
+
+中心に近いタイルを優先し、同じタイルの重複取得を抑止する。カメラ移動で不要になった処理はキャンセルし、generation IDが古いworker結果をGPUへアップロードしない。
+
+MVT decode結果と描画データを分離する。再利用可能な頂点、layer別index、material bucket、Feature IDとgeometry rangeの対応を保持し、色や表示状態の変更でMVTを再decodeしない。
+
+## 描画
+
+Flutter SceneのScene GraphをFeature単位では使用しない。`tile × layer × material`単位でmeshを結合し、GPU bucketを生成する。
+
+- Fillは穴付きPolygonをtriangulationする。
+- Lineはjoin/cap/widthを反映したmeshへ展開する。
+- 観測点はinstance bufferを利用する。
+- 震源や震度アイコンはtexture付きquadを利用する。
+- P/S波は中心と半径から直接円meshを更新する。
+- 区域状態変更はFeature IDに対応するindex rangeを再構成する。
+
+## ラベル
+
+PMTilesの専用Pointレイヤーは、安定ID、アンカー、文字列、優先度、zoom範囲を持つ。表示対象tileから候補を収集し、安定IDで重複排除した後、screen座標へ投影する。
+
+`TextPainter`は文字列、style、locale、text scale、DPRでcacheする。カメラ移動時は原則再layoutせず、screen位置とcollisionだけを更新する。優先度順にcollision gridへ配置し、採用されたラベルをFlutter Sceneの前景`CustomPainter`で画面正立に描画する。
+
+直前frameで表示されたラベルへ配置上の継続性を与え、zoom境界のちらつきを抑える。
+
+## Hit test
+
+screen座標をworld、tile、tile-local座標へ逆変換する。静的featureはtileごとの空間index、動的featureは専用indexで候補を絞り、実geometryで判定する。結果は描画順の上側から返し、現在の`queryLayers`相当のAPIを提供する。
+
+## Cacheとエラー
+
+PMTiles bytes、decoded MVT、GPU meshを独立したLRUで管理する。容量、先読み、並列取得、retryは設定モデルへ明示し、隠れた固定fallbackを設けない。
+
+読み込み中や部分的な取得失敗では、直前に正常描画されたtileまたは有効な親tileを維持する。壊れたPMTiles/MVTを空tileとして扱わず、失敗データをcacheしない。古い処理のcancelはエラーにしない。
+
+エラーはsource、TileKey、失敗段階、再試行可能性を持つFreezed unionとして通知する。集約状態は`ready`、`loading`、`degraded`、`failed`とし、一部tile失敗で地図全体や動的レイヤーを消さない。
+
+## 性能観測
+
+初期実装からframe reconciliation、tile cover、label placement、render submission、tile request、decode、mesh build、GPU uploadを計測する。cache使用量、tile queue、GPU bucket、label候補/採用数、動的feature差分数も集約する。
+
+Controllerは`ValueListenable<MapPerformanceSnapshot>`と`Stream<MapPerformanceEvent>`を公開する。観測レベルとsnapshot更新間隔は`MapPerformancePolicy`で設定可能にし、通常時は軽量集約、デバッグ時はtile単位イベントを利用できるようにする。
+
+HUD、Widget/Golden test、実機性能試験は後続TODOとするが、後から計測方式を変更しない。
+
+## 初期検証
+
+初期実装では純粋ロジックの単体テストを必須とする。
+
+- WGS84、Mercator、tile-local、screenの往復
+- tile cover、overscale、world wrap
+- MVT Point/LineString/Polygonと穴付きPolygon
+- extent外buffer geometry
+- Node/Elementのmount/update/reorder/unmount
+- revisionとFeature IDによる差分
+- ラベル重複排除、優先度、衝突、text scale
+- hit test、stale generation破棄、cache eviction
+
+## Stacked PR
+
+後続PRは前のPRだけへ依存させ、各stackを単独でreview可能にする。
+
+1. `01-design`: 設計書、README、将来TODO
+2. `02-foundation`: package scaffold、モデル、座標、Node/Element、性能観測
+3. `03-tile-pipeline`: PMTiles、MVT、worker、tile scheduler、cache
+4. `04-scene-renderer`: Flutter Scene、Fill/Line、GPU resource管理
+5. `05-labels`: ラベル候補、collision、TextPainter overlay
+6. `06-dynamic-interaction`: 動的feature、camera、fitBounds、hit test
+7. `07-home-integration`: Home Mapのデバッグ切り替えと並行検証
+
+各PRで生成、format、analyze、対象単体テスト、`git diff --check`を実行する。後続branchは直前stackから分岐し、base PR取り込み時はstackを順番にrebaseする。
+
+## 移行完了条件
+
+Home Mapでベース地図、ラベル、観測点、震源、P/S波、区域状態、camera、hit test、障害時表示が既存実装と同等になり、性能観測で継続利用可能と判断できるまでMapLibreを削除しない。その後も地図画面を一つずつ移行する。

--- a/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
+++ b/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
@@ -11,14 +11,17 @@ PMTiles内のMVTと型付き動的データをDart側で解釈し、Fill・Line�
 - 初期対象はiOSとAndroidのみ。
 - 初期カメラは北固定・真上視点とし、bearingとpitchは実装しない。
 - Flutter master channelとFlutter Sceneの利用を許容する。
+- Flutter Sceneはadapter境界の内側へ隔離し、FlutterとFlutter Sceneのrevisionを固定する。実装着手前にiOS/Android実機spikeを通す。
 - MapLibre Style JSON互換は持たず、型付きの独自レイヤー定義を使う。
-- ラベルアンカーはPMTiles生成時に専用Pointレイヤーへ事前格納する。
+- ラベルの地理anchorはPMTiles生成時に専用Pointレイヤーへ1点だけ格納する。表示位置候補はrendererが実測文字サイズとDPRからscreen上に生成する。
+- ラベルanchorを含むbase PMTilesは既存Asset Pack manifest/item schema v1と既存asset IDを維持したまま後方互換に拡張し、生成器、release検証器、schema/summary attestationをrendererより先に用意する。
 - 動的更新でGeoJSONを介さない。
-- 主要データモデルはFreezedと`json_serializable`へ対応する。
+- runtimeの`MapNode`を含む主要データモデルは不変かつ原則Freezedとする。JSONは明示的な保存・通信DTO/specだけに要求する。
 - FlutterのWidget型は使わず、Widget/Elementに似た宣言と実体の分離を採用する。
 - 性能HUDは後続実装とするが、性能観測基盤は初期実装に含める。
 - 将来の3D、地下震源、断層表示に備え、座標モデルからZ軸を削除しない。
 - 既存MapLibre実装は機能・障害時挙動の同等性を確認するまで残す。
+- 新しいHome rendererは回転gestureを無効化して北固定を明示する。legacy MapLibre surfaceが残る間は共有`lockBearing`設定とUIを維持し、全surface移行後の削除は別途承認する。
 - 実装は依存順のstacked PRで提供する。
 
 ## 対象外
@@ -67,6 +70,10 @@ final scene = MapScene(
       key: const MapNodeKey('ps-wave'),
       data: waveSnapshot,
     ),
+    CurrentLocationLayerNode(
+      key: const MapNodeKey('current-location'),
+      data: currentLocationSnapshot,
+    ),
   ],
 );
 
@@ -77,27 +84,39 @@ EqmonitorMapView(controller: controller, scene: scene);
 
 ## モデルと実行時オブジェクト
 
-座標、カメラ、source、layer、feature、ラベル候補、hit test結果、エラー、性能snapshotはFreezedモデルとし、JSONへ変換できるようにする。
+座標、カメラ、source、layer、feature、ラベル候補、hit test結果、エラー、性能snapshotなどのruntimeモデルは不変とし、原則Freezedで表現する。`json_serializable`を必須にするのは、設定の永続化、API/manifest/schemaなどJSONを契約に使う明示的な保存・通信DTO/specだけとする。runtimeの`MapNode`、frame snapshot、hot snapshot/deltaをJSON経路へ通すことは要求しない。
 
 Flutter SceneのGeometry/Material、GPU buffer、`TextPainter`、Controller、Repository、HTTP clientなど、状態や外部資源を持つ実行時オブジェクトはモデルに含めず、JSON対応の対象外とする。
 
-動的データは安定したFeature IDとrevisionを持つ。reconcilerはrevisionで更新有無を判定し、変更時だけFeature ID単位の差分を適用する。描画経路でJSONへの変換は行わない。
+動的データsourceは`sourceInstanceId`と単調増加する`snapshotRevision`を持つ。full snapshotは`sourceInstanceId`、`snapshotRevision`、重複のない安定Feature IDの完全な集合を持ち、省略されたFeatureは削除済みとみなす。deltaは`sourceInstanceId`、`baseRevision`、`targetRevision`、重複のないFeature IDごとの`upserts`と`removals`を持ち、同じIDを両方へ含めない。
+
+deltaは全項目を検証してから1回のcommitでatomicに適用する。`targetRevision <= currentRevision`または既適用の`targetRevision`はduplicate/staleとして拒否し、`baseRevision > currentRevision`はgap、`baseRevision < currentRevision`かつtargetが新しい場合は枝分かれしたstale deltaとして拒否する。`targetRevision`は`baseRevision`より大きくなければならない。どの拒否でも既存feature集合とrevisionを変更しない。gapまたは枝分かれを検出したsourceはdelta受付を停止し、full snapshot resyncを要求する。新しい`sourceInstanceId`はfull snapshotからだけ開始する。Feature単位revisionだけで完全性を推論する代替契約は採用せず、削除はdeltaの`removals`、完全性はfull snapshotでのみ表す。
+
+reconcilerはkey、型、revision metadataだけを比較し、geometry collectionのFreezed deep equalityやhashをhot pathで実行しない。描画経路でJSONへの変換は行わない。
+
+isolate間payload、GPU upload command、毎frameのpoint instance deltaは、JSON DTOとは別のversion付きimmutable runtime型とする。必要に応じてFreezedを使えるがJSON変換は要求せず、外部保存へ流用しない。
 
 ## 宣言的Nodeツリー
 
 Flutter内部APIへ結合せず、地図専用の軽量reconcilerを実装する。
 
 ```text
-MapNode            不変な宣言、Freezed/JSON
+MapNode            不変な宣言、原則Freezed（JSON必須ではない）
   ↓ keyとnode型でreconcile
 MapElement         mount/update/unmountと実行状態
   ↓ command queue
 MapRenderObject    CPU meshとGPU resource
 ```
 
-`MapNode`は毎回再生成してよい。同じkeyとnode型なら`MapElement`を更新し、異なる場合はunmount後にmountする。ネットワーク取得やGPU操作は宣言の組み立て中に実行せず、command queueをrender tickで適用する。
+`MapNode`は毎回再生成してよい。同じkeyとnode型なら`MapElement`を更新し、異なる場合はunmount後にmountする。ネットワーク取得やGPU操作は宣言の組み立て中に実行せず、command queueをrender tickで適用する。宣言順は描画順の唯一の根拠とし、hit testは同じ解決済み順序を逆から走査する。
 
-設定変更はstyleのみ、filter/source layer、動的feature、source交換に分類し、必要な範囲だけ再構築する。GPU resourceの解放は描画中の参照を避けるためframe終了後に行う。
+設定変更はstyleのみ、filter/source layer、動的feature、source交換に分類し、必要な範囲だけ再構築する。GPU resourceの解放は描画中・実行中のGPU参照を避け、後述のretirement方式で行う。
+
+各`MapElement`とsource mountは再利用されないincarnation tokenとowned cancellation scopeを持つ。network、worker、label、uploadを含む全async継続はawaitの前後でmounted状態とtokenを検証する。command queueはsource内で順序を保証し、同一resourceへの更新はlast-writer-wins、disposeはidempotentかつawait可能にする。古いtokenの結果とエラーはattachmentも通知もしない。
+
+render開始時に、camera、viewport、DPR、source/layer revision、app lifecycle、Flutter Scene context generationを固定したimmutable `MapFrameSnapshot`を作る。各render nodeはdirty reasonと`needsContinuousFrame`を返し、静的nodeは変更時だけ、P/S波など時間依存nodeだけは必要期間中に継続frameを要求する。detach/backgroundではanimation、request、decode、uploadを停止する。
+
+CPU frame終了はGPU完了を意味しない。GPU resourceはFlutter Scene/Flutter GPUのcompletion通知、または実機検証したframes-in-flight世代方式でretireする。context generationが変わったresourceを再利用しない。
 
 ## 座標系
 
@@ -119,6 +138,14 @@ WGS84 Geographic
 
 高zoomや将来の3DでGPU float精度を失わないよう、カメラ中心を原点とするorigin rebasingをrenderer境界で行う。高度からworld Zへの変換はprojection層へ集約し、メートルとMercator単位を混在させない。
 
+- projection入力の緯度はWeb Mercator限界の±85.0511287798066°へclampする。元のWGS84値は変更しない。
+- cameraはdate lineを連続移動できるunwrapped longitudeを持ち、tile addressは`[-180, 180)`へ正規化したlongitudeと明示的なworld wrapを使う。
+- normalized worldはXが東、Yが南、Zが上とする。CPU地理計算は`double`、GPUはorigin rebasing後の`float`とする。
+- CPU行列はcolumn vectorとして`clip = projection * view * model * position`の順に適用する。Flutter Scene固有表現への変換はadapter内だけで行う。
+- screen APIとhit testはlogical pixelを使い、Scene surface境界だけでDPRを掛けてphysical pixelへ変換する。
+- altitudeは緯度`lat`で`altitudeMeters / (earthCircumference * cos(lat))`のnormalized Mercator Zへ変換し、clamp済み緯度を使う。
+- P/S波の距離は地表のgeodesic meter radiusとし、方位ごとの地理座標を求めてから投影する。Mercator平面上の単純な円を距離表現には使わない。
+
 ## 静的タイルデータフロー
 
 ```text
@@ -132,78 +159,164 @@ camera change
   → UI isolateでFlutter Scene Geometryとlabel stateを更新
 ```
 
-`TileKey`はsource、Z/X/Y、world wrapを持つ。source zoomは連続camera zoomから決定し、sourceのmin/max zoomで制限する。max zoom超過時は親タイルをoverscaleする。
+cacheとrender entryの`TileKey`は`sourceInstanceId`、`sourceRevision`またはcontent digest、canonical Z/X/Y、world wrapを持つ。source交換時は新しいidentityを発行し、異なるrevisionのtileを引き継がない。source zoomは連続camera zoomからMapLibreと同じ規則で決定し、sourceのmin/max zoomで制限する。max zoom超過時は親タイルからoverscaled childへの座標変換とclipを明示して描画する。
 
-中心に近いタイルを優先し、同じタイルの重複取得を抑止する。カメラ移動で不要になった処理はキャンセルし、generation IDが古いworker結果をGPUへアップロードしない。
+中心に近いタイルを優先し、同じtile identityの重複取得を抑止する。カメラ移動で不要になった処理はキャンセルし、frame generationまたはincarnation tokenが古いworker結果をGPUへアップロードしない。workerは上限付きpersistent poolとし、queue backpressure、priority変更、decode/geometry構築中のcancellation checkpointを持つ。
 
 MVT decode結果と描画データを分離する。再利用可能な頂点、layer別index、material bucket、Feature IDとgeometry rangeの対応を保持し、色や表示状態の変更でMVTを再decodeしない。
+
+worker出力はversion付きflat payloadとする。`TransferableTypedData`内にvertex/index buffer、offset table、feature/property/string table、material bucket metadata、label candidate、構造化decode errorを格納する。payloadのbyte上限と各tableの件数上限、transfer後の所有権を定め、UI isolateでobject graphを再コピーしない。
+
+### PMTilesの信頼境界
+
+PMTiles/MVTはローカルでもremoteでもuntrustedなbounded inputとして扱う。上限値はversion付き`MapDecodeLimits`とAsset Pack schemaへ明示し、隠れた固定fallbackにしない。
+
+- Asset Packの取得、platform/release由来のmanifest trust、v1 manifest/item schema、`sizeBytes`、`sha256`の検証はappが所有する。appは検証後のpath、digest、size、semantic schema/summaryを持つimmutable verified source descriptorを`eqmonitor_map`へ渡す。packageは`app`へ依存せず、未検証pathやmanifest repositoryを受け取らない。
+- remoteはHTTPSとallowlist hostを基本とし、redirect回数、cross-host redirect、TLS downgradeをpolicyで制限する。
+- remote range合成はweakでないstrong ETag、またはAPIが提供して`If-Match`に利用できるimmutable digest/versionを最初のresponseで確立できる場合だけ行う。2回目以降の全Range requestへそのvalidatorを`If-Match`で送り、`206`、requested `Content-Range`、安定したarchive total length、同一validatorを必須とする。`412`、validator/total length不一致、validator欠落では、それまでに取得した全byteを破棄してtyped snapshot mismatchにする。
+- strong snapshot identityを得られないremoteはrangeを合成せず、上限付きの単一full-stream downloadだけを許可する。途中byteを別requestと結合しない。
+- archive offsetとlengthはchecked arithmeticで検証し、archive、directory depth/entry、compressed/uncompressed tile bytes、layer、feature、vertex、command、string、triangulation work、decode時間にhard limitを設ける。
+- `eqmonitor-backend`のproducer/release validatorはarchive全体を走査し、global coverage、zoom別feature count、必須ID集合、必須propertyと型、zoom範囲を検証する。検証済みsemantic schema/summaryはarchive SHA-256へ結び付けた署名済み、または同等にtrustedなrelease attestationとして配布する。
+- runtimeではappがmanifest trust、archive size/hash、attestationとdigestの対応を検証し、packageがPMTiles header/metadataとverified descriptorのschema/summaryの整合を検証する。その後は読み込んだ各tileへ件数、ID/property型、zoom、byte/work上限を適用する。runtimeがarchive全体をscanしてglobal coverageや全件数を再検証するとはしない。
+- limit超過、破損、semantic不足は空tileへ変換せずtyped errorにする。malformed/fuzz/decompression bomb/pathological polygon fixtureを単体テストへ含める。
+
+### Asset Pack rollout
+
+初期rolloutでは既存clientを壊さないことを必須とする。manifestと各itemの`schema_version`はv1のまま、asset IDは既存の`BASE_MAP_PMTILES`だけを使い、version付きlabel Point source layerを既存base PMTilesへ追加する。既存clientは未知のsource layerとPMTiles metadataを無視して従来layerを描画できなければならない。新しいasset IDは追加しない。
+
+producerは既存basemap layerの互換性fixtureと新旧client fixtureを通し、global semantic summary/schemaをrelease attestationへ出力する。v1 manifest itemの`sha256`とattestationのarchive digestを一致させることで、新しいlayer schema/summaryを既存asset digestへ結び付ける。manifest/item schemaを変更する方式は、producer先行、旧新consumer共存、store rollout、rollbackを別途実証したrelease sequenceが承認されるまで採用しない。
 
 ## 描画
 
 Flutter SceneのScene GraphをFeature単位では使用しない。`tile × layer × material`単位でmeshを結合し、GPU bucketを生成する。
 
+描画順は`render phase → 宣言layer order → source order → overscaled tile order → feature order`からなるcanonical `RenderSortKey`で固定する。material batchingはこの順を変えず、同じ連続範囲だけを結合する。hit testも同じkeyを利用する。
+
 - Fillは穴付きPolygonをtriangulationする。
-- Lineはjoin/cap/widthを反映したmeshへ展開する。
+- Fill/LineはMVT extent外bufferをmesh構築とtile edgeのjoinに保持し、最終描画はtile境界へscissorする。ring winding、hole分類、degenerate/invalid ringのreject規則を固定する。
+- Lineはjoin/cap/width、miter limit、antialiasingを反映したmeshへ展開し、隣接tileで端点処理が変わらないようbuffer内のline continuationを使う。
 - 観測点はinstance bufferを利用する。
 - 震源や震度アイコンはtexture付きquadを利用する。
-- P/S波は中心と半径から直接円meshを更新する。
+- P/S波は中心とgeodesic半径からsegmentを更新し、instance/update bufferだけを差し替える。
 - 区域状態変更はFeature IDに対応するindex rangeを再構成する。
+
+動的点群はWGS84からnormalized projectionへの結果をFeature ID単位でcacheし、zoom変更時はscaleとscreen transformだけを更新する。投影済み点とflat grid spatial indexを描画候補、label collision、hit testでimmutableに共有する。少数点は線形探索、多数点はgridを使う閾値をpolicyで設定する。hover/selectionはcollection objectではなく安定Feature IDで更新後のfeatureへ再束縛する。
+
+### Flutter Scene adapterと実装gate
+
+domain、reconciler、packed meshはFlutter Scene型へ依存させず、`MapSceneRendererAdapter`境界でGeometry/Material/bufferへ変換する。Flutter SDK revisionとFlutter Scene package revisionをlockfileと設計記録へ固定する。
+
+`02-scene-spike`ではiOS/Android実機で正射影のprocedural tile mesh、custom material、部分buffer更新、TextPainter overlay合成、surface resize、dispose、background/foreground、context再生成後のresource rebuild、GPU completionまたは安全なretirement方式を確認する。満たせない場合はfoundationを実装せず、この設計とadapterを見直す。
 
 ## ラベル
 
-PMTilesの専用Pointレイヤーは、安定ID、アンカー、文字列、優先度、zoom範囲を持つ。表示対象tileから候補を収集し、安定IDで重複排除した後、screen座標へ投影する。
+PMTilesの専用Pointレイヤーは、Feature geometryとして1つの地理anchor、安定ID、文字列、優先度、zoom範囲を持つ。alternate geographic anchorやleader line属性はMVTへ持たせない。layer IDとproperty型、ID生成規則、zoom policyをversion付きAsset Pack semantic schemaで管理し、生成器・producer validator・fixtureをrendererと同じ契約で検証する。
 
-`TextPainter`は文字列、style、locale、text scale、DPRでcacheする。カメラ移動時は原則再layoutせず、screen位置とcollisionだけを更新する。優先度順にcollision gridへ配置し、採用されたラベルをFlutter Sceneの前景`CustomPainter`で画面正立に描画する。
+表示対象tileから候補を収集し、source/layer/安定ID/world wrapで重複を解決した後、地理anchorをscreen座標へ投影する。rendererは`TextPainter`の実測boundsとDPRからright、left、up、downのscreen placement candidateを生成する。候補は優先度、layer order、stable ID、screen placement orderの決定的sort keyでcollision gridへ配置し、画面端補正を行う。既定のright以外へ退避したlabelのleader line要否、長さ、stroke、描画閾値はversion付きrenderer policyで決め、asset schemaへは含めない。
 
-直前frameで表示されたラベルへ配置上の継続性を与え、zoom境界のちらつきを抑える。
+`TextPainter`は文字列、text direction、locale、font family/fallback/load generation、weight/features、letter/word spacing、height、color、`TextScaler`、width、max lines、ellipsis、theme generation、DPRを完全なkeyとして、byte/count上限付きLRUでcacheする。font load、theme、locale、text scale、DPR、accessibility変更で対応entryをinvalidateする。カメラ移動時は原則再layoutせず、screen位置とcollisionだけを更新する。
+
+直前frameの配置へ限定的なhysteresisを与えてzoom境界のちらつきを抑えるが、priority変更を上書きしない。採用ラベルはFlutter Scene前景の`CustomPainter`で画面正立に描画する。装飾labelと操作・防災上重要なlabelを分類し、後者は`semanticsBuilder`または対応する`Semantics` surfaceで読み上げ、focus、activateを提供する。
 
 ## Hit test
 
-screen座標をworld、tile、tile-local座標へ逆変換する。静的featureはtileごとの空間index、動的featureは専用indexで候補を絞り、実geometryで判定する。結果は描画順の上側から返し、現在の`queryLayers`相当のAPIを提供する。
+`MapQueryRequest`はlogical pixelのpointまたはbox、対象layer key、hit toleranceを持つ。screen座標をworld、tile、tile-local座標へ逆変換し、現在commit済みの`MapFrameSnapshot`と空間indexだけを同期的に検索する。networkやdecodeは開始しない。
+
+visibility、min/max zoom、filter、fill hole、描画時のline/icon/label boundsを先に解決し、実際に描画したgeometryとscreen-space widthで判定する。結果はsource/layer/Feature IDの規則でtile/wrap重複を除き、canonical `RenderSortKey`の上側から、型付きpropertiesとprovenanceを含む`MapQueryResult`として返す。現在の`queryLayers`利用箇所ごとにparity fixtureを作る。
+
+現在の`queryLayers` callerはIntensity HistoryとEarthquake History detailsの2箇所であり、Home移行のgateにはしない。両surfaceの後続移行では、query hitだけでなく、その後に行うタップ地理座標からの最寄りJMA region/city、観測station/Shindo DB station検索とpopup/drill-downまでをparity gateにする。
+
+## 現在地
+
+appはpermission、location service、lifecycleを扱い、`CurrentLocationLayerNode`へ`availableFix`または理由付き`unavailable`を渡す。fixはcoordinate、非負の`accuracyMeters`、`capturedAt`、任意のcourse/speedと各値のvalidityを持つ。利用不能時に固定座標や疑似fixへfallbackしない。
+
+- available fixは現在地点とgeodesic meterのaccuracy radiusを描画する。accuracyが非finite、不正、またはapp policyの信頼上限外ならradiusを描画せず、その理由をobservable stateへ残す。
+- course indicatorは有効なcourseとapp側の信頼判定がある場合に、真北基準の向きで表示する。北固定cameraは地図の回転を止めるだけで、course indicatorを削除する根拠にはしない。
+- pulseはfresh fixだけに使い、`CurrentLocationPolicy`の周期・振幅、app lifecycle、reduced motionに従う。background、stale、reduced motionでは静止表示にする。
+- `now - capturedAt`が設定可能な`staleAfter`を超えたfixはstaleとし、pulseとcourseを止め、point/accuracyをstale styleへ変更し、semanticsとperformance eventへageを公開する。
+- unavailableではpoint、accuracy、courseを描画せず、permission denied、service disabled、no fixなどのtyped reasonをappへ通知する。appが適切な案内やretryを表示する。
 
 ## Cacheとエラー
 
-PMTiles bytes、decoded MVT、GPU meshを独立したLRUで管理する。容量、先読み、並列取得、retryは設定モデルへ明示し、隠れた固定fallbackを設けない。
+PMTiles bytes、decoded MVT、CPU mesh、GPU resource、TextPainterをresource ownership graph下のcacheで管理する。cache別上限に加えてaggregate CPU/GPU budgetを持ち、可視・upload中・frames-in-flightのresourceをpinする。容量、先読み、並列取得、retry、eviction順は設定モデルへ明示し、隠れた固定fallbackを設けない。
 
-読み込み中や部分的な取得失敗では、直前に正常描画されたtileまたは有効な親tileを維持する。壊れたPMTiles/MVTを空tileとして扱わず、失敗データをcacheしない。古い処理のcancelはエラーにしない。
+読み込み中や部分的な取得失敗のfallbackはsource criticalityごとに定義する。basemapは同一source revisionの直前正常tileまたは有効な親tileをprovenanceとage付きで維持できる。event固有・hazard sourceは異なるrevisionのtileを絶対に維持せず、fail closedして利用不可・stale状態を明示する。壊れたPMTiles/MVTを空tileとして扱わず、失敗データをcacheしない。古い処理のcancelはエラーにしない。
 
-エラーはsource、TileKey、失敗段階、再試行可能性を持つFreezed unionとして通知する。集約状態は`ready`、`loading`、`degraded`、`failed`とし、一部tile失敗で地図全体や動的レイヤーを消さない。
+エラーはsource identity、TileKey、失敗段階、再試行可能性、provenance、ageを持つFreezed unionとして通知する。集約状態は`ready`、`loading`、`degraded`、`failed`とし、一部basemap tile失敗で動的レイヤーを消さない。同一原因のtile errorは集約key、count、代表sampleを持たせ、rate limitとbounded deliveryで通知する。
+
+memory pressureでは非可視・非pin resourceから削除する。background/surface loss/context generation変更ではGPU resourceを破棄し、保持済みCPU mesh、decoded data、または再decodeの順で再構築する。current/peak bytes、pin、eviction/rebuild原因を性能snapshotへ記録する。
 
 ## 性能観測
 
-初期実装からframe reconciliation、tile cover、label placement、render submission、tile request、decode、mesh build、GPU uploadを計測する。cache使用量、tile queue、GPU bucket、label候補/採用数、動的feature差分数も集約する。
+初期実装からframe reconciliation、tile cover、label placement、render submission、tile request、decode、mesh build、GPU uploadをmonotonic clockで計測する。queue待機と実行、GPU submissionとcompletionを分離する。Flutterの`FrameTiming`でbuild/raster/vsync超過を取得し、cache hit/missとcurrent/peak bytes、request/decode byte、tile queue、GPU bucket、label候補/採用数、動的feature差分数、node/layer名とfeature数も集約する。
 
-Controllerは`ValueListenable<MapPerformanceSnapshot>`と`Stream<MapPerformanceEvent>`を公開する。観測レベルとsnapshot更新間隔は`MapPerformancePolicy`で設定可能にし、通常時は軽量集約、デバッグ時はtile単位イベントを利用できるようにする。
+Controllerはversion付き`ValueListenable<MapPerformanceSnapshot>`と`Stream<MapPerformanceEvent>`を公開する。観測レベル、sampling、集約window、percentile、snapshot更新間隔、ring buffer容量、drop policyを`MapPerformancePolicy`で設定可能にし、通常時はrate-limitedな軽量集約、デバッグ時はboundedなtile単位イベントを利用できるようにする。fixture IDをmetricsへ含め、instrumentation overhead budgetも計測する。
 
 HUD、Widget/Golden test、実機性能試験は後続TODOとするが、後から計測方式を変更しない。
+
+## KEViから採用する知見
+
+先行実装として、MIT Licenseの[ingen084/KyoshinEewViewerIngen](https://github.com/ingen084/KyoshinEewViewerIngen/tree/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f) commit `5a2bf513b6b9c93ee06473f70b6d27ee96070b3f`を参照した。
+
+- [`MapControl.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.CustomControl/MapControl.cs)と`MapLayer`で観測したUI/render間state snapshot、`RefreshRequested`、`NeedPersistentUpdate`を、`MapFrameSnapshot`とframe schedulingへ反映する。変更種別を表すtyped dirty reasonはEQMonitor側の強化であり、KEVi由来とはしない。
+- [`MapLayerHost.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.Map/Layers/MapLayerHost.cs)の宣言順描画・逆順hit testを、canonical render orderへ反映する。
+- [`PointLayoutCache.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.Map/Layers/PointLayoutCache.cs)と[`NormalizedPointSet.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.Map/Layers/NormalizedPointSet.cs)で観測したarray-backed point dataとprojection cacheを参考にする。projection結果とflat spatial indexをimmutableに共有することはEQMonitor側のpolicyである。
+- `HoverTracker`で観測したのはcaller提供のequalityによる再照合である。安定Feature IDによるhover/selection再束縛はEQMonitor側のpolicyとする。
+- [`MapLayerLabelRenderer.cs`](https://github.com/ingen084/KyoshinEewViewerIngen/blob/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f/src/KyoshinEewViewer.CustomControl/MapLayerLabelRenderer.cs)の実測文字サイズに基づくscreen placementとleader lineをrenderer policyの参考にする。alternate geographic anchorをKEViへ帰属させず、assetには1つの地理anchorだけを格納する。
+
+KEViはSkia/Avaloniaの直接描画で、PMTiles/MVT tile engineではない。Miller projection、1回だけのlongitude wrap、全体`SKPicture` invalidation、host lock中のrender、次frameでのresource dispose、毎frame全再描画は採用しない。tile selection、overzoom、wrap、Web MercatorはMapLibreの仕様・実装を正とする。
 
 ## 初期検証
 
 初期実装では純粋ロジックの単体テストを必須とする。
 
 - WGS84、Mercator、tile-local、screenの往復
-- tile cover、overscale、world wrap
+- Mercator緯度限界、date line、最大zoom、複数DPR、正負の高度、geodesic半径
+- tile cover、overscale child transform、world wrap、canonical render order
 - MVT Point/LineString/Polygonと穴付きPolygon
-- extent外buffer geometry
-- Node/Elementのmount/update/reorder/unmount
-- revisionとFeature IDによる差分
-- ラベル重複排除、優先度、衝突、text scale
-- hit test、stale generation破棄、cache eviction
+- extent外buffer geometry、tile edge line、invalid ring、resource limit、malformed/fuzz payload
+- Node/Elementのmount/update/reorder/unmount、同じkeyのremount、await中cancel、source交換、controller dispose
+- full snapshotと`baseRevision`/`targetRevision` deltaのatomic apply、duplicate/stale/gap reject、remove、full resync
+- strong ETag/immutable validator付きrange、`If-Match`、`206`/total length検証、range間でarchiveが変異して`412`またはvalidator不一致になるfixture、validatorなしfull-stream
+- producerのglobal semantic fixtureと、runtimeのdescriptor/metadata整合・bounded per-tile検証
+- ラベル重複排除、決定的優先順、right/left/up/down screen placement、衝突、leader line policy、hysteresis、cache invalidation、semantics
+- hit test parity、stale generation破棄、aggregate cache eviction、context generation rebuild
 
-## Stacked PR
+## Delivery graph
 
-後続PRは前のPRだけへ依存させ、各stackを単独でreview可能にする。
+### Cross-repository prerequisite
 
-1. `01-design`: 設計書、README、将来TODO
-2. `02-foundation`: package scaffold、モデル、座標、Node/Element、性能観測
-3. `03-tile-pipeline`: PMTiles、MVT、worker、tile scheduler、cache
-4. `04-scene-renderer`: Flutter Scene、Fill/Line、GPU resource管理
-5. `05-labels`: ラベル候補、collision、TextPainter overlay
-6. `06-dynamic-interaction`: 動的feature、camera、fitBounds、hit test
-7. `07-home-integration`: Home Mapのデバッグ切り替えと並行検証
+`eqmonitor-backend`側で先に`B1-label-asset-release` milestoneを完了する。既存base PMTilesへversion付きlabel Point layerを後方互換に追加するgenerator、archive全体のsemantic validator、digestへ結び付いたtrusted schema/summary attestation、mutation/旧新client fixture、Asset Pack releaseを同repositoryでreview・releaseする。このbranch/PRは`eqmonitor-backend`の既定branchまたは同repository内の先行branchから分岐し、EQMonitor repositoryのbranchやPRを祖先にしない。EQMonitor側はrelease済みartifact digestとattestationをfixtureとして受け取る。
 
-各PRで生成、format、analyze、対象単体テスト、`git diff --check`を実行する。後続branchは直前stackから分岐し、base PR取り込み時はstackを順番にrebaseする。
+### EQMonitor repository stacked PRs
+
+EQMonitor側の後続PRは前のEQMonitor PRだけへ依存させ、各stackを単独でreview可能にする。backend prerequisiteはbranch ancestryではなく、release artifact contractとして依存する。
+
+1. `01-design`: 設計書、README、知見、将来TODO
+2. `02-scene-spike`: minimalでcompile可能な`packages/eqmonitor_map` scaffoldとexample/harnessを作成し、revision固定、adapter prototype、iOS/Android実機gateを実行
+3. `03-foundation`: モデル、座標、Node/Element、FrameSnapshot、render order、packed mesh/render command契約とfake、性能観測
+4. `04-tile-pipeline`: verified source descriptor、trust policy、PMTiles、MVT、packed worker payload、tile scheduler、cache
+5. `05-label-asset-integration`: backend release fixture、semantic schema/summary contract、app側Asset Pack検証とpackage boundary、旧新client compatibility test
+6. `06-scene-renderer`: Flutter Scene adapter、Fill/Line、GPU lifecycleとcontext recovery
+7. `07-labels`: screen placement候補、collision、TextPainter overlay、leader line、semantics
+8. `08-dynamic-interaction`: atomic typed delta、point index、camera、fitBounds、現在地、hit test
+9. `09-home-integration`: Home Mapのデバッグ切り替え、北固定/rotation無効化、並行検証。共有`lockBearing`設定は削除しない
+
+各PRはその時点でcompileし、checked-in fixtureに対する実行可能なcontract testを持つ。後続consumerだけが使う未検証APIを先に公開しない。各PRで生成、format、analyze、対象単体テスト、`git diff --check`を実行する。後続branchは直前のEQMonitor stackから分岐し、base PR取り込み時はstackを順番にrebaseする。
 
 ## 移行完了条件
 
-Home Mapでベース地図、ラベル、観測点、震源、P/S波、区域状態、camera、hit test、障害時表示が既存実装と同等になり、性能観測で継続利用可能と判断できるまでMapLibreを削除しない。その後も地図画面を一つずつ移行する。
+Home Mapの移行matrixをstack内でversion管理する。
+
+| 項目 | 移行条件 |
+|------|----------|
+| pan / pinch zoom | min/max zoom、gesture enable、boundsを含め同等 |
+| rotation | 新Home rendererでgestureを明示的に無効化し北固定にする。legacy MapLibre consumer用`lockBearing`設定/UIは維持する |
+| camera | 初期位置、fitBounds、date line、viewport resize、状態復元が同等 |
+| 現在地 | permission/lifecycle/errorをapp側で扱い、accuracy、course、pulse、stale、unavailableの規定を型付き`CurrentLocationLayerNode`で満たす |
+| theme / layer | Light/Dark再構築、順序、visibility、loading/errorが同等 |
+| event / interaction | Homeで利用するgesture event、controller、hover/selectionがparity fixtureを通る。別surfaceの`queryLayers` parityはHome gateに含めない |
+| hazard | 観測点、震源、P/S波、区域状態でsource revisionとstale表示規則を満たす |
+| platform | label asset新schemaとFlutter Scene lifecycleをiOS/Android実機で検証済み |
+
+ベース地図、ラベル、観測点、震源、P/S波、区域状態、camera、現在地、Homeで実際に使うinteraction、障害時表示がmatrixを満たし、性能観測で継続利用可能と判断できるまでHomeのMapLibre pathを削除しない。その後は`docs/todo/780_eqmonitor_map_maplibre_surface_migrations.md`に従って地図surfaceを一つずつ移行し、全surface完了までMapLibre packageと共有設定を削除しない。

--- a/docs/todo/450_eqmonitor_map_future_surface.md
+++ b/docs/todo/450_eqmonitor_map_future_surface.md
@@ -1,0 +1,10 @@
+# eqmonitor_mapの対応surfaceを拡張する
+
+## 実施内容
+
+- Performance HUD
+- Web / macOS / Windows / Linux
+- 線上ラベルと文字回転
+- 汎用パッケージとして公開可能なAPI境界の検討
+
+初期iOS/Android版の性能と障害時挙動を確立した後に着手する。

--- a/docs/todo/650_eqmonitor_map_3d_camera.md
+++ b/docs/todo/650_eqmonitor_map_3d_camera.md
@@ -1,0 +1,16 @@
+# eqmonitor_mapを3D cameraと地下表示へ拡張する
+
+## 背景
+
+初期実装は北固定・真上視点だが、座標モデルは`altitudeMeters`を保持し、GPU頂点はXYZで扱う。
+
+## 実施内容
+
+- bearing / pitch
+- 透視投影
+- 地形と3D地物
+- 負の高度を使う地下震源要素
+- 断層面・断層モデル
+- 地表、地下、overlayのrender phaseとdepth policy
+
+既存featureモデルを作り直さずcamera/projection/rendererの拡張で実現する。

--- a/docs/todo/780_eqmonitor_map_maplibre_surface_migrations.md
+++ b/docs/todo/780_eqmonitor_map_maplibre_surface_migrations.md
@@ -1,0 +1,33 @@
+# MapLibre地図surfaceをeqmonitor_mapへ移行する
+
+## 背景
+
+Home Mapの初期移行だけではMapLibre依存は削除できない。2026-08-02時点で`MapLibreMap`を直接hostする全surfaceと、そのlayer・interactionの移行gateをこの文書で一元管理する。
+
+## Surface inventory
+
+- [ ] Home Map (`app/lib/feature/home/ui/component/map/home_map_view.dart`): base map、EEW推定震度/警報区域、強震観測点、P/S波、揺れ検知、震源、label、camera保存/復元、現在地、layer/debug control、map eventを移行する。これは初期rendererの対象とする。
+- [ ] Home表示範囲selector (`app/lib/feature/home/ui/page/home_map_bounds_selector_page.dart`): pan/zoom、visible region取得、custom bounds保存を移行する。
+- [ ] Live Monitor (`app/lib/feature/live_monitor/ui/components/live_monitor_map_host.dart`): realtimeのHome相当layer、earthquake historyの推定震度/区域/観測station/震源layer、automatic focus、map instance ownership、event配信を移行する。
+- [ ] EEW details (`app/lib/feature/eew/ui/components/eew_details_map_view.dart`): forecast region、static/simulation P/S波、震源、表示範囲を移行する。
+- [ ] Earthquake History details (`app/lib/feature/earthquake_history/ui/components/earthquake_history_details_map_view.dart`): region/city fill、推定震度、Shindo DB fill/station、観測station、震源/誤差、表示mode、fitBounds、tap popupを移行する。
+- [ ] Intensity History (`app/lib/feature/intensity_history/ui/intensity_history_page.dart`): prefecture/city fill、click/long-click、drill-down/back、fitBounds、detail modalを移行する。
+- [ ] Region picker (`app/lib/feature/earthquake_history/ui/components/region_picker_map_page.dart`): tap地理座標からのJMA地域解決、loading、選択確定を移行する。
+- [ ] Tsunami details (`app/lib/feature/tsunami/ui/components/tsunami_details_map_view.dart`): warning coastline、震源、観測station、station state、fitBounds、style resource lifecycleを移行する。
+- [ ] Seismicity (`app/lib/feature/seismicity/ui/seismicity_page.dart`): epicenter point、color/span変更、矩形選択、screen/geographic変換、analysis panel連携を移行する。
+- [ ] Hi-net Seismicity debug (`app/lib/feature/settings/children/config/debug/hinet_seismicity/ui/hinet_seismicity_page.dart`): epicenter point、filter、矩形選択、screen/geographic変換、analysis panel連携を移行する。
+- [ ] Shake Detection history details (`app/lib/feature/shake_detection/ui/shake_detection_history_details_page.dart`): event polygonのfill/line、fitBounds、style-load初期化をtyped Polygonへ移行する。
+
+## Query parity gates
+
+Home移行は`queryLayers` parityをgateにしない。現行callerは次の2つだけであり、各surface移行時に二段階の選択処理までfixture化する。
+
+- [ ] Intensity History: render hitでcity/region source layerを識別し、tap地理座標から`JmaMapUtility.findNearestItem`で最寄りregion/cityを解決してdrill-downまたはmodalを開く。
+- [ ] Earthquake History details: render hitでstation、Shindo DB station、city/regionを識別し、tap地理座標から最寄りstationまたはJMA region/cityを解決してpopupを開く。
+
+## Cross-surface completion gates
+
+- [ ] 各surfaceでbase map、layer順、Light/Dark、loading/degraded/error、camera、gesture、fitBounds、必要なhit testのparity fixtureを通す。
+- [ ] `MapLibreEventProvider`、`MapOperationQueueScope`、MapLibre style/source/layer helperとGeoJSON更新を、全consumer移行後にだけ削除する。
+- [ ] 共有`lockBearing`設定/UIはlegacy MapLibre consumerが1つでも残る間は維持する。全surfaceでrotation policyを決定し、別途承認したmigrationでfield/UIを削除する。
+- [ ] MapLibre packageとplatform asset連携は全surface、test、debug routeから参照がなくなったことを確認してから削除する。

--- a/docs/todo/800_eqmonitor_map_deferred_verification.md
+++ b/docs/todo/800_eqmonitor_map_deferred_verification.md
@@ -11,7 +11,9 @@
 - Light/Darkとtext scale 1.0/1.5/2.0のGolden test
 - iOS/Androidの基準端末と地図fixtureの選定
 - 高速移動、offline復帰、background復帰、memory pressureの実機試験
-- frame、decode、mesh build、GPU upload、cacheの回帰基準策定
+- context loss/rebuildとframes-in-flight resource retirementの反復・長時間実機試験
+- frame、queue待機、decode、mesh build、GPU submission/completion、cacheの回帰基準策定
+- metrics収集自体のCPU/memory overhead上限とevent drop検証
 
 ## 前提
 

--- a/docs/todo/800_eqmonitor_map_deferred_verification.md
+++ b/docs/todo/800_eqmonitor_map_deferred_verification.md
@@ -1,0 +1,18 @@
+# eqmonitor_mapの描画・性能検証を拡充する
+
+## 背景
+
+初期実装は座標、tile、MVT、reconciler、label、hit testなどの単体テストを優先する。Widget test、Golden test、実機性能試験は性能観測APIが安定した後に追加する。
+
+## 実施内容
+
+- パン、pinch zoom、loading、degraded表示のWidget test
+- 固定PMTiles、viewport、DPRを使うFill/Line/labelのGolden test
+- Light/Darkとtext scale 1.0/1.5/2.0のGolden test
+- iOS/Androidの基準端末と地図fixtureの選定
+- 高速移動、offline復帰、background復帰、memory pressureの実機試験
+- frame、decode、mesh build、GPU upload、cacheの回帰基準策定
+
+## 前提
+
+`MapPerformanceSnapshot`と`MapPerformanceEvent`は初期実装で提供し、このTODOで計測方式を作り直さない。

--- a/packages/eqmonitor_map/README.md
+++ b/packages/eqmonitor_map/README.md
@@ -2,7 +2,7 @@
 
 EQMonitor専用のFlutter地図レンダラーです。
 
-Flutter SceneをGPU描画基盤としてPMTiles/MVTの地物を描画し、ラベルは事前計算済みアンカーからFlutterの`TextPainter`で描画します。MapLibre Style JSON互換ではなく、型付きの宣言的`MapNode`ツリーを利用します。
+Flutter SceneをGPU描画基盤としてPMTiles/MVTの地物を描画し、ラベルはasset内の1つの地理anchorから、実測文字サイズとDPRに応じたscreen placement候補を生成してFlutterの`TextPainter`で描画します。MapLibre Style JSON互換ではなく、型付きの宣言的`MapNode`ツリーを利用します。
 
 > [!NOTE]
 > 現在は設計段階です。実装はstacked PRで段階的に追加します。
@@ -12,34 +12,46 @@ Flutter SceneをGPU描画基盤としてPMTiles/MVTの地物を描画し、ラ�
 - iOS / Android
 - Flutter master channel
 - 北固定・真上視点のパンとzoom
-- ローカル / HTTP PMTiles
+- ローカル / HTTPS PMTiles
 - MVT Fill / Line
 - TextPainterラベル
 - 型付き動的Point / Circle / Polygon状態
 - camera controller、fitBounds、座標変換、hit test
 - 性能イベントとsnapshot
 
+remote PMTilesのstrong validator付きrange合成、appが検証したAsset Pack descriptor、producerのglobal semantic検証とruntimeのbounded per-tile検証は、実装stackで追加する計画です。現行manifestがsemantic validationを提供済みという意味ではありません。source revisionを跨いだtile fallbackは行いません。
+
 設計の正本は[`docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md`](../../docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md)です。
 
 ## 設計原則
 
-- データモデルは基本的にFreezed + `json_serializable`へ対応する。
+- runtimeの`MapNode`を含むデータモデルは不変かつ原則Freezedとし、JSONは明示的な保存・通信DTO/specだけに要求する。
 - 描画経路でGeoJSONやJSON serializationを使わない。
+- hot pathのsnapshot/deltaとpacked bufferはversion付きruntime型とし、JSONやgeometryのdeep equalityを使わない。deltaは`baseRevision`/`targetRevision`をatomicに検証し、gap時はfull snapshotへresyncする。
 - Feature単位のScene Nodeを作らず、tile/layer/material単位でbatchする。
 - UI IsolateでMVT decodeやmesh構築を行わない。
+- source identity、async incarnation、GPU completion/context generationを分離して管理する。
+- Asset Pack manifest/trust/size/hashはappが検証し、packageへimmutable verified source descriptorを渡す。`eqmonitor_map`は`app`へ依存しない。
 - 2D初期実装でも座標モデルからZ軸を削除しない。
 - 性能HUDより先に、軽量で常時利用できる観測基盤を実装する。
-- MapLibre版は移行完了条件を満たすまで削除しない。
+- MapLibre版と共有`lockBearing`設定は残存surfaceの移行完了まで削除しない。新Home rendererだけが回転を明示的に無効化する。
+- Flutter Sceneはadapter内へ隔離し、固定revisionのiOS/Android実機spikeを実装gateにする。
 
-## Stacked PR
+## Delivery graph
+
+`eqmonitor-backend`でmanifest/item schema v1と既存asset IDを維持した`BASE_MAP_PMTILES`へ後方互換なlabel Point layer、global validator、digest-bound schema/summary、releaseを先行して独立に完了します。backend branchはEQMonitor branchを祖先にしません。
+
+EQMonitor repositoryのstackは次の順です。
 
 1. Design
-2. Foundation
-3. Tile pipeline
-4. Flutter Scene renderer
-5. Labels
-6. Dynamic layers and interaction
-7. Home Map integration
+2. Minimal compilable package/example scaffold and Flutter Scene device spike
+3. Foundation and render contracts
+4. Trusted tile pipeline
+5. Label Asset Pack integration
+6. Flutter Scene renderer
+7. Labels and semantics
+8. Dynamic layers and interaction
+9. Home Map integration with north-fixed rotation disabled
 
 ## TODO
 

--- a/packages/eqmonitor_map/README.md
+++ b/packages/eqmonitor_map/README.md
@@ -19,7 +19,7 @@ Flutter SceneをGPU描画基盤としてPMTiles/MVTの地物を描画し、ラ�
 - camera controller、fitBounds、座標変換、hit test
 - 性能イベントとsnapshot
 
-remote PMTilesのstrong validator付きrange合成、appが検証したAsset Pack descriptor、producerのglobal semantic検証とruntimeのbounded per-tile検証は、実装stackで追加する計画です。現行manifestがsemantic validationを提供済みという意味ではありません。source revisionを跨いだtile fallbackは行いません。
+remote PMTilesのidentity encoding/strong validator付きrange合成、appがsigned sidecarまで検証したAsset Pack descriptor、producerのglobal semantic検証とruntimeのbounded per-tile検証は、実装stackで追加する計画です。現行manifestがsemantic validationを提供済みという意味ではありません。source revisionを跨いだtile fallbackは行いません。
 
 設計の正本は[`docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md`](../../docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md)です。
 
@@ -27,11 +27,14 @@ remote PMTilesのstrong validator付きrange合成、appが検証したAsset Pac
 
 - runtimeの`MapNode`を含むデータモデルは不変かつ原則Freezedとし、JSONは明示的な保存・通信DTO/specだけに要求する。
 - 描画経路でGeoJSONやJSON serializationを使わない。
-- hot pathのsnapshot/deltaとpacked bufferはversion付きruntime型とし、JSONやgeometryのdeep equalityを使わない。deltaは`baseRevision`/`targetRevision`をatomicに検証し、gap時はfull snapshotへresyncする。
+- hot pathのsnapshot/deltaとpacked bufferはversion付きruntime型とし、JSONやgeometryのdeep equalityを使わない。deltaは`baseRevision`/`targetRevision`をatomicに検証し、gap時は完全検証済みのより新しいauthoritative full snapshotへresyncする。
+- full snapshotは全内容の検証後だけatomic commitし、低revision、同一revisionのdigest競合、malformed snapshotを既存stateへ適用しない。新しいsource identityもfull commit成功後だけ交換する。
+- 注入clockのwall/monotonic時刻をframeごとに1回だけ固定する。動的sourceのfresh/stale/expiredはload stateと分離し、staleはage/provenanceを公開、expired hazardと現在地はanimationを止めてfail closedする。
 - Feature単位のScene Nodeを作らず、tile/layer/material単位でbatchする。
+- 描画順とhit test順はphaseを含むcanonical `RenderSortKey`だけから決める。宣言順はphase内だけで有効とし、labelとleader lineは`labelForeground` phaseに置く。
 - UI IsolateでMVT decodeやmesh構築を行わない。
 - source identity、async incarnation、GPU completion/context generationを分離して管理する。
-- Asset Pack manifest/trust/size/hashはappが検証し、packageへimmutable verified source descriptorを渡す。`eqmonitor_map`は`app`へ依存しない。
+- Asset Pack manifest/trust/size/hashと、PMTiles隣の`*.eqmonitor-attestation.v1.json`の署名・expiry・sequenceはappが検証し、packageへimmutable verified source descriptorを渡す。sidecarがmissing/unknown/invalid/expiredなら新rendererはsourceをmountしない。`eqmonitor_map`は`app`へ依存しない。
 - 2D初期実装でも座標モデルからZ軸を削除しない。
 - 性能HUDより先に、軽量で常時利用できる観測基盤を実装する。
 - MapLibre版と共有`lockBearing`設定は残存surfaceの移行完了まで削除しない。新Home rendererだけが回転を明示的に無効化する。
@@ -39,15 +42,15 @@ remote PMTilesのstrong validator付きrange合成、appが検証したAsset Pac
 
 ## Delivery graph
 
-`eqmonitor-backend`でmanifest/item schema v1と既存asset IDを維持した`BASE_MAP_PMTILES`へ後方互換なlabel Point layer、global validator、digest-bound schema/summary、releaseを先行して独立に完了します。backend branchはEQMonitor branchを祖先にしません。
+`eqmonitor-backend`のB1でmanifest/item schema v1と既存asset IDを維持した`BASE_MAP_PMTILES`へ後方互換なlabel Point layer、global validator、version付きsigned sidecarの生成・署名/mutation fixture、releaseを先行して独立に完了します。backend branchはEQMonitor branchを祖先にしません。
 
 EQMonitor repositoryのstackは次の順です。
 
 1. Design
 2. Minimal compilable package/example scaffold and Flutter Scene device spike
 3. Foundation and render contracts
-4. Trusted tile pipeline
-5. Label Asset Pack integration
+4. Trusted tile pipeline（identity encoding/range body length fixtureを含む）
+5. Label Asset Pack integration（sidecar signature/readback/replay/rollback fixtureを含む）
 6. Flutter Scene renderer
 7. Labels and semantics
 8. Dynamic layers and interaction

--- a/packages/eqmonitor_map/README.md
+++ b/packages/eqmonitor_map/README.md
@@ -1,0 +1,59 @@
+# eqmonitor_map
+
+EQMonitor専用のFlutter地図レンダラーです。
+
+Flutter SceneをGPU描画基盤としてPMTiles/MVTの地物を描画し、ラベルは事前計算済みアンカーからFlutterの`TextPainter`で描画します。MapLibre Style JSON互換ではなく、型付きの宣言的`MapNode`ツリーを利用します。
+
+> [!NOTE]
+> 現在は設計段階です。実装はstacked PRで段階的に追加します。
+
+## 初期スコープ
+
+- iOS / Android
+- Flutter master channel
+- 北固定・真上視点のパンとzoom
+- ローカル / HTTP PMTiles
+- MVT Fill / Line
+- TextPainterラベル
+- 型付き動的Point / Circle / Polygon状態
+- camera controller、fitBounds、座標変換、hit test
+- 性能イベントとsnapshot
+
+設計の正本は[`docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md`](../../docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md)です。
+
+## 設計原則
+
+- データモデルは基本的にFreezed + `json_serializable`へ対応する。
+- 描画経路でGeoJSONやJSON serializationを使わない。
+- Feature単位のScene Nodeを作らず、tile/layer/material単位でbatchする。
+- UI IsolateでMVT decodeやmesh構築を行わない。
+- 2D初期実装でも座標モデルからZ軸を削除しない。
+- 性能HUDより先に、軽量で常時利用できる観測基盤を実装する。
+- MapLibre版は移行完了条件を満たすまで削除しない。
+
+## Stacked PR
+
+1. Design
+2. Foundation
+3. Tile pipeline
+4. Flutter Scene renderer
+5. Labels
+6. Dynamic layers and interaction
+7. Home Map integration
+
+## TODO
+
+- Performance HUD
+- Widget test
+- Golden test
+- iOS / Android実機性能試験と基準端末の選定
+- bearing / pitch
+- 透視投影と3D camera
+- 3D地形・地物
+- 地下震源要素
+- 断層面・断層モデル
+- Web / macOS / Windows / Linux
+- 線上ラベル
+- 汎用パッケージ化
+
+プロジェクトTODOは`docs/todo/`にも登録します。


### PR DESCRIPTION
# Summary

- Base: `develop`
- Head: `codex/eqmonitor-map-01-design`
- EQMonitor専用Flutter地図レンダラーの設計正本、package README、運用知見、将来TODOを整備します。
- 設計成果は8ファイルで、すべてdocumentation-onlyです。このPRではFlutter packageやrendererの実装、既存MapLibre surfaceの変更は行いません。

# Why

緊急地震速報など生命に関わる表示を扱うため、MapLibre Nativeからの段階的な移行に先立ち、描画・データ鮮度・入力検証・GPU resource lifecycle・障害時挙動の契約を固定する必要があります。

特に、Flutter Sceneの成熟度を実機で確認するgate、PMTiles/MVTとAsset Packの信頼境界、動的hazard dataのatomic updateとexpiry、既存MapLibre pathを維持した段階移行を、実装着手前のreview対象として明文化します。

# Scope

- [`docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md`](../specs/2026-08-02-eqmonitor-map-renderer-design.md): 公開境界、座標系、tile pipeline、label、hit test、cache/error、性能観測、移行gate、stacked deliveryを定義します。
- [`packages/eqmonitor_map/README.md`](../../../packages/eqmonitor_map/README.md): packageの目的、初期スコープ、設計原則、delivery graphを記録します。package自体はまだ作成しません。
- [`docs/knowledge/20260802_eqmonitor_map_renderer_constraints.md`](../../knowledge/20260802_eqmonitor_map_renderer_constraints.md): 今後の実装で維持する安全・互換性・性能上の制約を記録します。
- [`docs/knowledge/20260802_kevi_map_renderer_reference.md`](../../knowledge/20260802_kevi_map_renderer_reference.md): KEViから参照した知見と、採用しない境界を固定します。
- `docs/todo/`の4ファイル: 初期PRに含めないsurface拡張、3D camera、MapLibre surface移行、追加検証を追跡します。

# Architecture / safety highlights

- 公開APIは不変かつ型付きの`MapScene` / `MapNode`ツリーとし、内部の`MapElement` / `MapRenderObject`がkeyとnode型でreconcileします。描画hot pathではGeoJSONやJSON serialization、geometryのdeep equalityを使いません。
- Flutter Scene型はadapter内へ隔離し、Flutter SDKとFlutter Scene revisionを固定します。foundation実装前にiOS/Android実機spikeを通し、gateを満たせない場合は実装を進めず設計を更新します。
- PMTiles/MVTはlocal/remoteを問わずuntrustedなbounded inputとして扱います。appがmanifest、archive size/hash、署名済みsidecarを検証したimmutable descriptorだけをpackageへ渡し、missing/unknown/invalid/expiredなattestationでは新rendererをmountしません。
- remote range取得はidentity encodingとstrong validatorを必須とし、validatorやtotal length、`Content-Range`、body lengthが不一致なら取得済みbyteを破棄します。壊れた入力を空tileや固定値へfallbackしません。
- 動的sourceは`sourceInstanceId`とrevisionを持ち、full snapshot / deltaを完全検証後にatomic commitします。gapやbranchではdelta受付を止め、より新しいauthoritative full snapshotでのみ復旧します。
- freshnessはload stateから分離し、注入したmonotonic clockで`fresh` / `stale` / `expired`を評価します。expiredなhazardと現在地はanimationを止めて描画せず、typed unavailableへfail closedします。
- 描画順とhit test順はphaseを含むcanonical `RenderSortKey`を唯一の正本とし、async continuation、source identity、GPU completion/context generationを分離して古い結果やresourceを再利用しません。
- Home移行で新rendererの回転gestureは無効化しますが、既存MapLibre pathと共有`lockBearing`設定/UIは全surfaceのparity確認が完了するまで残します。

# KEVi research attribution

設計上の先行調査として、MIT License（Copyright © 2019 ingen084）の[`ingen084/KyoshinEewViewerIngen`](https://github.com/ingen084/KyoshinEewViewerIngen/tree/5a2bf513b6b9c93ee06473f70b6d27ee96070b3f)を固定commit `5a2bf513b6b9c93ee06473f70b6d27ee96070b3f`で参照しています。

UI/render間state snapshot、phase内のordered layer、array-backed point data、実測文字サイズに基づくscreen label placementを参考にします。一方、Web Mercator、tile cover、overzoom、world wrap、MVT/PMTiles処理や、EQMonitor固有のrevision/freshness/fail-closed policyはKEVi由来とせず、Miller projection、全`SKPicture` invalidation、次frameでのGPU resource disposeなども採用しません。

# Stacked follow-ups

先に別repositoryの`eqmonitor-backend`で`B1-label-asset-release`を独立して完了し、後方互換なlabel Point layer、global validator、署名済みsidecar、release fixtureを提供します。これはGit ancestryではなくrelease artifact contractとして依存します。

EQMonitor側はこのDesign PRを起点に、次の順でstackします。

1. `02-scene-spike`: minimal compilable scaffold、adapter prototype、iOS/Android実機gate
2. `03-foundation`: 型付きモデル、座標、reconciler、frame/render契約、性能観測
3. `04-tile-pipeline`: verified source、PMTiles/MVT、remote range fixture、worker/cache
4. `05-label-asset-integration`: backend fixture、sidecar検証、Asset Pack境界
5. `06-scene-renderer`: Flutter Scene adapter、Fill/Line、GPU lifecycle
6. `07-labels`: placement、collision、TextPainter overlay、semantics
7. `08-dynamic-interaction`: atomic delta、camera、現在地、hit test
8. `09-home-integration`: Home Mapの並行検証と北固定移行

# Validation

- Final subagent reviews: clean（最終指摘なし）
- Branch hook: 設計成果8ファイルに対して完了
- Gitleaks: branch上の3コミットを検査済み
- `git diff --check`: pass
- Flutter tests: documentation-onlyのため該当なし。Flutter/Dart実装の動作確認は後続stackで実施します。

# Deferred work

- [`450_eqmonitor_map_future_surface.md`](../../todo/450_eqmonitor_map_future_surface.md): Performance HUD、desktop/Web、線上ラベル、汎用package化
- [`650_eqmonitor_map_3d_camera.md`](../../todo/650_eqmonitor_map_3d_camera.md): bearing/pitch、透視投影、3D地形、地下震源、断層
- [`780_eqmonitor_map_maplibre_surface_migrations.md`](../../todo/780_eqmonitor_map_maplibre_surface_migrations.md): Home以外を含む全MapLibre surfaceのparity確認と段階移行
- [`800_eqmonitor_map_deferred_verification.md`](../../todo/800_eqmonitor_map_deferred_verification.md): Widget/Golden test、iOS/Android実機性能・復帰・memory pressure・context rebuild検証

これらは本PRで実装・検証済みという意味ではありません。各後続PRでcompile、生成、format、analyze、対象test、fixture、実機gateをその時点のscopeに合わせて実行します。
