### PR TITLE
Fix: ベースマップのLine描画とCD配布での.fmat欠落を修正

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -218,6 +218,18 @@ flutter:
     # package:sqlite3 v3 はビルドフック(native assets)で libsqlite3 を同梱する。
     # 無効だと .so が同梱されず drift が起動時にクラッシュするため必須。
     enable-native-assets: true
+    # eqmonitor_map の hook/build.dart が `.fmat` を Dart Data Asset として
+    # 生成する。このfeatureは master で `available` だが `enabledByDefault`
+    # ではないため(flutter_tools の features.dart の `dartDataAssets` 参照)、
+    # 明示的に有効化しないと同梱されず、実行時に
+    # `base_map_fill.fmat was not found` になる。
+    #
+    # `flutter config --enable-dart-data-assets` はマシンごとのglobal設定で
+    # repositoryへコミットされないためCI/CDには効かない。pubspecの
+    # `flutter: config:` はglobal設定より優先される
+    # (flutter_tools の flutter_features_config.dart の
+    # `_isEnabledAtProjectLevel`)ので、ここへ書くことでCDでも有効になる。
+    enable-dart-data-assets: true
   uses-material-design: true
   assets:
     - assets/

--- a/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
+++ b/docs/superpowers/specs/2026-08-02-eqmonitor-map-renderer-design.md
@@ -246,11 +246,30 @@ Fillはtile-local座標だけを持つ頂点と、穴込みearcutの三角形ind
 fillのshaderは行列積だけであり、複雑さはすべて頂点生成側に置く。
 
 Lineは中心線の各頂点に押し出し法線を持たせ、shaderで押し出す。押し出しは変換前の座標へ足さず、
-押し出しベクトルを同じtile行列で変換して**変換後に加算**する。正射影かつpitch 0ではこれがworld
-空間の押し出しと等価になるため、半線幅をworld単位で与えればscreen上で一定幅になる。半線幅の
-world単位換算はCPUで毎frame確定し、uniformとして渡す。
+押し出しベクトルを変換後の空間で加算する。正射影かつpitch 0では変換がaffineな対角スケールと
+平行移動だけになるため、この加算はworld空間の押し出しと等価である。
 
-初期実装の頂点属性はfloat32とする。MapLibreの6 byte packing（座標を2倍して最下位bitへフラグを
+**押し出しをどの空間で行うかは、cameraをどう配線したかで決まる。両者を一致させること。**
+Flutter Sceneの生成shaderは`world_position = model_transform * position`を求めてから
+material側の`Vertex()`を呼び、その後で`camera_transform`を掛ける。したがってmodel transformへ
+view/projectionまで焼き込む配線（`_IdentityCameraProjection`を使い
+`viewProjectionMatrixFor * tileMatrixFor`をnodeのlocalTransformへ入れる方式）では、`Vertex()`が
+受け取る`world_position`は既にclip/NDC空間であり、**半線幅もNDC単位で渡さなければならない**。
+NDCはviewportの`width × height` logical pixelに対して`[-1, 1]`を張るので、1 logical pixelは
+x軸で`2/width`、y軸で`2/height`になる。正射影は回転を含まない対角スケールなので、押し出し
+ベクトルへ成分ごとにこの係数を掛ければscreen上では等方な線幅になる。半線幅の換算はCPUで
+viewportから毎frame確定し、`vec2`のuniformとして渡す。viewport変更時は再計算する。
+
+この不一致は実際に不具合として発現した。doc commentが「`world_position`はtile行列適用後・
+camera/projection適用前」と仮定したまま半線幅をlogical pixelの生値で渡していたため、NDC空間で
+`1.0`（可視範囲±1の半分）の押し出しとなり画面が塗り潰された。経緯は
+`docs/todo/800_eqmonitor_map_deferred_verification.md`に記録する。
+
+初期実装の頂点属性はfloat32とする。押し出し法線は`MeshGeometry.fromArrays`の組み込み
+`texCoords`（`vec2`）で渡す。`Geometry.setCustomAttribute`経由のcustom vertex attributeは、
+値がshaderへ届かず同じ頂点の`position`が読まれる不具合を実機で確認したため使わない。UVでは
+なく押し出し法線を運ぶという意味論の逸脱になるので、materialとgeometry factoryの両方へ根拠を
+doc commentで残す。MapLibreの6 byte packing（座標を2倍して最下位bitへフラグを
 同居させ、押し出し法線を±63へ量子化しoffset 128でuint8化し、線に沿った距離を14bitで分割する
 方式）は、`gpu.VertexFormat`のint16/uint8正規化対応を実機で検証できるまで採用しない。packing方式
 自体は後段の最適化候補として残し、頂点生成器の出力型を差し替えられる境界を保つ。

--- a/docs/todo/800_eqmonitor_map_deferred_verification.md
+++ b/docs/todo/800_eqmonitor_map_deferred_verification.md
@@ -63,32 +63,81 @@
   描画されても`baseMapLayerSpecs`の色が全て不透明なため見た目には現れないが、
   半透明色を導入する場合は排除が必要になる。
 
-## 既知の不具合(Task 10の実機確認で発見、flood発生元のlayerを特定・未修正)
+## Task 10で観測したfloodの真因(特定済み、修正は別コミット)
 
-**海(land以外の領域)が`areaForecastLocalEwLine`(source layer:
-`areaForecastLocalEew`, 名目色`0xFFFF7043`のオレンジ)の色で塗られたように
-見える不具合がある。**
+Task 10の実機確認で「海(land以外の領域)が単一のLine layerの色で塗り潰される」
+現象が観測された。当初は`areaForecastLocalEewLine`のLine mesh生成、または
+ring境界処理の不具合と推測していたが、**いずれも反証され、真因はGPUへの
+頂点属性の受け渡しにあった。**
 
-当初「`countriesLine`のLine meshに縮退した巨大三角形が2枚混入している」
-という仮説を報告したが、**この仮説は別agentの検証により反証された。**
-問題の三角形の座標は`(4096,4176)→(0,4176)`であり、`y=4176 = extent(4096) +
-buffer(80)`と一致する、MVT tile bufferのclip辺という正当な地物だった
-(南極付近のWeb Mercator clip辺)。独立実装によるring分離の再検証でも
-`crossRingViolations=0`、`bigTriCount=0`が確認されており、
-**`LineMeshBuilder`と`_polygonFeatureAsClosedLines`は正常と確定した。**
+### 反証された仮説(記録として残す)
 
-`BaseMapMaterialLibrary`をlayerごとに独立したmaterial instanceを持つ設計へ
-変更し(`spec.color`が実際に反映されるようにした)、zoom=4のデバッグページを
-screenshot確認したところ、**画面の海に見える領域全体が`areaForecastLocalEwLine`
-の名目色(オレンジ`0xFFFF7043`)そのもので塗りつぶされていた。** land部分は
-正しい`countriesFill`/`areaForecastLocalEFill`のベージュ系色で、他のLine layer
-(`countriesLine`のグレー、`areaForecastLocalELine`のグレー等)の色は画面上に
-確認できなかった。
+以下はすべて測定によって否定された。同じ仮説が再燃したときの参照用に残す。
 
-以上より、flood(画面のほぼ全域を単一のLine layerの色が覆う現象)の原因は
-`areaForecastLocalEwLine`(source layer `areaForecastLocalEew`)のLine mesh
-生成、またはその元になるMVT座標に何らかの異常がある可能性が高いと推測される
-が、**具体的な原因(ring境界か、座標スケールか、tile座標の解釈かなど)は
-未特定であり、これ以上の追跡は行っていない。** 該当layerを扱うコードが
-`lib/src/mesh/`・`lib/src/tile/`(Task 10の変更対象外)にあるため、修正は
-別途担当agent/taskへ引き継ぐ。
+- **ring境界を越えた頂点接続**: production非依存の独立実装で可視6タイル全数を
+  照合し、`crossRingViolations=0`。`LineMeshBuilder.build`は`localOffset`で
+  ringを正しく分離している。当初「巨大三角形2枚」と見えたものは、tile buffer
+  のclip辺(`y = extent 4096 + buffer 80`)という正当な地物であり、報告値
+  16384と4096の差はhalfWidth 4と1の違いで完全に説明できた。
+- **MVT extentのハードコード**: `base_map_view.dart`がtile行列へ
+  `mvtDefaultExtent`(4096)を固定で渡しているが、実archiveの全layerが
+  `extent=4096`であり縮尺の破綻はない(後述の潜在的脆さは別項)。
+- **miter limit clampの漏れ**: 可視6タイル全layerの全頂点で押し出し長は
+  `[1.0, 4.0000002]`に収まり、上限超過は0件。
+- **world空間での過大三角形**: `tileMatrixFor`適用後のworld座標で測っても
+  最大534px^2(viewport面積の0.15%以下)であり、画面を覆う規模の三角形は
+  1件も存在しない。
+
+### 真因: `setCustomAttribute`の値がshaderへ届かない
+
+`Geometry.setCustomAttribute('extrude', ...)`で渡した押し出し法線がshaderへ
+届かず、**代わりに同じ頂点の`position`データが読まれていた**(slot/stride
+不整合)。
+
+GPUレベルの実験で確認した。`base_map_line.fmat`のfragment shaderを
+`base_color = vec4(abs(extrude.x), abs(extrude.y), 0, 1)`へ差し替えて描画した
+ところ、本来`extrude`は`(0, ±1)`の単位ベクトルなので緑一色の帯になるはずが、
+**画面中央でぴったり0(黒)、上下端へ向かって単調増加するV字グラデーション**が
+画面全高に出た。これはorigin rebasing後の`position`の振る舞い(camera中心で0、
+外側へ増加)と完全に一致し、値も数万オーダー(zoom 5のworld pixel座標)で
+ランダムノイズではなかった。
+
+これで全症状が説明できる。
+
+- 押し出しが巨大化したlayerは画面を塗り潰す(`areaForecastLocalEewLine`)
+- 別のlayerは画面外へ飛んで見えない(`countriesLine`、`areaForecastLocalELine`)
+- **Fillはcustom attributeを使わないため正常に描画される**
+
+実験の詳細とevidence画像は
+`.superpowers/sdd/2026-08-05-eqmonitor-map-base-layer-pmtiles/extrude-gpu-probe-report.md`
+にある(このディレクトリはgit管理外)。
+
+## spike用camera配線が描画されない(未修正)
+
+上記の実験中に別の不具合が判明した。**`scene_spike_camera.dart`と同型の
+camera配線(`scene.NodeCamera` + `EqmonitorOrthographicProjection`)は、この
+環境で可視レンダリングを一切生成しない。** production実績のある
+`base_map_fill.fmat`を使っても何も描画されず、`BaseMapMaterialPreflightView`
+をそのままマウントしても同様だった。段階的なsanity checkで、組み込み
+geometry/material + `PerspectiveCamera`は正常に描画され、custom `.fmat` +
+`MeshGeometry.fromArrays` + `PerspectiveCamera`も正常に描画されるが、camera
+だけを`NodeCamera` + 正射影へ替えた瞬間に黒へ戻ることを確認している。
+
+つまり **Task 1の`BaseMapMaterialPreflightView`は、実際に画面へ何かが出ることを
+一度も目視確認されていない。** Task 1では`.fmat`がimpellercでコンパイルされ
+shaderbundleに`in vec2 extrude;`が入ることまでは確認したが、描画そのものは
+確認していなかった。`BaseMapView`は別のcamera配線
+(`_IdentityCameraProjection` + `viewProjectionMatrixFor`をnodeへ焼き込む方式)を
+使っており、そちらでは描画される。
+
+`FlutterSceneSpikeView`と`BaseMapMaterialPreflightView`が実際に描画されるかは
+別途確認が必要である。
+
+## `BaseMapTileGeometry`がMVT extentを運んでいない(潜在的な脆さ)
+
+`base_map_view.dart`はtile行列へ`mvtDefaultExtent`(4096)を固定で渡している。
+`BaseMapTileGeometry`がどの`extent`でdecodeしたかを保持していないためである。
+実archiveの全layerが`extent=4096`なので現時点で実害はないが、異なる`extent`を
+持つarchiveでは縮尺が壊れる。設計正本は「MVT extentは固定値ではなくtileごとに
+layer宣言値を読む」と定めており、この固定化はそれに反する。計画側でextentの
+伝搬を指定しなかった漏れである。

--- a/docs/todo/800_eqmonitor_map_deferred_verification.md
+++ b/docs/todo/800_eqmonitor_map_deferred_verification.md
@@ -54,46 +54,41 @@
   `BaseMapView`のスコープ外。
 - `BaseMapTileGeometry`はdecodeに使ったMVT `extent`を保持しないため、
   `BaseMapView`はtile行列へ`mvtDefaultExtent`(4096)を固定値として渡している。
-  同梱PMTilesが4096以外の`extent`を宣言するsource layerを持つ場合、
+  実archive(z0/0/0、z4/14/6、z6/57/25で実測)は全layerが`extent=4096`
+  だったため現状は破綻しないが、これは計画の漏れであり、4096以外の`extent`を
+  宣言するsource layerを持つarchiveでは壊れる潜在的な脆さが残っている。
   layerごとの実際の`extent`を`BaseMapTileGeometry`まで伝播する必要がある。
-- `BaseMapMaterialLibrary`が`fillMaterial`/`lineMaterial`の2つだけを共有する
-  設計のため、`BaseMapView`は`docs/map_spec_v3.md`が定義するlayerごとの
-  カラーテーマを再現せず、`baseMapLayerSpecs`の`countries`行の色を代表値
-  として全fill/line層に一律適用している。実配色の反映にはlayerごとの
-  material分離かper-instance color override機構が要る。
 - tile coverの複数tileが同じ祖先へfallbackした場合の重複描画排除
   (`_BaseMapController._rebuildSceneNodes`)。現状は同じtileが複数回
   描画されても`baseMapLayerSpecs`の色が全て不透明なため見た目には現れないが、
   半透明色を導入する場合は排除が必要になる。
 
-## 既知の不具合(Task 10の実機確認で発見、未修正)
+## 既知の不具合(Task 10の実機確認で発見、flood発生元のlayerを特定・未修正)
 
