### PR TITLE
codex/seismicity flutter scene design

### DIFF
--- a/docs/knowledge/20260802_flutter_scene_large_static_instances.md
+++ b/docs/knowledge/20260802_flutter_scene_large_static_instances.md
@@ -32,7 +32,11 @@ Flutter Sceneの`InstancedMesh`は各インスタンスを`List<Matrix4>`で保�
 実ポリゴン球を大量に描画せず、共有四角形を使う球インポスターを採用する。
 遠景は点、近景は球面法線と陰影を持つ球表示とし、投影後のピクセル直径で連続遷移させる。
 
-PMTiles全件を表示する場合は、Dioでアーカイブ全体を検証付きキャッシュへ取得してからローカル解析する。
+PMTilesは共通のrandom-access reader境界を設け、Network、File、Assetを同じ解析器へ渡す。
+NetworkはDioのHTTP Range Requestを使い、`206`、`Content-Range`、取得長、strong ETagを検証する。`200`を全体ダウンロードとして受理しない。
+Fileはrandom access、Flutter Assetは注入loaderから全bytesを読み込む。Asset APIにはファイル内random accessがないため、Assetだけは全体メモリ化を許容する。
+
+全震源を表示する場合、対象データズームのtile payloadは最終的に全て必要になる。Range方式は全体ファイル保存の回避、段階的解析、キャンセル、range単位の再利用に使う。
 PMTilesの固定データズームでは間引きと重複を禁止し、元データ件数との一致を生成時とクライアント側の両方で検証する。
 
 ## 参照

--- a/docs/knowledge/20260802_flutter_scene_large_static_instances.md
+++ b/docs/knowledge/20260802_flutter_scene_large_static_instances.md
@@ -1,0 +1,42 @@
+# Flutter Sceneで大量の静的インスタンスを描画する際の注意
+
+## Flutter SDK
+
+Flutter Scene 0.20.0はpre-1.0で、実際には新しいFlutter masterとFlutter GPUを要求する。
+pubspecのFlutter stable下限だけを見て導入可否を判断しない。
+
+```sh
+mise exec -- flutter --version
+mise exec -- flutter run --enable-flutter-gpu --enable-impeller
+```
+
+Flutter master移行は機能導入と分離し、既存テスト、iOSビルド、プラグイン互換性を先に確認する。
+
+## 標準InstancedMeshの特性
+
+Flutter Sceneの`InstancedMesh`は各インスタンスを`List<Matrix4>`で保持する。
+描画時にはインスタンスごとの行列を16個のfloatへパックし、フレーム一時GPU領域へ転送する。
+
+数万件の一般的なインスタンスには適するが、200万件の静的点群では次が問題になる。
+
+- Matrix4だけで約128MB必要
+- Dartオブジェクト数が大きい
+- フレームごとの行列計算と再パックが発生する
+- 静的データでも大きな転送が繰り返される
+
+大量の静的点群では、位置、色、半径等を固定長レコードへ詰め、永続GPUバッファへ一度だけアップロードするGeometryを使う。
+カメラ操作や点・球LODはShader内で処理し、Dart側の全件走査を発生させない。
+
+## 震源表示
+
+実ポリゴン球を大量に描画せず、共有四角形を使う球インポスターを採用する。
+遠景は点、近景は球面法線と陰影を持つ球表示とし、投影後のピクセル直径で連続遷移させる。
+
+PMTiles全件を表示する場合は、Dioでアーカイブ全体を検証付きキャッシュへ取得してからローカル解析する。
+PMTilesの固定データズームでは間引きと重複を禁止し、元データ件数との一致を生成時とクライアント側の両方で検証する。
+
+## 参照
+
+- https://pub.dev/packages/flutter_scene
+- https://github.com/bdero/flutter_scene/blob/master/packages/flutter_scene/lib/src/instanced_mesh.dart
+- https://github.com/bdero/flutter_scene/blob/master/packages/flutter_scene/lib/src/render/instance_packing.dart

