### PR TITLE
docs: Computed GeoJSONグリッド設計

### DIFF
--- a/docs/superpowers/plans/2026-08-02-eqmonitor-lat-lng-grid.md
+++ b/docs/superpowers/plans/2026-08-02-eqmonitor-lat-lng-grid.md
@@ -1,0 +1,1044 @@
+# EQMonitor Latitude/Longitude Grid Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin EQMonitor to the completed YumNumm/flutter-maplibre computed-source stack and add an opt-in latitude/longitude grid to home and live-monitor maps on iOS and Android.
+
+**Architecture:** A deterministic map-domain builder generates bounded GeoJSON from native tile bounds and integer zoom. A thin provider binds it to `ComputedGeoJsonSource`; a reusable layer widget owns source/layer lifecycle through the existing map operation queue. Grid settings are stored separately from `HomeMapSettings`, so toggling the grid rebuilds only the overlay and never changes map instance identity.
+
+**Tech Stack:** Flutter 3.44.4, Dart 3.12, Riverpod 3 mutations, flutter_hooks, Freezed/json_serializable, MapLibre fork computed-source API, Talker, Flutter unit/widget tests.
+
+## Global Constraints
+
+- Pin all six MapLibre dependency overrides to one immutable commit SHA from the completed F3 fork branch; never use a mutable branch ref.
+- Use only `https://github.com/YumNumm/flutter-maplibre.git`; never push to or open a PR against `maplibre/flutter-maplibre`.
+- Run every Flutter/Dart command through `mise exec --`.
+- The computed provider is exactly synchronous `String Function({required LngLatBounds bounds, required int zoomLevel})`.
+- The grid is disabled by default and appears only on home and live-monitor maps.
+- The grid is not mounted on Web or desktop, and EQMonitor has no Flutter canvas/camera-event fallback.
+- The first release draws lines only: no coordinate labels and no user-configurable interval/style controls.
+- Use `ColorScheme.outlineVariant`, width `1.0`, and opacity `0.30`.
+- Place the grid below `BaseLayer.areaForecastLocalELine.name` and therefore below all safety-related overlays.
+- Valid zoom is `0...30`; valid longitude is `-180...180`; valid latitude is `-90...90`.
+- Intersect valid latitude with Web Mercator `-85.0511287798066...85.0511287798066`.
+- Select the smallest approved interval greater than or equal to one eighth of `360 / 2^zoomLevel`, floor at `0.01`, and emit at most 20 features per request.
+- Invalid inputs throw; the plugin reports the error and supplies an empty tile. Never substitute a fixed region.
+- The provider callback body performs no Riverpod read/watch, I/O, logging, network, storage, UI operation, or `compute()`; its typed `onError` handler may report through Talker.
+- Use Talker instead of `print()`; do not show raw callback errors to users.
+- Do not introduce `dynamic`, unconstrained `Object`, null assertions, or hard-coded preference keys.
+- Record the native callback/lifecycle knowledge in `docs/knowledge/20260802_maplibre_computed_geojson_source.md`.
+
+---
+
+## Stack Setup
+
+The EQMonitor stack includes the already committed design/plan branch:
+
+```text
+develop
+ └─ codex/computed-geojson-grid-design   (EQ0 docs)
+     └─ codex/maplibre-computed-source-pin  (E1)
+         └─ codex/lat-lng-grid              (E2)
+```
+
+EQ0 targets `develop`. E1 targets EQ0 until EQ0 merges, then is retargeted to
+`develop`. E2 targets E1. E1 is created only after the plugin F3 branch has
+an immutable pushed commit.
+
+## File Responsibility Map
+
+- `app/lib/feature/map/data/logic/lat_lng_grid_interval_selector.dart`: zoom-to-degree interval selection.
+- `app/lib/feature/map/data/logic/lat_lng_grid_geo_json_builder.dart`: bounds validation, snapping, antimeridian splitting, FeatureCollection generation.
+- `app/lib/feature/map/data/provider/lat_lng_grid_geo_json_provider.dart`: exact plugin callback adapter.
+- `app/lib/feature/map/data/logic/lat_lng_grid_platform_support.dart`: pure mobile-support decision.
+- `app/lib/feature/map/ui/layer/lat_lng_grid_style.dart`: source/layer add/remove operations.
+- `app/lib/feature/map/ui/layer/lat_lng_grid_layer.dart`: Hook lifecycle and map-operation queue integration.
+- `app/lib/feature/map/ui/layer/lat_lng_grid_layer_visibility.dart`: reusable enabled/platform gate for home/live.
+- `app/lib/feature/home/data/model/home_configuration_model.dart`: persisted `HomeMapGridSettings`.
+- `app/lib/feature/home/data/notifier/home_configuration_notifier.dart`: dedicated `updateMapGrid` mutation target.
+- `app/lib/feature/home/ui/component/map/home_map_grid_setting_tile.dart`: one switch bound to Riverpod mutation.
+- `app/lib/feature/home/data/model/home_map_instance_key.dart`: stable home map identity excluding grid state.
+- `app/lib/feature/home/ui/component/map/home_map_view.dart`: home overlay insertion without map-key changes.
+- `app/lib/feature/live_monitor/data/model/live_monitor_map_instance_key.dart`: stable live map identity excluding grid state.
+- `app/lib/feature/live_monitor/ui/components/live_monitor_map_host.dart`: live overlay insertion without instance-key changes.
+
+---
+
+### Task EQ0: Publish the approved design and plans
+
+**Files:**
+- Existing: `docs/superpowers/specs/2026-08-02-computed-geojson-grid-design.md`
+- Existing: `docs/superpowers/plans/2026-08-02-flutter-maplibre-computed-geojson-source.md`
+- Existing: `docs/superpowers/plans/2026-08-02-eqmonitor-lat-lng-grid.md`
+
+**Interfaces:**
+- Consumes: approved design commit `b13fd5c4b`.
+- Produces: documentation-only EQ0 PR.
+
+- [ ] **Step 1: Verify the docs branch**
+
+```bash
+git --no-pager status --short --branch
+git --no-pager log -3 --oneline
+git --no-pager diff develop...HEAD --stat
+```
+
+Expected: only the approved spec and these two plans differ from `develop`.
+
+- [ ] **Step 2: Run documentation checks**
+
+```bash
+git --no-pager diff --check develop...HEAD
+rg -n "T""BD|TO""DO|FIX""ME" docs/superpowers/specs/2026-08-02-computed-geojson-grid-design.md docs/superpowers/plans/2026-08-02-*.md
+rg -n "gh pr create --repo ""maplibre/flutter-maplibre|git push .*maplibre/flutter-maplibre" docs/superpowers/specs/2026-08-02-computed-geojson-grid-design.md docs/superpowers/plans/2026-08-02-*.md
+```
+
+Expected: no whitespace errors and no placeholders or upstream-PR instruction.
+
+- [ ] **Step 3: Push and create EQ0**
+
+```bash
+git remote get-url origin
+git push -u origin codex/computed-geojson-grid-design
+gh pr create --repo YumNumm/EQMonitor --base develop --head codex/computed-geojson-grid-design --draft --title "docs: Computed GeoJSONグリッド設計" --body-file /tmp/eqmonitor-eq0.md
+```
+
+---
+
+### Task E1.1: Pin the completed plugin stack
+
+**Files:**
+- Modify: `app/pubspec.yaml`
+- Modify: `pubspec.lock`
+
+**Interfaces:**
+- Consumes: immutable F3 commit SHA from `YumNumm/flutter-maplibre`.
+- Produces: all MapLibre packages resolved from that exact SHA.
+
+- [ ] **Step 1: Create E1 from EQ0**
+
+```bash
+git switch codex/computed-geojson-grid-design
+git switch -c codex/maplibre-computed-source-pin
+```
+
+- [ ] **Step 2: Record and verify the F3 SHA**
+
+```bash
+git ls-remote https://github.com/YumNumm/flutter-maplibre.git codex/computed-geojson-ios
+```
+
+Copy the 40-character commit hash printed for that exact ref. Verify the same
+commit contains `ComputedGeoJsonSource`, Android
+`CustomGeometrySource`, and iOS `MLNComputedShapeSource` commits before
+editing EQMonitor.
+
+- [ ] **Step 3: Replace all six refs atomically**
+
+In `app/pubspec.yaml`, replace the old
+`88c76eb0980d03504dc71c69ff50a4080e202e08` ref for:
+
+```text
+maplibre
+maplibre_android
+maplibre_ios
+maplibre_platform_interface
+maplibre_web
+maplibre_webview
+```
+
+with the exact F3 hash. Do not change the repository URL or package paths.
+
+- [ ] **Step 4: Resolve and prove one revision**
+
+```bash
+mise exec -- flutter pub get
+rg -n "resolved-ref|flutter-maplibre" pubspec.lock
+```
+
+Expected: every Git-sourced MapLibre package resolves to the same F3 hash.
+
+- [ ] **Step 5: Run existing map regression tests**
+
+```bash
+cd app
+mise exec -- flutter test test/core/util/map test/feature/home/ui/component/map/layer test/feature/live_monitor/ui/components/live_monitor_map_host_test.dart
+mise exec -- flutter analyze
+```
+
+Expected: all existing tests pass and analysis reports no issues. If the
+dependency pin alone breaks an existing API, stop E1 and diagnose it with
+`superpowers:systematic-debugging`; do not mix speculative compatibility
+changes into E2.
+
+- [ ] **Step 6: Build both mobile targets**
+
+```bash
+cd app
+mise exec -- flutter build apk --debug
+mise exec -- flutter build ios --simulator --no-codesign
+```
+
+Expected: both builds succeed.
+
+- [ ] **Step 7: Commit the pin**
+
+```bash
+git add app/pubspec.yaml pubspec.lock
+git commit -m "deps: Computed GeoJSON対応MapLibreへ更新"
+```
+
+- [ ] **Step 8: Push and create E1**
+
+```bash
+git remote get-url origin
+git push -u origin codex/maplibre-computed-source-pin
+gh pr create --repo YumNumm/EQMonitor --base codex/computed-geojson-grid-design --head codex/maplibre-computed-source-pin --draft --title "deps: Computed GeoJSON対応MapLibreへ更新" --body-file /tmp/eqmonitor-e1.md
+```
+
+---
+
+### Task E2.1: Zoom interval selector
+
+**Files:**
+- Create: `app/lib/feature/map/data/logic/lat_lng_grid_interval_selector.dart`
+- Test: `app/test/feature/map/data/logic/lat_lng_grid_interval_selector_test.dart`
+
+**Interfaces:**
+- Consumes: integer `zoomLevel`.
+- Produces: `LatLngGridIntervalSelector.select({required int zoomLevel}) -> double`.
+
+- [ ] **Step 1: Create E2 and write the interval table test**
+
+```bash
+git switch codex/maplibre-computed-source-pin
+git switch -c codex/lat-lng-grid
+```
+
+```dart
+test('selects the smallest approved interval above tileSpan / 8', () {
+  const selector = LatLngGridIntervalSelector();
+  const expected = {
+    0: 45.0,
+    1: 30.0,
+    2: 15.0,
+    3: 10.0,
+    4: 5.0,
+    5: 2.0,
+    6: 1.0,
+    7: 0.5,
+    8: 0.25,
+    9: 0.1,
+    10: 0.05,
+    11: 0.025,
+    12: 0.025,
+    13: 0.01,
+    30: 0.01,
+  };
+
+  for (final entry in expected.entries) {
+    expect(selector.select(zoomLevel: entry.key), entry.value);
+  }
+});
+```
+
+Also assert `-1` and `31` throw `RangeError`.
+
+- [ ] **Step 2: Run the test and confirm RED**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/data/logic/lat_lng_grid_interval_selector_test.dart
+```
+
+Expected: compilation fails because the selector does not exist.
+
+- [ ] **Step 3: Implement the selector**
+
+```dart
+final class LatLngGridIntervalSelector {
+  const LatLngGridIntervalSelector();
+
+  static const intervals = <double>[
+    90,
+    45,
+    30,
+    15,
+    10,
+    5,
+    2,
+    1,
+    0.5,
+    0.25,
+    0.1,
+    0.05,
+    0.025,
+    0.01,
+  ];
+
+  double select({required int zoomLevel}) {
+    if (zoomLevel < 0 || zoomLevel > 30) {
+      throw RangeError.range(zoomLevel, 0, 30, 'zoomLevel');
+    }
+    final tileSpan = 360 / math.pow(2, zoomLevel);
+    final threshold = tileSpan / 8;
+    return intervals.reversed.firstWhere(
+      (interval) => interval >= threshold,
+      orElse: () => intervals.last,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test/analyze and commit**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/data/logic/lat_lng_grid_interval_selector_test.dart
+mise exec -- flutter analyze lib/feature/map/data/logic/lat_lng_grid_interval_selector.dart
+cd ..
+git add app/lib/feature/map/data/logic/lat_lng_grid_interval_selector.dart
+git add app/test/feature/map/data/logic/lat_lng_grid_interval_selector_test.dart
+git commit -m "feat: グリッド間隔選択を追加"
+```
+
+---
+
+### Task E2.2: Deterministic GeoJSON grid builder
+
+**Files:**
+- Create: `app/lib/feature/map/data/logic/lat_lng_grid_geo_json_builder.dart`
+- Test: `app/test/feature/map/data/logic/lat_lng_grid_geo_json_builder_test.dart`
+
+**Interfaces:**
+- Consumes: `LngLatBounds`, integer zoom, and `LatLngGridIntervalSelector`.
+- Produces: `LatLngGridGeoJsonBuilder.build(...) -> String`.
+
+- [ ] **Step 1: Write normal-bounds and determinism tests**
+
+For bounds `west=139, east=140, south=35, north=36` at zoom 7, decode the
+result and require:
+
+- root `type == FeatureCollection`;
+- exactly six features;
+- vertical values `139, 139.5, 140`;
+- horizontal values `35, 35.5, 36`;
+- every coordinate is `[longitude, latitude]`;
+- two calls return byte-identical strings.
+
+```dart
+final result = const LatLngGridGeoJsonBuilder().build(
+  bounds: const LngLatBounds(
+    longitudeWest: 139,
+    longitudeEast: 140,
+    latitudeSouth: 35,
+    latitudeNorth: 36,
+  ),
+  zoomLevel: 7,
+);
+final decoded = jsonDecode(result) as Map<String, dynamic>;
+expect(decoded['type'], 'FeatureCollection');
+expect(decoded['features'], hasLength(6));
+```
+
+- [ ] **Step 2: Write boundary/error tests**
+
+Add cases for antimeridian bounds `179...-179`, exact `-180/180`, tiny
+bounds, latitude `-90...90`, a region entirely outside Web Mercator, all
+non-finite values, reversed latitude, out-of-range longitude, zoom `-1/31`,
+and a world-width high-zoom request that exceeds 20 features.
+
+Expected behavior:
+
+- antimeridian horizontal lines split at the meridian;
+- the antimeridian vertical line is emitted once per request;
+- latitude endpoints are clipped to `±85.0511287798066`;
+- an empty Mercator intersection yields a valid empty FeatureCollection;
+- invalid input and feature overflow throw.
+
+- [ ] **Step 3: Run tests and confirm RED**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/data/logic/lat_lng_grid_geo_json_builder_test.dart
+```
+
+- [ ] **Step 4: Implement validation, snapping, and stable ordering**
+
+```dart
+final class LatLngGridGeoJsonBuilder {
+  const LatLngGridGeoJsonBuilder({
+    this.intervalSelector = const LatLngGridIntervalSelector(),
+  });
+
+  static const mercatorLimit = 85.0511287798066;
+  static const maxFeatureCount = 20;
+
+  final LatLngGridIntervalSelector intervalSelector;
+
+  String build({
+    required LngLatBounds bounds,
+    required int zoomLevel,
+  });
+}
+```
+
+Implementation rules:
+
+1. Validate finite/range/order inputs before normalization.
+2. Intersect latitude with `±mercatorLimit`; return the canonical empty
+   FeatureCollection if empty.
+3. Generate snapped coordinates by integer index
+   `ceil(min / interval)...floor(max / interval)`, not repeated floating
+   addition.
+4. Normalize each emitted number with
+   `double.parse(value.toStringAsFixed(12))` and convert `-0.0` to `0.0`.
+5. Emit vertical features in ascending longitude order, then horizontal
+   features in ascending latitude and west-to-east segment order.
+6. Split crossing horizontal lines into `[west, 180]` and
+   `[-180, east]`.
+7. Check `features.length <= 20` before `jsonEncode`; otherwise throw
+   `StateError`.
+
+Each feature is:
+
+```dart
+{
+  'type': 'Feature',
+  'properties': <String, dynamic>{},
+  'geometry': {
+    'type': 'LineString',
+    'coordinates': coordinates,
+  },
+}
+```
+
+- [ ] **Step 5: Run focused tests and commit**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/data/logic/lat_lng_grid_geo_json_builder_test.dart
+mise exec -- flutter analyze lib/feature/map/data/logic
+cd ..
+git add app/lib/feature/map/data/logic/lat_lng_grid_geo_json_builder.dart
+git add app/test/feature/map/data/logic/lat_lng_grid_geo_json_builder_test.dart
+git commit -m "feat: 緯度経度グリッドGeoJSONを生成"
+```
+
+---
+
+### Task E2.3: Provider and supported-platform boundary
+
+**Files:**
+- Create: `app/lib/feature/map/data/provider/lat_lng_grid_geo_json_provider.dart`
+- Create: `app/lib/feature/map/data/logic/lat_lng_grid_platform_support.dart`
+- Test: `app/test/feature/map/data/provider/lat_lng_grid_geo_json_provider_test.dart`
+- Test: `app/test/feature/map/data/logic/lat_lng_grid_platform_support_test.dart`
+
+**Interfaces:**
+- Consumes: grid builder, `TargetPlatform`, and Web flag.
+- Produces: callable provider and pure mobile support predicate.
+
+- [ ] **Step 1: Write provider and platform matrix tests**
+
+```dart
+test('provider exposes the exact synchronous named-argument contract', () {
+  const provider = LatLngGridGeoJsonProvider();
+  final ComputedGeoJsonProvider callback = provider.call;
+  final result = callback(
+    bounds: const LngLatBounds(
+      longitudeWest: 139,
+      longitudeEast: 140,
+      latitudeSouth: 35,
+      latitudeNorth: 36,
+    ),
+    zoomLevel: 7,
+  );
+  expect(jsonDecode(result), isA<Map<String, dynamic>>());
+});
+```
+
+Test `isLatLngGridSupportedPlatform` returns true only for non-Web Android
+and iOS, and false for Web, Linux, macOS, Windows, and Fuchsia.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/data/provider/lat_lng_grid_geo_json_provider_test.dart test/feature/map/data/logic/lat_lng_grid_platform_support_test.dart
+```
+
+- [ ] **Step 3: Implement the thin adapters**
+
+```dart
+final class LatLngGridGeoJsonProvider {
+  const LatLngGridGeoJsonProvider({
+    this.builder = const LatLngGridGeoJsonBuilder(),
+  });
+
+  final LatLngGridGeoJsonBuilder builder;
+
+  String call({
+    required LngLatBounds bounds,
+    required int zoomLevel,
+  }) => builder.build(bounds: bounds, zoomLevel: zoomLevel);
+}
+```
+
+```dart
+bool isLatLngGridSupportedPlatform({
+  required bool isWeb,
+  required TargetPlatform platform,
+}) => !isWeb &&
+    (platform == TargetPlatform.android || platform == TargetPlatform.iOS);
+```
+
+- [ ] **Step 4: Run tests/analyze and commit**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/data/provider/lat_lng_grid_geo_json_provider_test.dart test/feature/map/data/logic/lat_lng_grid_platform_support_test.dart
+mise exec -- flutter analyze lib/feature/map/data/provider/lat_lng_grid_geo_json_provider.dart lib/feature/map/data/logic/lat_lng_grid_platform_support.dart
+cd ..
+git add app/lib/feature/map/data/provider/lat_lng_grid_geo_json_provider.dart
+git add app/lib/feature/map/data/logic/lat_lng_grid_platform_support.dart
+git add app/test/feature/map/data/provider/lat_lng_grid_geo_json_provider_test.dart
+git add app/test/feature/map/data/logic/lat_lng_grid_platform_support_test.dart
+git commit -m "feat: グリッドprovider境界を追加"
+```
+
+---
+
+### Task E2.4: Persisted grid setting
+
+**Files:**
+- Modify: `app/lib/feature/home/data/model/home_configuration_model.dart`
+- Regenerate: `app/lib/feature/home/data/model/home_configuration_model.freezed.dart`
+- Regenerate: `app/lib/feature/home/data/model/home_configuration_model.g.dart`
+- Modify: `app/lib/feature/home/data/notifier/home_configuration_notifier.dart`
+- Regenerate: `app/lib/feature/home/data/notifier/home_configuration_notifier.g.dart`
+- Test: `app/test/feature/home/data/notifier/home_map_grid_settings_test.dart`
+
+**Interfaces:**
+- Consumes: existing `home_configuration` preference.
+- Produces: `HomeMapGridSettings(enabled: false)` and `updateMapGrid`.
+
+- [ ] **Step 1: Write backward-compatibility and persistence tests**
+
+Assert `HomeConfigurationModel.fromJson({})` yields disabled grid and
+`toJson()` uses the `map_grid` key.
+
+Use `SharedPreferences.setMockInitialValues({})`, a `ProviderContainer`,
+and `homeConfigurationProvider.notifier.updateMapGrid` to enable the grid.
+Read the stored `SharedPreferencesKey.homeConfiguration` JSON and assert
+`map_grid.enabled == true`. Dispose that container, create a new one, and
+assert the saved grid setting reloads as enabled.
+
+- [ ] **Step 2: Run test and confirm RED**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/home/data/notifier/home_map_grid_settings_test.dart
+```
+
+- [ ] **Step 3: Add the model and notifier method**
+
+```dart
+@freezed
+abstract class HomeMapGridSettings with _$HomeMapGridSettings {
+  @JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+  const factory HomeMapGridSettings({
+    @Default(false) bool enabled,
+  }) = _HomeMapGridSettings;
+
+  factory HomeMapGridSettings.fromJson(Map<String, dynamic> json) =>
+      _$HomeMapGridSettingsFromJson(json);
+}
+```
+
+Add
+`@Default(HomeMapGridSettings()) HomeMapGridSettings mapGrid` to
+`HomeConfigurationModel`, not `HomeMapSettings`.
+
+```dart
+Future<void> updateMapGrid(HomeMapGridSettings mapGrid) async {
+  final current = await future;
+  await save(current.copyWith(mapGrid: mapGrid));
+}
+```
+
+Do not add a new preference enum value.
+
+- [ ] **Step 4: Regenerate, test, and commit**
+
+```bash
+cd app
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+mise exec -- flutter test test/feature/home/data/notifier/home_map_grid_settings_test.dart
+mise exec -- flutter analyze lib/feature/home/data/model/home_configuration_model.dart lib/feature/home/data/notifier/home_configuration_notifier.dart
+cd ..
+git add app/lib/feature/home/data/model/home_configuration_model.dart
+git add app/lib/feature/home/data/model/home_configuration_model.freezed.dart
+git add app/lib/feature/home/data/model/home_configuration_model.g.dart
+git add app/lib/feature/home/data/notifier/home_configuration_notifier.dart
+git add app/lib/feature/home/data/notifier/home_configuration_notifier.g.dart
+git add app/test/feature/home/data/notifier/home_map_grid_settings_test.dart
+git commit -m "feat: グリッド表示設定を保存"
+```
+
+---
+
+### Task E2.5: MapLibre source/layer lifecycle
+
+**Files:**
+- Create: `app/lib/feature/map/ui/layer/lat_lng_grid_style.dart`
+- Create: `app/lib/feature/map/ui/layer/lat_lng_grid_layer.dart`
+- Create: `app/lib/feature/map/ui/layer/lat_lng_grid_layer_visibility.dart`
+- Test: `app/test/feature/map/ui/layer/lat_lng_grid_style_test.dart`
+- Test: `app/test/feature/map/ui/layer/lat_lng_grid_layer_visibility_test.dart`
+
+**Interfaces:**
+- Consumes: computed provider, Talker, operation queue, theme color, and BaseLayer.
+- Produces: stable source/layer IDs and reusable enabled/platform gate.
+
+- [ ] **Step 1: Write style lifecycle tests**
+
+With a recording `StyleController`, call `LatLngGridStyle.add` and require:
+
+- source ID `lat-lng-grid-source`;
+- layer ID `lat-lng-grid-line`;
+- source is `ComputedGeoJsonSource`;
+- source is added before layer;
+- line paint is the supplied color, width `1.0`, opacity `0.30`;
+- `belowLayerId == BaseLayer.areaForecastLocalELine.name`.
+
+Call `remove` and require layer removal before source removal. Pass
+`isDisposed: () => true` after source insertion and require no layer add.
+
+- [ ] **Step 2: Write visibility widget tests**
+
+`LatLngGridLayerVisibility(enabled: false, isSupported: true)` and
+`(enabled: true, isSupported: false)` both render `SizedBox.shrink`.
+Only `(enabled: true, isSupported: true)` contains `LatLngGridLayer`.
+
+- [ ] **Step 3: Run tests and confirm RED**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/ui/layer/lat_lng_grid_style_test.dart test/feature/map/ui/layer/lat_lng_grid_layer_visibility_test.dart
+```
+
+- [ ] **Step 4: Implement the style owner**
+
+```dart
+final class LatLngGridStyle {
+  const LatLngGridStyle({required this.lineColor});
+
+  static const sourceId = 'lat-lng-grid-source';
+  static const lineLayerId = 'lat-lng-grid-line';
+  static const provider = LatLngGridGeoJsonProvider();
+
+  final String lineColor;
+
+  Future<void> add({
+    required StyleController styleController,
+    required bool Function() isDisposed,
+  }) async {
+    await styleController.addSource(
+      ComputedGeoJsonSource(
+        id: sourceId,
+        provider: provider.call,
+        onError: (error) => talker.handle(error, error.stackTrace),
+      ),
+    );
+    if (isDisposed()) return;
+    await styleController.addLayer(
+      LineStyleLayer(
+        id: lineLayerId,
+        sourceId: sourceId,
+        paint: {
+          'line-color': lineColor,
+          'line-width': 1.0,
+          'line-opacity': 0.30,
+        },
+      ),
+      belowLayerId: BaseLayer.areaForecastLocalELine.name,
+    );
+  }
+
+  Future<void> remove({required StyleController styleController}) =>
+      removeMapStyleResources(
+        styleController: styleController,
+        layerIds: const [lineLayerId],
+        sourceIds: const [sourceId],
+      );
+}
+```
+
+- [ ] **Step 5: Implement Hook lifecycle and visibility**
+
+`LatLngGridLayer` reads `MapController.maybeOf(context)?.style`, captures
+`Theme.of(context).colorScheme.outlineVariant.toHexString()`, and uses
+`useMapOperationQueue`. Its effect sets `disposed = true` before enqueuing
+`style.remove` during cleanup. It returns `SizedBox.shrink` and defines no
+widget helper methods/getters.
+
+`LatLngGridLayerVisibility` is a small stateless widget with required
+`enabled` and `isSupported` fields; it returns the grid layer only when
+both are true.
+
+- [ ] **Step 6: Run tests/analyze and commit**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/ui/layer/lat_lng_grid_style_test.dart test/feature/map/ui/layer/lat_lng_grid_layer_visibility_test.dart
+mise exec -- flutter analyze lib/feature/map/ui/layer
+cd ..
+git add app/lib/feature/map/ui/layer/lat_lng_grid_style.dart
+git add app/lib/feature/map/ui/layer/lat_lng_grid_layer.dart
+git add app/lib/feature/map/ui/layer/lat_lng_grid_layer_visibility.dart
+git add app/test/feature/map/ui/layer/lat_lng_grid_style_test.dart
+git add app/test/feature/map/ui/layer/lat_lng_grid_layer_visibility_test.dart
+git commit -m "feat: グリッドレイヤーを追加"
+```
+
+---
+
+### Task E2.6: Home and live-monitor composition
+
+**Files:**
+- Create: `app/lib/feature/home/data/model/home_map_instance_key.dart`
+- Create: `app/lib/feature/live_monitor/data/model/live_monitor_map_instance_key.dart`
+- Modify: `app/lib/feature/home/ui/component/map/home_map_view.dart`
+- Modify: `app/lib/feature/live_monitor/ui/components/live_monitor_map_host.dart`
+- Test: `app/test/feature/live_monitor/ui/components/live_monitor_map_host_test.dart`
+- Test: `app/test/feature/home/ui/component/map/home_map_grid_identity_test.dart`
+
+**Interfaces:**
+- Consumes: persisted `mapGrid.enabled`, platform support predicate, and visibility widget.
+- Produces: grid on both primary map hosts without key/identity changes.
+
+- [ ] **Step 1: Write identity tests against explicit key builders**
+
+Define these public, pure identity boundaries so tests do not depend on private
+widget internals:
+
+```dart
+typedef HomeMapInstanceKey = ({
+  String styleString,
+  HomeMapSettings mapSettings,
+  bool showLocation,
+});
+
+HomeMapInstanceKey homeMapInstanceKey({
+  required String styleString,
+  required HomeMapSettings mapSettings,
+  required bool showLocation,
+}) => (
+  styleString: styleString,
+  mapSettings: mapSettings,
+  showLocation: showLocation,
+);
+
+typedef LiveMonitorMapInstanceKey = ({
+  String slotId,
+  String styleString,
+  HomeMapSettings mapSettings,
+});
+```
+
+Add the corresponding named-argument `liveMonitorMapInstanceKey` builder.
+Create two `HomeConfigurationModel` values that differ only in
+`mapGrid.enabled`; require both builders to produce equal keys for them.
+Require the live key fields to remain exactly `slotId`, `styleString`, and
+`mapSettings`.
+
+Widget-test `LatLngGridLayerVisibility` is already covered in E2.5; these
+tests protect the two host identity boundaries.
+
+- [ ] **Step 2: Insert the home grid first**
+
+In `_MapContent.build`, replace the current record used by `mapKey` with
+`homeMapInstanceKey(...)`, then compute:
+
+```dart
+final gridEnabled = homeAsync.value?.mapGrid.enabled ?? false;
+final gridSupported = isLatLngGridSupportedPlatform(
+  isWeb: kIsWeb,
+  platform: defaultTargetPlatform,
+);
+```
+
+Insert
+`LatLngGridLayerVisibility(enabled: gridEnabled, isSupported: gridSupported)`
+as the first `MapLibreMap.children` entry. Do not add either value to
+`mapKey`.
+
+- [ ] **Step 3: Insert the live-monitor grid**
+
+Read `mapGrid.enabled` in `_LiveMonitorMapViewport`, pass it and the pure
+platform-support result to `_LiveMonitorMapContent`, and prepend the same
+visibility widget to `children`. Build both the owner `instanceKey` and
+`MapLibreMap.key` through `liveMonitorMapInstanceKey(...)`; do not add grid
+state.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/home/ui/component/map/home_map_grid_identity_test.dart test/feature/live_monitor/ui/components/live_monitor_map_host_test.dart test/feature/map/ui/layer/lat_lng_grid_layer_visibility_test.dart
+mise exec -- flutter analyze lib/feature/home/data/model/home_map_instance_key.dart lib/feature/live_monitor/data/model/live_monitor_map_instance_key.dart lib/feature/home/ui/component/map/home_map_view.dart lib/feature/live_monitor/ui/components/live_monitor_map_host.dart
+cd ..
+git add app/lib/feature/home/data/model/home_map_instance_key.dart
+git add app/lib/feature/live_monitor/data/model/live_monitor_map_instance_key.dart
+git add app/lib/feature/home/ui/component/map/home_map_view.dart
+git add app/lib/feature/live_monitor/ui/components/live_monitor_map_host.dart
+git add app/test/feature/home/ui/component/map/home_map_grid_identity_test.dart
+git add app/test/feature/live_monitor/ui/components/live_monitor_map_host_test.dart
+git commit -m "feat: ホームとライブ地図へグリッドを統合"
+```
+
+---
+
+### Task E2.7: Mobile-only settings switch
+
+**Files:**
+- Create: `app/lib/feature/home/ui/component/map/home_map_grid_setting_tile.dart`
+- Modify: `app/lib/feature/home/ui/page/home_map_layer_page.dart`
+- Test: `app/test/feature/home/ui/component/map/home_map_grid_setting_tile_test.dart`
+
+**Interfaces:**
+- Consumes: `HomeMapGridSettings`, `HomeConfigurationNotifier.saveMutation`.
+- Produces: one opt-in switch on iOS/Android.
+
+- [ ] **Step 1: Write the switch test**
+
+Pump `HomeMapGridSettingTile` inside `ProviderScope` after
+`SharedPreferences.setMockInitialValues({})`. Assert title
+`緯度・経度グリッド`, subtitle
+`ズームに合わせた緯度・経度の線を表示します。`, and an off switch.
+Tap the switch, pump, and assert
+`homeConfigurationProvider.future` yields `mapGrid.enabled == true`.
+
+- [ ] **Step 2: Run test and confirm RED**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/home/ui/component/map/home_map_grid_setting_tile_test.dart
+```
+
+- [ ] **Step 3: Implement the tile**
+
+Implement `HomeMapGridSettingTile` directly with the same `ListTile` and
+`AppSwitch` structure as the existing `_SettingSwitchTile`; leave the existing
+private component in place because it is not shared outside its page.
+Its `onChanged` runs:
+
+```dart
+await HomeConfigurationNotifier.saveMutation.run(
+  ref,
+  (tsx) async => tsx
+      .get(homeConfigurationProvider.notifier)
+      .updateMapGrid(config.mapGrid.copyWith(enabled: enabled)),
+);
+```
+
+- [ ] **Step 4: Add it only on supported platforms**
+
+In `HomeMapLayerPage.build`, compute the pure support value with `kIsWeb`
+and `defaultTargetPlatform`. Add `HomeMapGridSettingTile` as the first child
+of the `マップ` section only when supported. Update that section description
+to `地図のグリッド、回転、ズーム、初期表示範囲を設定します。`
+
+- [ ] **Step 5: Run tests/analyze and commit**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/home/ui/component/map/home_map_grid_setting_tile_test.dart test/feature/map/data/logic/lat_lng_grid_platform_support_test.dart
+mise exec -- flutter analyze lib/feature/home/ui/component/map/home_map_grid_setting_tile.dart lib/feature/home/ui/page/home_map_layer_page.dart
+cd ..
+git add app/lib/feature/home/ui/component/map/home_map_grid_setting_tile.dart
+git add app/lib/feature/home/ui/page/home_map_layer_page.dart
+git add app/test/feature/home/ui/component/map/home_map_grid_setting_tile_test.dart
+git commit -m "feat: グリッド表示スイッチを追加"
+```
+
+---
+
+### Task E2.8: Failure isolation and lifecycle regression tests
+
+**Files:**
+- Modify: `app/test/feature/map/ui/layer/lat_lng_grid_style_test.dart`
+- Create: `app/test/feature/map/ui/layer/lat_lng_grid_layer_lifecycle_test.dart`
+
+**Interfaces:**
+- Consumes: completed layer/style.
+- Produces: regression coverage for rapid lifecycle and source error isolation.
+
+- [ ] **Step 1: Add failing lifecycle cases**
+
+Use a recording controller and the real `MapOperationQueue` to cover:
+
+- mount → unmount → mount serializes add/remove/add;
+- rapid enable/disable leaves one active source/layer at most;
+- style controller replacement cleans the old controller;
+- a provider throw records one Talker/plugin error and does not remove a
+  pre-registered fake safety layer;
+- source error does not prevent the queue's next operation.
+
+For the provider failure case, retrieve the registered
+`ComputedGeoJsonSource` from the recording controller and invoke
+`computeGeoJson` with deterministic bounds and zoom. The provider body itself
+does no logging; its `onError` path records the typed failure through Talker.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/ui/layer/lat_lng_grid_style_test.dart test/feature/map/ui/layer/lat_lng_grid_layer_lifecycle_test.dart
+```
+
+Expected: pass without increasing arbitrary delays. If a race is found,
+diagnose it before changing the shared queue.
+
+- [ ] **Step 3: Commit regression coverage**
+
+```bash
+git add app/test/feature/map/ui/layer/lat_lng_grid_style_test.dart
+git add app/test/feature/map/ui/layer/lat_lng_grid_layer_lifecycle_test.dart
+git commit -m "test: グリッドライフサイクルを検証"
+```
+
+---
+
+### Task E2.9: Knowledge and map architecture
+
+**Files:**
+- Create: `docs/knowledge/20260802_maplibre_computed_geojson_source.md`
+- Modify: `docs/map-architecture.md`
+
+**Interfaces:**
+- Consumes: verified plugin/application behavior.
+- Produces: operational rules for future agents and developers.
+
+- [ ] **Step 1: Record the platform knowledge**
+
+Document:
+
+- exact synchronous callback signature;
+- Android `CustomGeometrySource` and retained JNI proxy;
+- iOS `MLNComputedShapeSourceDataSource.implementAsBlocking` and weak Native
+  data-source ownership;
+- provider no-I/O rule;
+- FeatureCollection validation/error/empty-tile behavior;
+- iOS/Android support and unsupported-platform guard;
+- jnigen/ffigen regeneration commands;
+- source removal/style replacement/disposal ordering;
+- Android/iOS integration and build commands;
+- the rule forbidding upstream PR/push.
+
+- [ ] **Step 2: Update the map inventory**
+
+Add the grid source/layer IDs, owning widget/style class, placement below
+`BaseLayer.areaForecastLocalELine`, home/live scope, default-off setting, and
+unsupported-platform behavior to `docs/map-architecture.md`.
+
+- [ ] **Step 3: Commit documentation**
+
+```bash
+git add docs/knowledge/20260802_maplibre_computed_geojson_source.md docs/map-architecture.md
+git commit -m "docs: Computed GeoJSON運用知見を記録"
+```
+
+---
+
+### Task E2.10: Full verification and E2 pull request
+
+**Files:**
+- Verify all E2 files.
+
+**Interfaces:**
+- Consumes: E2.1-E2.9.
+- Produces: reviewable E2 PR and evidence.
+
+- [ ] **Step 1: Regenerate and require a clean diff**
+
+```bash
+cd app
+mise exec -- dart run build_runner build --delete-conflicting-outputs
+cd ..
+git --no-pager diff --exit-code
+```
+
+- [ ] **Step 2: Run all focused tests**
+
+```bash
+cd app
+mise exec -- flutter test test/feature/map/data/logic/lat_lng_grid_interval_selector_test.dart test/feature/map/data/logic/lat_lng_grid_geo_json_builder_test.dart test/feature/map/data/logic/lat_lng_grid_platform_support_test.dart test/feature/map/data/provider/lat_lng_grid_geo_json_provider_test.dart test/feature/map/ui/layer/lat_lng_grid_style_test.dart test/feature/map/ui/layer/lat_lng_grid_layer_visibility_test.dart test/feature/map/ui/layer/lat_lng_grid_layer_lifecycle_test.dart test/feature/home/data/notifier/home_map_grid_settings_test.dart test/feature/home/ui/component/map/home_map_grid_identity_test.dart test/feature/home/ui/component/map/home_map_grid_setting_tile_test.dart test/feature/live_monitor/ui/components/live_monitor_map_host_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run repository analysis and full tests**
+
+```bash
+mise exec -- dart run melos run analyze
+mise exec -- dart run melos run test
+```
+
+Expected: zero analysis issues and all workspace tests pass.
+
+- [ ] **Step 4: Build both mobile applications**
+
+```bash
+cd app
+mise exec -- flutter build apk --debug
+mise exec -- flutter build ios --simulator --no-codesign
+```
+
+- [ ] **Step 5: Perform visual safety checks**
+
+On Android and iOS, enable the switch and inspect home and live-monitor maps
+in light/dark themes at zoom levels 3, 7, 13, and the app's maximum zoom.
+Trigger or replay views containing EEW fill, P/S waves, hypocenter, observation
+points, shake detection, tsunami/intensity overlays where available. Confirm
+the 1px/0.30 grid remains behind them. Disable the switch and confirm the
+source/layer disappears without camera reset.
+
+- [ ] **Step 6: Update E1 to the merged F3 SHA**
+
+After the plugin stack merges, replace the pre-merge F3 commit with its final
+merged commit SHA in all six overrides. Perform the update on E1, then replay
+E2 on the refreshed dependency branch:
+
+```bash
+git switch codex/maplibre-computed-source-pin
+# Replace all six app/pubspec.yaml git refs with the immutable merged F3 SHA.
+cd app
+mise exec -- flutter pub get
+cd ..
+git add app/pubspec.yaml pubspec.lock
+git commit -m "deps: MapLibreの統合済みSHAへ追従"
+git push origin codex/maplibre-computed-source-pin
+git switch codex/lat-lng-grid
+git rebase codex/maplibre-computed-source-pin
+# Use --force-with-lease only when this E2 branch was pushed before the rebase.
+git push --force-with-lease origin codex/lat-lng-grid
+```
+
+Require `rg -n "ref:" app/pubspec.yaml` to show that same immutable SHA six
+times, then repeat Steps 1-4 on the rebased E2 head.
+
+- [ ] **Step 7: Push and create E2**
+
+```bash
+git remote get-url origin
+git push -u origin codex/lat-lng-grid
+gh pr create --repo YumNumm/EQMonitor --base codex/maplibre-computed-source-pin --head codex/lat-lng-grid --draft --title "feat: 緯度経度グリッドを追加" --body-file /tmp/eqmonitor-e2.md
+```
+
+- [ ] **Step 8: Read back the full stack**
+
+Confirm EQ0/E1/E2 repository owner, bases, heads, draft state, check runs, and
+links to F1/F2/F3. Confirm no PR or pushed branch exists in
+`maplibre/flutter-maplibre`.

--- a/docs/superpowers/plans/2026-08-02-flutter-maplibre-computed-geojson-source.md
+++ b/docs/superpowers/plans/2026-08-02-flutter-maplibre-computed-geojson-source.md
@@ -1,0 +1,950 @@
+# flutter-maplibre Computed GeoJSON Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one synchronous `ComputedGeoJsonSource` Dart API backed by Android `CustomGeometrySource` and iOS `MLNComputedShapeSource`, with explicit unsupported behavior elsewhere.
+
+**Architecture:** The platform interface owns provider execution, FeatureCollection validation, empty-tile recovery, and error notification. Android and iOS adapters only convert native bounds, retain callback proxies, translate the validated GeoJSON into native feature collections, and forward invalidation. Three stacked pull requests isolate the public contract, Android backend, and iOS backend/documentation.
+
+**Tech Stack:** Flutter 3.44+, Dart 3.12+, the MapLibre Native Android version pinned by the fork, MapLibre Native iOS 6.27, jni/jnigen, objective_c/ffigen, Flutter integration_test, GitHub Actions.
+
+## Global Constraints
+
+- Work from the current `main` branch of `https://github.com/YumNumm/flutter-maplibre.git`, not EQMonitor's old pub-cache checkout.
+- Never push to or open a pull request against `maplibre/flutter-maplibre`.
+- The provider signature is exactly `String Function({required LngLatBounds bounds, required int zoomLevel})`.
+- Provider execution is synchronous and must not perform I/O, return a `Future`, or touch Flutter UI state.
+- Only GeoJSON objects with `type: "FeatureCollection"` and a list-valued `features` member are accepted.
+- A provider, validation, or native-conversion failure reports once and returns `{"type":"FeatureCollection","features":[]}`.
+- Region and tile invalidation are public; manual `setTileData` is not.
+- Web and webview desktop implementations throw `UnsupportedError`; there is no fallback renderer.
+- Nullable source options defer to each Native SDK default.
+- iOS data-source callbacks use `implementAsBlocking` and the adapter is strongly retained because Native holds a weak data-source reference.
+- Generated JNI/FFI files are regenerated from configuration and are never manually edited.
+- Before every push, verify `git remote get-url origin` is the YumNumm fork.
+
+---
+
+## Repository and Stack Setup
+
+Use `superpowers:using-git-worktrees` before implementation. Create an isolated checkout whose `origin` is exactly the YumNumm fork, then create these dependent branches:
+
+```text
+main
+ └─ codex/computed-geojson-contract
+     └─ codex/computed-geojson-android
+         └─ codex/computed-geojson-ios
+```
+
+F1 targets `main`; F2 targets `codex/computed-geojson-contract`; F3 targets `codex/computed-geojson-android`. Use `--repo YumNumm/flutter-maplibre` for every PR command.
+
+## File Responsibility Map
+
+- `packages/maplibre_platform_interface/lib/src/style/sources/computed_geo_json_source.dart`: public model, provider/error types, common validation and recovery.
+- `packages/maplibre_platform_interface/lib/src/style/sources/source.dart`: source part/import registration.
+- `packages/maplibre_platform_interface/lib/src/style_controller.dart`: invalidation contract and unsupported defaults.
+- `packages/maplibre/lib/maplibre.dart`: public exports.
+- `packages/maplibre_android/lib/src/computed_geo_json_source.dart`: JNI callback binding and lifecycle.
+- `packages/maplibre_android/lib/src/style_controller.dart`: Android source registration/removal/invalidation.
+- `packages/maplibre_android/tool/jnigen.dart`: explicit `FeatureCollection` generation.
+- `packages/maplibre_ios/lib/src/computed_geo_json_source.dart`: Objective-C callback binding and lifecycle.
+- `packages/maplibre_ios/lib/src/style_controller.dart`: iOS source registration/removal/invalidation.
+- `packages/maplibre_ios/ios/maplibre_ios/Sources/maplibre_ios/Helpers.swift`: narrow GeoJSON-to-feature-array converter.
+- `packages/maplibre_ios/tool/ffigen.dart`: computed-source header/interface/protocol allowlists.
+- `examples/integration_test/computed_geo_json_source_test.dart`: shared Android/iOS behavioral test.
+- `examples/lib/style_sources_computed_geo_json_page.dart`: asset-free public example.
+
+---
+
+### Task F1.1: Public source, validation, and error contract
+
+**Files:**
+- Create: `packages/maplibre_platform_interface/lib/src/style/sources/computed_geo_json_source.dart`
+- Modify: `packages/maplibre_platform_interface/lib/src/style/sources/source.dart`
+- Modify: `packages/maplibre/lib/maplibre.dart`
+- Test: `packages/maplibre/test/style/source/computed_geo_json_source_test.dart`
+
+**Interfaces:**
+- Consumes: `LngLatBounds`, `Source`, and Flutter error reporting.
+- Produces: `ComputedGeoJsonProvider`, `ComputedGeoJsonErrorCallback`, `ComputedGeoJsonSourceErrorKind`, `ComputedGeoJsonSourceError`, and `ComputedGeoJsonSource`.
+
+- [ ] **Step 1: Write provider and recovery tests**
+
+```dart
+test('passes named bounds and integer zoomLevel to the provider', () {
+  const bounds = LngLatBounds(
+    longitudeWest: 139,
+    longitudeEast: 140,
+    latitudeSouth: 35,
+    latitudeNorth: 36,
+  );
+  LngLatBounds? receivedBounds;
+  int? receivedZoom;
+  final source = ComputedGeoJsonSource(
+    id: 'computed',
+    provider: ({required bounds, required zoomLevel}) {
+      receivedBounds = bounds;
+      receivedZoom = zoomLevel;
+      return '{"type":"FeatureCollection","features":[]}';
+    },
+  );
+
+  final result = source.computeGeoJson(bounds: bounds, zoomLevel: 7);
+
+  expect(result, ComputedGeoJsonSource.emptyFeatureCollection);
+  expect(receivedBounds, bounds);
+  expect(receivedZoom, 7);
+});
+
+test('reports invalid root and returns an empty FeatureCollection', () {
+  ComputedGeoJsonSourceError? received;
+  final source = ComputedGeoJsonSource(
+    id: 'computed',
+    provider: ({required bounds, required zoomLevel}) =>
+        '{"type":"Feature","geometry":null,"properties":{}}',
+    onError: (error) => received = error,
+  );
+
+  final result = source.computeGeoJson(
+    bounds: const LngLatBounds(
+      longitudeWest: 0,
+      longitudeEast: 1,
+      latitudeSouth: 0,
+      latitudeNorth: 1,
+    ),
+    zoomLevel: 3,
+  );
+
+  expect(result, ComputedGeoJsonSource.emptyFeatureCollection);
+  expect(received?.kind, ComputedGeoJsonSourceErrorKind.invalidGeoJson);
+  expect(received?.sourceId, 'computed');
+});
+```
+
+Add separate tests for provider throws, malformed JSON, a missing/list-invalid `features` member, default `FlutterError.reportError`, an `onError` callback that itself throws, and preservation of every nullable option.
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run:
+
+```bash
+cd packages/maplibre
+mise exec -- flutter test test/style/source/computed_geo_json_source_test.dart
+```
+
+Expected: compilation fails because `ComputedGeoJsonSource` is not defined.
+
+- [ ] **Step 3: Implement the exact public types**
+
+```dart
+typedef ComputedGeoJsonProvider = String Function({
+  required LngLatBounds bounds,
+  required int zoomLevel,
+});
+
+typedef ComputedGeoJsonErrorCallback = void Function(
+  ComputedGeoJsonSourceError error,
+);
+
+enum ComputedGeoJsonSourceErrorKind {
+  provider,
+  invalidGeoJson,
+  nativeConversion,
+}
+
+final class ComputedGeoJsonSourceError implements Exception {
+  const ComputedGeoJsonSourceError({
+    required this.sourceId,
+    required this.kind,
+    required this.message,
+    required this.stackTrace,
+  });
+
+  final String sourceId;
+  final ComputedGeoJsonSourceErrorKind kind;
+  final String message;
+  final StackTrace stackTrace;
+}
+```
+
+Implement `ComputedGeoJsonSource` with the approved constructor fields and:
+
+```dart
+static const emptyFeatureCollection =
+    '{"type":"FeatureCollection","features":[]}';
+
+@internal
+String computeGeoJson({
+  required LngLatBounds bounds,
+  required int zoomLevel,
+});
+
+@internal
+String recoverFromError({
+  required ComputedGeoJsonSourceErrorKind kind,
+  required String message,
+  required StackTrace stackTrace,
+});
+```
+
+`computeGeoJson` calls the provider inside one try/catch, then decodes the returned string inside a second try/catch. Require a map root, `type == 'FeatureCollection'`, and a list-valued `features`. `recoverFromError` invokes `onError` or `FlutterError.reportError` and always returns `emptyFeatureCollection`. If `onError` throws, report that callback failure with `FlutterError.reportError` and still return empty.
+
+Add `part 'computed_geo_json_source.dart';` and the `dart:convert` / Flutter foundation imports to `source.dart`. Export all five public symbols from `packages/maplibre/lib/maplibre.dart`.
+
+- [ ] **Step 4: Run tests and analysis**
+
+```bash
+cd packages/maplibre
+mise exec -- flutter test test/style/source/computed_geo_json_source_test.dart
+cd ../..
+mise exec -- dart analyze packages/maplibre_platform_interface packages/maplibre
+```
+
+Expected: all focused tests pass and analysis reports no issues.
+
+- [ ] **Step 5: Commit the common source contract**
+
+```bash
+git add packages/maplibre_platform_interface/lib/src/style/sources/source.dart
+git add packages/maplibre_platform_interface/lib/src/style/sources/computed_geo_json_source.dart
+git add packages/maplibre/lib/maplibre.dart
+git add packages/maplibre/test/style/source/computed_geo_json_source_test.dart
+git commit -m "feat: Computed GeoJSON source契約を追加"
+```
+
+---
+
+### Task F1.2: Invalidation contract and unsupported platforms
+
+**Files:**
+- Modify: `packages/maplibre_platform_interface/lib/src/style_controller.dart`
+- Modify: `packages/maplibre_web/lib/src/style_controller.dart`
+- Modify: `packages/maplibre_webview/lib/src/style_controller.dart`
+- Test: `packages/maplibre/test/style/computed_geo_json_style_controller_test.dart`
+
+**Interfaces:**
+- Consumes: `ComputedGeoJsonSource` from F1.1.
+- Produces: region/tile invalidation methods with default `UnsupportedError`.
+
+- [ ] **Step 1: Write unsupported-contract tests**
+
+Create a concrete test controller that extends `StyleController` and satisfies unrelated abstract methods through `noSuchMethod`. Assert both default invalidation calls throw:
+
+```dart
+expect(
+  () => controller.invalidateComputedGeoJsonSourceRegion(
+    id: 'computed',
+    bounds: const LngLatBounds(
+      longitudeWest: 0,
+      longitudeEast: 1,
+      latitudeSouth: 0,
+      latitudeNorth: 1,
+    ),
+  ),
+  throwsA(isA<UnsupportedError>()),
+);
+expect(
+  () => controller.invalidateComputedGeoJsonSourceTile(
+    id: 'computed',
+    x: 1,
+    y: 2,
+    zoomLevel: 3,
+  ),
+  throwsA(isA<UnsupportedError>()),
+);
+```
+
+- [ ] **Step 2: Run the test and confirm RED**
+
+```bash
+cd packages/maplibre
+mise exec -- flutter test test/style/computed_geo_json_style_controller_test.dart
+```
+
+Expected: compilation fails because the invalidation methods do not exist.
+
+- [ ] **Step 3: Add default controller methods**
+
+```dart
+Future<void> invalidateComputedGeoJsonSourceRegion({
+  required String id,
+  required LngLatBounds bounds,
+}) async => throw UnsupportedError(
+  'ComputedGeoJsonSource is not supported on this platform.',
+);
+
+Future<void> invalidateComputedGeoJsonSourceTile({
+  required String id,
+  required int x,
+  required int y,
+  required int zoomLevel,
+}) async => throw UnsupportedError(
+  'ComputedGeoJsonSource is not supported on this platform.',
+);
+```
+
+In Web and WebView `addSource` switches, add an explicit
+`case ComputedGeoJsonSource():` that throws the same message before bridge
+access. Do not add invalidation overrides; the platform-interface defaults are
+the supported contract.
+
+- [ ] **Step 4: Verify tests, Web unit tests, and desktop/Web builds**
+
+```bash
+cd packages/maplibre
+mise exec -- flutter test test/style/computed_geo_json_style_controller_test.dart
+cd ../maplibre_webview
+mise exec -- flutter test
+cd ../../examples
+mise exec -- flutter build web
+mise exec -- flutter build macos --debug
+```
+
+On a non-macOS worker, run the Web test/build locally and leave the macOS build
+to CI; do not mark F1 ready until CI reports it green.
+
+- [ ] **Step 5: Commit unsupported behavior**
+
+```bash
+git add packages/maplibre_platform_interface/lib/src/style_controller.dart
+git add packages/maplibre_web/lib/src/style_controller.dart
+git add packages/maplibre_webview/lib/src/style_controller.dart
+git add packages/maplibre/test/style/computed_geo_json_style_controller_test.dart
+git commit -m "feat: Computed sourceの非対応契約を追加"
+```
+
+---
+
+### Task F1.3: Contract documentation and F1 pull request
+
+**Files:**
+- Modify: `packages/maplibre/CHANGELOG.md`
+- Modify: `packages/maplibre_platform_interface/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: F1.1/F1.2.
+- Produces: reviewable F1 branch and PR.
+
+- [ ] **Step 1: Add Unreleased entries**
+
+Document the new synchronous provider, strict FeatureCollection requirement,
+error callback, invalidation methods, and iOS/Android-only support. Do not
+claim either mobile backend is implemented in the F1 text.
+
+- [ ] **Step 2: Run the F1 gate**
+
+```bash
+mise exec -- dart format --set-exit-if-changed packages/maplibre_platform_interface packages/maplibre
+mise exec -- dart analyze --fatal-warnings --fatal-infos
+cd packages/maplibre
+mise exec -- flutter test
+cd ../maplibre_webview
+mise exec -- flutter test
+```
+
+Expected: zero formatting changes, zero analysis issues, and all unit tests pass.
+
+- [ ] **Step 3: Commit documentation**
+
+```bash
+git add packages/maplibre/CHANGELOG.md packages/maplibre_platform_interface/CHANGELOG.md
+git commit -m "docs: Computed source契約を記録"
+```
+
+- [ ] **Step 4: Push and create F1 only in the fork**
+
+```bash
+git remote get-url origin
+git push -u origin codex/computed-geojson-contract
+gh pr create --repo YumNumm/flutter-maplibre --base main --head codex/computed-geojson-contract --draft --title "feat: Computed GeoJSON source contract" --body-file /tmp/flutter-maplibre-f1.md
+```
+
+The remote check must print the YumNumm repository. The PR body lists provider
+synchrony, strict validation, unsupported platforms, tests, and F2/F3 follow-up
+links. Never use `--repo maplibre/flutter-maplibre`.
+
+---
+
+### Task F2.1: Failing Android integration test
+
+**Files:**
+- Create: `examples/integration_test/computed_geo_json_source_test.dart`
+- Modify: `examples/integration_test/main.dart`
+
+**Interfaces:**
+- Consumes: F1 public API.
+- Produces: one shared mobile scenario that initially fails on Android and is reused by iOS.
+
+- [ ] **Step 1: Create a deterministic computed line fixture**
+
+The provider records each `({LngLatBounds bounds, int zoomLevel})` request and
+returns one diagonal line within those bounds:
+
+```dart
+String computedLine({
+  required LngLatBounds bounds,
+  required int zoomLevel,
+}) => jsonEncode({
+  'type': 'FeatureCollection',
+  'features': [
+    {
+      'type': 'Feature',
+      'properties': {'zoomLevel': zoomLevel},
+      'geometry': {
+        'type': 'LineString',
+        'coordinates': [
+          [bounds.longitudeWest, bounds.latitudeSouth],
+          [bounds.longitudeEast, bounds.latitudeNorth],
+        ],
+      },
+    },
+  ],
+});
+```
+
+Use an empty style JSON, center `(10, 10)`, zoom `4`, source ID
+`computed-source`, and line-layer ID `computed-line`. Add a five-second
+condition-based waiter; do not use an unbounded delay.
+
+- [ ] **Step 2: Test callback, rendered query, and both invalidations**
+
+Assert the first callback has finite ordered bounds and `zoomLevel == 4`.
+Query rendered features across the full map viewport and require a feature
+from `computed-line`. Save the callback count, invalidate the visible region,
+and require the count to increase. Then invalidate the visible center tile
+`z=4, x=8, y=7` and require another increase.
+
+Add a second test whose provider throws `StateError('provider failed')`;
+require one `ComputedGeoJsonSourceErrorKind.provider` notification and no
+crash. Remove line then source at the end of each test.
+
+Register `computed_geo_json_source_test.test()` from
+`examples/integration_test/main.dart`.
+
+- [ ] **Step 3: Run Android integration and confirm RED**
+
+```bash
+cd examples
+mise exec -- flutter test integration_test/main.dart -d emulator-5554 --timeout=1800s -r expanded
+```
+
+Expected: the computed source add fails with the Android unsupported-source
+error. If no emulator exists, start the repository's documented Android test
+device before running this command.
+
+- [ ] **Step 4: Commit the red integration test**
+
+```bash
+git add examples/integration_test/computed_geo_json_source_test.dart examples/integration_test/main.dart
+git commit -m "test: Android computed sourceの期待動作を追加"
+```
+
+---
+
+### Task F2.2: Generate complete Android GeoJSON bindings
+
+**Files:**
+- Modify: `packages/maplibre_android/tool/jnigen.dart`
+- Regenerate: `packages/maplibre_android/lib/src/jni.g.dart`
+
+**Interfaces:**
+- Consumes: jnigen configuration.
+- Produces: non-stub `jni.FeatureCollection.fromJson(JString)`.
+
+- [ ] **Step 1: Add the explicit class**
+
+```dart
+'org.maplibre.geojson.Feature',
+'org.maplibre.geojson.FeatureCollection',
+```
+
+- [ ] **Step 2: Regenerate and inspect**
+
+```bash
+cd packages/maplibre_android
+mise exec -- dart tool/jnigen.dart
+cd ../..
+mise exec -- dart format packages/maplibre_android/lib/src/jni.g.dart
+rg -n "static FeatureCollection.*fromJson" packages/maplibre_android/lib/src/jni.g.dart
+```
+
+Expected: `FeatureCollection` is no longer marked as a stub and has a static
+`fromJson` binding.
+
+- [ ] **Step 3: Commit configuration and generated output**
+
+```bash
+git add packages/maplibre_android/tool/jnigen.dart packages/maplibre_android/lib/src/jni.g.dart
+git commit -m "build: FeatureCollection JNI bindingを生成"
+```
+
+---
+
+### Task F2.3: Android callback adapter and lifecycle
+
+**Files:**
+- Create: `packages/maplibre_android/lib/src/computed_geo_json_source.dart`
+- Modify: `packages/maplibre_android/lib/src/map_state.dart`
+- Modify: `packages/maplibre_android/lib/src/style_controller.dart`
+
+**Interfaces:**
+- Consumes: `ComputedGeoJsonSource.computeGeoJson`, `recoverFromError`, and generated `FeatureCollection.fromJson`.
+- Produces: retained `_ComputedGeoJsonSourceAndroidBinding` and Android invalidation overrides.
+
+- [ ] **Step 1: Register the adapter part and binding map**
+
+Add `part 'computed_geo_json_source.dart';` to `map_state.dart`. Make the
+`StyleControllerAndroid._` constructor non-const and add:
+
+```dart
+final _computedGeoJsonSources =
+    <String, _ComputedGeoJsonSourceAndroidBinding>{};
+```
+
+- [ ] **Step 2: Implement the binding**
+
+```dart
+final class _ComputedGeoJsonSourceAndroidBinding {
+  _ComputedGeoJsonSourceAndroidBinding({
+    required this.source,
+    required this.nativeSource,
+    required this.tileProvider,
+  });
+
+  final ComputedGeoJsonSource source;
+  final jni.CustomGeometrySource nativeSource;
+  final jni.GeometryTileProvider tileProvider;
+  bool isActive = true;
+
+  void dispose() {
+    isActive = false;
+    if (!nativeSource.isReleased) nativeSource.release();
+    if (!tileProvider.isReleased) tileProvider.release();
+  }
+}
+```
+
+Create the proxy with
+`jni.GeometryTileProvider.implement(jni.$GeometryTileProvider(...))`.
+The `getFeaturesForBounds` callback:
+
+1. Returns a parsed empty collection without notification when `isActive` is false.
+2. Converts `jni.LatLngBounds` with `toLngLatBounds`.
+3. Calls `source.computeGeoJson(bounds: ..., zoomLevel: zoomLevel)`.
+4. Parses with `jni.FeatureCollection.fromJson`.
+5. On parser/null failure, calls `source.recoverFromError(kind: nativeConversion, ...)` and parses the constant empty collection.
+
+Do not register the native source or provider with a temporary JNI arena that
+releases them at callback return.
+
+- [ ] **Step 3: Apply nullable Native options and add the source**
+
+Build `jni.CustomGeometrySourceOptions`; call `withMinZoom`,
+`withMaxZoom`, `withBuffer`, `withTolerance`, `withWrap`, and
+`withClip` only for non-null Dart values. Construct
+`jni.CustomGeometrySource(jId, options, tileProvider)`, add it to the style,
+then retain the binding by source ID. If style insertion throws, dispose the
+binding before rethrowing.
+
+- [ ] **Step 4: Implement invalidation and deterministic release**
+
+```dart
+@override
+Future<void> invalidateComputedGeoJsonSourceRegion({
+  required String id,
+  required LngLatBounds bounds,
+}) async {
+  final binding = _computedGeoJsonSources[id];
+  if (binding == null) throw StateError('Computed source "$id" does not exist.');
+  using((arena) {
+    binding.nativeSource.invalidateRegion(
+      bounds.toJLatLngBounds(arena: arena),
+    );
+  });
+}
+
+@override
+Future<void> invalidateComputedGeoJsonSourceTile({
+  required String id,
+  required int x,
+  required int y,
+  required int zoomLevel,
+}) async {
+  final binding = _computedGeoJsonSources[id];
+  if (binding == null) throw StateError('Computed source "$id" does not exist.');
+  binding.nativeSource.invalidateTile(zoomLevel, x, y);
+}
+```
+
+In `removeSource`, mark/remove the retained binding, remove the native style
+source, and dispose the binding in `finally`. In controller `dispose`, mark
+all bindings inactive and release them before releasing `_jStyle`.
+
+- [ ] **Step 5: Run the Android integration test and confirm GREEN**
+
+```bash
+cd examples
+mise exec -- flutter test integration_test/main.dart -d emulator-5554 --timeout=1800s -r expanded
+```
+
+Expected: callback, rendered query, region invalidation, tile invalidation,
+error notification, and source removal all pass.
+
+- [ ] **Step 6: Commit Android implementation**
+
+```bash
+git add packages/maplibre_android/lib/src/map_state.dart
+git add packages/maplibre_android/lib/src/style_controller.dart
+git add packages/maplibre_android/lib/src/computed_geo_json_source.dart
+git commit -m "feat: Android computed sourceを実装"
+```
+
+---
+
+### Task F2.4: Android CI, changelog, and F2 pull request
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `packages/maplibre/CHANGELOG.md`
+- Modify: `packages/maplibre_android/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: F2.1-F2.3.
+- Produces: reproducible Android binding check and F2 PR.
+
+- [ ] **Step 1: Enable the Android codegen job**
+
+Uncomment `codegen-android`. Keep Java 21, build the example before jnigen,
+format the generated file, and fail when `git status --porcelain` is nonempty.
+
+- [ ] **Step 2: Add Android Unreleased notes**
+
+Document `CustomGeometrySource`, synchronous callback behavior, both
+invalidations, lifecycle retention, and error isolation.
+
+- [ ] **Step 3: Run the F2 gate**
+
+```bash
+mise exec -- dart format --set-exit-if-changed packages/maplibre_android examples/integration_test
+mise exec -- dart analyze --fatal-warnings --fatal-infos
+cd examples
+mise exec -- flutter build apk
+```
+
+Then regenerate jnigen once more and require a clean diff:
+
+```bash
+cd ../packages/maplibre_android
+mise exec -- dart tool/jnigen.dart
+cd ../..
+mise exec -- dart format packages/maplibre_android/lib/src/jni.g.dart
+git --no-pager diff --exit-code
+```
+
+- [ ] **Step 4: Commit CI/docs**
+
+```bash
+git add .github/workflows/ci.yml packages/maplibre/CHANGELOG.md packages/maplibre_android/CHANGELOG.md
+git commit -m "ci: Android binding再生成を検証"
+```
+
+- [ ] **Step 5: Push and create F2 only in the fork**
+
+```bash
+git remote get-url origin
+git push -u origin codex/computed-geojson-android
+gh pr create --repo YumNumm/flutter-maplibre --base codex/computed-geojson-contract --head codex/computed-geojson-android --draft --title "feat: Android computed GeoJSON source" --body-file /tmp/flutter-maplibre-f2.md
+```
+
+---
+
+### Task F3.1: iOS Swift conversion helper and FFI generation
+
+**Files:**
+- Modify: `packages/maplibre_ios/ios/maplibre_ios/Sources/maplibre_ios/Helpers.swift`
+- Regenerate: `packages/maplibre_ios/ios/maplibre_ios/Sources/maplibre_ios/MapLibreIos.h`
+- Modify: `packages/maplibre_ios/tool/ffigen.dart`
+- Regenerate: `packages/maplibre_ios/lib/src/maplibre_ffi.g.dart`
+- Regenerate: `packages/maplibre_ios/lib/src/maplibre_ffi.g.dart.m`
+
+**Interfaces:**
+- Consumes: a validated FeatureCollection string.
+- Produces: `Helpers.parseComputedGeoJsonFeatures(raw:)`, `MLNComputedShapeSource`, and `MLNComputedShapeSourceDataSource` FFI bindings.
+
+- [ ] **Step 1: Add the narrow Swift helper**
+
+```swift
+@objc public static func parseComputedGeoJsonFeatures(
+    raw: String
+) -> NSArray? {
+    guard let data = raw.data(using: .utf8) else {
+        return nil
+    }
+    do {
+        let shape = try MLNShape(
+            data: data,
+            encoding: String.Encoding.utf8.rawValue
+        )
+        guard let collection = shape as? MLNShapeCollectionFeature else {
+            return nil
+        }
+        return collection.shapes as NSArray
+    } catch {
+        return nil
+    }
+}
+```
+
+The helper returns nil rather than printing or throwing across FFI; Dart
+reports the typed native-conversion error.
+
+- [ ] **Step 2: Regenerate the Swift header**
+
+```bash
+cd packages/maplibre_ios/ios/maplibre_ios/Sources/maplibre_ios
+./gen_swift_headers.sh
+rg -n "parseComputedGeoJsonFeatures" MapLibreIos.h
+```
+
+Expected: the generated Objective-C `Helpers` interface exposes the method.
+
+- [ ] **Step 3: Expand ffigen allowlists**
+
+Add `MLNComputedShapeSource.h` to the header set,
+`MLNComputedShapeSource` to interfaces, and
+`MLNComputedShapeSourceDataSource` to protocols. Do not add
+`MLNShapeCollectionFeature`: the helper's public return type is `NSArray`, so
+the generated Dart interface does not expose that subtype.
+
+- [ ] **Step 4: Regenerate FFI and inspect the blocking callback**
+
+```bash
+cd packages/maplibre_ios
+mise exec -- dart tool/ffigen.dart
+rg -n "MLNComputedShapeSourceDataSource.*implementAsBlocking" lib/src/maplibre_ffi.g.dart
+rg -n "computedShapeSource_featuresInCoordinateBounds_zoomLevel_" lib/src/maplibre_ffi.g.dart
+```
+
+Expected: the protocol has an `implementAsBlocking` builder member named
+`computedShapeSource_featuresInCoordinateBounds_zoomLevel_`.
+
+- [ ] **Step 5: Commit helper and generated bindings**
+
+```bash
+git add packages/maplibre_ios/ios/maplibre_ios/Sources/maplibre_ios/Helpers.swift
+git add packages/maplibre_ios/ios/maplibre_ios/Sources/maplibre_ios/MapLibreIos.h
+git add packages/maplibre_ios/tool/ffigen.dart
+git add packages/maplibre_ios/lib/src/maplibre_ffi.g.dart
+git add packages/maplibre_ios/lib/src/maplibre_ffi.g.dart.m
+git commit -m "build: Computed shape FFI bindingを生成"
+```
+
+---
+
+### Task F3.2: iOS callback adapter and lifecycle
+
+**Files:**
+- Create: `packages/maplibre_ios/lib/src/computed_geo_json_source.dart`
+- Modify: `packages/maplibre_ios/lib/src/map_state.dart`
+- Modify: `packages/maplibre_ios/lib/src/style_controller.dart`
+
+**Interfaces:**
+- Consumes: F1 source contract and F3.1 generated FFI.
+- Produces: retained `_ComputedGeoJsonSourceIosBinding` and iOS invalidation overrides.
+
+- [ ] **Step 1: Register the part and retained binding map**
+
+Add `part 'computed_geo_json_source.dart';` to `map_state.dart` and:
+
+```dart
+final _computedGeoJsonSources =
+    <String, _ComputedGeoJsonSourceIosBinding>{};
+```
+
+- [ ] **Step 2: Implement the blocking data source**
+
+Create `MLNComputedShapeSourceDataSource.implementAsBlocking` with only
+`computedShapeSource_featuresInCoordinateBounds_zoomLevel_`. Ignore the
+native source argument, convert `MLNCoordinateBounds` to `LngLatBounds`,
+convert `zoomLevel` to `int`, and call `source.computeGeoJson`.
+
+Pass the returned string to
+`Helpers.parseComputedGeoJsonFeaturesWithRaw(...toNSString())`. When the
+binding is inactive, return an initialized empty `NSArray` without
+notification. When the helper returns nil, call
+`source.recoverFromError(kind: nativeConversion, ...)` and return an empty
+`NSArray`.
+
+- [ ] **Step 3: Construct the computed source and options**
+
+Create an `NSMutableDictionary` and set only non-null values with these
+MapLibre keys:
+
+```text
+MLNComputedShapeSourceOptionMinimumZoomLevel
+MLNComputedShapeSourceOptionMaximumZoomLevel
+MLNComputedShapeSourceOptionBuffer
+MLNComputedShapeSourceOptionSimplificationTolerance
+MLNComputedShapeSourceOptionWrapsCoordinates
+MLNComputedShapeSourceOptionClipsCoordinates
+```
+
+Initialize `MLNComputedShapeSource` with identifier, data source, and options,
+add it to the style, and retain a binding containing the Dart source, native
+source, and data-source proxy. If style insertion throws, deactivate the
+binding before rethrowing.
+
+- [ ] **Step 4: Implement invalidation/removal/dispose**
+
+Region invalidation calls Native `invalidateBounds`. Tile invalidation calls
+`invalidateTileAtX(x, y: y, zoomLevel: zoomLevel)`. A missing ID throws
+`StateError('Computed source "$id" does not exist.')`.
+
+On `removeSource`, deactivate the binding before removing the native source,
+then drop the strong proxy reference in `finally`. On controller `dispose`,
+deactivate and clear all bindings. This ordering prevents a worker callback
+from entering a released Dart provider.
+
+- [ ] **Step 5: Run the shared iOS integration test**
+
+```bash
+cd examples
+mise exec -- flutter test integration_test/main.dart -d "iPhone 16 Pro" --timeout=1800s -r expanded
+```
+
+Expected: the same callback/render/invalidation/error scenario that passed on
+Android passes on iOS.
+
+- [ ] **Step 6: Commit iOS implementation**
+
+```bash
+git add packages/maplibre_ios/lib/src/map_state.dart
+git add packages/maplibre_ios/lib/src/style_controller.dart
+git add packages/maplibre_ios/lib/src/computed_geo_json_source.dart
+git commit -m "feat: iOS computed sourceを実装"
+```
+
+---
+
+### Task F3.3: Public example and source documentation
+
+**Files:**
+- Create: `examples/lib/style_sources_computed_geo_json_page.dart`
+- Modify: `examples/lib/main.dart`
+- Modify: `examples/lib/menu_page.dart`
+- Modify: `website/docs/sources.md`
+- Modify: `packages/maplibre/CHANGELOG.md`
+- Modify: `packages/maplibre_ios/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: completed iOS/Android API.
+- Produces: asset-free usage example and user-facing constraints.
+
+- [ ] **Step 1: Add the computed grid example**
+
+Create a stateful page at
+`/style-sources/computed-geo-json`. In `onStyleLoaded`, add a
+`ComputedGeoJsonSource` whose provider generates longitude/latitude lines at
+10-degree intervals within the requested bounds, then add a blue
+`LineStyleLayer`. Report errors with `debugPrint` in the example only.
+Guard the menu item with iOS/Android platform support so Web/desktop example
+builds do not invoke the source.
+
+- [ ] **Step 2: Document source behavior**
+
+In `website/docs/sources.md`, include:
+
+- exact provider signature;
+- FeatureCollection-only return;
+- synchronous/no-I/O warning;
+- `onError` and empty-tile behavior;
+- region/tile invalidation examples;
+- iOS/Android support and explicit Web/desktop `UnsupportedError`.
+
+- [ ] **Step 3: Add Unreleased notes**
+
+Update the main and iOS changelogs. The main entry now states both mobile
+backends are implemented.
+
+- [ ] **Step 4: Verify example and docs changes**
+
+```bash
+mise exec -- dart format --set-exit-if-changed examples/lib
+mise exec -- dart analyze --fatal-warnings --fatal-infos
+cd examples
+mise exec -- flutter build apk
+mise exec -- flutter build ios --simulator --no-codesign
+mise exec -- flutter build web
+```
+
+- [ ] **Step 5: Commit docs/example**
+
+```bash
+git add examples/lib/style_sources_computed_geo_json_page.dart
+git add examples/lib/main.dart examples/lib/menu_page.dart
+git add website/docs/sources.md packages/maplibre/CHANGELOG.md packages/maplibre_ios/CHANGELOG.md
+git commit -m "docs: Computed sourceの使用例を追加"
+```
+
+---
+
+### Task F3.4: iOS integration/codegen CI and final fork PR
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: all F1-F3 implementation.
+- Produces: cross-platform required checks and F3 PR.
+
+- [ ] **Step 1: Enable one focused iOS integration job**
+
+Uncomment `integration-test-ios`, reduce the matrix to the maintained
+`26.2` simulator runtime, keep the 30-minute timeout, and run the shared
+`integration_test/main.dart`.
+
+- [ ] **Step 2: Enable deterministic iOS codegen**
+
+Uncomment `codegen-ios`. Clone `maplibre/maplibre-native` at the exact
+`ios-v6.27.0` tag with `--branch ios-v6.27.0 --depth 1`, build that framework,
+regenerate `MapLibreIos.h`, run ffigen, and fail on any uncommitted generated
+diff. Keep the tag synchronized with both `Package.swift` and the podspec; do
+not generate against a moving Native revision.
+
+- [ ] **Step 3: Run the full local gate**
+
+```bash
+mise exec -- dart format --set-exit-if-changed .
+mise exec -- dart analyze --fatal-warnings --fatal-infos
+cd packages/maplibre
+mise exec -- flutter test
+cd ../maplibre_webview
+mise exec -- flutter test
+cd ../../examples
+mise exec -- flutter build apk
+mise exec -- flutter build ios --simulator --no-codesign
+mise exec -- flutter build web
+```
+
+Regenerate both bindings and require a clean diff before committing.
+
+- [ ] **Step 4: Commit CI**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: iOS computed sourceを実機検証"
+```
+
+- [ ] **Step 5: Push and create F3 only in the fork**
+
+```bash
+git remote get-url origin
+git push -u origin codex/computed-geojson-ios
+gh pr create --repo YumNumm/flutter-maplibre --base codex/computed-geojson-android --head codex/computed-geojson-ios --draft --title "feat: iOS computed GeoJSON source" --body-file /tmp/flutter-maplibre-f3.md
+```
+
+- [ ] **Step 6: Read back all three PRs**
+
+Confirm repository owner, base/head branches, draft state, check runs, and
+cross-links. If any PR targets `maplibre/flutter-maplibre`, close it
+immediately without pushing another branch there and report the incident.

--- a/docs/superpowers/specs/2026-08-02-computed-geojson-grid-design.md
+++ b/docs/superpowers/specs/2026-08-02-computed-geojson-grid-design.md
@@ -1,0 +1,396 @@
+# Computed GeoJSON Source and Latitude/Longitude Grid Design
+
+## Goal
+
+Add a generic, synchronous computed GeoJSON source to the
+`YumNumm/flutter-maplibre` fork for iOS and Android, then use it in EQMonitor
+to render an optional latitude/longitude grid on the home and live-monitor
+maps.
+
+All work stays in repositories owned by `YumNumm`. Do not push branches or
+open pull requests against the `maplibre/flutter-maplibre` upstream
+repository.
+
+## Scope
+
+### flutter-maplibre
+
+- Add one platform-neutral `ComputedGeoJsonSource` API.
+- Accept a synchronous provider with named `bounds` and `zoomLevel`
+  parameters.
+- Support region and tile invalidation.
+- Implement the source with Android `CustomGeometrySource` and iOS
+  `MLNComputedShapeSource`.
+- Report provider, GeoJSON parsing, and native conversion failures before
+  returning an empty tile.
+- Throw an explicit `UnsupportedError` on Web and desktop implementations.
+- Add API documentation, a minimal example, unit tests, native integration
+  tests, and generated-binding checks.
+
+### EQMonitor
+
+- Pin `maplibre` to the completed fork commit before adding the feature.
+- Add an opt-in grid to the home and live-monitor maps only.
+- Draw lines without coordinate labels in the first release.
+- Keep the grid behind all earthquake, tsunami, intensity, hypocenter,
+  observation, and wave layers.
+- Keep all other maps, including detail and bounds-selection maps, unchanged.
+- Do not implement a Flutter canvas or camera-event fallback on unsupported
+  platforms.
+
+## Non-goals
+
+- A public API that exposes JNI or Objective-C generated binding types.
+- Asynchronous source providers, isolates, network access, or storage access
+  inside a tile callback.
+- Manual `setTileData` support in the first API version.
+- PluginLayer/Metal rendering.
+- Web or desktop grid rendering.
+- Coordinate labels, user-configurable intervals, colors, widths, or opacity
+  in the first EQMonitor release.
+- Automatic rollout to every `MapLibreMap` in EQMonitor.
+- Any upstream `maplibre/flutter-maplibre` branch, push, issue, or pull request.
+
+## Chosen Architecture
+
+Use a common Dart API with platform-specific callback adapters. This keeps
+native ownership and conversion details inside each backend while giving
+applications one source model and one invalidation contract.
+
+The alternatives were rejected for the following reasons:
+
+- Exposing raw JNI/Objective-C types would make application code
+  platform-specific and leak generated binding lifecycles into consumers.
+- Implementing all native behavior directly in handwritten FFI without a
+  narrow conversion helper would increase Objective-C collection bridging
+  complexity without adding application capability.
+- Rendering in Flutter from camera events would duplicate MapLibre's tile
+  scheduling, projection, clipping, and cache invalidation behavior.
+
+## Public Dart API
+
+The public API is owned by `maplibre_platform_interface` and exported by
+`maplibre`.
+
+```dart
+typedef ComputedGeoJsonProvider = String Function({
+  required LngLatBounds bounds,
+  required int zoomLevel,
+});
+
+typedef ComputedGeoJsonErrorCallback = void Function(
+  ComputedGeoJsonSourceError error,
+);
+
+final class ComputedGeoJsonSource extends Source {
+  const ComputedGeoJsonSource({
+    required super.id,
+    required this.provider,
+    this.onError,
+    this.minZoom,
+    this.maxZoom,
+    this.buffer,
+    this.tolerance,
+    this.wrapsCoordinates,
+    this.clipsCoordinates,
+  });
+
+  final ComputedGeoJsonProvider provider;
+  final ComputedGeoJsonErrorCallback? onError;
+  final int? minZoom;
+  final int? maxZoom;
+  final int? buffer;
+  final double? tolerance;
+  final bool? wrapsCoordinates;
+  final bool? clipsCoordinates;
+}
+```
+
+Nullable options mean "use the native SDK default". Neither the plugin nor
+EQMonitor substitutes fixed fallback values for omitted native options.
+
+`ComputedGeoJsonSourceError` contains a source ID, an error kind, a safe
+message, and a stack trace. Its error kinds distinguish provider execution,
+invalid GeoJSON, and native conversion failures. It does not
+expose JNI, Objective-C, or unconstrained `Object` values.
+
+`StyleController` adds:
+
+```dart
+Future<void> invalidateComputedGeoJsonSourceRegion({
+  required String id,
+  required LngLatBounds bounds,
+});
+
+Future<void> invalidateComputedGeoJsonSourceTile({
+  required String id,
+  required int x,
+  required int y,
+  required int zoomLevel,
+});
+```
+
+Invalidating an absent source or a source of another type throws a
+`StateError` containing the source ID. Web and desktop controllers throw
+`UnsupportedError` before performing any native or JavaScript operation.
+
+The provider must return a GeoJSON `FeatureCollection` string. A single
+feature, a bare geometry, and malformed JSON are errors rather than being
+implicitly converted differently on each platform.
+
+## Android Backend
+
+The Android backend uses MapLibre Native's `CustomGeometrySource`,
+`CustomGeometrySourceOptions`, and `GeometryTileProvider`.
+
+1. Add `org.maplibre.geojson.FeatureCollection` to the jnigen class list and
+   regenerate bindings.
+2. Create a `GeometryTileProvider.implement` adapter for each computed source.
+3. Convert native bounds to `LngLatBounds` and forward the native integer zoom
+   as `zoomLevel`.
+4. Parse the provider string with `FeatureCollection.fromJson`.
+5. Keep the JNI provider proxy and source registration strongly referenced by
+   source ID.
+6. Forward region/tile invalidation to the corresponding native methods.
+7. Release references on source removal, style replacement, and controller
+   disposal.
+
+## iOS Backend
+
+The iOS backend uses `MLNComputedShapeSource` and the bounds-based
+`MLNComputedShapeSourceDataSource` callback.
+
+1. Add `MLNComputedShapeSource.h`, `MLNComputedShapeSource`, and
+   `MLNComputedShapeSourceDataSource` to the ffigen allowlists and regenerate
+   the Objective-C bindings.
+2. Implement exactly the bounds/zoom data-source callback with
+   `implementAsBlocking`, because MapLibre requests data synchronously from its
+   source request queue.
+3. Add a narrow helper alongside the existing iOS helpers that parses a
+   GeoJSON `FeatureCollection` string and returns the Objective-C feature
+   array required by the data-source callback.
+4. Keep the data-source adapter strongly referenced by source ID because the
+   native source's `dataSource` reference is weak.
+5. Forward region/tile invalidation to `MLNComputedShapeSource`.
+6. Invalidate the Dart adapter before releasing it on source removal, style
+   replacement, and controller disposal.
+
+No callback dispatches to the main isolate for UI work. Provider code must be
+small, deterministic, synchronous, and free of I/O.
+
+## Lifecycle and Error Handling
+
+Adding a source creates both the native source and its callback adapter.
+Removing the source marks the adapter invalid before native and Dart
+references are released. A callback that was already in flight when removal
+began returns an empty FeatureCollection without reporting an application
+error, because removal is an expected lifecycle event.
+
+For all other failures:
+
+1. Wrap the failure as `ComputedGeoJsonSourceError`.
+2. Invoke `onError` when supplied; otherwise call `FlutterError.reportError`.
+3. Return an empty FeatureCollection for that tile only.
+4. Continue serving other tiles and other map layers.
+
+Errors are never silently swallowed. One bad grid tile must not remove or
+block EEW, tsunami, intensity, hypocenter, observation, or P/S-wave layers.
+
+## EQMonitor Grid Generation
+
+`LatLngGridGeoJsonBuilder` is a pure, synchronous class in the shared map
+feature. It depends on neither Riverpod, widgets, `MapController`, nor I/O.
+Its input is `LngLatBounds` and `int zoomLevel`; its output is a GeoJSON
+`FeatureCollection` containing horizontal and vertical `LineString` features.
+
+The builder selects a globally consistent interval from this descending list:
+
+```text
+90, 45, 30, 15, 10, 5, 2, 1, 0.5, 0.25, 0.1, 0.05, 0.025, 0.01 degrees
+```
+
+For a zoom level `z`, compute the equatorial tile longitude span as
+`360 / 2^z`. Select the smallest listed interval that is greater than or
+equal to one eighth of that span, capped at 90 degrees and floored at 0.01
+degrees. Because the choice depends only on integer zoom, adjacent native
+tiles use the same grid interval. A request produces no more than 20 line
+features; exceeding that invariant is treated as an error rather than
+silently dropping arbitrary lines.
+
+Coordinates snap to integer multiples of the chosen interval. Bounds that
+cross the antimeridian are split into `[west, 180]` and `[-180, east]`, with
+the antimeridian emitted only once. Input longitude must be in
+`[-180, 180]`, input latitude must be in `[-90, 90]`, and zoom must be in
+`[0, 30]`. Valid latitude bounds are intersected with MapLibre's Web Mercator
+domain of `[-85.0511287798066, 85.0511287798066]`; an empty intersection
+returns an empty FeatureCollection. Non-finite coordinates, reversed latitude
+bounds, out-of-range coordinates or zoom, malformed bounds, and violated
+feature limits throw. The plugin adapter reports the failure and returns an
+empty tile; the builder does not substitute Japan or another fixed region.
+
+The provider object only binds this builder to the plugin callback signature.
+It does not call `ref.read`, `ref.watch`, `compute`, logging, storage, or a
+network API from the callback.
+
+## EQMonitor Presentation and Settings
+
+`LatLngGridLayer` owns source/layer registration and cleanup. It uses the
+existing map operation queue and removes resources in layer-then-source order.
+It uses one computed source and one line layer with stable IDs.
+
+The layer is inserted into the shared home/live-monitor map composition below
+all safety-related overlays. It uses `ColorScheme.outlineVariant`, a
+1-logical-pixel line width, and 0.30 opacity in both light and dark themes.
+There are no labels. Layer errors are reported through Talker without
+presenting raw exceptions to users.
+
+Grid enablement is stored as a separate `HomeMapGridSettings` field on
+`HomeConfigurationModel`, defaulting to `enabled: false`. The existing
+home-configuration preference key remains in use, so no new hard-coded
+storage key is introduced. A dedicated notifier mutation persists changes.
+Keeping the setting outside `HomeMapSettings` prevents the grid toggle from
+changing the existing map instance identity and remounting or refocusing the
+map.
+
+The settings page exposes one enable/disable switch on iOS and Android. The
+switch is hidden and the grid layer is not mounted on unsupported platforms;
+EQMonitor never invokes the unsupported plugin API as a fallback path.
+
+## Stacked Pull Requests
+
+The two repositories have separate stacks.
+
+### YumNumm/flutter-maplibre stack
+
+1. **F1: Common contract and unsupported implementations**
+   - Public source, callback, error, and invalidation contracts.
+   - Web/desktop `UnsupportedError` behavior.
+   - Exports, Dartdoc, and contract unit tests.
+2. **F2: Android backend**
+   - jnigen configuration and generated bindings.
+   - Custom geometry source, lifecycle, errors, and invalidation.
+   - Android integration tests.
+3. **F3: iOS backend and cross-platform documentation**
+   - ffigen configuration, generated bindings, and narrow GeoJSON helper.
+   - Computed shape source, lifecycle, errors, and invalidation.
+   - iOS integration tests, example, website docs, and changelog entries.
+
+Branches are based on the preceding branch. Pull requests target only the
+`YumNumm/flutter-maplibre` default branch or the preceding branch in that same
+repository. Work starts from the fork's current default branch, not the old
+pub-cache checkout pinned by EQMonitor.
+
+### YumNumm/EQMonitor stack
+
+1. **E1: Pin and compatibility verification**
+   - Update `maplibre` to the exact F3 commit SHA.
+   - Make only compatibility changes required by that dependency update.
+   - Run existing map regression tests and Android/iOS builds.
+2. **E2: Latitude/longitude grid**
+   - Builder, provider, settings, layer, home/live integration, tests, and
+     operational knowledge documentation.
+
+E2 is based on E1. While the plugin stack is open, E1 uses the immutable F3
+commit SHA. After the plugin stack is merged, E1 receives a follow-up commit
+that pins the final merged SHA. No mutable branch reference is used in
+`pubspec.yaml`.
+
+## Testing
+
+### flutter-maplibre contract tests
+
+- Source constructor and option preservation.
+- Exact callback signature with named `bounds` and integer `zoomLevel`.
+- Error structure and default reporting path.
+- Web and webview/desktop controllers throw `UnsupportedError` before bridge
+  access.
+- Invalidating a missing or wrong source type throws the documented exception.
+
+### Native adapter tests
+
+- Bounds conversion, including antimeridian semantics.
+- Valid FeatureCollection conversion.
+- Provider throw, malformed JSON, wrong GeoJSON root, and native conversion
+  failure each report once and return an empty tile.
+- An invalidated/disposed adapter returns empty without reporting a spurious
+  error.
+- Source removal and style replacement release retained callbacks.
+
+### Mobile integration tests
+
+Use a minimal style, computed line source, and line layer. Record callback
+arguments with a timeout and verify:
+
+- The callback is invoked with finite ordered bounds and an integer zoom.
+- The returned line is returned by a rendered-feature query.
+- Region invalidation requests data again.
+- Tile invalidation requests data again.
+- Removing the source stops new callbacks and does not crash.
+- Provider failure affects only the requested tile.
+
+Run the shared scenario on Android and iOS. Register the test explicitly in
+the integration-test entry point. Enable one focused iOS simulator integration
+job instead of relying on an iOS build alone.
+
+### EQMonitor tests
+
+- Interval selection at every zoom boundary.
+- Coordinate ordering is `[longitude, latitude]`.
+- Snap/clip behavior, tiny bounds, antimeridian crossing, `-180`/`180`, and
+  high-latitude bounds.
+- Invalid bounds and feature-limit violations fail closed through the plugin
+  error path.
+- Identical input produces byte-identical output.
+- The builder remains within the feature-count limit on representative
+  worst-case inputs.
+- Older saved configuration without `mapGrid` decodes to disabled.
+- Save/reload and rapid toggle behavior.
+- Grid toggling does not remount or refocus the map.
+- Source-before-layer creation and layer-before-source removal.
+- Repeated mount, unmount, style replacement, and rapid toggle leave no
+  duplicate IDs or retained source.
+- Grid failure leaves all safety-related layers registered.
+- Light/dark visual checks confirm that the grid remains subordinate to
+  safety-related overlays.
+
+## CI and Verification
+
+The flutter-maplibre stack runs formatting, analysis, Swift formatting,
+Kotlin lint, package unit tests, Android integration on the maintained API
+levels, a focused iOS simulator integration test, Android/iOS builds,
+Web/WASM/macOS/Windows builds, and Web/webview unsupported-contract tests.
+
+Both jnigen and ffigen are regenerated from configuration. CI regenerates them
+and requires a clean `git diff`, so generated files are never maintained as
+handwritten patches.
+
+The EQMonitor stack runs the repository's Flutter status check, focused grid
+and map lifecycle tests, the full workspace test suite, Android debug build,
+and iOS simulator build. All Flutter and Dart commands run through
+`mise exec --`.
+
+## Documentation and Operational Knowledge
+
+The plugin adds Dartdoc, a `website/docs/sources.md` section, changelog entries,
+and an asset-free example that draws a computed grid.
+
+EQMonitor adds
+`docs/knowledge/20260802_maplibre_computed_geojson_source.md` during
+implementation. It records callback synchronization, native ownership,
+platform support, binding regeneration, and verification commands. The grid
+is also added to `docs/map-architecture.md`.
+
+## Success Criteria
+
+- The same Dart source declaration works on iOS and Android.
+- Native map movement requests only the visible computed tiles without a
+  Flutter camera-event rendering loop.
+- Both invalidation methods cause native data to be recomputed.
+- Provider failures are observable and isolated to the grid tile.
+- Removing or replacing a style does not leave callable native adapters.
+- Unsupported platforms fail explicitly at the plugin boundary and EQMonitor
+  does not call that boundary.
+- The opt-in grid works on home and live-monitor maps without remounting the
+  map or obscuring safety-related layers.
+- Every PR remains reviewable and verifiable independently in dependency
+  order.


### PR DESCRIPTION
## 概要

MapLibre Native の ComputedShapeSource / CustomGeometrySource を Dart から利用し、EQMonitor に緯度経度グリッドを追加するための設計と実装計画です。

## 変更内容

- Computed GeoJSON source の共通契約、Android JNI、iOS FFI の設計
- YumNumm/flutter-maplibre だけを対象とする stacked PR 方針
- EQMonitor の決定的なグリッド生成、設定、レイヤー統合計画
- iOS / Android を別マシンで検証するための具体的なコマンドと受け入れ条件

## 影響

ドキュメントのみの変更です。アプリや依存関係の挙動は変わりません。

## 検証

- `git diff --check develop...HEAD`
- placeholder検索
- upstream `maplibre/flutter-maplibre` へのPR/push命令が含まれないことを確認

## Stacked PR

このPRをEQ0とし、pluginの不変SHAをpinするE1、グリッド実装のE2を後続PRとして分離します。