-`countriesLine`(source layer: `countries`)のLine meshに、他のline layer
-(`areaForecastLocalEewLine`/`areaForecastLocalELine`/`areaInformationCityQuakeLine`)
-と比べて桁違いに大きい縮退三角形が2枚混入している。本番相当archive
-(`app/android/app/src/debug/assets/eqmonitor_assets/map/all.pmtiles`,
-zoom 0..8)のz0/0/0タイルを`decodeBaseMapTileSync`で直接decodeし、押し出し後の
-三角形面積を計測して確認した:
+**海(land以外の領域)が`areaForecastLocalEwLine`(source layer:
+`areaForecastLocalEew`, 名目色`0xFFFF7043`のオレンジ)の色で塗られたように
+見える不具合がある。**
 
-```
-LINE countriesLine: maxTriArea=16384.0, bigTriCount(>5000)=2
-LINE areaForecastLocalEewLine: maxTriArea=141.9  bigTriCount=0
-LINE areaForecastLocalELine:   maxTriArea=125.5  bigTriCount=0
-LINE areaInformationCityQuakeLine(z7): maxTriArea=209.9 bigTriCount=0
-```
+当初「`countriesLine`のLine meshに縮退した巨大三角形が2枚混入している」
+という仮説を報告したが、**この仮説は別agentの検証により反証された。**
+問題の三角形の座標は`(4096,4176)→(0,4176)`であり、`y=4176 = extent(4096) +
+buffer(80)`と一致する、MVT tile bufferのclip辺という正当な地物だった
+(南極付近のWeb Mercator clip辺)。独立実装によるring分離の再検証でも
+`crossRingViolations=0`、`bigTriCount=0`が確認されており、
+**`LineMeshBuilder`と`_polygonFeatureAsClosedLines`は正常と確定した。**
 
-extrude長自体はmiter limit(4)以内で正常なため、押し出しの暴走ではなく
-centerline側のpositionが離れた2点を繋ぐ縮退三角形になっていると考えられる。
-`countries`層は日本・周辺国など複数ringを持つ数少ないlayerであり、ringの
-継ぎ目(`lib/src/tile/base_map_tile_decoder.dart`の`_polygonFeatureAsClosedLines`
-によるring closure、または`lib/src/mesh/line_mesh_builder.dart`のring遷移処理)
-で1本余計な三角形が生成されている可能性が高い。他の(単一国内の行政区分のみを
-持つ)source layerではこの症状が出ていない。
+`BaseMapMaterialLibrary`をlayerごとに独立したmaterial instanceを持つ設計へ
+変更し(`spec.color`が実際に反映されるようにした)、zoom=4のデバッグページを
+screenshot確認したところ、**画面の海に見える領域全体が`areaForecastLocalEwLine`
+の名目色(オレンジ`0xFFFF7043`)そのもので塗りつぶされていた。** land部分は
+正しい`countriesFill`/`areaForecastLocalEFill`のベージュ系色で、他のLine layer
+(`countriesLine`のグレー、`areaForecastLocalELine`のグレー等)の色は画面上に
+確認できなかった。
 
-`countries`はこのarchiveのz0にしか存在しないため、zoom 0..8を許すarchiveでは
-高いzoomほどoverscale倍率が大きくなり(z8で256倍)、tile-local空間ではごく
-小さい欠陥(全体4096²の約0.1%)が画面の大部分を覆って見える
-(iOS simulatorでの実機確認で、海に見える領域全体がline色で塗られたように
-見える現象として観測)。
-
-`lib/src/mesh/`・`lib/src/tile/`はTask 10の変更対象外のため未修正。
+以上より、flood(画面のほぼ全域を単一のLine layerの色が覆う現象)の原因は
+`areaForecastLocalEwLine`(source layer `areaForecastLocalEew`)のLine mesh
+生成、またはその元になるMVT座標に何らかの異常がある可能性が高いと推測される
+が、**具体的な原因(ring境界か、座標スケールか、tile座標の解釈かなど)は
+未特定であり、これ以上の追跡は行っていない。** 該当layerを扱うコードが
+`lib/src/mesh/`・`lib/src/tile/`(Task 10の変更対象外)にあるため、修正は
+別途担当agent/taskへ引き継ぐ。

--- a/packages/eqmonitor_map/README.md
+++ b/packages/eqmonitor_map/README.md
@@ -131,9 +131,6 @@ Task 10で、iPhone 17 Pro simulator (iOS 27.0)を使い、appのデバッグペ
 - 1本指ドラッグ(pan)でcamera中心が実際に動き、表示される地物も追従して変化する。
   HUDの`visibleTiles`/`decoding`もtile読み込みに応じて変化し、0へ収束する。
 - zoomはarchiveのheaderから実測した範囲(このarchiveでは`[0, 8]`)でclampされる。
-- archiveの`countries`データが存在しないzoom(このarchiveではz0にしか実データが
-  無い)でも、tileの祖先fallback(`BaseMapTileCache.lookupWithFallback`)により
-  陸地の形状が正しい位置に表示され続ける(overscaleが機能している)。
 
 ### 確認できなかったこと
 
@@ -145,6 +142,14 @@ Task 10で、iPhone 17 Pro simulator (iOS 27.0)を使い、appのデバッグペ
 - 線幅(`half_width_world`)や色の見た目の確認、tile境界の隙間・重複の確認。
   上記不具合の影響で判別できませんでした。
 - iOS/Android物理端末での確認(simulatorのみ実施)。
+- `BaseMapTileCache.lookupWithFallback`の祖先fallback(overscale)が実際に
+  画面上で発動する様子。z4のtileには`countriesFill`/`countriesLine`が空の
+  layerとして含まれており(=exact hitで、fallbackは発動していない)、その
+  zoomで見えている陸地は`areaForecastLocalEFill`が描いています。祖先
+  fallback自体はunit test(`base_map_tile_cache_test.dart`)で検証済みですが、
+  実機のscreenshot上でfallbackが実際に効いている場面を具体的に特定・
+  確認してはいません(以前の版のこのREADMEには、これをoverscale確認済みと
+  誤って記載していました。team-leadの指摘により訂正しています)。
 
 ### 既知の不具合(未修正)
 
@@ -160,6 +165,30 @@ Task 10で、iPhone 17 Pro simulator (iOS 27.0)を使い、appのデバッグペ
 どちらもTask 10の変更対象外のため未修正です。詳細は
 [`docs/todo/800_eqmonitor_map_deferred_verification.md`](../../docs/todo/800_eqmonitor_map_deferred_verification.md)
 を参照してください。
+
+### 修正済み: decode中は上位zoomのtileを表示し続ける(zoom窓の非対称化)
+
+`BaseMapTileCache`のzoom窓は元々`|entry.z - activeZoom| > 1`という対称な
+±1窓だった。pinchでzoomが2段以上一気に動く(例: z4→z6)と、要求tileの
+祖先(z4)がまだdecode済みであっても即座に窓の外へ出て破棄され、
+`lookupWithFallback`の`maxParentSteps`引数をどれだけ大きくしても遡る先が
+無くなる、という計画上の矛盾があった(decode中に粗いtileを表示し続けたい
+というユーザー要求を満たせない)。
+
+`BaseMapTileCache`のconstructorに`maxParentFallbackSteps`を追加し、窓を
+非対称にした: 上方向は`activeZoom + 1`のまま、下方向は
+`activeZoom - maxParentFallbackSteps`まで保持する(低zoomのtileは1archive
+あたりの総数が指数的に少ないため、深く保持してもメモリ増分は小さい)。
+`test/tile/base_map_tile_cache_test.dart`にzoom跳躍後も祖先が残り
+`lookupWithFallback`が祖先を返すこと、`maxParentFallbackSteps`を超えた
+祖先はそれでも破棄されることのunit testを追加し、対称±1へ戻すbug
+injectionで新規testが落ちることも確認した。
+
+**この修正の効果(decode中に粗いtileが表示され続けること)は、
+unit testでは検証済みだが、実機/simulatorのscreenshotでは確認していない。**
+pinch-zoomがこのセッションのtooling(mouseベースの`cliclick`、
+`device-interaction` skillの実ツール未提供)では再現できず、zoomの
+瞬間的な遷移を伴う実機確認ができなかったため。
 
 ## Delivery graph
 

--- a/packages/eqmonitor_map/README.md
+++ b/packages/eqmonitor_map/README.md
@@ -7,13 +7,15 @@ Flutter SceneをGPU描画基盤としてPMTiles/MVTの地物を描画し、ラ�
 > [!WARNING]
 > `BaseMapView`でベースレイヤー(Fill/Line)のpan/pinch zoom付き描画を実装し、
 > iOS simulatorで実際に描画されることとpanでtileが差し替わることを確認済みです
-> (下記「実機/simulatorでの確認結果」参照)。ただし、`countriesLine`のLine mesh
-> に2枚の縮退三角形が混入しており、archiveがoverscaleされるzoomでは海(land以外)
-> の広い範囲がline色で塗られたように見える既知の不具合があります(未修正、
-> `docs/todo/800_eqmonitor_map_deferred_verification.md`参照)。pinch-zoomの
-> 実機/simulator確認、線幅・tile境界の目視確認、background色が実際に画面へ
-> 出ることの確認はできていません。iOS/Android実機(simulatorではない物理端末)の
-> profile/release確認は実施していません。
+> (下記「実機/simulatorでの確認結果」参照)。ただし、海(land以外)の広い範囲が
+> `areaForecastLocalEwLine`(名目色オレンジ`0xFFFF7043`)の色で塗られたように
+> 見える既知の不具合があります(発生元layerを特定済み・原因/修正は未着手、
+> `docs/todo/800_eqmonitor_map_deferred_verification.md`参照)。当初の
+> `countriesLine`のLine meshに縮退三角形が混入しているという仮説は別agentの
+> 検証により反証されており、mesh生成コード自体は正常と確認されています。
+> pinch-zoomの実機/simulator確認、線幅・tile境界の目視確認、background色が
+> 実際に画面へ出ることの確認はできていません。iOS/Android実機(simulatorでは
+> ない物理端末)のprofile/release確認は実施していません。
 
 ## appからの利用
 
@@ -24,10 +26,13 @@ Flutter SceneをGPU描画基盤としてPMTiles/MVTの地物を描画し、ラ�
 流す。デバッグページ専用のmanual override経路も持つ)、そのarchiveのPMTiles headerから
 実際の`minZoom`/`maxZoom`を読んで`MapBaseLayerLimits`を組み立てます。
 
-`.fmat`はpackage rootの`hook/build.dart`がDart Data Assetとして生成します。実行前に
-マシンごとに一度`mise exec -- flutter config --enable-dart-data-assets`が必要です。未設定だと
-`Scene.initializeStaticResources()`が失敗し`Flutter Scene is not ready to render.`が出続けます。
-詳細は[`docs/knowledge/20260803_flutter_scene_dart_data_assets.md`](../../docs/knowledge/20260803_flutter_scene_dart_data_assets.md)を参照してください。
+`.fmat`はpackage rootの`hook/build.dart`がDart Data Assetとして生成します。`app`は
+`pubspec.yaml`の`flutter: config: enable-dart-data-assets: true`で有効化済みのため、
+マシンごとの`flutter config --enable-dart-data-assets`は**不要**です(CD配布バイナリで
+`.fmat`が見つからない不具合の修正として追加されました。pubspecの`flutter: config:`は
+マシンごとのglobal設定より優先されます)。未設定/未反映だと`Scene.initializeStaticResources()`
+が失敗し`Flutter Scene is not ready to render.`が出続けます。詳細は
+[`docs/knowledge/20260803_flutter_scene_dart_data_assets.md`](../../docs/knowledge/20260803_flutter_scene_dart_data_assets.md)を参照してください。
 
 ## 初期スコープ
 
@@ -77,9 +82,11 @@ Flutter SDKはYumNumm版`mise-flutter`と`mise.toml`、Flutter Sceneはpackage�
 `mise exec --`経由で実行します。
 
 Flutter Sceneのbase shader bundleと`assets/map_spike.fmat`はbuild hookが生成する
-Dart Data Assetです。machineごとに1度だけ次を実行してからbuildします。未設定の場合
-`Scene.initializeStaticResources()`が失敗し、`Flutter Scene is not ready to render.`が
-毎frame出力されます。詳細は
+Dart Data Assetです。**`packages/eqmonitor_map/example`は独自の`pubspec.yaml`を持ち、
+`app`のような`flutter: config: enable-dart-data-assets: true`をまだ持たないため**、
+example配下でbuildする場合は引き続きmachineごとに1度だけ次を実行してからbuildします。
+未設定の場合`Scene.initializeStaticResources()`が失敗し、
+`Flutter Scene is not ready to render.`が毎frame出力されます。詳細は
 [`docs/knowledge/20260803_flutter_scene_dart_data_assets.md`](../../docs/knowledge/20260803_flutter_scene_dart_data_assets.md)
 を参照してください。
 
@@ -151,20 +158,41 @@ Task 10で、iPhone 17 Pro simulator (iOS 27.0)を使い、appのデバッグペ
   確認してはいません(以前の版のこのREADMEには、これをoverscale確認済みと
   誤って記載していました。team-leadの指摘により訂正しています)。
 
-### 既知の不具合(未修正)
+### 既知の不具合(flood発生元のlayerを特定・未修正)
 