--- a/docs/superpowers/plans/2026-08-03-seismicity-3d-delivery.md
+++ b/docs/superpowers/plans/2026-08-03-seismicity-3d-delivery.md
@@ -1,0 +1,45 @@
+# Seismicity 3D Stacked Delivery Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement each plan in order. Do not start a dependent stack layer until the previous layer has task review and focused verification.
+
+**Goal:** 既存の全震源カタログとFlutter Scene基盤を再利用し、Network/File/Asset PMTilesから全震源を読み込んで深さ付き3D表示するStacked PR群を公開する。
+
+**Architecture:** PMTiles v3のrandom accessとdecodeは純Dartの`seismicity_pmtiles`へ隔離する。描画は`eqmonitor_map`を3Dへ拡張し、Flutter Scene forkの永続instance buffer APIだけに依存する。アプリは既存manifest/archive選択をpackage descriptorへ変換し、既存2D画面を残したまま3Dページを追加する。
+
+**Baseline:** Flutter master、`eqmonitor_map` Scene spike、`/v2/hypocenters/manifest`のアプリ型と2D表示は`develop`に導入済みであり、再実装しない。
+
+## Resolved Decisions
+
+- `pmtiles 2.2.0`の非公開`ReadAt`/directoryへ依存せず、必要最小限のPMTiles v3 readerを`seismicity_pmtiles`内に実装する。
+- `depth_km`欠損はvalidity bitを保持し、実深度とは別の「深さ不明」専用平面へ専用styleで表示する。
+- Network manifestは既存アプリrepositoryで取得し、独立packageはEQMonitor API型へ依存しない。
+- 新規Widget testは作らず、package、camera、projector、buffer、stateのunit testをgateにする。
+
+## Stack
+
+| Order | Branch | Deliverable | Gate |
+|---:|---|---|---|
+| 1 | `codex/seismicity-flutter-scene-design` | 最新developに整合した設計と実装計画 | docs review |
+| 2 | `codex/seismicity-backend-contract-pin` | Backend gitlinkを震源catalog契約を含む`0e520aa1`へ復旧 | OpenAPI/model parity |
+| 3 | `codex/seismicity-pmtiles-core` | Freezed契約、File/Asset reader、PMTiles v3 header/directory | focused Dart tests |
+| 4 | `codex/seismicity-pmtiles-network` | Dio Range、206/Content-Range、strong ETag、If-Match、LRU、cancel | mocked network tests |
+| 5 | `codex/seismicity-pmtiles-decoder` | zoom 14非空tile列挙、MVT point列形式decode、Isolate転送 | archive/decoder tests |
+| 6 | Flutter Scene fork PR | 永続packed billboard bufferとresource lifecycle API | fork tests/API review |
+| 7 | `codex/seismicity-scene-foundation` | perspective/orbit camera、地上・地下phase、pin/provenance同期 | pure unit tests + compile |
+| 8 | `codex/seismicity-static-renderer` | 点/球impostor、半透明地表、200万件benchmark harness | physical profile/release evidence |
+| 9 | `codex/seismicity-3d-integration` | archive adapter、3D page、route、日本地図、loading/error/retry | focused app tests + analyze |
+
+各EQMonitor branchは`gh stack add`で直前branchを親に登録する。各taskはimplementer、task reviewer、必要なfix loopを完了してからcommit/pushする。
+
+## Blocking Gates
+
+- `packages/eqmonitor_map/pubspec.yaml`はFlutter Scene `7f71993...`、README/evidence定数は`695c954...`で不一致。Scene foundationで依存APIを再監査し、同一SHAへ一括同期する。
+- 200万件30fps、5分間memory安定、GPU resource retirementは物理iOS/Android profile/releaseでのみ合格判定する。Linuxの合成testだけで完了扱いにしない。
+- Backend gitlink復旧後、現行PMTiles metadataと生成OpenAPIがアプリ側契約に一致することを確認する。
+- 日本地図meshは既存`app/assets/jma_map.pb`から生成可能かをScene integration前に確認し、区域境界では不足する場合だけ海岸線assetを追加する。
+
+## Component Plans
+
+- [`2026-08-03-seismicity-backend-contract-pin.md`](2026-08-03-seismicity-backend-contract-pin.md)
+- [`2026-08-03-seismicity-pmtiles-core.md`](2026-08-03-seismicity-pmtiles-core.md)
+- Network、decoder、Flutter Scene fork、scene/integrationは各stack layer着手前に個別planを追加する。

--- a/docs/superpowers/plans/2026-08-03-seismicity-backend-contract-pin.md
+++ b/docs/superpowers/plans/2026-08-03-seismicity-backend-contract-pin.md
@@ -1,0 +1,47 @@
+# Seismicity Backend Contract Pin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` for this task and request task review before commit.
+
+**Goal:** 親repositoryのBackend gitlinkを、アプリがすでに利用している震源catalog manifest/PMTiles revision契約を含むcommitへ復旧する。
+
+**Architecture:** Backend実装自体は変更せず、PR #954のmerge commit `0e520aa1`へgitlinkを進める。親側の生成済み`eqmonitor_api`が持つ`query_revision`/`expected_revision`とBackend OpenAPIを照合し、gitlinkだけの独立Stacked PRにする。
+
+**Tech Stack:** Git submodule / pnpm 11 / Vitest / OpenAPI / generated Dart client
+
+---
+
+### Task 1: Restore the catalog-bearing Backend revision
+
+**Files:**
+- Modify: `backend` gitlink only
+
+- [ ] `git -C backend merge-base --is-ancestor 93848cd5 0e520aa1`が成功し、fast-forward可能な復旧であることを確認する。
+- [ ] `git -C backend switch --detach 0e520aa1`でsubmoduleを固定する。
+- [ ] `service/hypocenter-catalog`、`GET /v2/hypocenters/manifest`、`query_revision`、`expected_revision`が固定commitに存在することを確認する。
+- [ ] Backend submodule内に変更がなく、親repositoryの差分がgitlink 1件だけであることを確認する。
+
+### Task 2: Verify contract parity
+
+**Files:**
+- Verify: `backend/api/api/openapi.json`
+- Verify: `packages/eqmonitor_api/lib/src/models/archives.dart`
+- Verify: `packages/eqmonitor_api/lib/src/clients/hypocenters_api_client.dart`
+
+- [ ] Backend OpenAPIのarchiveに`query_revision`、hypocenter searchに`expected_revision`がrequired/optionalの意図どおり存在することを確認する。
+- [ ] Dart clientの`Archives.queryRevision`とsearch methodの`expectedRevision`へ対応していることを確認する。
+- [ ] Backend依存が利用可能なら、次を実行する。
+
+```bash
+cd backend
+mise exec -- pnpm --filter @eqmonitor-backend/hypocenter-catalog exec vitest run \
+  src/pmtiles/archive-planner.test.ts \
+  src/pmtiles/generator.test.ts \
+  src/pmtiles/validator.test.ts
+mise exec -- pnpm --filter @eqmonitor-backend/api exec vitest run \
+  test/hypocenter/hypocenter-routes.test.ts \
+  test/hypocenter/manifest-datasource.test.ts
+```
+
+- [ ] 依存取得や実行環境でtest不能の場合は成功扱いにせず、PRへ`NOT RUN`と静的照合結果を記録する。
+- [ ] `git --no-pager diff --submodule=log develop...HEAD`で無関係な親repository差分がないことを確認する。
+

