### PR TITLE
Fix: テーマプリセット選択が必ず例外になる不具合を解消

### DIFF
--- a/app/lib/feature/settings/features/display_settings/ui/theme/theme_settings_page.dart
+++ b/app/lib/feature/settings/features/display_settings/ui/theme/theme_settings_page.dart
@@ -69,13 +69,10 @@ class _ModeSection extends ConsumerWidget {
           const SizedBox(height: 8),
           RadioGroup<AppTheme>(
             groupValue: currentTheme,
-            onChanged: (themeName) async {
-              if (themeName == null) {
+            onChanged: (preset) async {
+              if (preset == null) {
                 return;
               }
-              final preset = presets.firstWhere(
-                (preset) => preset.name == themeName,
-              );
               await ref
                   .read(appThemeProvider.notifier)
                   .setThemeForMode(mode, preset);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

テーマ設定画面でプリセット（EQMonitor / JMA Standard）をタップすると
`Bad state: No element` で必ず例外になっていた不具合を修正しました。

## 原因

`RadioGroup<AppTheme>` の `onChanged` は選択された `AppTheme` を渡しますが、
コールバック側では `String` として扱い `preset.name == themeName` で比較していました。
この比較は常に false になるため、直後の `firstWhere` が `Bad state: No element` を投げます。

```dart
onChanged: (themeName) async {          // 実際には AppTheme
  final preset = presets.firstWhere(
    (preset) => preset.name == themeName, // String と AppTheme の比較 → 常に false
  );
```

## 変更内容

`onChanged` が渡す `AppTheme` をそのまま保存し、`firstWhere` による引き直しを削除しました。
`RadioListTile.value` には `presets` の要素をそのまま渡しているため、再検索は不要です。

## 経緯

[#1583](https://github.com/YumNumm/EQMonitor/pull/1583) で `flutter-test` の
CI 実行を復旧させたところ、`theme_settings_page_test.dart` の
「JMA Standardプリセットをタップするとlightテーマに保存される」が
この production 例外で失敗することが判明しました。テストの期待値は正しく、
production 側の不具合です。

## 確認

- `PR Flutter Check / flutter-test`: **success**（該当テストを含む app 全体のテストが green）
- この Linux 環境では Flutter ツールチェーンが使えないため、ローカル実行は未実施です。

## 既知の残課題（本PR対象外）

`flutter-analyze` は `app` 配下の custom lint 違反 1,414 件（error 0 / warning 1,414）で
落ち続けています。`docs/todo/760_existing_eqmonitor_custom_lint_debt.md` に記録済みの
既存 debt であり、本PRの変更とは無関係です。同 todo の方針どおり一括 ignore や
非blocking 化は行っていません。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fda91-f009-7019-b977-3efdc19dc6b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fda91-f009-7019-b977-3efdc19dc6b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