-`countriesLine`(source layer: `countries`)のLine meshに、他のline layerと
-比べて桁違いに大きい縮退三角形が2枚混入しています。本番相当archiveのz0/0/0
-タイルを直接decodeし、押し出し後の三角形面積を計測して確認しました
-(`countriesLine`のmax三角形面積が16384、他のline layerは125〜210程度)。
-`countries`はこのarchiveのz0にしか存在しないため、zoom 0..8を許すarchiveでは
-高いzoomほどoverscale倍率が大きくなり(z8で256倍)、tile-local空間ではごく
-小さい欠陥(全体の約0.1%)が画面の大部分を覆って見えます。原因は
-`lib/src/mesh/line_mesh_builder.dart`または`lib/src/tile/base_map_tile_decoder.dart`
-の`_polygonFeatureAsClosedLines`(ring継ぎ目の処理)にあると推測されますが、
-どちらもTask 10の変更対象外のため未修正です。詳細は
+海(land以外の領域)が`areaForecastLocalEwLine`(source layer:
+`areaForecastLocalEew`, 名目色`0xFFFF7043`のオレンジ)の色で塗られたように
+見える不具合があります。
+
+当初「`countriesLine`のLine meshに縮退した巨大三角形が2枚混入している」と
+報告しましたが、**この仮説は別agentの検証により反証されました。** 問題の
+三角形の座標は`(4096,4176)→(0,4176)`で、`y=4176 = extent(4096) + buffer(80)`
+と一致する、MVT tile bufferのclip辺という正当な地物でした。独立実装による
+ring分離の再検証でも`crossRingViolations=0`・`bigTriCount=0`が確認されており、
+**`LineMeshBuilder`と`_polygonFeatureAsClosedLines`は正常と確定しています。**
+
+`BaseMapMaterialLibrary`をlayerごとに独立したmaterial instanceを持つ設計へ
+変更し(`spec.color`を実際に反映させ)、zoom=4のデバッグページをscreenshot
+確認したところ、画面の海に見える領域全体が`areaForecastLocalEwLine`の名目色
+そのもので塗りつぶされていました。原因(ring境界か、座標スケールか、tile
+座標の解釈かなど)は未特定で、これ以上の追跡は行っていません。詳細と最新
+状況は
 [`docs/todo/800_eqmonitor_map_deferred_verification.md`](../../docs/todo/800_eqmonitor_map_deferred_verification.md)
 を参照してください。
+
+### 未解決の疑問点: `countriesLine`以外のLine layerが画面上で見えない
+
+`areaForecastLocalELine`/`areaForecastLocalEewLine`/`areaInformationCityQuakeLine`
+が、screenshot上のどの位置でも視覚的に確認できませんでした。実際に画面へ
+表示されていたはずのtileを座標から逆算して直接decodeしたところ、これらの
+layerには非空・十分な量の頂点データが実在していました(例:
+`areaInformationCityQuakeLine`が1 tileあたり84780頂点)。データの欠如では
+なく、`countriesLine`は(bugはあるが)実際に画面へ出ている以上Line用
+material/shader自体は機能しているにもかかわらず、他のLine specだけが
+不可視という状態の原因は特定できていません。`lib/src/tile/base_map_tile_decoder.dart`・
+`lib/src/mesh/line_mesh_builder.dart`は別agentが並行して書き換え中のため、
+自分のcode(`base_map_view.dart`)由来か並行作業中の一時的な状態由来かを
+切り分けられていません。
 
 ### 修正済み: decode中は上位zoomのtileを表示し続ける(zoom窓の非対称化)
 

--- a/packages/eqmonitor_map/assets/base_map_line.fmat
+++ b/packages/eqmonitor_map/assets/base_map_line.fmat
@@ -20,14 +20,41 @@
 // 「tile-local空間でextrudeを加算してからcamera/projection*tileMatrixForを
 // 掛けた」結果と一致する。したがってworld_position側で押し出す本実装は、
 // MapLibreの「変換後に加算」と数学的に同じ効果を持つ。