--- a/docs/superpowers/plans/2026-08-03-seismicity-pmtiles-core.md
+++ b/docs/superpowers/plans/2026-08-03-seismicity-pmtiles-core.md
@@ -1,0 +1,147 @@
+# Seismicity PMTiles Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Strict RED/GREEN TDD is not required, but every public contract and parser boundary below requires focused unit coverage before task review.
+
+**Goal:** 純Dartの`seismicity_pmtiles` packageを作り、Freezed公開契約、File/Asset random access、PMTiles v3 header/directory/leafの厳密な読み込みと指定zoomの非空tile列挙を提供する。
+
+**Architecture:** 全sourceを`SeismicityRandomAccessReader`へ統一し、PMTiles parserはそのreaderだけに依存する。公開データ契約はFreezed、内部parserはimmutableな小さな値だけを扱う。Network実装とMVT feature decodeは後続stackへ分離する。
+
+**Tech Stack:** Dart 3.11+ / Freezed / json_serializable / crypto / test / eqmonitor_lints
+
+---
+
+### Task 1: Package scaffold and Freezed public contracts
+
+**Files:**
+- Create: `packages/seismicity_pmtiles/pubspec.yaml`
+- Create: `packages/seismicity_pmtiles/analysis_options.yaml`
+- Create: `packages/seismicity_pmtiles/lib/seismicity_pmtiles.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/model/seismicity_pmtiles_source.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/model/seismicity_pmtiles_archive_descriptor.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/model/seismicity_pmtiles_bounds.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/model/seismicity_pmtiles_load_state.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/model/seismicity_pmtiles_exception.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/model/seismicity_pmtiles_result.dart`
+- Create generated `*.freezed.dart` and `*.g.dart` beside each JSON model
+- Test: `packages/seismicity_pmtiles/test/model/public_contracts_test.dart`
+
+**Public contracts:**
+
+```dart
+@freezed
+sealed class SeismicityPmTilesSource with _$SeismicityPmTilesSource {
+  const factory SeismicityPmTilesSource.network({required Uri archiveUri}) =
+      SeismicityPmTilesNetworkSource;
+  const factory SeismicityPmTilesSource.file({required String path}) =
+      SeismicityPmTilesFileSource;
+  const factory SeismicityPmTilesSource.asset({required String assetKey}) =
+      SeismicityPmTilesAssetSource;
+}
+
+@freezed
+abstract class SeismicityPmTilesArchiveDescriptor
+    with _$SeismicityPmTilesArchiveDescriptor {
+  const factory SeismicityPmTilesArchiveDescriptor({
+    required SeismicityPmTilesSource source,
+    required int schemaVersion,
+    required int dataZoom,
+    required int expectedSizeBytes,
+    required int expectedFeatureCount,
+    required String archiveRevision,
+    required DateTime periodFrom,
+    required DateTime periodTo,
+  }) = _SeismicityPmTilesArchiveDescriptor;
+}
+```
+
+`SeismicityPmTilesException`は`Exception`を実装するFreezed unionで、少なくとも`invalidDescriptor`、`invalidRange`、`corruptArchive`、`unsupportedCompression`、`unsupportedSource`、`sourceReadFailed`を持つ。`SeismicityPmTilesResult<T>`は`success`/`failure`、load stateは`idle`、`openingSource`、`readingDirectory`、`completed`、`failed`、`cancelled`を持つ。
+
+- [ ] Minimal pubspecを作り、依存はpackageディレクトリで`mise exec -- flutter pub add ...`を使って追加する。
+- [ ] JSON round-trip、3 source union、generic result、exception/load-state分岐をtestする。
+- [ ] `mise exec -- dart run build_runner build --delete-conflicting-outputs`で生成する。
+- [ ] `mise exec -- dart test test/model/public_contracts_test.dart`を通す。
+
+### Task 2: Common reader, File, and Asset implementations
+
+**Files:**
+- Create: `packages/seismicity_pmtiles/lib/src/reader/seismicity_random_access_reader.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/reader/seismicity_range_validator.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/reader/file_random_access_reader.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/reader/asset_random_access_reader.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/reader/seismicity_pmtiles_asset_loader.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/reader/seismicity_random_access_reader_factory.dart`
+- Test: `packages/seismicity_pmtiles/test/reader/file_random_access_reader_test.dart`
+- Test: `packages/seismicity_pmtiles/test/reader/asset_random_access_reader_test.dart`
+- Test: `packages/seismicity_pmtiles/test/reader/seismicity_random_access_reader_factory_test.dart`
+
+**Reader boundary:**
+
+```dart
+typedef SeismicityPmTilesAssetLoader =
+    Future<Uint8List> Function({required String assetKey});
+
+abstract interface class SeismicityRandomAccessReader {
+  int get sizeBytes;
+
+  Future<Uint8List> readAt({required int offset, required int length});
+
+  Future<void> close();
+}
+```
+
+- [ ] 共通validatorで負offset、非正length、overflow、EOF超過を読み込み前に拒否する。
+- [ ] Fileは1つの`RandomAccessFile`を所有し、並行readのposition競合を直列化する。exact length以外を失敗にする。
+- [ ] Assetは注入loaderを1回だけ呼び、archive全体を保持してsliceする。Flutterをimportしない。
+- [ ] factoryはNetwork sourceを後続PRまで`unsupportedSource`として明示的に返し、File/Assetへfallbackしない。
+- [ ] temp file、並行read、範囲外、close後、loader一回、source分岐をtestする。
+
+### Task 3: Strict PMTiles v3 header and directory traversal
+
+**Files:**
+- Create: `packages/seismicity_pmtiles/lib/src/archive/pmtiles_v3_header.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/archive/pmtiles_v3_header_decoder.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/archive/pmtiles_v3_compression_decoder.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/archive/pmtiles_v3_directory_entry.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/archive/pmtiles_v3_directory_decoder.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/archive/pmtiles_v3_tile_id.dart`
+- Create: `packages/seismicity_pmtiles/lib/src/archive/seismicity_pmtiles_archive.dart`
+- Test: `packages/seismicity_pmtiles/test/archive/pmtiles_v3_header_decoder_test.dart`
+- Test: `packages/seismicity_pmtiles/test/archive/pmtiles_v3_directory_decoder_test.dart`
+- Test: `packages/seismicity_pmtiles/test/archive/seismicity_pmtiles_archive_test.dart`
+- Create: `packages/seismicity_pmtiles/test/support/pmtiles_v3_fixture_builder.dart`
+
+**Archive boundary:**
+
+`PmTilesV3Header`と`PmTilesV3DirectoryEntry`もFreezedで生成し、巨大listを持たないimmutable valueとして扱う。
+
+```dart
+abstract interface class SeismicityPmTilesArchive {
+  PmTilesV3Header get header;
+
+  Stream<int> occupiedTileIdsAtZoom({required int zoom});
+
+  Future<Uint8List> readTile({required int tileId});
+
+  Future<void> close();
+}
+```
+
+- [ ] 127-byte headerをlittle-endianで解析し、magic/version、section bounds、tile type MVT、zoom range、descriptor size/dataZoomを検証する。
+- [ ] PMTiles v3のunsigned varint、delta tile ID、run length、length、offset+1を仕様どおりdecodeする。
+- [ ] rootとleafをreaderから必要範囲だけ取得し、section外参照、空directory、zero length、順序逆転、3段超過を拒否する。
+- [ ] internal/tile compressionは`none`と`gzip`を実装し、brotli/zstd/unknownを明示的なunsupported errorにする。
+- [ ] 指定zoomのtile ID範囲とentry runの交差だけを展開し、bbox全総当たりをしない。
+- [ ] `readTile`はdirectory entryを解決し、tile data sectionからexact rangeを読む。同じcontentを指すrunを正しく扱う。
+- [ ] fixture builderでroot-only、leaf、gzip、run length、corrupt boundsを生成してtestする。外部ネットワークfixtureへ依存しない。
+
+### Task 4: Core verification and documentation
+
+**Files:**
+- Create: `packages/seismicity_pmtiles/README.md`
+- Modify: `docs/knowledge/20260802_flutter_scene_large_static_instances.md` only if a cross-component invariant changed
+
+- [ ] `mise exec -- dart format packages/seismicity_pmtiles`を実行する。
+- [ ] `mise exec -- dart analyze packages/seismicity_pmtiles --fatal-infos`を通す。
+- [ ] `mise exec -- dart test packages/seismicity_pmtiles/test`を通す。
+- [ ] public barrelがpackage利用者に必要なFreezed契約、reader、archiveだけをexportし、内部decoder helperをexportしないことを確認する。
+- [ ] READMEにNetworkは次stackであり、File/AssetのみがこのPRの完成範囲であることを明記する。

