### PR TITLE
docs: 市区町村ポリゴン欠落 todo に Asset Pack CD 停止の実態を追記

### DIFF
--- a/docs/todo/500_asset_pack_city_polygons_dropped.md
+++ b/docs/todo/500_asset_pack_city_polygons_dropped.md
@@ -3,7 +3,36 @@
 配信中の `asset-pack-v0.0.2` の `map/all.pmtiles` に市区町村ポリゴンがほぼ入っておらず、
 市区町村単位の塗りつぶしが描画されない。
 
-backend 側の修正 PR: <https://github.com/YumNumm/eqmonitor-backend/pull/980>
+backend 側の修正 PR: <https://github.com/YumNumm/eqmonitor-backend/pull/980>（2026-08-03 マージ済み）
+
+## 現状（2026-08-06）: 修正はマージ済みだが配信されていない
+
+PR #980 はマージ済みだが、**backend の Asset Pack CD が 2026-07-31 以降ずっと
+失敗しており、v0.0.2 (2026-07-29) から新しい pack が 1 つも publish されていない**。
+そのため #980 の tippecanoe 2.79.0 固定は**まだ配信物に反映されていない**。
+「#980 マージ後の pack を待つ」だけでは永久に解消しないので注意。
+
+CD が落ちているのは `generate-parameters` ジョブで、本 Issue とは別原因:
+強震モニタ観測点への JMA コード PIP 付与が gitignore された中間物
+`tools/base-map-pmtiles/data/lookup/*.json` に依存しており、CI のクリーンな
+checkout には存在しないため `ENOENT` で落ちる。
+
+CD 復旧 PR: <https://github.com/YumNumm/eqmonitor-backend/pull/992>
+
+なお、この 992 では GDAL も固定している。CI の GDAL 3.8.4 が一部ポリゴンを
+`GeometryCollection` に変換する問題（後述の「兵庫県北部・兵庫が塗れない」）も
+同時に解消する見込み。
+
+配信中の v0.0.2 を実測した結果（全ズームのタイルをデコードして得た distinct
+`regioncode`）:
+
+| zoom | distinct `regioncode` |
+| --- | --- |
+| z6 | 15 |
+| z7 | 31 |
+| z8 | **69** |
+
+期待値は 1894。`tilestats.count` は v0.0.2 でも 1914 を返すため検知できない（後述）。
 
 ## 影響
 
@@ -67,6 +96,10 @@ CI の GDAL 3.8.4 と `COORDINATE_PRECISION=7` の組み合わせにより、
 | `areaForecastLocalEew` | `9280` | 兵庫 |
 
 backend 側 todo: `docs/todo/600_base_map_gdal_geometrycollection_loss.md`
+→ CD 復旧 PR <https://github.com/YumNumm/eqmonitor-backend/pull/992> で
+GDAL を `ghcr.io/osgeo/gdal:ubuntu-small-3.11.3` に固定し、変換段で
+`GeometryCollection` を検出したらビルドを落とすようにして対応済み
+（同 PR で backend の todo 600 は削除）。
 
 ## 暫定対応（ローカル / 検証）
 
@@ -117,7 +150,16 @@ adb install -r build/app/outputs/flutter-apk/app-debug.apk
 adb shell pm clear net.yumnumm.eqmonitor
 ```
 
-恒久対応は PR #980 マージ後にリリースされる新しい pack を使うこと。
+恒久対応は backend PR #992（CD 復旧）マージ後にリリースされる pack
+（v0.0.3 以降）を使うこと。#980 だけでは pack が publish されない。
+
+pack が出たら以下を実測してから本 todo を閉じる:
+
+```bash
+# 期待値: z8 の distinct regioncode = 1894, GeometryCollection 由来の
+# areaForecastLocalE 530 / areaForecastLocalEew 9280 も存在すること
+GH_TOKEN=... tool/asset_pack/stage_from_release.sh --target android-debug
+```
 
 ## 低ズームで塗られない件は別問題（対応済み）
 


### PR DESCRIPTION
## 背景

`docs/todo/500_asset_pack_city_polygons_dropped.md` は「恒久対応は PR #980 マージ後にリリースされる新しい pack を使うこと」と書いているが、**この前提が成り立っていない**。

- backend PR #980（tippecanoe 2.79.0 固定）は 2026-08-03 にマージ済み
- しかし backend の Release Asset Pack ワークフローは **2026-07-31 以降すべて失敗**しており、**v0.0.2 (2026-07-29) から新しい pack が 1 つも publish されていない**

つまり #980 の修正は配信物に到達しておらず、このドキュメントに従って「新しい pack を待つ」と永久に解消しない。

CD が落ちている原因は本 Issue とは別で、`generate-parameters` ジョブが gitignore された中間物 `tools/base-map-pmtiles/data/lookup/*.json` に依存しており CI のクリーン checkout で `ENOENT` になるため。復旧 PR: YumNumm/eqmonitor-backend#992

## 変更内容

`docs/todo/500_asset_pack_city_polygons_dropped.md` のみ（コード変更なし）。

- 「現状（2026-08-06）: 修正はマージ済みだが配信されていない」節を追加。CD 停止の事実・原因・復旧 PR へのリンクを記載
- 恒久対応の記述を #980 → #992 に訂正し、pack が出た後に実測してから todo を閉じる手順を追記
- 配信中 v0.0.2 の実測値を追記（全ズームのタイルをデコードして得た distinct `regioncode`: z6=15 / z7=31 / **z8=69**、期待値 1894）
- 「兵庫県北部・兵庫が塗れない」節に、GDAL 3.8.4 の `GeometryCollection` 化が #992 で GDAL 固定 + 変換段ゲート追加により対応済みであることを追記

## 補足: アプリ側の実装は変更不要

改めて確認したが、アプリ側のフィルタ・属性キーは正しい。

- 配信中 v0.0.2 のタイルをデコードすると、市区町村レイヤの property は `regioncode` / `regionname` / `name` / `namekana`
- `earthquake_history_fill_layer.dart` / `intensity_fill_layer.dart` はいずれも `['get', 'regioncode']` で照合しており一致（JMA の 市町村等（地震津波関係） シェープでは `regioncode` が 7 桁の市区町村コード）
- 生き残っている 69 件は 小笠原村 のような離島が中心で、これは tippecanoe 2.49.0 が密なタイルの feature を `dropped_by_rate` で捨てた結果と整合する

Asset Pack CD（`upload-asset-pack.yaml`）自体も正常で、最後の `asset_pack_released` (2026-07-29, run 30487545826) は download/verify・iOS Managed Background Assets upload とも成功している。pack のバージョンは `stage_from_release.sh` が最新 Release を動的に解決するため、アプリリポジトリ側にピン留めはなく、v0.0.3 が publish されれば自動で取り込まれる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)