+//
+// # なぜ`vertex.uv`(texture coordinates)に押し出し法線を積んでいるか
+//
+// `vertex.uv`は本来テクスチャサンプリング用のUV座標(`vec2`)を運ぶための
+// フィールドだが、このmaterialは意図的にその意味論を外れ、押し出し法線
+// (同じく`vec2`)を運ばせている。理由は、以前使っていた
+// `attributes: [ { type: vec2, name: extrude } ]` + Dart側
+// `Geometry.setCustomAttribute('extrude', ...)`という custom vertex
+// attribute経由の受け渡しが、この環境ではGPUへ値を届けないバグを持って
+// いたため:
+//
+// GPUレベルの実験
+// (`.superpowers/sdd/2026-08-05-eqmonitor-map-base-layer-pmtiles/
+// extrude-gpu-probe-report.md`)で、fragment shaderを
+// `base_color = vec4(abs(extrude.x), abs(extrude.y), 0, 1)`にして描画した
+// ところ、本来`(0, ±1)`の単位ベクトルが出すはずの緑一色の帯ではなく、画面
+// 中央でぴったり0(黒)・上下端へ向かって単調増加するV字グラデーションが
+// 画面全高に出た。これは`extrude`という名前のcustom attributeではなく、
+// 同じ頂点の`position`(origin rebasing後のworld pixel座標。zoom 5で数万
+// オーダー)がshaderへ渡っていたことと完全に一致する。つまりcustom
+// attributeのslot/stride対応が壊れており、`setCustomAttribute`経由では
+// 正しい値がshaderに渡らない。
+//
+// `vertex.uv`(`MeshGeometry.fromArrays`の`texCoords:`引数がGPUへ渡る先。
+// `lib/src/flutter_scene/base_map_geometry_factory.dart`の`lineGeometry`
+// doc comment参照)は型が`vec2`で押し出し法線と完全に一致し、custom
+// attributeを経由しない組み込み属性のためproduction実績のある経路であり、
+// このバグを回避できる。このmaterialはtextureを一切サンプリングしない
+// ため、UVとして解釈されるはずの値を押し出し法線として使っても副作用は
+// ない。
 material {
   name: "BaseMapLine",
   shading_model: unlit,
   blending: opaque,
   culling: none,
-  attributes: [
-    { type: vec2, name: extrude },
-  ],
   parameters: [
     { type: vec4, name: line_color, hint: source_color, default: [1.0, 1.0, 1.0, 1.0] },
     { type: float, name: half_width_world, default: 1.0 },
@@ -36,7 +63,9 @@ material {
 
 vertex {
   void Vertex(inout VertexInputs vertex) {
-    vertex.world_position.xy += extrude * material_params.half_width_world;
+    // vertex.uvはUV座標ではなく押し出し法線(vec2)を運ぶ
+    // (このファイル冒頭のdoc comment参照)。
+    vertex.world_position.xy += vertex.uv * material_params.half_width_world;
   }
 }
 

--- a/packages/eqmonitor_map/assets/base_map_line.fmat
+++ b/packages/eqmonitor_map/assets/base_map_line.fmat
@@ -3,23 +3,30 @@
 // `extrude`はLineMeshBuilderが頂点ごとに詰める押し出し法線(tile-localの
 // 座標系とは独立な、方向のみを持つ単位ベクトル。直線部分・capでは長さ1、
 // miter joinでは`joinNormal * miterLength`。lib/src/mesh/line_mesh.dartの
-// doc comment参照)。`half_width_world`はCPU側で毎frame確定するworld単位の
-// 半線幅で、shader内でzoomから再計算しない
+// doc comment参照)。`half_width_ndc`はCPU側で毎frame確定するNDC単位の
+// 半線幅(`vec2`。x/yで異なる値を持つ)で、shader内でzoomから再計算しない
 // (lib/src/flutter_scene/base_map_material_library.dartのdoc comment参照)。
 //
-// 押し出しはvertex.world_position(モデル変換=tileMatrixFor適用後、まだ
-// camera/projection適用前のworld座標)へ直接加算する。これがMapLibreの
-// `gl_Position = u_matrix*vec4(pos,0,1) + u_matrix*vec4(extrude,0,0)`
-// (変換後に加算)と等価になる根拠は
-// docs/knowledge/20260805_maplibre_native_renderer_reference.md
-// 「Line shader」節に記録されている:
-// 正射影・pitch 0の2D行列はaffine(線形部+平行移動)であり、affine変換は
-// ベクトル加算に分配する(M*(pos+ext) == M*pos + M*ext、ただしextの
-// homogeneous wは0で平行移動を受けない)。camera/projection行列もaffineな
-// ので、world_positionへ加算してからcamera/projectionを掛けた結果は、
-// 「tile-local空間でextrudeを加算してからcamera/projection*tileMatrixForを
-// 掛けた」結果と一致する。したがってworld_position側で押し出す本実装は、
-// MapLibreの「変換後に加算」と数学的に同じ効果を持つ。
+// # なぜworld単位ではなくNDC単位のvec2か(訂正の経緯)
+//
+// 以前の版はここで「vertex.world_positionはtileMatrixFor適用後・
+// camera/projection適用**前**のworld座標であり、affine変換はベクトル
+// 加算に分配するのでMapLibreの`u_matrix*(pos+extrude)`と数学的に同じ
+// 効果を持つ」と説明していたが、**この前提は誤りだった。**
+// `lib/src/widget/base_map_view.dart`の`_combinedTransformFor`が
+// `viewProjectionMatrixFor * tileMatrixFor`を丸ごとnodeの`localTransform`
+// (flutter_sceneのmodel transform)として焼き込み、Scene側camera
+// (`_IdentityCameraProjection`)は何も変換しないため、`Vertex()`が
+// 受け取る`vertex.world_position`は実際には**tileMatrixForとview
+// projectionの両方を通し終えた後**の値であり、実質NDCに近い空間に
+// なっている。ここへ`extrude`を素の値のまま加算すると、加算量は
+// world pixel単位ではなくNDC単位として効くため、world単位で導出した
+// 半線幅(旧`half_width_world`)を使うと画面全体を塗り潰す不具合になる
+// (詳細は`base_map_material_library.dart`の`halfLineWidthNdcFor`
+// doc commentと
+// `.superpowers/sdd/2026-08-05-eqmonitor-map-base-layer-pmtiles/
+// extrude-fix-report.md`参照)。このため半線幅はCPU側でNDC単位の`vec2`
+// へ変換してから渡す。
 //
 // # なぜ`vertex.uv`(texture coordinates)に押し出し法線を積んでいるか
 //
@@ -57,7 +64,7 @@ material {
   culling: none,
   parameters: [
     { type: vec4, name: line_color, hint: source_color, default: [1.0, 1.0, 1.0, 1.0] },
-    { type: float, name: half_width_world, default: 1.0 },
+    { type: vec2, name: half_width_ndc, default: [0.0, 0.0] },
   ],
 }
 
@@ -65,7 +72,12 @@ vertex {
   void Vertex(inout VertexInputs vertex) {
     // vertex.uvはUV座標ではなく押し出し法線(vec2)を運ぶ
     // (このファイル冒頭のdoc comment参照)。
-    vertex.world_position.xy += vertex.uv * material_params.half_width_world;
+    // half_width_ndcはx/y成分ごとに独立な係数を持つNDC単位の半線幅
+    // (base_map_material_library.dartのhalfLineWidthNdcFor doc comment
+    // 参照)。vertex.world_positionはこの時点で実質NDC相当の空間にいる
+    // ため、成分ごとの掛け算(vec2 * vec2)がそのまま正しいNDCオフセット
+    // になる。
+    vertex.world_position.xy += vertex.uv * material_params.half_width_ndc;
   }
 }
 

--- a/packages/eqmonitor_map/lib/src/flutter_scene/base_map_geometry_factory.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/base_map_geometry_factory.dart
@@ -37,20 +37,24 @@ class BaseMapGeometryFactory {
 
   /// [mesh]から線描画用の`scene.Geometry`を作る。
   ///
-  /// [LineMesh.extrudes]は`setCustomAttribute`で`extrude`という名前の頂点
-  /// 属性として渡す。この名前は`base_map_line.fmat`の
-  /// `attributes: [ { type: vec2, name: extrude } ]`宣言と対応しており、
-  /// 名前が一致しない限りshaderの`in vec2 extrude`は値を受け取れない。
-  /// storageの選び方は[fillGeometry]と同じ理由で`fixed`。
+  /// [LineMesh.extrudes]は`MeshGeometry.fromArrays`の組み込み`texCoords`
+  /// 引数(`vec2`)へ渡す。以前は`setCustomAttribute('extrude', ...)`で
+  /// custom vertex attributeとして渡していたが、この環境ではGPUへ値が
+  /// 届かず、代わりに同じ頂点の`position`(origin rebasing後の座標)が
+  /// shaderで読まれてしまうバグがあることをGPUレベルの実験で確認した
+  /// (`.superpowers/sdd/2026-08-05-eqmonitor-map-base-layer-pmtiles/
+  /// extrude-gpu-probe-report.md`参照)。custom attributeを経由しない
+  /// `texCoords`は型が`vec2`で押し出し法線と完全に一致し、production実績の
+  /// ある経路のためこのバグを回避できる。`base_map_line.fmat`側はこの値を
+  /// `vertex.uv`として読む(同ファイル冒頭のdoc comment参照。UVではなく
+  /// 押し出し法線を運んでいるという意味論の逸脱がある)。storageの選び方は
+  /// [fillGeometry]と同じ理由で`fixed`。
   scene.MeshGeometry lineGeometry(LineMesh mesh) {
     final args = buildLineGeometryArgs(mesh);
     return scene.MeshGeometry.fromArrays(
       positions: args.positions,
+      texCoords: args.extrudes,
       indices: args.indices,
-    )..setCustomAttribute(
-      'extrude',
-      args.extrudes,
-      components: 2,
     );
   }
 }
@@ -71,9 +75,9 @@ class FillGeometryArgs {
   final Uint16List indices;
 }
 
-/// [BaseMapGeometryFactory.lineGeometry]が`MeshGeometry.fromArrays`と
-/// `setCustomAttribute`へ渡す引数そのもの。[FillGeometryArgs]と同じ理由で
-/// pure関数として切り出している。
+/// [BaseMapGeometryFactory.lineGeometry]が`MeshGeometry.fromArrays`へ渡す
+/// 引数そのもの。[FillGeometryArgs]と同じ理由でpure関数として切り出して
+/// いる。
 @immutable
 class LineGeometryArgs {
   const LineGeometryArgs({
@@ -88,9 +92,12 @@ class LineGeometryArgs {
   /// [LineMesh.indices]をそのまま渡す。
   final Uint16List indices;
 
-  /// [LineMesh.extrudes]をそのまま渡す(2成分、z拡張は不要。`extrude`は
-  /// 座標ではなく`vec2`の押し出し方向属性であり、`MeshGeometry.fromArrays`
-  /// の`positions`のような3成分要求を持たない)。
+  /// [LineMesh.extrudes]をそのまま渡す(2成分、z拡張は不要。押し出し方向は
+  /// 座標ではなく`vec2`の方向ベクトルであり、`MeshGeometry.fromArrays`の
+  /// `positions`のような3成分要求を持たない)。`lineGeometry`が
+  /// `MeshGeometry.fromArrays`の`texCoords:`引数へそのまま渡す
+  /// (`lineGeometry`のdoc comment参照。custom attributeの不具合を避ける
+  /// ため、組み込みのtexCoordsへ押し出し法線を積んでいる)。
   final Float32List extrudes;
 }
 

--- a/packages/eqmonitor_map/lib/src/flutter_scene/base_map_material_library.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/base_map_material_library.dart
@@ -2,64 +2,56 @@ import 'dart:ui';
 
 import 'package:flutter_scene/scene.dart' as scene;
 
-/// `base_map_fill.fmat`/`base_map_line.fmat`を読み込み、色と線幅を設定する
-/// 公開methodを持つ。
+/// `base_map_fill.fmat`/`base_map_line.fmat`から、layerごとに独立した
+/// `scene.PreprocessedMaterial`を1つずつ作る静的factory。
 ///
-/// [load]は2つのmaterialを1回だけ読み、以後は同じ`PreprocessedMaterial`
-/// インスタンスを返す。ベースレイヤーの描画はtileごと・layerごとに新しい
-/// meshを作るが、そのすべてが`fillMaterial`/`lineMaterial`という同じ2つの
-/// materialインスタンスを共有する(`tile × layer × material`単位でbatchを
-/// 分けるとしても、materialの実体は`tile`や`layer`の数によらず2つのまま)。
-/// tileやlayerが増えるたびに`loadFmatMaterial`を呼び直さないこと。
+/// # 設計変更の経緯
+///
+/// 以前は`load()`がfill/line用に1つずつしかmaterialを作らず、全fill layer・
+/// 全line layerがその2つのinstanceを共有していた。`docs/map_spec_v3.md`が
+/// layerごとに定義する色(`baseMapLayerSpecs`の`color`)は、共有materialの
+/// 1色にしか反映できず、結果として全fill layerが同じ色・全line layerが
+/// 同じ色で描かれ、`spec.color`は事実上使われていなかった
+/// (実機確認でこれが判明した。team-lead指摘)。
+///
+/// `tile × layer × material`単位でbatchするという設計原則(Global
+/// Constraints)は、「1つのmaterial instanceを複数のtileのnodeで使い回す」
+/// ことを求めているのであって、「1つのmaterial instanceを複数のlayerでも
+/// 使い回す」ことまでは求めていない。layerごとに1つのmaterial instanceを
+/// 持たせても、tileの数やnodeの数には依存しないため原則には反しない。
+///
+/// このため、[loadFillMaterial]/[loadLineMaterial]は呼ばれるたびに新しい
+/// `PreprocessedMaterial`を1つ読み込み、指定された色(と線幅)をその場で
+/// 焼き込んで返す。呼び出し側(`_BaseMapController`)が
+/// `baseMapLayerSpecs`の非background行ごとに1回ずつ呼び、
+/// `styleLayerId`をkeyにして結果を保持する。
 class BaseMapMaterialLibrary {
-  const BaseMapMaterialLibrary._({
-    required this.fillMaterial,
-    required this.lineMaterial,
-  });
+  const BaseMapMaterialLibrary._();
 
-  /// `assets/base_map_fill.fmat`と`assets/base_map_line.fmat`を読み込む。
-  static Future<BaseMapMaterialLibrary> load() async {
-    final fillMaterial = await scene.loadFmatMaterial(
-      'assets/base_map_fill.fmat',
-    );
-    final lineMaterial = await scene.loadFmatMaterial(
-      'assets/base_map_line.fmat',
-    );
-    return BaseMapMaterialLibrary._(
-      fillMaterial: fillMaterial,
-      lineMaterial: lineMaterial,
-    );
+  /// `assets/base_map_fill.fmat`を新しく1つ読み込み、[color]を設定する。
+  static Future<scene.PreprocessedMaterial> loadFillMaterial({
+    required Color color,
+  }) async {
+    final material = await scene.loadFmatMaterial('assets/base_map_fill.fmat');
+    material.parameters.setColor('fill_color', color);
+    return material;
   }
 
-  /// Fillレイヤーに使うmaterial。`fill_color`のみを持つ
-  /// (`assets/base_map_fill.fmat`参照)。
-  final scene.PreprocessedMaterial fillMaterial;
-
-  /// Lineレイヤーに使うmaterial。`line_color`と`half_width_world`を持つ
-  /// (`assets/base_map_line.fmat`参照)。
-  final scene.PreprocessedMaterial lineMaterial;
-
-  /// Fillレイヤーの色を設定する。
-  void setFillColor(Color color) {
-    fillMaterial.parameters.setColor('fill_color', color);
-  }
-
-  /// Lineレイヤーの色を設定する。
-  void setLineColor(Color color) {
-    lineMaterial.parameters.setColor('line_color', color);
-  }
-
-  /// Lineレイヤーの半線幅を設定する。[halfWidthLogicalPixels]はlogical pixel
-  /// 単位の半線幅で、[halfLineWidthWorldFor]でworld単位へ換算してから
-  /// materialへ渡す。呼び出し側(cameraやstyleが変わり得るdraw loop)が毎
-  /// frame呼ぶことを想定しており、shader側では換算しない
-  /// (`assets/base_map_line.fmat`のdoc comment、[halfLineWidthWorldFor]の
-  /// doc comment参照)。
-  void setLineHalfWidth({required double halfWidthLogicalPixels}) {
-    lineMaterial.parameters.setFloat(
-      'half_width_world',
-      halfLineWidthWorldFor(halfWidthLogicalPixels: halfWidthLogicalPixels),
-    );
+  /// `assets/base_map_line.fmat`を新しく1つ読み込み、[color]と
+  /// [halfWidthLogicalPixels]を設定する。[halfWidthLogicalPixels]の単位・
+  /// 換算方法は[halfLineWidthWorldFor]のdoc comment参照。
+  static Future<scene.PreprocessedMaterial> loadLineMaterial({
+    required Color color,
+    required double halfWidthLogicalPixels,
+  }) async {
+    final material = await scene.loadFmatMaterial('assets/base_map_line.fmat');
+    material.parameters
+      ..setColor('line_color', color)
+      ..setFloat(
+        'half_width_world',
+        halfLineWidthWorldFor(halfWidthLogicalPixels: halfWidthLogicalPixels),
+      );
+    return material;
   }
 }
 

--- a/packages/eqmonitor_map/lib/src/flutter_scene/base_map_material_library.dart
+++ b/packages/eqmonitor_map/lib/src/flutter_scene/base_map_material_library.dart
@@ -1,6 +1,8 @@
 import 'dart:ui';
 
+import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:flutter_scene/scene.dart' as scene;
+import 'package:vector_math/vector_math.dart' show Vector2;
 
 /// `base_map_fill.fmat`/`base_map_line.fmat`から、layerごとに独立した
 /// `scene.PreprocessedMaterial`を1つずつ作る静的factory。
@@ -37,71 +39,107 @@ class BaseMapMaterialLibrary {
     return material;
   }
 
-  /// `assets/base_map_line.fmat`を新しく1つ読み込み、[color]と
-  /// [halfWidthLogicalPixels]を設定する。[halfWidthLogicalPixels]の単位・
-  /// 換算方法は[halfLineWidthWorldFor]のdoc comment参照。
+  /// `assets/base_map_line.fmat`を新しく1つ読み込み、[color]を設定し、
+  /// [setLineHalfWidth]で[halfWidthLogicalPixels]と[viewport]から求めた
+  /// NDC単位の半線幅を焼き込む。[viewport]が変わったら[setLineHalfWidth]を
+  /// 呼び直す必要がある(このメソッドは初期値を設定するだけ)。
   static Future<scene.PreprocessedMaterial> loadLineMaterial({
     required Color color,
     required double halfWidthLogicalPixels,
+    required MapViewport viewport,
   }) async {
     final material = await scene.loadFmatMaterial('assets/base_map_line.fmat');
-    material.parameters
-      ..setColor('line_color', color)
-      ..setFloat(
-        'half_width_world',
-        halfLineWidthWorldFor(halfWidthLogicalPixels: halfWidthLogicalPixels),
-      );
+    material.parameters.setColor('line_color', color);
+    setLineHalfWidth(
+      material: material,
+      halfWidthLogicalPixels: halfWidthLogicalPixels,
+      viewport: viewport,
+    );
     return material;
+  }
+
+  /// 既存の[material]の`half_width_ndc`パラメータを、[halfWidthLogicalPixels]
+  /// と[viewport]から[halfLineWidthNdcFor]で求め直して上書きする。
+  ///
+  /// NDC単位の換算は[viewport]の`logicalSize`(width/height)に依存するため、
+  /// viewportが変わる度(resize・画面回転)に呼び直す必要がある
+  /// (`lib/src/widget/base_map_view.dart`の`updateViewport`参照)。
+  static void setLineHalfWidth({
+    required scene.PreprocessedMaterial material,
+    required double halfWidthLogicalPixels,
+    required MapViewport viewport,
+  }) {
+    material.parameters.setVec2(
+      'half_width_ndc',
+      halfLineWidthNdcFor(
+        halfWidthLogicalPixels: halfWidthLogicalPixels,
+        viewport: viewport,
+      ),
+    );
   }
 }
 
 /// logical pixel単位の半線幅を、`base_map_line.fmat`の`vertex{}`が
-/// `vertex.world_position`へ加算するworld単位の半線幅へ換算する。
+/// `vertex.world_position`(実質NDC相当。下記「訂正」節参照)へ加算する
+/// NDC単位のvec2半線幅へ換算する。
 ///
 /// # 換算式
 ///
-/// 換算係数は1、つまり`half_width_world == halfWidthLogicalPixels`である。
-/// zoomに依存する項は存在しない。
+/// ```dart
+/// half_width_ndc = (
+///   2 * halfWidthLogicalPixels / viewport.logicalSize.width,
+///   2 * halfWidthLogicalPixels / viewport.logicalSize.height,
+/// )
+/// ```
 ///
-/// # 導出根拠
+/// NDCは`viewport.logicalSize`の`width × height`(logical px)に対して
+/// `[-1, 1]`(全幅/全高2)を張る座標系なので、1 logical pxはNDCでx軸
+/// `2/width`、y軸`2/height`に相当する。world空間では1 world px=1
+/// logical pxで等方(x/yで同じ換算係数)だが、NDCは軸ごとに正規化されて
+/// いるため、xとyで異なる係数を掛けて初めて画面上で等方な線幅になる
+/// (`viewProjectionMatrixFor`が組み立てる正射影はY反転と平行移動を含む
+/// affine変換だが回転を含まない対角scaleであるため、押し出しベクトルの
+/// x/y成分をこの係数で独立に掛けるだけで正しいNDCオフセットが求まる)。
 ///
-/// `assets/base_map_line.fmat`の`Vertex()`は`extrude`(方向のみを持つ
-/// 単位ベクトル。tile-local座標のscaleを持たない。`lib/src/mesh/line_mesh.dart`
-/// のdoc comment参照)を、tileMatrixFor適用後・camera/projection適用前の
-/// `vertex.world_position`へ直接加算する。この`world_position`が使う
-/// world座標系は、次の2つの理由から常に「1 world単位 == 1 logical pixel」
-/// になるよう設計されている(zoomや`tileMatrixFor`のscaleは無関係)。
+/// # 訂正: このdoc commentは以前「1 world単位=1 logical pixel」という
+/// 誤った前提の恒等関数を導出していた
 ///
-/// 1. `geo/tile_matrix.dart`の`viewProjectionMatrixFor`が組み立てる正射影
-///    (`EqmonitorOrthographicProjection`)は、`worldHalfHeight`に
-///    `viewport.logicalSize.height / 2`──画面のlogical pixel高さの半分
-///    ──を渡す。zoomや`MapCamera.zoom`はここに一切現れない。
-/// 2. `geo/tile_matrix.dart`の`tileMatrixFor`はtile-local座標を
-///    `MapMercatorProjection.worldSizeForZoom(zoom)`基準のworld pixel座標へ
-///    配置し、`geo/map_camera.dart`の`MapCamera.worldCenter`も同じ
-///    `worldSizeForZoom(zoom)`でcamera中心をworld座標へ投影する。つまり
-///    zoomが変わっても、tileとcamera中心は「同じzoom基準のworld pixel
-///    座標系」の中で一貫して動くだけで、(1)の正射影のworldHalfHeightは
-///    変化しない。
+/// 以前のバージョンは、`extrude`が「tileMatrixFor適用後・camera/projection
+/// 適用**前**のworld_positionへ加算される」という前提のもとで
+/// `half_width_world == halfWidthLogicalPixels`という換算式(実質恒等関数)
+/// を導出し、それをレビューで「world空間の縮尺だけを検証して正しい」と
+/// 確認していた。**しかしこの確認はworld空間の縮尺だけを見ており、
+/// 押し出しの加算がパイプラインの実際どの時点で起きるかを見落として
+/// いた。**
 ///
-/// (1)(2)を合わせると、正射影が「world高さ`viewport.logicalSize.height`を
-/// 画面いっぱい(`viewport.logicalSize.height` logical pixel)へ写す」写像
-/// である以上、1 world単位は常に1 logical pixelに写る。zoomはtileや
-/// cameraをworld座標系の中でどれだけ広げるか(=画面上でどれだけ大きく
-/// 見えるか)だけを変え、world座標系そのものとscreen座標系の縮尺関係は
-/// 変えない。
+/// 実際には`lib/src/widget/base_map_view.dart`の`_combinedTransformFor`が
+/// 各tileのnodeへ`viewProjectionMatrixFor(camera, viewport) * tileMatrixFor`
+/// を丸ごと`localTransform`(flutter_sceneのmodel transform)として焼き込み、
+/// Scene側camera(`_IdentityCameraProjection`)は何も変換しない。flutter_scene
+/// の生成頂点シェーダー(`flutter_scene_unskinned_body.glsl`)は
+/// `vertex.world_position = model_transform * position`を`Vertex()`
+/// 呼び出し**前**に計算し、`Vertex()`が`world_position`を書き換えた後で
+/// `gl_Position = camera_transform * vec4(world_position, 1.0)`
+/// (`camera_transform`はIdentity)を計算する。つまり`extrude`の加算は
+/// tileMatrixForとviewProjectionForの**両方を通し終えた後**、実質NDCに
+/// 近い空間に対して行われており、「camera/projection適用前」という
+/// 旧doc commentの前提はこの camera 配線では成り立たない。
 ///
-/// この設計は、`extrude`をtile-local座標(zoom依存のscaleを持つ座標系)へ
-/// 加算してから変換するMapLibreの実装(`u_ratio`でzoom依存のtile座標scaleを
-/// 補正する。
-/// docs/knowledge/20260805_maplibre_native_renderer_reference.md
-/// 「Line頂点生成」「Line shader」節参照)とは異なる。EQMonitorの`extrude`
-/// はtile-local座標のscaleを最初から持たない方向ベクトルであり、
-/// world座標(zoom非依存のscreen pixel scale)へ直接加算するため、
-/// zoom依存の補正が要らない。**shader内で`half_width_world`をzoomから
-/// 再計算する実装(例: `scaleForZoom(zoom)`を掛ける)は上記の等価性を壊す
-/// ので行わないこと。**
-double halfLineWidthWorldFor({required double halfWidthLogicalPixels}) {
+/// この結果、旧換算式の`half_width_world=1.0`はNDCで1.0(可視範囲±1の
+/// 半分)もの押し出しとなり、画面全体を線色で塗り潰す不具合を生んで
+/// いた(harness実験・実機確認で再現。詳細は
+/// `.superpowers/sdd/2026-08-05-eqmonitor-map-base-layer-pmtiles/
+/// extrude-fix-report.md`参照)。この事実に基づき、換算をworld単位の
+/// 恒等関数からNDC単位のvec2へ変更した。
+///
+/// **shader内で`half_width_ndc`をzoomから再計算する実装(例:
+/// `scaleForZoom(zoom)`を掛ける)は行わないこと。** `viewProjectionMatrixFor`
+/// のY反転・平行移動はzoomに依存せず、`half_width_ndc`はviewportの
+/// logical sizeだけに依存する(導出根拠は上記の換算式参照)。
+Vector2 halfLineWidthNdcFor({
+  required double halfWidthLogicalPixels,
+  required MapViewport viewport,
+}) {
   if (!halfWidthLogicalPixels.isFinite || halfWidthLogicalPixels < 0) {
     throw ArgumentError.value(
       halfWidthLogicalPixels,
@@ -109,5 +147,8 @@ double halfLineWidthWorldFor({required double halfWidthLogicalPixels}) {
       'must be finite and non-negative',
     );
   }
-  return halfWidthLogicalPixels;
+  return Vector2(
+    2 * halfWidthLogicalPixels / viewport.logicalSize.width,
+    2 * halfWidthLogicalPixels / viewport.logicalSize.height,
+  );
 }

--- a/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/fill_mesh_builder_limits.freezed.dart
@@ -19,7 +19,7 @@ mixin _$FillMeshBuilderLimits {
 /// 行っている制限と同じ位置付け。
  int get maxHolesPerPolygon;/// 1つのfeatureが持つ全ring(外形+穴、複数polygon分の合算)の頂点数の
 /// 上限。三角形化前の頂点バッファ確保量を抑える早期チェックとして働く。
- int get maxVerticesPerFeature;/// 1つの[FillMesh] segmentに積める頂点数の上限。index bufferが
+ int get maxVerticesPerFeature;/// 1つの`FillMesh` segmentに積める頂点数の上限。index bufferが
 /// `Uint16List`であるため、呼び出し側がこの値を65536以下に設定しない
 /// 場合`FillMeshBuilder`はArgumentErrorを投げる(index値がuint16の範囲を
 /// 静かに超えて壊れたmeshを生成することを避けるための防御)。
@@ -227,7 +227,7 @@ class _FillMeshBuilderLimits implements FillMeshBuilderLimits {
 /// 1つのfeatureが持つ全ring(外形+穴、複数polygon分の合算)の頂点数の
 /// 上限。三角形化前の頂点バッファ確保量を抑える早期チェックとして働く。
 @override final  int maxVerticesPerFeature;
-/// 1つの[FillMesh] segmentに積める頂点数の上限。index bufferが
+/// 1つの`FillMesh` segmentに積める頂点数の上限。index bufferが
 /// `Uint16List`であるため、呼び出し側がこの値を65536以下に設定しない
 /// 場合`FillMeshBuilder`はArgumentErrorを投げる(index値がuint16の範囲を
 /// 静かに超えて壊れたmeshを生成することを避けるための防御)。

--- a/packages/eqmonitor_map/lib/src/mesh/line_mesh.dart
+++ b/packages/eqmonitor_map/lib/src/mesh/line_mesh.dart
@@ -32,6 +32,10 @@ final class LineMesh {
   /// (`LineMeshBuilder`のdoc comment参照)。shaderはこの値をそのまま線幅の
   /// 半分に掛けて`position + extrude * halfWidth`のように中心線から押し出す
   /// 想定であり、miter joinの伸長分もこの1本の値で表現される。
+  ///
+  /// GPUへは`BaseMapGeometryFactory.lineGeometry`が`MeshGeometry.fromArrays`
+  /// の`texCoords`引数として渡す(custom attributeの不具合回避。詳細は
+  /// `base_map_geometry_factory.dart`のdoc comment参照)。
   final Float32List extrudes;
 
   /// 3個1組でtriangleを表すindex buffer。[positions]内の頂点index

--- a/packages/eqmonitor_map/lib/src/tile/base_map_tile_cache.dart
+++ b/packages/eqmonitor_map/lib/src/tile/base_map_tile_cache.dart
@@ -19,11 +19,27 @@ import 'package:flutter/foundation.dart';
 /// # eviction
 ///
 /// [noteActiveZoom]で通知された「直近使用zoom」(`CanonicalTileId.z`と同じ
-/// 整数)を基準に、`|entry.z - activeZoom| > 1`のentryを都度破棄する
-/// (`docs/knowledge/20260802_kevi_map_renderer_reference.md`
-/// 「ジオメトリcache戦略」節: 「直近使用zoom±1以外を破棄」)。件数上限
-/// [maxEntries]は呼び出し側が渡す固定値(Global Constraints「上限値は
-/// 呼び出し側が渡す`limits`引数で明示する」)で、この上限を超えた分は
+/// 整数)を基準にentryを破棄するが、**上方向(高zoom側)と下方向(低zoom側)で
+/// 窓の深さが非対称**になっている(fix round 2)。
+///
+/// - 上方向: `entry.z > activeZoom + 1`を破棄する(元の
+///   `docs/knowledge/20260802_kevi_map_renderer_reference.md`
+///   「ジオメトリcache戦略」節の「直近使用zoom+1」をそのまま踏襲)。
+/// - 下方向: `entry.z < activeZoom - maxParentFallbackSteps`を破棄する。
+///
+/// 対称な`±1`窓だったfix round 1の実装は、`lookupWithFallback`の祖先
+/// fallback(下記「子→親fallback」節)と両立しなかった。zoomが2段以上一気に
+/// 上がるpinch(例: z4→z6)では、要求tileの祖先(z4)がまだ子孫(z6)より
+/// decodeが終わっているにもかかわらず、窓が`activeZoom(z6)±1`= `[5,7]`
+/// しか許さないためz4は即座に破棄され、`maxParentFallbackSteps`を
+/// どれだけ大きく設定しても遡る先が存在しなくなっていた(祖先を`±1`windowと
+/// `maxParentSteps`引数の両方で保持しなければならないのに、片方(`±1`)しか
+/// 実装していなかった)。低zoomのtileは1つのarchiveあたりの総数が
+/// 指数的に少ない(zoom `z`の全世界tile数は`4^z`)ため、深く保持しても
+/// メモリ増分は小さい。
+///
+/// 件数上限[maxEntries]は呼び出し側が渡す固定値(Global Constraints「上限値は
+/// 呼び出し側が渡すlimits引数で明示する」)で、この上限を超えた分は
 /// **最も長く参照されていないentry(LRU)**から破棄する。ズーム窓とは独立な
 /// 安全弁であり、ズーム窓を通過したentryが極端に多いarchiveでもメモリを
 /// 無制限に使わないためのもの。
@@ -36,6 +52,15 @@ import 'package:flutter/foundation.dart';
 /// 見ておらずx/y方向のpanには反応しない)、直近まで表示していたtileが
 /// 単純なFIFOで先に捨てられてpan往復のたびに再decodeが起きる、という
 /// 実測された不具合をLRU化で塞ぐ(fix round 1)。
+///
+/// **LRU容量evictionと低zoom祖先の保持の相互作用**: 低zoomの祖先を
+/// `lookupWithFallback`が実際にfallback先として使うたびに[get]を呼ぶため、
+/// fallbackとして現役の間はLRUの「最近使った」扱いを受け続け、容量evictionの
+/// 対象になりにくい。祖先を明示的にpinする機構は追加していない
+/// (fallbackが不要になった祖先まで無条件に保持し続ける理由がなく、
+/// 必要性を論証できない複雑化を避けるため)。祖先が実際にfallbackとして
+/// 使われなくなった後は、通常のLRU順序に従って他のentryと同様に
+/// 破棄され得る。
 ///
 /// # incarnation token
 ///
@@ -60,11 +85,24 @@ import 'package:flutter/foundation.dart';
 /// 見つかった祖先で打ち切る。遡る段数の上限`maxParentSteps`は呼び出し側が
 /// 渡す(Global Constraints)。
 final class BaseMapTileCache {
-  BaseMapTileCache({required this.maxEntries})
-    : assert(maxEntries > 0, 'maxEntries must be positive');
+  BaseMapTileCache({
+    required this.maxEntries,
+    required this.maxParentFallbackSteps,
+  }) : assert(maxEntries > 0, 'maxEntries must be positive'),
+       assert(
+         maxParentFallbackSteps >= 0,
+         'maxParentFallbackSteps must be non-negative',
+       );
 
   /// cacheへ保持できるentryの最大件数。
   final int maxEntries;
+
+  /// zoom窓の下方向(低zoom側)の深さ。[lookupWithFallback]へ渡す
+  /// `maxParentSteps`と同じ値を呼び出し側が渡すことを想定している
+  /// (呼び出し側=`BaseMapView`が`MapBaseLayerLimits.maxParentFallbackSteps`
+  /// を両方へ渡す)。cache自身が`lookupWithFallback`の引数を検査して
+  /// 一致を強制することはしない(cacheとlookupは疎結合なままにする)。
+  final int maxParentFallbackSteps;
 
   final _generationOwner = SceneSpikeAsyncGenerationOwner();
 
@@ -114,7 +152,8 @@ final class BaseMapTileCache {
   }
 
   /// 現在activeなzoom(整数、例えば`camera.zoom.floor()`)を通知する。
-  /// 呼ぶたびに窓の外(`|z - zoom| > 1`)のentryを破棄する。
+  /// 呼ぶたびに窓の外(`z > activeZoom + 1`または
+  /// `z < activeZoom - maxParentFallbackSteps`)のentryを破棄する。
   void noteActiveZoom(int zoom) {
     _activeZoom = zoom;
     _evictOutsideActiveZoomWindow();
@@ -125,9 +164,10 @@ final class BaseMapTileCache {
     if (activeZoom == null) {
       return;
     }
-    _entries.removeWhere(
-      (key, value) => (key.$2.z - activeZoom).abs() > 1,
-    );
+    _entries.removeWhere((key, value) {
+      final z = key.$2.z;
+      return z > activeZoom + 1 || z < activeZoom - maxParentFallbackSteps;
+    });
   }
 
   /// `_entries`の先頭(挿入順で最古、かつ[get]がhitするたびに末尾へ

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -274,24 +274,19 @@ class _BaseMapController extends ChangeNotifier {
   static const _decoder = BaseMapTileDecoder();
   static const _geometryFactory = BaseMapGeometryFactory();
 
-  // debug描画専用の単色。`BaseMapMaterialLibrary`はtile×layerで新しい
-  // materialを作らず`fillMaterial`/`lineMaterial`の2つだけを共有するため
-  // (`base_map_material_library.dart`のdoc comment)、layerごとに
-  // `docs/map_spec_v3.md`が定義する色を出し分けることはできない。
-  // `baseMapLayerSpecs`が定義する色のうち、最下段の`countries`行の色を
-  // 代表として使う。
-  static final Color _debugFillColor = baseMapLayerSpecs
-      .firstWhere((spec) => spec.styleLayerId == 'countriesFill')
-      .color;
-  static final Color _debugLineColor = baseMapLayerSpecs
-      .firstWhere((spec) => spec.styleLayerId == 'countriesLine')
-      .color;
+  // Line layerの半線幅(全layer共通)。`docs/map_spec_v3.md`は線幅もzoomで
+  // 変化させるが、Task 10のスコープでは固定値のdebug描画とする。
   static const _debugLineHalfWidthLogicalPixels = 1.0;
 
   MapCamera _camera;
   MapViewport? _viewport;
   BaseMapTileRepository? _repository;
-  BaseMapMaterialLibrary? _materials;
+
+  /// `styleLayerId`ごとに独立した`scene.PreprocessedMaterial`。
+  /// `baseMapLayerSpecs`の`color`をlayerごとに反映するため、fill/line
+  /// それぞれ1つを全layerで共有していた旧実装から変更した
+  /// (`base_map_material_library.dart`のdoc comment参照)。
+  Map<String, scene.PreprocessedMaterial>? _materialsByStyleLayerId;
   Object? _initError;
   var _isReady = false;
   var _isDisposed = false;
@@ -318,13 +313,25 @@ class _BaseMapController extends ChangeNotifier {
   Future<void> initialize() async {
     try {
       await scene.Scene.initializeStaticResources();
-      final materials = await BaseMapMaterialLibrary.load();
-      materials
-        ..setFillColor(_debugFillColor)
-        ..setLineColor(_debugLineColor)
-        ..setLineHalfWidth(
-          halfWidthLogicalPixels: _debugLineHalfWidthLogicalPixels,
-        );
+      final materialsByStyleLayerId = <String, scene.PreprocessedMaterial>{};
+      for (final spec in baseMapLayerSpecs) {
+        switch (spec.kind) {
+          case BaseMapLayerKind.background:
+            // backgroundはtileのmaterialを持たない(`ColoredBox`側で描く)。
+            continue;
+          case BaseMapLayerKind.fill:
+            materialsByStyleLayerId[spec.styleLayerId] =
+                await BaseMapMaterialLibrary.loadFillMaterial(
+                  color: spec.color,
+                );
+          case BaseMapLayerKind.line:
+            materialsByStyleLayerId[spec.styleLayerId] =
+                await BaseMapMaterialLibrary.loadLineMaterial(
+                  color: spec.color,
+                  halfWidthLogicalPixels: _debugLineHalfWidthLogicalPixels,
+                );
+        }
+      }
       final repository = await BaseMapTileRepository.open(
         source: source,
         limits: limits.pmTilesLimits,
@@ -333,7 +340,7 @@ class _BaseMapController extends ChangeNotifier {
         await repository.close();
         return;
       }
-      _materials = materials;
+      _materialsByStyleLayerId = materialsByStyleLayerId;
       _repository = repository;
       _isReady = true;
       _refresh();
@@ -414,8 +421,8 @@ class _BaseMapController extends ChangeNotifier {
     required List<OverscaledTileId> cover,
     required MapViewport viewport,
   }) {
-    final materials = _materials;
-    if (materials == null) {
+    final materialsByStyleLayerId = _materialsByStyleLayerId;
+    if (materialsByStyleLayerId == null) {
       return;
     }
     final resolved = [
@@ -459,7 +466,7 @@ class _BaseMapController extends ChangeNotifier {
                 wrap: entry.tile.wrap,
                 tileId: entry.tile.canonical,
                 geometry: geometry,
-                materials: materials,
+                materialsByStyleLayerId: materialsByStyleLayerId,
                 transform: transformFor(entry.tile.wrap, entry.tile.canonical),
               ),
             );
@@ -470,7 +477,7 @@ class _BaseMapController extends ChangeNotifier {
                 wrap: entry.tile.wrap,
                 tileId: tileId,
                 geometry: geometry,
-                materials: materials,
+                materialsByStyleLayerId: materialsByStyleLayerId,
                 transform: transformFor(entry.tile.wrap, tileId),
               ),
             );
@@ -483,7 +490,7 @@ class _BaseMapController extends ChangeNotifier {
                   wrap: entry.tile.wrap,
                   tileId: childIds[i],
                   geometry: children[i],
-                  materials: materials,
+                  materialsByStyleLayerId: materialsByStyleLayerId,
                   transform: transformFor(entry.tile.wrap, childIds[i]),
                 ),
               );
@@ -501,7 +508,7 @@ class _BaseMapController extends ChangeNotifier {
     required int wrap,
     required CanonicalTileId tileId,
     required BaseMapTileGeometry geometry,
-    required BaseMapMaterialLibrary materials,
+    required Map<String, scene.PreprocessedMaterial> materialsByStyleLayerId,
     required scene_math.Matrix4 transform,
   }) {
     final meshesByLayer = _sceneMeshCache.getOrBuild(
@@ -509,7 +516,7 @@ class _BaseMapController extends ChangeNotifier {
       tileId: tileId,
       geometry: geometry,
       geometryFactory: _geometryFactory,
-      materials: materials,
+      materialsByStyleLayerId: materialsByStyleLayerId,
     );
     final meshes = meshesByLayer[spec.styleLayerId];
     if (meshes == null || meshes.isEmpty) {
@@ -652,7 +659,7 @@ class _TileSceneMeshCache {
     required CanonicalTileId tileId,
     required BaseMapTileGeometry geometry,
     required BaseMapGeometryFactory geometryFactory,
-    required BaseMapMaterialLibrary materials,
+    required Map<String, scene.PreprocessedMaterial> materialsByStyleLayerId,
   }) {
     final key = (sourceInstanceId, tileId);
     final cached = _entries[key];
@@ -666,14 +673,14 @@ class _TileSceneMeshCache {
             for (final mesh in meshes)
               scene.Mesh(
                 geometryFactory.fillGeometry(mesh),
-                materials.fillMaterial,
+                materialsByStyleLayerId[layer.styleLayerId]!,
               ),
           ],
           BaseMapTileLineLayerGeometry(:final meshes) => [
             for (final mesh in meshes)
               scene.Mesh(
                 geometryFactory.lineGeometry(mesh),
-                materials.lineMaterial,
+                materialsByStyleLayerId[layer.styleLayerId]!,
               ),
           ],
         },

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -310,10 +310,23 @@ class _BaseMapController extends ChangeNotifier {
       .firstWhere((spec) => spec.kind == BaseMapLayerKind.background)
       .color;
 
+  /// [_viewport]がまだ設定されていない場合に[initialize]がmaterial生成時
+  /// だけ使う暫定値。`_refresh`は`viewport == null`の間nodeを一切追加しない
+  /// (`_refresh`の早期returnを参照)ため、この値で計算された
+  /// `half_width_ndc`が実際に画面へ出ることはなく、最初の`updateViewport`
+  /// 呼び出しで(`initialize`完了時の再適用、または以後の`updateViewport`
+  /// 自体が持つ再適用ロジックにより)即座に正しい値へ上書きされる。
+  static final _placeholderViewportBeforeFirstUpdate = MapViewport(
+    logicalSize: const Size(1, 1),
+    devicePixelRatio: 1,
+  );
+
   Future<void> initialize() async {
     try {
       await scene.Scene.initializeStaticResources();
       final materialsByStyleLayerId = <String, scene.PreprocessedMaterial>{};
+      final viewportForInitialLoad =
+          _viewport ?? _placeholderViewportBeforeFirstUpdate;
       for (final spec in baseMapLayerSpecs) {
         switch (spec.kind) {
           case BaseMapLayerKind.background:
@@ -329,6 +342,7 @@ class _BaseMapController extends ChangeNotifier {
                 await BaseMapMaterialLibrary.loadLineMaterial(
                   color: spec.color,
                   halfWidthLogicalPixels: _debugLineHalfWidthLogicalPixels,
+                  viewport: viewportForInitialLoad,
                 );
         }
       }
@@ -343,6 +357,14 @@ class _BaseMapController extends ChangeNotifier {
       _materialsByStyleLayerId = materialsByStyleLayerId;
       _repository = repository;
       _isReady = true;
+      // `_viewport`がここまでの間(loadLineMaterialの非同期処理中)に
+      // 判明していれば、暫定値で焼き込んだ`half_width_ndc`を正しい値へ
+      // 上書きする。`_refresh`はこの後に呼ぶため、上書き前にnodeが
+      // 構築されることはない。
+      final viewport = _viewport;
+      if (viewport != null) {
+        _applyLineHalfWidthToAllMaterials(viewport);
+      }
       _refresh();
       // 初期化失敗の原因はGPU初期化・material読み込み・archive openなど
       // 多岐にわたり、握り潰さずそのまま`_initError`へ入れてUIへ出すために
@@ -362,8 +384,37 @@ class _BaseMapController extends ChangeNotifier {
       return;
     }
     _viewport = viewport;
+    // NDC単位の半線幅はviewportのlogical sizeに依存するため、resizeや
+    // 画面回転でviewportが変わる度に再計算して既存materialへ反映する
+    // (`base_map_material_library.dart`の`halfLineWidthNdcFor`doc comment
+    // 参照)。
+    _applyLineHalfWidthToAllMaterials(viewport);
     _refresh();
     notifyListeners();
+  }
+
+  /// 全line layerのmaterialへ、[viewport]から求め直した`half_width_ndc`を
+  /// 再適用する。materialがまだ`initialize`で構築されていなければ何もしない
+  /// (`initialize`側がその後で改めて呼ぶ)。
+  void _applyLineHalfWidthToAllMaterials(MapViewport viewport) {
+    final materialsByStyleLayerId = _materialsByStyleLayerId;
+    if (materialsByStyleLayerId == null) {
+      return;
+    }
+    for (final spec in baseMapLayerSpecs) {
+      if (spec.kind != BaseMapLayerKind.line) {
+        continue;
+      }
+      final material = materialsByStyleLayerId[spec.styleLayerId];
+      if (material == null) {
+        continue;
+      }
+      BaseMapMaterialLibrary.setLineHalfWidth(
+        material: material,
+        halfWidthLogicalPixels: _debugLineHalfWidthLogicalPixels,
+        viewport: viewport,
+      );
+    }
   }
 
   void beginGesture() {

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.dart
@@ -68,6 +68,14 @@ abstract class MapBaseLayerLimits with _$MapBaseLayerLimits {
     required int maxCachedTileGeometries,
 
     /// [BaseMapTileCache.lookupWithFallback]が祖先を遡る最大段数。
+    ///
+    /// [BaseMapTileCache]のzoom窓(低zoom側)の深さにも同じ値を渡す
+    /// (`base_map_tile_cache.dart`の「LRU容量evictionと低zoom祖先の保持の
+    /// 相互作用」節参照)。祖先を`lookupWithFallback`が実際に遡れる段数と、
+    /// その祖先がcacheの窓から破棄されずに残る段数を分けて設定できても
+    /// 意味がない(遡れる段数より深く保持しても使われず、遡れる段数より
+    /// 浅くしか保持しなければ遡っても見つからない)ため、1つの値を両方へ
+    /// 渡す。
     required int maxParentFallbackSteps,
   }) = _MapBaseLayerLimits;
 }
@@ -258,6 +266,7 @@ class _BaseMapController extends ChangeNotifier {
 
   late final _cache = BaseMapTileCache(
     maxEntries: limits.maxCachedTileGeometries,
+    maxParentFallbackSteps: limits.maxParentFallbackSteps,
   );
   late final _sceneMeshCache = _TileSceneMeshCache(
     maxEntries: limits.maxCachedTileGeometries,

--- a/packages/eqmonitor_map/lib/src/widget/base_map_view.freezed.dart
+++ b/packages/eqmonitor_map/lib/src/widget/base_map_view.freezed.dart
@@ -37,6 +37,14 @@ mixin _$MapBaseLayerLimits {
 /// 覚えておくか」という運用値を指しているため、別々の上限値を持たせる
 /// 理由がない。
  int get maxCachedTileGeometries;/// [BaseMapTileCache.lookupWithFallback]が祖先を遡る最大段数。
+///
+/// [BaseMapTileCache]のzoom窓(低zoom側)の深さにも同じ値を渡す
+/// (`base_map_tile_cache.dart`の「LRU容量evictionと低zoom祖先の保持の
+/// 相互作用」節参照)。祖先を`lookupWithFallback`が実際に遡れる段数と、
+/// その祖先がcacheの窓から破棄されずに残る段数を分けて設定できても
+/// 意味がない(遡れる段数より深く保持しても使われず、遡れる段数より
+/// 浅くしか保持しなければ遡っても見つからない)ため、1つの値を両方へ
+/// 渡す。
  int get maxParentFallbackSteps;
 /// Create a copy of MapBaseLayerLimits
 /// with the given fields replaced by the non-null parameter values.
@@ -283,6 +291,14 @@ class _MapBaseLayerLimits implements MapBaseLayerLimits {
 /// 理由がない。
 @override final  int maxCachedTileGeometries;
 /// [BaseMapTileCache.lookupWithFallback]が祖先を遡る最大段数。
+///
+/// [BaseMapTileCache]のzoom窓(低zoom側)の深さにも同じ値を渡す
+/// (`base_map_tile_cache.dart`の「LRU容量evictionと低zoom祖先の保持の
+/// 相互作用」節参照)。祖先を`lookupWithFallback`が実際に遡れる段数と、
+/// その祖先がcacheの窓から破棄されずに残る段数を分けて設定できても
+/// 意味がない(遡れる段数より深く保持しても使われず、遡れる段数より
+/// 浅くしか保持しなければ遡っても見つからない)ため、1つの値を両方へ
+/// 渡す。
 @override final  int maxParentFallbackSteps;
 
 /// Create a copy of MapBaseLayerLimits

--- a/packages/eqmonitor_map/test/flutter_scene/base_map_geometry_factory_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/base_map_geometry_factory_test.dart
@@ -8,8 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 // このtestはGPU初期化を必要としない範囲だけを検証する。
 // `BaseMapGeometryFactory.fillGeometry`/`lineGeometry`自体は
-// `scene.MeshGeometry.fromArrays`/`setCustomAttribute`というGPUへの
-// buffer作成・アップロードを呼ぶため、`test/flutter_scene`の既存test
+// `scene.MeshGeometry.fromArrays`というGPUへのbuffer作成・アップロードを
+// 呼ぶため、`test/flutter_scene`の既存test
 // (`flutter_scene_spike_controller_test.dart`)が実際のGPU呼び出しをすべて
 // fakeで避けているのと同じ理由で、ここでは呼ばない。代わりに、それら2
 // methodがGPU呼び出しの直前に組み立てる引数(`buildFillGeometryArgs`/
@@ -98,8 +98,8 @@ void main() {
 
       expect(args.extrudes, Float32List.fromList(const [0.6, 0.8, -0.6, -0.8]));
       // zパディングは`positions`だけの事情(`MeshGeometry.fromArrays`が
-      // 3成分を要求する)であり、`extrude`は`setCustomAttribute`へ
-      // `components: 2`で渡すvec2属性なので触ってはいけない。触っていない
+      // 3成分を要求する)であり、`extrudes`は`MeshGeometry.fromArrays`の
+      // `texCoords:`引数へ渡すvec2属性なので触ってはいけない。触っていない
       // ことを同一インスタンスであることで確認する。
       expect(identical(args.extrudes, extrudes), isTrue);
     });

--- a/packages/eqmonitor_map/test/flutter_scene/base_map_geometry_factory_test.dart
+++ b/packages/eqmonitor_map/test/flutter_scene/base_map_geometry_factory_test.dart
@@ -1,10 +1,13 @@
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:eqmonitor_map/src/flutter_scene/base_map_geometry_factory.dart';
 import 'package:eqmonitor_map/src/flutter_scene/base_map_material_library.dart';
+import 'package:eqmonitor_map/src/geo/map_viewport.dart';
 import 'package:eqmonitor_map/src/mesh/fill_mesh.dart';
 import 'package:eqmonitor_map/src/mesh/line_mesh.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math.dart' show Vector2;
 
 // このtestはGPU初期化を必要としない範囲だけを検証する。
 // `BaseMapGeometryFactory.fillGeometry`/`lineGeometry`自体は
@@ -120,39 +123,72 @@ void main() {
     });
   });
 
-  group('halfLineWidthWorldFor', () {
+  group('halfLineWidthNdcFor', () {
     // 換算式のtestは実装を呼んで得た値ではなく、doc commentに書いた導出
-    // (1 world単位 == 1 logical pixel、zoom非依存)から手計算で独立に
-    // 求めた固定値で検証する。
-    test('logical pixelの半線幅をそのままworld単位として返す', () {
-      // 手計算: 換算係数は1なので、half_width_world == halfWidthLogicalPixels。
-      // 2.5という半端な値を選び、「2倍にする」「四捨五入する」といった
-      // バグを検出できるようにしている。
+    // (NDCはviewportのwidth/heightに対して[-1,1]を張るので1 logical px
+    // == (2/width, 2/height))から手計算で独立に求めた固定値で検証する。
+    test('logical pixelの半線幅をNDC単位のvec2へ換算する', () {
+      // 手計算: halfPx=1, width=400, height=800 のとき
+      // (2*1/400, 2*1/800) = (0.005, 0.0025)。
+      // width/heightをわざと非正方形にして、x/yで異なる係数が掛かる
+      // (成分ごとの独立換算)ことを検出できるようにしている。
+      final viewport = MapViewport(
+        logicalSize: const Size(400, 800),
+        devicePixelRatio: 1,
+      );
+
+      final result = halfLineWidthNdcFor(
+        halfWidthLogicalPixels: 1,
+        viewport: viewport,
+      );
+
+      expect(result, Vector2(0.005, 0.0025));
+    });
+
+    test('0を渡すと(0, 0)を返す', () {
+      final viewport = MapViewport(
+        logicalSize: const Size(400, 800),
+        devicePixelRatio: 1,
+      );
+
       expect(
-        halfLineWidthWorldFor(halfWidthLogicalPixels: 2.5),
-        2.5,
+        halfLineWidthNdcFor(halfWidthLogicalPixels: 0, viewport: viewport),
+        Vector2.zero(),
       );
     });
 
-    test('0を渡すと0を返す', () {
-      expect(halfLineWidthWorldFor(halfWidthLogicalPixels: 0), 0);
-    });
-
     test('負値はArgumentErrorを投げる', () {
+      final viewport = MapViewport(
+        logicalSize: const Size(400, 800),
+        devicePixelRatio: 1,
+      );
+
       expect(
-        () => halfLineWidthWorldFor(halfWidthLogicalPixels: -0.1),
+        () => halfLineWidthNdcFor(
+          halfWidthLogicalPixels: -0.1,
+          viewport: viewport,
+        ),
         throwsArgumentError,
       );
     });
 
     test('非finite値はArgumentErrorを投げる', () {
+      final viewport = MapViewport(
+        logicalSize: const Size(400, 800),
+        devicePixelRatio: 1,
+      );
+
       expect(
-        () => halfLineWidthWorldFor(halfWidthLogicalPixels: double.nan),
+        () => halfLineWidthNdcFor(
+          halfWidthLogicalPixels: double.nan,
+          viewport: viewport,
+        ),
         throwsArgumentError,
       );
       expect(
-        () => halfLineWidthWorldFor(
+        () => halfLineWidthNdcFor(
           halfWidthLogicalPixels: double.infinity,
+          viewport: viewport,
         ),
         throwsArgumentError,
       );

--- a/packages/eqmonitor_map/test/mesh/line_mesh_builder_test.dart
+++ b/packages/eqmonitor_map/test/mesh/line_mesh_builder_test.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:eqmonitor_map/src/mesh/line_mesh.dart';
 import 'package:eqmonitor_map/src/mesh/line_mesh_build_exception.dart';
 import 'package:eqmonitor_map/src/mesh/line_mesh_builder.dart';
 import 'package:eqmonitor_map/src/mesh/line_mesh_builder_limits.dart';
@@ -379,6 +380,149 @@ void main() {
           6,
           reason: '縮退したringの頂点が混ざらず、有効なringの3点×2だけになる',
         );
+      },
+    );
+  });
+
+  group('multiple rings in a single feature', () {
+    // 1 featureが複数ringを持つケース(`countries`のようなPolygon由来の
+    // Line layerが典型例。多数の国・島を1 featureの複数ringとして持つ)を
+    // 直接検証する。三角形の3頂点がすべて同一ring由来であることを
+    // 不変条件として固定する(特定のindex配列と比較する形にはしない)。
+    //
+    // ring境界を検出する方法: 各ringはdedup後の頂点数nに対し、常に
+    // 2n個の頂点(各点のplus/minus)を生成し、feature内ではring登場順に
+    // 連続したindex区間を占める(`LineMeshBuilder.build`のlocalOffset
+    // 累積)。よってringごとの頂点数さえ分かれば、区間境界は
+    // このtestの入力から導出できる(実装のindex配列そのものを直接
+    // 比較するわけではない)。
+    void expectNoCrossRingTriangle(
+      LineMesh mesh,
+      List<int> vertexCountPerRing,
+    ) {
+      final ringStart = <int>[];
+      var offset = 0;
+      for (final count in vertexCountPerRing) {
+        ringStart.add(offset);
+        offset += count;
+      }
+      int ringIndexOf(int vertexIndex) {
+        for (var r = ringStart.length - 1; r >= 0; r--) {
+          if (vertexIndex >= ringStart[r]) {
+            return r;
+          }
+        }
+        throw StateError('vertexIndex $vertexIndex is out of range');
+      }
+
+      for (var i = 0; i + 2 < mesh.indices.length; i += 3) {
+        final ring0 = ringIndexOf(mesh.indices[i]);
+        final ring1 = ringIndexOf(mesh.indices[i + 1]);
+        final ring2 = ringIndexOf(mesh.indices[i + 2]);
+        expect(
+          {ring0, ring1, ring2},
+          hasLength(1),
+          reason:
+              'triangle at indices[$i..${i + 2}] mixes vertices from '
+              'different rings (ring0=$ring0, ring1=$ring1, ring2=$ring2), '
+              'which means a ring boundary was bridged.',
+        );
+      }
+    }
+
+    double triArea(
+      LineMesh mesh,
+      int ia,
+      int ib,
+      int ic, {
+      double halfWidth = 1,
+    }) {
+      double px(int idx) =>
+          mesh.positions[idx * 2] + mesh.extrudes[idx * 2] * halfWidth;
+      double py(int idx) =>
+          mesh.positions[idx * 2 + 1] + mesh.extrudes[idx * 2 + 1] * halfWidth;
+      final ax = px(ia);
+      final ay = py(ia);
+      final bx = px(ib);
+      final by = py(ib);
+      final cx = px(ic);
+      final cy = py(ic);
+      return ((bx - ax) * (cy - ay) - (cx - ax) * (by - ay)).abs() / 2;
+    }
+
+    test(
+      'a feature with two widely separated closed rings never produces a '
+      'triangle whose vertices span both rings, and the extruded '
+      "triangle areas stay within each ring's own small bounding box "
+      '(no bridge across the ~4000-unit gap between the rings)',
+      () {
+        // ringA: tile-local (0,0)を中心とした10x10の小さな正方形。
+        // ringB: ringAから4000単位離れた(4000,4000)を中心とした同じ大きさの
+        // 正方形。もしring遷移でindexが分離されず橋渡しされていれば、
+        // 2つのringの頂点(距離約4000)を結ぶ巨大な三角形が生成されるはずで
+        // あり、その面積は数千のオーダーになる(ring単独の押し出し後
+        // 三角形の面積はたかだか数十のオーダー)。
+        final ringA = _ring([(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]);
+        final ringB = _ring([
+          (4000, 4000),
+          (4010, 4000),
+          (4010, 4010),
+          (4000, 4010),
+          (4000, 4000),
+        ]);
+        final feature = _lineFeature([ringA, ringB]);
+
+        final meshes = _builder().build([feature]);
+
+        expect(meshes, hasLength(1));
+        final mesh = meshes.single;
+        // 各ringは4点(dedup+closing後)なので、plus/minusで8頂点ずつ。
+        expect(mesh.vertexCount, 16);
+        expectNoCrossRingTriangle(mesh, [8, 8]);
+
+        var maxArea = 0.0;
+        for (var i = 0; i + 2 < mesh.indices.length; i += 3) {
+          final area = triArea(
+            mesh,
+            mesh.indices[i],
+            mesh.indices[i + 1],
+            mesh.indices[i + 2],
+          );
+          if (area > maxArea) {
+            maxArea = area;
+          }
+        }
+        // ringAの1辺は10、押し出しはmiter joinを含めても最大miterLimit
+        // (既定4)倍。単独ringの三角形面積は明らかに1000を超えない
+        // (10 * 4 = 40程度が上限のオーダー)。一方、橋渡しが起きた場合の
+        // 面積は距離差(約4000)に比例するため、1000という閾値は
+        // 「橋渡しがあれば必ず検出でき、橋渡しがなければ絶対に超えない」
+        // 安全なマージンを持つ。
+        expect(
+          maxArea,
+          lessThan(1000),
+          reason:
+              'a triangle this large can only be explained by a vertex from '
+              'ringA being connected to a vertex from ringB',
+        );
+      },
+    );
+
+    test(
+      'a feature with two widely separated open line rings also keeps '
+      'triangles within their own ring',
+      () {
+        final ringA = _ring([(0, 0), (10, 0), (10, 10)]);
+        final ringB = _ring([(4000, 4000), (4010, 4000), (4010, 4010)]);
+        final feature = _lineFeature([ringA, ringB]);
+
+        final meshes = _builder().build([feature]);
+
+        expect(meshes, hasLength(1));
+        final mesh = meshes.single;
+        // 開いたlineはring1本につき3点×2(plus/minus) = 6頂点。
+        expect(mesh.vertexCount, 12);
+        expectNoCrossRingTriangle(mesh, [6, 6]);
       },
     );
   });

--- a/packages/eqmonitor_map/test/tile/base_map_tile_cache_test.dart
+++ b/packages/eqmonitor_map/test/tile/base_map_tile_cache_test.dart
@@ -34,7 +34,7 @@ int _markerOf(BaseMapTileGeometry geometry) {
 void main() {
   group('cache key', () {
     test('the same sourceInstanceId+tileId retrieves the same entry', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       const tileId = CanonicalTileId(z: 5, x: 3, y: 4);
       cache.put(
         sourceInstanceId: 'a',
@@ -49,7 +49,7 @@ void main() {
     });
 
     test('a different sourceInstanceId is a different entry', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       const tileId = CanonicalTileId(z: 5, x: 3, y: 4);
       cache.put(
         sourceInstanceId: 'a',
@@ -65,7 +65,10 @@ void main() {
       'the integer zoom is part of the key: tiles with the same x/y but '
       'different z do not collide',
       () {
-        final cache = BaseMapTileCache(maxEntries: 10);
+        final cache = BaseMapTileCache(
+          maxEntries: 10,
+          maxParentFallbackSteps: 1,
+        );
         const tileIdZ5 = CanonicalTileId(z: 5, x: 1, y: 1);
         const tileIdZ6 = CanonicalTileId(z: 6, x: 1, y: 1);
         cache
@@ -95,7 +98,10 @@ void main() {
       'repeated noteActiveZoom calls with the same floor (simulating a '
       'fractional camera zoom change) do not invalidate the entry',
       () {
-        final cache = BaseMapTileCache(maxEntries: 10);
+        final cache = BaseMapTileCache(
+          maxEntries: 10,
+          maxParentFallbackSteps: 1,
+        );
         const tileId = CanonicalTileId(z: 5, x: 0, y: 0);
         cache.put(
           sourceInstanceId: 'a',
@@ -116,64 +122,180 @@ void main() {
   });
 
   group('eviction (zoom window)', () {
-    test('keeps entries within activeZoom ± 1 and evicts the rest', () {
-      final cache = BaseMapTileCache(maxEntries: 100);
-      for (final z in [3, 4, 5, 6, 7]) {
+    test(
+      'with maxParentFallbackSteps=1, keeps entries within activeZoom ± 1 '
+      'and evicts the rest (the symmetric ±1 special case)',
+      () {
+        final cache = BaseMapTileCache(
+          maxEntries: 100,
+          maxParentFallbackSteps: 1,
+        );
+        for (final z in [3, 4, 5, 6, 7]) {
+          cache.put(
+            sourceInstanceId: 'a',
+            tileId: CanonicalTileId(z: z, x: 0, y: 0),
+            geometry: _geometry(z),
+            token: cache.beginDecode(),
+          );
+        }
+
+        cache.noteActiveZoom(5);
+
+        expect(
+          cache.get(
+            sourceInstanceId: 'a',
+            tileId: const CanonicalTileId(z: 3, x: 0, y: 0),
+          ),
+          isNull,
+          reason: 'z=3 is outside [4, 6]',
+        );
+        expect(
+          cache.get(
+            sourceInstanceId: 'a',
+            tileId: const CanonicalTileId(z: 4, x: 0, y: 0),
+          ),
+          isNotNull,
+        );
+        expect(
+          cache.get(
+            sourceInstanceId: 'a',
+            tileId: const CanonicalTileId(z: 5, x: 0, y: 0),
+          ),
+          isNotNull,
+        );
+        expect(
+          cache.get(
+            sourceInstanceId: 'a',
+            tileId: const CanonicalTileId(z: 6, x: 0, y: 0),
+          ),
+          isNotNull,
+        );
+        expect(
+          cache.get(
+            sourceInstanceId: 'a',
+            tileId: const CanonicalTileId(z: 7, x: 0, y: 0),
+          ),
+          isNull,
+          reason: 'z=7 is outside [4, 6]',
+        );
+        expect(cache.length, 3);
+      },
+    );
+
+    test(
+      'the upper bound stays activeZoom + 1 regardless of '
+      'maxParentFallbackSteps (only the lower bound goes deeper)',
+      () {
+        final cache = BaseMapTileCache(
+          maxEntries: 100,
+          maxParentFallbackSteps: 4,
+        );
+        for (final z in [5, 6, 7]) {
+          cache.put(
+            sourceInstanceId: 'a',
+            tileId: CanonicalTileId(z: z, x: 0, y: 0),
+            geometry: _geometry(z),
+            token: cache.beginDecode(),
+          );
+        }
+
+        cache.noteActiveZoom(5);
+
+        expect(
+          cache.get(
+            sourceInstanceId: 'a',
+            tileId: const CanonicalTileId(z: 6, x: 0, y: 0),
+          ),
+          isNotNull,
+          reason: 'z=6 is activeZoom + 1',
+        );
+        expect(
+          cache.get(
+            sourceInstanceId: 'a',
+            tileId: const CanonicalTileId(z: 7, x: 0, y: 0),
+          ),
+          isNull,
+          reason:
+              'z=7 is activeZoom + 2; a large maxParentFallbackSteps must '
+              'not loosen the upper bound',
+        );
+      },
+    );
+
+    test(
+      'a zoom jump that skips levels (e.g. z4 -> z6, as a pinch can '
+      'produce) keeps the ancestor that lookupWithFallback needs, unlike '
+      'the old symmetric ±1 window',
+      () {
+        final cache = BaseMapTileCache(
+          maxEntries: 100,
+          maxParentFallbackSteps: 4,
+        );
+        const ancestorId = CanonicalTileId(z: 4, x: 0, y: 0);
         cache.put(
           sourceInstanceId: 'a',
-          tileId: CanonicalTileId(z: z, x: 0, y: 0),
-          geometry: _geometry(z),
+          tileId: ancestorId,
+          geometry: _geometry(4),
           token: cache.beginDecode(),
         );
-      }
 
-      cache.noteActiveZoom(5);
+        // ピンチでz4からz6へ一気に動いた想定。z5を経由しない。
+        cache.noteActiveZoom(6);
 
-      expect(
-        cache.get(
+        // z4はactiveZoom(6)から見て2段下だが、maxParentFallbackSteps=4の
+        // 範囲内なので生き残っているはず。
+        expect(
+          cache.get(sourceInstanceId: 'a', tileId: ancestorId),
+          isNotNull,
+          reason: 'z=4 is within activeZoom(6) - maxParentFallbackSteps(4) = 2',
+        );
+
+        final requestedTileId = ancestorId.scaledTo(6);
+        final result = cache.lookupWithFallback(
           sourceInstanceId: 'a',
-          tileId: const CanonicalTileId(z: 3, x: 0, y: 0),
-        ),
-        isNull,
-        reason: 'z=3 is outside [4, 6]',
-      );
-      expect(
-        cache.get(
+          tileId: requestedTileId,
+          maxParentSteps: 4,
+        );
+
+        expect(result, isA<BaseMapTileFallbackParent>());
+        final parent = result as BaseMapTileFallbackParent;
+        expect(_markerOf(parent.geometry), 4);
+        expect(parent.tileId, ancestorId);
+        expect(parent.stepsUp, 2);
+      },
+    );
+
+    test(
+      'an ancestor beyond maxParentFallbackSteps is still evicted (the '
+      'lower bound does not turn into unlimited retention)',
+      () {
+        final cache = BaseMapTileCache(
+          maxEntries: 100,
+          maxParentFallbackSteps: 2,
+        );
+        const tooDeepAncestorId = CanonicalTileId(z: 1, x: 0, y: 0);
+        cache.put(
           sourceInstanceId: 'a',
-          tileId: const CanonicalTileId(z: 4, x: 0, y: 0),
-        ),
-        isNotNull,
-      );
-      expect(
-        cache.get(
-          sourceInstanceId: 'a',
-          tileId: const CanonicalTileId(z: 5, x: 0, y: 0),
-        ),
-        isNotNull,
-      );
-      expect(
-        cache.get(
-          sourceInstanceId: 'a',
-          tileId: const CanonicalTileId(z: 6, x: 0, y: 0),
-        ),
-        isNotNull,
-      );
-      expect(
-        cache.get(
-          sourceInstanceId: 'a',
-          tileId: const CanonicalTileId(z: 7, x: 0, y: 0),
-        ),
-        isNull,
-        reason: 'z=7 is outside [4, 6]',
-      );
-      expect(cache.length, 3);
-    });
+          tileId: tooDeepAncestorId,
+          geometry: _geometry(1),
+          token: cache.beginDecode(),
+        );
+
+        cache.noteActiveZoom(6);
+
+        expect(
+          cache.get(sourceInstanceId: 'a', tileId: tooDeepAncestorId),
+          isNull,
+          reason: 'z=1 is below activeZoom(6) - maxParentFallbackSteps(2) = 4',
+        );
+      },
+    );
   });
 
   group('eviction (capacity, LRU)', () {
     test('without an intervening get(), evicts in pure insertion order '
         '(baseline contrast for the LRU tests below)', () {
-      final cache = BaseMapTileCache(maxEntries: 2);
+      final cache = BaseMapTileCache(maxEntries: 2, maxParentFallbackSteps: 1);
       cache
         ..put(
           sourceInstanceId: 'a',
@@ -224,7 +346,10 @@ void main() {
       'inserted first (the regression scenario found in review: '
       'maxEntries=3, put A,B -> get A(hit) -> put C,D)',
       () {
-        final cache = BaseMapTileCache(maxEntries: 3);
+        final cache = BaseMapTileCache(
+          maxEntries: 3,
+          maxParentFallbackSteps: 1,
+        );
         const tileA = CanonicalTileId(z: 5, x: 0, y: 0);
         const tileB = CanonicalTileId(z: 5, x: 1, y: 0);
         const tileC = CanonicalTileId(z: 5, x: 2, y: 0);
@@ -284,7 +409,10 @@ void main() {
       'without a get() in between, the same put sequence evicts the '
       'first-inserted entry instead (contrast with the test above)',
       () {
-        final cache = BaseMapTileCache(maxEntries: 3);
+        final cache = BaseMapTileCache(
+          maxEntries: 3,
+          maxParentFallbackSteps: 1,
+        );
         const tileA = CanonicalTileId(z: 5, x: 0, y: 0);
         const tileB = CanonicalTileId(z: 5, x: 1, y: 0);
         const tileC = CanonicalTileId(z: 5, x: 2, y: 0);
@@ -331,7 +459,7 @@ void main() {
 
   group('incarnation token', () {
     test('put is dropped once the token has been cancelled', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       const tileId = CanonicalTileId(z: 5, x: 0, y: 0);
 
       final token = cache.beginDecode();
@@ -351,7 +479,7 @@ void main() {
     });
 
     test('a token issued after cancellation still writes normally', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       const tileId = CanonicalTileId(z: 5, x: 0, y: 0);
 
       cache.cancelInFlight();
@@ -369,7 +497,7 @@ void main() {
 
   group('lookupWithFallback', () {
     test('returns an exact hit when the tile itself is cached', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       const tileId = CanonicalTileId(z: 5, x: 2, y: 2);
       cache.put(
         sourceInstanceId: 'a',
@@ -392,7 +520,10 @@ void main() {
       'falls back to the 4 children when all 4 are cached and the tile '
       'itself is not',
       () {
-        final cache = BaseMapTileCache(maxEntries: 10);
+        final cache = BaseMapTileCache(
+          maxEntries: 10,
+          maxParentFallbackSteps: 1,
+        );
         const tileId = CanonicalTileId(z: 5, x: 2, y: 2);
         final childIds = tileId.children();
         for (var i = 0; i < childIds.length; i++) {
@@ -419,7 +550,10 @@ void main() {
     test(
       'does not use a partial set of 3 children as a children-fallback',
       () {
-        final cache = BaseMapTileCache(maxEntries: 10);
+        final cache = BaseMapTileCache(
+          maxEntries: 10,
+          maxParentFallbackSteps: 1,
+        );
         const tileId = CanonicalTileId(z: 5, x: 2, y: 2);
         final childIds = tileId.children();
         for (var i = 0; i < 3; i++) {
@@ -442,7 +576,7 @@ void main() {
     );
 
     test('falls back to the nearest cached ancestor within maxParentSteps', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       const tileId = CanonicalTileId(z: 5, x: 4, y: 4);
       // z=3の祖先だけをcacheする(z=4の親はcacheしない)。
       final grandparentId = tileId.scaledTo(3);
@@ -467,7 +601,7 @@ void main() {
     });
 
     test('gives up once maxParentSteps is exceeded', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       const tileId = CanonicalTileId(z: 5, x: 4, y: 4);
       final grandparentId = tileId.scaledTo(3);
       cache.put(
@@ -490,7 +624,10 @@ void main() {
       'prefers the 4 children over an available parent (children→parent '
       'order, not parent→children)',
       () {
-        final cache = BaseMapTileCache(maxEntries: 10);
+        final cache = BaseMapTileCache(
+          maxEntries: 10,
+          maxParentFallbackSteps: 1,
+        );
         const tileId = CanonicalTileId(z: 5, x: 2, y: 2);
         final childIds = tileId.children();
         for (var i = 0; i < childIds.length; i++) {
@@ -526,7 +663,7 @@ void main() {
     );
 
     test('returns a miss when nothing is cached', () {
-      final cache = BaseMapTileCache(maxEntries: 10);
+      final cache = BaseMapTileCache(maxEntries: 10, maxParentFallbackSteps: 1);
       final result = cache.lookupWithFallback(
         sourceInstanceId: 'a',
         tileId: const CanonicalTileId(z: 5, x: 2, y: 2),


### PR DESCRIPTION
PR #1579 のフォローアップです。**#1579 に含まれていた「線が海を塗り潰す」不具合を修正し、
実機で Fill + Line の両方が正しく描画されることを確認しました。**

あわせて、CD 配布バイナリで `.fmat` が同梱されず起動時にエラーになる問題も修正しています。

## 修正した不具合

### 1. CD 配布バイナリで `base_map_fill.fmat was not found`

`dartDataAssets` feature は master でも `available` だが `enabledByDefault` ではないため、
明示的な有効化が必要でした。`flutter config --enable-dart-data-assets` はマシンごとの
global 設定でコミットされず、`deploy-app.yaml` が実行しているのは
`--enable-swift-package-manager` だけなので、**CI/CD では一度も有効化されていませんでした。**

`app/pubspec.yaml` の `flutter: config:` へ追加して解決しています。pubspec は global 設定より
優先されます(`flutter_features_config.dart` の `_isEnabledAtProjectLevel`)。対照実験で確認済み:

| pubspec | global | `.fmat` 同梱 |
|---|---|---|
| `true` | `false` (CI と同条件) | される |
| `false` | `false` | されない |

なお **CD の Flutter は master pin で正常**でした(`mise.toml` の
`4dacd3fc91d96262a33e5c598e17d816f0b35641`)。そちらは原因ではありません。

### 2. 線が海を塗り潰す(#1579 の既知の不具合)

**2 つの独立したバグが重なっていました。**

**(a) `setCustomAttribute('extrude')` の値が shader へ届かない**

押し出し法線の代わりに、同じ頂点の `position` が読まれていました。fragment shader を
`base_color = vec4(abs(extrude.x), abs(extrude.y), 0, 1)` にして描画したところ、本来
`(0, ±1)` の単位ベクトルなら緑一色になるはずが、**画面中央で 0・端へ単調増加する V 字
グラデーション**が出ました。これは origin rebasing 後の `position` の振る舞いと完全に一致します。

→ `MeshGeometry.fromArrays` の組み込み `texCoords`(`vec2`)で渡すよう変更。

**(b) 押し出しが NDC 空間で起きるのに、半線幅を logical pixel の生値で渡していた**

Flutter Scene の生成 shader は `world_position = model_transform * position` を求めてから
material の `Vertex()` を呼びます。`BaseMapView` は `viewProjectionMatrixFor * tileMatrixFor` を
node の localTransform へ焼き込み camera を恒等にしているため、`Vertex()` の時点で
`world_position` は既に NDC 空間でした。`half_width_world = 1.0` は NDC の 1.0、
可視範囲 ±1 の半分の押し出しになり画面が埋まります。

→ 半線幅を `vec2(2 * halfPx / width, 2 * halfPx / height)` として NDC 単位で渡すよう変更。

## 実機での確認結果

iOS 27.0 simulator (iPhone 17 Pro)、zoom=4 のデバッグページ。**判定は目視ではなくピクセル値の
実測**で行いました(地図描画領域 1206×1500px のヒストグラム)。

| 色 | 該当 | 占有 |
|---|---|---|
| `#F5F5F0` | **背景(海)** — 期待値と完全一致 | 56% |
| `(214,208,195)` | 陸の Fill | 25% |
| `#959580` | 行政界の線 | 1.3% |
| `(240,99,48)` 近傍 | EEW 区域境界の線 | 0.1% |

**背景が支配的で、線は 1〜2% 以下の細線相応**です。修正前は線の色が海全体を覆っていました。

## その他の修正

- **decode 中に低ズームタイルを表示**するため、cache の zoom 窓を非対称化
  (上は `activeZoom + 1`、下は `activeZoom - maxParentFallbackSteps`)。従来は対称 ±1 だったため
  zoom 跳躍で親が即座に破棄され、`maxParentFallbackSteps` が実質機能していませんでした
- `spec.color` が共有 material のせいで無視されていたのを layer ごとに反映
- README の「祖先 fallback で陸地が表示され続ける」という誤った記述を訂正
- 生成物とソースの doc comment 不一致を解消

## ドキュメント

設計正本へ**押し出しをどの空間で行うかは camera 配線で決まるので両者を一致させること**を明記し、
NDC 換算式とその根拠を記録しました。`docs/todo/800_...` には、**反証された 4 つの仮説**
(ring 境界の橋渡し / extent ハードコード / miter clamp 漏れ / mesh の巨大三角形)を測定値付きで
残しています。同じ仮説が再燃したときに即座に否定できるようにするためです。

## 既知の問題(未修正)

- **spike 用 camera 配線(`NodeCamera` + 正射影)がこの環境で何も描画しません。**
  `PerspectiveCamera` なら描画されるところまで切り分け済み。つまり Task 1 の
  `BaseMapMaterialPreflightView` は一度も目視でレンダリング確認されていませんでした
- `BaseMapTileGeometry` が MVT extent を運んでおらず `mvtDefaultExtent`(4096)を固定で渡している。
  実 archive は全 layer 4096 なので現時点で実害なし
- pinch-zoom / 画面回転時の `half_width_ndc` 再計算は実機目視が未確認
  (simulator の mouse 操作では 2 本指ジェスチャを合成できないため)。コードとテストでは担保済み

## テスト

`packages/eqmonitor_map` 209 tests / `packages/pmtiles_v3` 51 tests /
`packages/seismicity_pmtiles` 16 tests、`dart analyze` clean。

https://claude.ai/code/session_01Q8LRrEeFtj7FCUwkCRyvqS