--- a/docs/superpowers/specs/2026-08-02-seismicity-flutter-scene-design.md
+++ b/docs/superpowers/specs/2026-08-02-seismicity-flutter-scene-design.md
@@ -16,7 +16,8 @@
 - 色、半径、遷移閾値、地図透明度をDart側の引数として渡す。
 - 1本指で回転、ピンチでズーム、2本指ドラッグで平行移動できる。
 - PMTilesの取得と解析は独立した`seismicity_pmtiles`パッケージに置く。
-- ネットワーク取得にはDioを使う。
+- PMTilesはNetwork、File、Flutter Assetの3種類から読み込める。
+- Network取得にはDioのHTTP Range Requestを使い、アーカイブ全体をファイルとしてダウンロードしない。
 - 公開データ型、状態、結果、例外はFreezedで生成する。
 - Flutter masterを基底PRで導入し、その上にStacked PRを積む。
 
@@ -59,17 +60,19 @@ EQMonitorはforkの内部APIを直接importせず、公開APIだけを使う。
 
 `packages/seismicity_pmtiles/`は次を担当する。
 
-- Dioによるmanifest取得
-- DioによるPMTiles全体のダウンロード
-- 一時ファイル、検証済みキャッシュ、atomic renameの管理
-- SHA-256、スキーマバージョン、件数の検証
-- ローカルPMTilesアーカイブの読み込み
+- Network、File、Assetを共通のrandom-access readerへ変換
+- Dioによるmanifest取得とPMTilesのHTTP Range取得
+- `206 Partial Content`、`Content-Range`、取得長、ETagの検証
+- Fileのrandom accessとAsset bytesの読み込み
+- PMTiles v3のheader、root directory、leaf directory、tile dataの読み込み
+- スキーマバージョン、アーカイブ識別子、件数の検証
+- bounded memory LRUによる取得済みrangeのキャッシュ
 - 固定データズームのMVT Point解析
 - Isolate上でのチャンク変換
 - `TransferableTypedData`による解析結果の転送
 - Freezedによる状態、結果、例外の公開
 
-Flutter、Flutter Scene、Riverpod、EQMonitor UIには依存しない。キャッシュ先は呼び出し側から明示的に渡す。
+Flutter、Flutter Scene、Riverpod、EQMonitor UIには依存しない。AssetはFlutterの`AssetBundle`を直接参照せず、呼び出し側からasset keyをbytesへ解決するloaderを注入する。
 
 ### 構成
 
@@ -78,12 +81,14 @@ packages/seismicity_pmtiles/
 ├── lib/src/data_source/
 ├── lib/src/decoder/
 ├── lib/src/model/
