### PR TITLE
feat: ホームシートのスクロールを上Clamp・下Bounceに統一

### DIFF
--- a/app/lib/core/component/scroll/bottom_bouncing_scroll_physics.dart
+++ b/app/lib/core/component/scroll/bottom_bouncing_scroll_physics.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+
+/// 上端は Clamp、下端は Bounce する [ScrollPhysics]。
+///
+/// Android / iOS 共通で同じ挙動にする。
+class BottomBouncingScrollPhysics extends BouncingScrollPhysics {
+  const BottomBouncingScrollPhysics({
+    super.parent,
+    super.decelerationRate,
+  });
+
+  @override
+  BottomBouncingScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return BottomBouncingScrollPhysics(
+      parent: buildParent(ancestor),
+      decelerationRate: decelerationRate,
+    );
+  }
+
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    // Underscroll (top)
+    if (value < position.pixels &&
+        position.pixels <= position.minScrollExtent) {
+      return value - position.pixels;
+    }
+    // Hit top edge
+    if (value < position.minScrollExtent &&
+        position.minScrollExtent < position.pixels) {
+      return value - position.minScrollExtent;
+    }
+    // Bottom: allow overscroll for bouncing
+    return 0;
+  }
+}

--- a/app/lib/page/home_page.dart
+++ b/app/lib/page/home_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:eqmonitor/core/component/scroll/bottom_bouncing_scroll_physics.dart';
 import 'package:eqmonitor/core/component/sheet/basic_modal_sheet.dart';
 import 'package:eqmonitor/core/designsystem/design_system_build_context_x.dart';
 import 'package:eqmonitor/core/router/router.dart';
@@ -147,6 +148,7 @@ class _SheetBody extends ConsumerWidget {
     );
     final padding = MediaQuery.paddingOf(context);
     return SingleChildScrollView(
+      physics: const BottomBouncingScrollPhysics(),
       child: SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- Android / iOS 共通で、ホームシート内スクロールを「上端は Bounce しない・下端は Bounce する」挙動に揃える
- 再利用可能な `BottomBouncingScrollPhysics` を `core/component/scroll` に追加し、`HomePage` の `SingleChildScrollView` に適用

## Test plan
- [ ] iOS: ホームシートを上端までスクロールし、上側に Bounce しないこと
- [ ] iOS: 下端までスクロールし、下側に Bounce すること
- [ ] Android: 同様に上 Clamp / 下 Bounce であること
- [ ] シート自体のスナップ伸縮（`SnapSheetPhysics`）が従来どおり動くこと