+├── lib/src/reader/
 └── lib/src/repository/
 ```
 
 主要な型は次とする。
 
 - `SeismicityPmTilesManifest`
+- `SeismicityPmTilesSource`
 - `SeismicityPmTilesLayer`
 - `SeismicityPmTilesChunk`
 - `SeismicityPmTilesDataset`
@@ -94,9 +99,33 @@ packages/seismicity_pmtiles/
 200万件を個別のFreezedモデルには変換しない。`SeismicityPmTilesChunk`は緯度、経度、深さ、マグニチュード、発生時刻、震度フラグを列形式のバッファとして保持する。
 巨大バッファを持つFreezed型は`@Freezed(equal: false)`とし、意図しない全要素比較を防ぐ。
 
+### Sourceとrandom access
+
+`SeismicityPmTilesSource`は次のFreezed unionとする。
+
+- `network`: manifest URIを持つ。manifestからversioned archive URIを解決し、DioでRange取得する。
+- `file`: manifest pathとPMTiles pathを持つ。`RandomAccessFile`で必要範囲だけ読む。
+- `asset`: manifest asset keyとPMTiles asset keyを持つ。注入された`SeismicityPmTilesAssetLoader`でbytesを取得する。
+
+`SeismicityPmTilesAssetLoader`は`Future<Uint8List> Function({required String assetKey})`とする。EQMonitor側のadapterが`AssetBundle.load`の結果を`Uint8List`へ変換する。loaderはrepositoryへ依存注入し、JSON変換対象の`SeismicityPmTilesSource`には保持しない。
+
+3経路は最終的に`pmtiles.ReadAt.readAt(int offset, int length)`へ統一し、`pmtiles`パッケージ2.2系の`PmTilesArchive.fromReadAt(..., strict: true)`へ渡す。PMTiles解析ロジックを経路ごとに複製しない。
+
+FlutterのAsset APIはファイル内random accessを提供しないため、Asset経路だけはPMTiles asset全体を一度メモリへ読み込む。Network経路でこのフォールバックを使うことは禁止する。
+
+Network readerは次を保証する。
+
+- `Range: bytes=<offset>-<inclusiveEnd>`と`ResponseType.bytes`を使用する。
+- 初回range応答のstrong ETagをアーカイブ識別子として固定し、後続rangeへ`If-Match`を付ける。
+- `206 Partial Content`以外を拒否し、`200 OK`を全体ファイルとして受理しない。
+- `Content-Range`の開始、終了、全体長と実データ長をmanifestおよび要求範囲と照合する。
+- `412 Precondition Failed`またはETag変更時は、異なる世代のrangeを混在させず読み込み全体を失敗させる。
+- 同じアーカイブ識別子、offset、lengthのrangeはbounded memory LRUから再利用する。
+- Dioの`CancelToken`で未完了requestを停止する。
+
 ### PMTiles生成契約
 
-manifestは少なくともURL、SHA-256、ファイルサイズ、生成日時、スキーマバージョン、データズーム、フィーチャー件数を含む。
+manifestは少なくともversioned archive URI、ファイルサイズ、生成日時、スキーマバージョン、データズーム、地理範囲、フィーチャー件数を含む。FileとAsset用manifestも同じ論理フィールドを持ち、archive URIだけをローカルsource識別子へ置き換える。
 
 PMTiles生成処理は次を保証する。
 
@@ -105,16 +134,20 @@ PMTiles生成処理は次を保証する。
 - 同じ`event_id`を同一データズーム内で重複させない。
 - 元データ件数、ユニークID件数、PMTiles内件数が一致する。
 - 必須プロパティの型と欠損をリリース前に検証する。
+- Network配信先はbyte Rangeをサポートし、正しい`206`、`Content-Range`、strong ETagを返す。
+- 公開後のarchive URIは内容を上書きせず、更新時は新しいversioned URIを発行する。
 
-クライアントは件数やハッシュが一致しないデータを表示しない。
+クライアントはアーカイブ識別子、サイズ、range、件数が一致しないデータを表示しない。全体を取得しないNetwork経路ではアーカイブ全体のSHA-256をクライアント検証要件にしない。FileとAssetではmanifestにSHA-256がある場合だけ全体検証を行う。
 
 ## データフロー
 
 ```text
-manifest取得
-  → PMTilesを*.partialへDio.download
-  → SHA-256とサイズを検証
-  → 検証済みキャッシュへatomic rename
+sourceとmanifestを解決
+  → Network: 先頭16KiBをDio Range取得しETagを固定
+  → File: RandomAccessFileをopen
+  → Asset: 注入loaderでbytesを取得
+  → header/root/leafから対象dataZoomのtile rangeを解決
+  → 必要なtile dataだけをrange単位で取得
   → Worker IsolateでMVTをタイル単位に解析
   → 列形式チャンクをTransferableTypedDataで転送
   → 正距方位図法でkm座標へ変換
@@ -124,6 +157,8 @@ manifest取得
 
 GPUレコードは東西・深さ・南北位置、マグニチュード、発生時刻、震度等のフラグを持ち、1件あたり24バイトを目安とする。
 200万件で約48MBとなる。Dartヒープに200万個のイベントオブジェクトは保持しない。
+
+全震源を個別表示するため、Network経路でも最終的には対象dataZoomに存在する全tile payloadを取得する。Range方式の目的は、PMTiles全体ファイルの保存を避け、directoryや不要領域の転送を抑え、段階的解析、キャンセル、range単位の再利用を可能にすることである。
 
 ## 座標と地図
 
@@ -163,12 +198,11 @@ depthScale = 1.0
 
 ## 状態と障害対応
 
-`SeismicityPmTilesLoadState`は`idle`、`fetchingManifest`、`downloading`、`verifying`、`decoding`、`completed`、`failed`、`cancelled`をFreezed unionで表す。
+`SeismicityPmTilesLoadState`は`idle`、`fetchingManifest`、`openingSource`、`fetchingRanges`、`decoding`、`completed`、`failed`、`cancelled`をFreezed unionで表す。
 
 - 期間変更時はDioの`CancelToken`と解析Isolateを停止する。
-- 不完全な一時ファイルだけを削除し、検証済みキャッシュは保持する。
-- キャッシュ利用は期間、スキーマバージョン、SHA-256が一致する場合だけ許可する。
-- キャッシュ利用時は生成日時と前回データであることを明示する。
+- Network range cacheはアーカイブURIとETagが一致する場合だけ再利用する。
+- FileとAssetはmanifestのsource識別子、サイズ、任意SHA-256が一致する場合だけ受理する。
 - 生の例外文字列をUIへ表示しない。
 - 不明値を固定値やランダム値で補完しない。
 - manifest件数と解析件数が一致しなければ描画しない。
@@ -178,9 +212,13 @@ depthScale = 1.0
 ### 独立パッケージ
 
 - manifestのFreezed JSON変換
-- Dio取得、キャンセル、進捗通知
-- SHA-256不一致時の拒否
-- atomic cache更新と検証済みキャッシュ保持
+- Source Freezed unionのNetwork、File、Asset分岐
+- Dio Range header、キャンセル、進捗通知
+- `206`と`Content-Range`の厳密検証、および`200`応答の拒否
+- ETag固定、`If-Match`送信、`412`と世代変更の拒否
+- bounded range LRUのhit、eviction、アーカイブ識別子分離
+- File random accessと範囲外readの拒否
+- Asset loaderからの読み込みとNetwork経路への全体loadフォールバック禁止
 - MVT Pointとプロパティの解析
 - 不正型、欠損、未知スキーマの拒否
 - manifest件数と解析件数の一致
@@ -195,7 +233,9 @@ depthScale = 1.0
 - 半透明地図越しの地下表示
 - カメラ回転、移動、ズーム、リセット
 - GPUバッファが初回またはデータ変更時だけ転送されること
-- 読み込み、エラー、検証済みキャッシュ表示のWidgetテスト
+- 読み込み状態、キャンセル、エラー変換のunit test
+
+今回の機能追加では新しいWidget testを必須にしない。3D画面の描画確認は実機smoke testと性能ゲートで行う。
 
 ## 性能ゲート
 

--- a/docs/superpowers/specs/2026-08-02-seismicity-flutter-scene-design.md
+++ b/docs/superpowers/specs/2026-08-02-seismicity-flutter-scene-design.md
@@ -19,7 +19,7 @@
 - PMTilesはNetwork、File、Flutter Assetの3種類から読み込める。
 - Network取得にはDioのHTTP Range Requestを使い、アーカイブ全体をファイルとしてダウンロードしない。
 - 公開データ型、状態、結果、例外はFreezedで生成する。
-- Flutter masterを基底PRで導入し、その上にStacked PRを積む。
+- `develop`で導入済みのFlutter masterと`eqmonitor_map` Scene spikeを基盤にし、震源3D専用のStacked PRを積む。
 
 ## 対象外
 
@@ -109,7 +109,9 @@ packages/seismicity_pmtiles/
 
 `SeismicityPmTilesAssetLoader`は`Future<Uint8List> Function({required String assetKey})`とする。EQMonitor側のadapterが`AssetBundle.load`の結果を`Uint8List`へ変換する。loaderはrepositoryへ依存注入し、JSON変換対象の`SeismicityPmTilesSource`には保持しない。
 
-3経路は最終的に`pmtiles.ReadAt.readAt(int offset, int length)`へ統一し、`pmtiles`パッケージ2.2系の`PmTilesArchive.fromReadAt(..., strict: true)`へ渡す。PMTiles解析ロジックを経路ごとに複製しない。
+3経路は最終的にパッケージ公開の`SeismicityRandomAccessReader.readAt`へ統一する。`pmtiles` 2.2系は`ReadAt`、directory、全非空tile列挙を公開しておらず、EQMonitorのlintで禁止される`src/` importが必要になる。このため、`seismicity_pmtiles`内にPMTiles v3のheader、directory、leaf、tile rangeを扱う必要最小限のreaderを実装し、公式仕様fixtureで厳密に検証する。解析ロジックを経路ごとに複製しない。
+
+Network sourceは既存の`GET /v2/hypocenters/manifest`をアプリ側で取得し、URL、サイズ、feature count、query revision、期間をパッケージのarchive descriptorへ変換する。独立パッケージからEQMonitor API型へ依存したり、同じmanifestを再取得したりしない。FileとAssetも同じdescriptor JSONを呼び出し側から渡せる。
 
 FlutterのAsset APIはファイル内random accessを提供しないため、Asset経路だけはPMTiles asset全体を一度メモリへ読み込む。Network経路でこのフォールバックを使うことは禁止する。
 
@@ -146,7 +148,7 @@ sourceとmanifestを解決
   → Network: 先頭16KiBをDio Range取得しETagを固定
   → File: RandomAccessFileをopen
   → Asset: 注入loaderでbytesを取得
-  → header/root/leafから対象dataZoomのtile rangeを解決
+  → 独自PMTiles v3 readerでheader/root/leafから対象dataZoomの非空tile rangeを列挙
   → 必要なtile dataだけをrange単位で取得
   → Worker IsolateでMVTをタイル単位に解析
   → 列形式チャンクをTransferableTypedDataで転送
@@ -173,6 +175,8 @@ depthScale = 1.0
 
 日本地図は同じ投影法で生成した半透明のGLBメッシュとする。地表はY=0、両面描画とし、地下から見上げた場合も輪郭を確認できる。
 地図は半透明パスで深度書き込みを行わず、地下の震源を隠さない。震源は円形外を破棄する不透明パスで描画し、震源同士の深度判定を行う。
+
+`depth_km`が欠損する震源は値を0km等へ補完しない。validity bitを保持したまま、実深度volumeとは分離した「深さ不明」専用平面へ専用styleで個別表示する。専用平面の位置とstyleはDart引数とし、凡例で実深度ではないことを明示する。
 
 ## アプリ側コンポーネント
 
@@ -250,13 +254,15 @@ depthScale = 1.0
 
 ## Stacked PR
 
-1. Flutter master移行と必要なプラグイン更新
-2. `seismicity_pmtiles`独立パッケージ
-3. Flutter Scene導入、fork固定、空Sceneとカメラ操作
-4. 静的GPUバッファ、点・球Shader、200万件実機ベンチマーク
-5. PMTiles実データ、日本地図、`Seismicity3dPage`統合
+1. 最新`develop`との設計整合、Backend震源catalog contractのgitlink復旧
+2. `seismicity_pmtiles`のFreezed契約、File/Asset reader、PMTiles v3 core
+3. Dio Range reader、strong ETag、LRU、キャンセル
+4. zoom 14非空tile列挙、MVT列形式decode、Isolate転送
+5. Flutter Scene forkの永続static instance bufferとresource lifecycle公開API
+6. `eqmonitor_map`のperspective/orbit camera、震源Shader、200万件実機ベンチマーク
+7. PMTiles実データ、日本地図、`Seismicity3dPage`統合
 
-各PRは直前のPRをbaseとし、順番にレビュー・マージする。Flutter Scene fork側の変更は汎用APIとして別PRにし、EQMonitor側では固定コミットを参照する。
+各EQMonitor PRは直前のPRをbaseとし、順番にレビュー・マージする。Flutter masterと空Scene spikeはすでに`develop`へ入っているため再導入しない。Flutter Scene fork側の変更は汎用APIとして別PRにし、EQMonitor側では固定コミットを参照する。現在のFlutter Scene依存SHAとScene evidenceの期待SHAが不一致なので、Scene実装前にAPI再監査とprovenance同期を行う。
 
 ## 参照
 

--- a/docs/superpowers/specs/2026-08-02-seismicity-flutter-scene-design.md
+++ b/docs/superpowers/specs/2026-08-02-seismicity-flutter-scene-design.md
@@ -1,0 +1,227 @@
+# Flutter Scene 震源3D表示 設計
+
+## 目的
+
+気象庁の震源データを格納したPMTilesを読み込み、Flutter Scene上で日本列島と震源の深さを3次元表示する。
+年間約200万件を集約・間引きせず個別表示し、iPhone 13相当以上で操作中30fpsを満たすことを目標とする。
+
+## 確定要件
+
+- MapLibreには依存しない独立した3D画面とする。
+- 深さ0kmに半透明の日本地図を配置する。
+- 水平距離と深さはkm単位で統一し、深さ倍率はDart定数の`1.0`とする。
+- 年間約200万件を同時に個別表示する。密度集約や件数間引きは行わない。
+- 遠景は点、近景はShader生成の球インポスターとして表示する。
+- 点と球の切り替えは画面上の直径で判定し、境界では連続的に遷移する。
+- 色、半径、遷移閾値、地図透明度をDart側の引数として渡す。
+- 1本指で回転、ピンチでズーム、2本指ドラッグで平行移動できる。
+- PMTilesの取得と解析は独立した`seismicity_pmtiles`パッケージに置く。
+- ネットワーク取得にはDioを使う。
+- 公開データ型、状態、結果、例外はFreezedで生成する。
+- Flutter masterを基底PRで導入し、その上にStacked PRを積む。
+
+## 対象外
+
+- MapLibreとのカメラ・深度・レイヤー同期
+- 震源のクラスタリング、ヒートマップ、密度による間引き
+- 初期リリースでの震源タップ選択と詳細表示
+- 初期リリースでのカメラ慣性
+- DuckDB、Parquet、SQLiteによる端末内分析
+- 既存の2D地震活動ページの置き換え
+
+## 採用方式
+
+### 描画
+
+Flutter Scene標準の`InstancedMesh`は、各インスタンスを`Matrix4`として保持し、描画時に16個のfloatへ再パックする。
+200万件では変換行列だけで約128MBとなり、毎フレームのCPU処理と転送も大きいため使わない。
+
+標準の`BillboardGeometry`もインスタンスデータをフレーム一時領域へ転送するため、そのままでは使わない。
+Flutter Sceneのforkへ、静的インスタンスデータを永続GPUバッファへ一度だけアップロードする汎用Geometryを追加する。
+EQMonitorはforkの内部APIを直接importせず、公開APIだけを使う。
+
+各震源は共有四角形をインスタンス描画する。Fragment Shaderが円形外を破棄し、近景では球面法線、陰影、補正深度を生成する。
+これにより実ポリゴン球より大幅に三角形数を減らしながら、震源ごとの奥行き関係を維持する。
+
+### 点・球LOD
+
+任意視点の3D空間では地図のZoomLevelを定義せず、投影後の震源直径をピクセル単位で使う。
+
+- `pointMinDiameterPx`: 遠景でも消失させない最小点径
+- `sphereTransitionStartPx`: 点から球へ移り始める直径
+- `sphereTransitionEndPx`: 完全な球表示になる直径
+
+判定と補間はShader内で行う。カメラ操作時にDart側で200万件を走査したりGPUバッファを再構築したりしない。
+
+## `seismicity_pmtiles`パッケージ
+
+### 責務
+
+`packages/seismicity_pmtiles/`は次を担当する。
+
+- Dioによるmanifest取得
+- DioによるPMTiles全体のダウンロード
+- 一時ファイル、検証済みキャッシュ、atomic renameの管理
+- SHA-256、スキーマバージョン、件数の検証
+- ローカルPMTilesアーカイブの読み込み
+- 固定データズームのMVT Point解析
+- Isolate上でのチャンク変換
+- `TransferableTypedData`による解析結果の転送
+- Freezedによる状態、結果、例外の公開
+
+Flutter、Flutter Scene、Riverpod、EQMonitor UIには依存しない。キャッシュ先は呼び出し側から明示的に渡す。
+
+### 構成
+
+```text
+packages/seismicity_pmtiles/
+├── lib/src/data_source/
+├── lib/src/decoder/
+├── lib/src/model/
+└── lib/src/repository/
+```
+
+主要な型は次とする。
+
+- `SeismicityPmTilesManifest`
+- `SeismicityPmTilesLayer`
+- `SeismicityPmTilesChunk`
+- `SeismicityPmTilesDataset`
+- `SeismicityPmTilesLoadState`
+- `SeismicityPmTilesResult`
+- `SeismicityPmTilesException`
+
+200万件を個別のFreezedモデルには変換しない。`SeismicityPmTilesChunk`は緯度、経度、深さ、マグニチュード、発生時刻、震度フラグを列形式のバッファとして保持する。
+巨大バッファを持つFreezed型は`@Freezed(equal: false)`とし、意図しない全要素比較を防ぐ。
+
+### PMTiles生成契約
+
+manifestは少なくともURL、SHA-256、ファイルサイズ、生成日時、スキーマバージョン、データズーム、フィーチャー件数を含む。
+
+PMTiles生成処理は次を保証する。
+
+- manifestの`dataZoom`で全震源を保持する。
+- 密度やタイルサイズを理由に点を削除しない。
+- 同じ`event_id`を同一データズーム内で重複させない。
+- 元データ件数、ユニークID件数、PMTiles内件数が一致する。
+- 必須プロパティの型と欠損をリリース前に検証する。
+
+クライアントは件数やハッシュが一致しないデータを表示しない。
+
+## データフロー
+
+```text
+manifest取得
+  → PMTilesを*.partialへDio.download
+  → SHA-256とサイズを検証
+  → 検証済みキャッシュへatomic rename
+  → Worker IsolateでMVTをタイル単位に解析
+  → 列形式チャンクをTransferableTypedDataで転送
+  → 正距方位図法でkm座標へ変換
+  → 24バイト固定長のGPUレコードを構築
+  → 静的GPUバッファへ一度だけアップロード
+```
+
+GPUレコードは東西・深さ・南北位置、マグニチュード、発生時刻、震度等のフラグを持ち、1件あたり24バイトを目安とする。
+200万件で約48MBとなる。Dartヒープに200万個のイベントオブジェクトは保持しない。
+
+## 座標と地図
+
+日本中心の正距方位図法を使い、水平座標をkmへ変換する。
+
+```text
+X = 東方向 km
+Y = -深さ km
+Z = 北方向 km
+depthScale = 1.0
+```
+
+日本地図は同じ投影法で生成した半透明のGLBメッシュとする。地表はY=0、両面描画とし、地下から見上げた場合も輪郭を確認できる。
+地図は半透明パスで深度書き込みを行わず、地下の震源を隠さない。震源は円形外を破棄する不透明パスで描画し、震源同士の深度判定を行う。
+
+## アプリ側コンポーネント
+
+- `HypocenterCoordinateProjector`: 緯度経度と深さをシーン座標へ変換
+- `HypocenterGpuBufferBuilder`: パッケージのチャンクからGPUレコードを構築
+- `Seismicity3dDatasetNotifier`: 読み込み、キャンセル、進捗、再試行を管理
+- `HypocenterSceneStyle`: 色、半径、LOD閾値、地図透明度を保持
+- `HypocenterSceneController`: SceneとGPUリソースの生成・破棄
+- `OrbitCameraController`: タッチ入力からカメラ姿勢を計算
+- `HypocenterSceneView`: Flutter Sceneを表示
+- `Seismicity3dPage`: 期間、色モード、読み込み状態を統合
+
+既存の2D地震活動ページは維持し、3D表示は別ページとして追加する。既存の期間・色モード選択UIは再利用する。
+
+## 視点操作
+
+- 1本指ドラッグ: トラックボール方式で360度回転
+- ピンチ: カメラ距離を指数的に変更
+- 2本指ドラッグ: 視線に直交する平面上で平行移動
+- ダブルタップまたはリセットボタン: 日本全体が収まる初期視点へ戻す
+
+カメラの近遠クリップ面はデータ境界から決定する。カメラ操作だけでは震源バッファを変更しない。
+
+## 状態と障害対応
+
+`SeismicityPmTilesLoadState`は`idle`、`fetchingManifest`、`downloading`、`verifying`、`decoding`、`completed`、`failed`、`cancelled`をFreezed unionで表す。
+
+- 期間変更時はDioの`CancelToken`と解析Isolateを停止する。
+- 不完全な一時ファイルだけを削除し、検証済みキャッシュは保持する。
+- キャッシュ利用は期間、スキーマバージョン、SHA-256が一致する場合だけ許可する。
+- キャッシュ利用時は生成日時と前回データであることを明示する。
+- 生の例外文字列をUIへ表示しない。
+- 不明値を固定値やランダム値で補完しない。
+- manifest件数と解析件数が一致しなければ描画しない。
+
+## テスト
+
+### 独立パッケージ
+
+- manifestのFreezed JSON変換
+- Dio取得、キャンセル、進捗通知
+- SHA-256不一致時の拒否
+- atomic cache更新と検証済みキャッシュ保持
+- MVT Pointとプロパティの解析
+- 不正型、欠損、未知スキーマの拒否
+- manifest件数と解析件数の一致
+- `TransferableTypedData`のIsolate転送
+- 200万件相当で個別Freezedオブジェクトを生成しないこと
+
+### Flutter Sceneとアプリ
+
+- 点表示と球インポスター表示
+- 点と球の遷移境界のスモークレンダー
+- 色、半径、深さ、補正深度のShader入力
+- 半透明地図越しの地下表示
+- カメラ回転、移動、ズーム、リセット
+- GPUバッファが初回またはデータ変更時だけ転送されること
+- 読み込み、エラー、検証済みキャッシュ表示のWidgetテスト
+
+## 性能ゲート
+
+200万件の合成データを使い、iPhone 13相当の実機でProfileまたはReleaseビルドを計測する。
+
+- 操作中30fps以上を継続する。
+- カメラ操作中にDart側の全件走査を行わない。
+- フレームごとの巨大バッファ確保やGPU転送を行わない。
+- 5分間の連続操作でクラッシュ、Jetsam、継続的なメモリ増加がない。
+
+性能ゲートを満たさない場合、実データ画面の統合PRへ進まない。
+
+## Stacked PR
+
+1. Flutter master移行と必要なプラグイン更新
+2. `seismicity_pmtiles`独立パッケージ
+3. Flutter Scene導入、fork固定、空Sceneとカメラ操作
+4. 静的GPUバッファ、点・球Shader、200万件実機ベンチマーク
+5. PMTiles実データ、日本地図、`Seismicity3dPage`統合
+
+各PRは直前のPRをbaseとし、順番にレビュー・マージする。Flutter Scene fork側の変更は汎用APIとして別PRにし、EQMonitor側では固定コミットを参照する。
+
+## 参照
+
+- [Flutter Scene](https://pub.dev/packages/flutter_scene)
+- [Flutter Scene InstancedMesh](https://github.com/bdero/flutter_scene/blob/master/packages/flutter_scene/lib/src/instanced_mesh.dart)
+- [PMTiles v3 specification](https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md)
+- [pmtiles Dart package](https://pub.dev/packages/pmtiles)
+- [vector_tile Dart package](https://pub.dev/packages/vector_tile)


### PR DESCRIPTION
## 概要

- Flutter Sceneによる震源3D表示の設計を追加
- Network/File/Asset対応の独立PMTiles package境界を定義
- Dio HTTP Range、strong ETag、列形式decode、200万件static GPU bufferを設計
- 最新developで導入済みのFlutter master/eqmonitor_mapを再利用するStacked PR計画へ更新
- pmtiles 2.2.0の非公開APIには依存せず、必要最小限のPMTiles v3 readerを実装する方針を記録
- 深さ不明震源は値を捏造せず、専用平面へ専用styleで表示する方針を記録

## 検証

- git diff --check
- ドキュメントのみ

## Stack

このPRがStackの親です。後続PRでBackend contract pin、seismicity_pmtiles、Flutter Scene fork/API、renderer、アプリ統合を段階導入します。
