### PR TITLE
Fix: Asset Pack manifest の未知 asset id で全アセットが失われる不具合を解消

### DIFF
--- a/app/lib/feature/asset_pack/data/model/asset_pack_manifest.dart
+++ b/app/lib/feature/asset_pack/data/model/asset_pack_manifest.dart
@@ -4,8 +4,13 @@ part 'asset_pack_manifest.g.dart';
 
 /// Stable identifiers for assets shipped inside the platform Asset Pack.
 ///
-/// Must stay in sync with the backend Valibot `AssetId` picklist
-/// (`backend/packages/types/src/asset-pack.ts`).
+/// A *subset* of the backend Valibot `AssetId` picklist
+/// (`backend/packages/types/src/asset-pack.ts`): the ids this app build knows
+/// how to consume. The backend may ship ids that are absent here — those
+/// entries are skipped by [AssetPackManifest.fromJson] (see the
+/// forward-compatibility note there), so this enum never needs to be updated
+/// in lockstep with the backend. Add an id here only when this app actually
+/// starts reading that asset.
 @JsonEnum()
 enum AssetPackAssetId {
   @JsonValue('BASE_MAP_PMTILES')
@@ -58,6 +63,9 @@ final _sha256Pattern = RegExp(r'^[0-9a-f]{64}$');
 /// `json_annotation`'s `CheckedFromJsonException` — on any mismatch. There
 /// is no fake-data fallback: an invalid manifest must fail loudly rather
 /// than producing a partially-valid object.
+///
+/// The one deliberate exception is asset ids unknown to this build, which are
+/// skipped rather than rejected — see [fromJson].
 @JsonSerializable(createFactory: false)
 class AssetPackManifest {
   AssetPackManifest({
@@ -67,6 +75,22 @@ class AssetPackManifest {
     required this.assets,
   });
 
+  /// Parses a manifest, **skipping entries whose `id` this build doesn't
+  /// know** while still validating everything else strictly.
+  ///
+  /// Skipping unknown ids is required for forward compatibility, not a
+  /// convenience: Managed Background Assets (iOS) and Play Asset Delivery
+  /// (Android) hand the *latest* Pack to *every* installed app build, so the
+  /// backend adding an asset id must not make older builds reject the
+  /// manifest. Rejecting one entry means rejecting the whole file — and
+  /// `AssetPackRepository.readManifest` gates every asset lookup, so the base
+  /// map and all parameters would become unreachable at once. That is exactly
+  /// what happened when Pack v0.0.3 introduced `KYOSHIN_STATIONS` to app
+  /// 3.0.0.
+  ///
+  /// Only the `id` is treated as an open set. `schema_version` is the
+  /// compatibility gate for everything else, so any other mismatch (bad
+  /// `sha256`, unknown `kind` for a known id, missing field) still throws.
   factory AssetPackManifest.fromJson(Map<String, dynamic> json) {
     final packVersion = _requireString(json, 'pack_version');
     final schemaVersion = _requireInt(json, 'schema_version');
@@ -75,10 +99,10 @@ class AssetPackManifest {
     if (assetsJson is! List) {
       throw const FormatException('assets must be a list');
     }
-    final assets = assetsJson
-        .map((e) => AssetPackManifestItem.fromJson(_requireObject(e, 'assets[]')))
-        .toList();
 
+    // Validated before the per-item parse so that a bumped schema_version is
+    // reported as such, rather than as whatever the new schema's items happen
+    // to violate.
     if (schemaVersion != 1) {
       throw FormatException(
         'Unsupported manifest schema_version: $schemaVersion (expected 1)',
@@ -87,8 +111,23 @@ class AssetPackManifest {
     if (!_packVersionPattern.hasMatch(packVersion)) {
       throw FormatException('Invalid pack_version: $packVersion');
     }
-    if (assets.isEmpty) {
+    if (assetsJson.isEmpty) {
       throw const FormatException('assets must not be empty');
+    }
+
+    final assets = <AssetPackManifestItem>[];
+    for (var i = 0; i < assetsJson.length; i++) {
+      final itemJson = _requireObject(assetsJson[i], 'assets[$i]');
+      if (!_assetIdByJsonValue.containsKey(itemJson['id'])) {
+        continue;
+      }
+      assets.add(AssetPackManifestItem.fromJson(itemJson));
+    }
+    if (assets.isEmpty) {
+      throw FormatException(
+        'Asset Pack manifest lists no asset id known to this app build: '
+        '${assetsJson.map((e) => e is Map ? e['id'] : e).toList()}',
+      );
     }
 
     return AssetPackManifest(
@@ -131,7 +170,10 @@ class AssetPackManifest {
 ///
 /// [fromJson] is hand-written for the same reason as
 /// [AssetPackManifest.fromJson]: a plain, unwrapped [FormatException] on
-/// any validation failure.
+/// any validation failure — including an `id` this build doesn't know.
+/// [AssetPackManifest.fromJson] filters those entries out before delegating
+/// here, so an unknown id only reaches this constructor when it is called
+/// directly.
 @JsonSerializable(createFactory: false)
 class AssetPackManifestItem {
   AssetPackManifestItem({

--- a/app/test/feature/asset_pack/asset_pack_repository_test.dart
+++ b/app/test/feature/asset_pack/asset_pack_repository_test.dart
@@ -113,11 +113,90 @@ void main() {
       expect(() => AssetPackManifest.fromJson(json), throwsFormatException);
     });
 
-    test('rejects an unknown asset id', () {
+    test('skips an unknown asset id and keeps the known ones', () {
+      // Forward compatibility: the platform hands the latest Pack to every
+      // installed build, so a backend-added id must not invalidate the whole
+      // manifest (Pack v0.0.3 / KYOSHIN_STATIONS regression).
       final json = _validManifestJson();
-      (json['assets']! as List).cast<Map<String, Object?>>().first['id'] =
-          'SOMETHING_ELSE';
-      expect(() => AssetPackManifest.fromJson(json), throwsA(isA<Object>()));
+      (json['assets']! as List).cast<Map<String, Object?>>().add({
+        'id': 'SOMETHING_ELSE',
+        'kind': 'json',
+        'path': 'parameters/something_else.json',
+        'schema_version': 1,
+        'source_version': '20260807',
+        'source_updated_at': null,
+        'source_urls': <String>[],
+        'sha256': _sha256A,
+        'size_bytes': 3,
+      });
+
+      final manifest = AssetPackManifest.fromJson(json);
+
+      expect(manifest.assets, hasLength(2));
+      expect(
+        manifest.assets.map((a) => a.id),
+        containsAll(<AssetPackAssetId>[
+          AssetPackAssetId.baseMapPmtiles,
+          AssetPackAssetId.jmaCodeTable,
+        ]),
+      );
+    });
+
+    test('skips an unknown asset id even when its entry is malformed', () {
+      // An id this build doesn't know is never read, so its entry must not be
+      // validated at all — otherwise a future asset carrying a new `kind` (or
+      // any added field constraint) would still break old builds.
+      final json = _validManifestJson();
+      (json['assets']! as List).cast<Map<String, Object?>>().add({
+        'id': 'SOMETHING_ELSE',
+        'kind': 'webp',
+        'path': 'something_else.webp',
+        'schema_version': 2,
+        'source_version': '20260807',
+        'source_updated_at': null,
+        'source_urls': <String>[],
+        'sha256': 'not-a-hash',
+        'size_bytes': -1,
+      });
+
+      final manifest = AssetPackManifest.fromJson(json);
+
+      expect(manifest.assets, hasLength(2));
+      expect(manifest.findAsset(AssetPackAssetId.jmaCodeTable), isNotNull);
+    });
+
+    test('rejects a manifest whose ids are all unknown to this build', () {
+      final json = _validManifestJson();
+      for (final asset
+          in (json['assets']! as List).cast<Map<String, Object?>>()) {
+        asset['id'] = 'SOMETHING_ELSE';
+      }
+      expect(() => AssetPackManifest.fromJson(json), throwsFormatException);
+    });
+
+    test('reports a bumped schema_version even when every id is unknown', () {
+      final json = _validManifestJson()..['schema_version'] = 2;
+      for (final asset
+          in (json['assets']! as List).cast<Map<String, Object?>>()) {
+        asset['id'] = 'SOMETHING_ELSE';
+      }
+      expect(
+        () => AssetPackManifest.fromJson(json),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('schema_version'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects an unknown asset id when the item is parsed directly', () {
+      final json = _validManifestJson();
+      final item = (json['assets']! as List).cast<Map<String, Object?>>().first
+        ..['id'] = 'SOMETHING_ELSE';
+      expect(() => AssetPackManifestItem.fromJson(item), throwsFormatException);
     });
   });
 


### PR DESCRIPTION
## 概要

バックエンドが Asset Pack **v0.0.3**（2026-08-07 05:58 UTC）で asset id `KYOSHIN_STATIONS` を追加した結果、**3.0.0 (1782) で manifest のパースが全面的に失敗**し、ベース地図 PMTiles と全 parameters が取得不能になっていた。未知の asset id を skip する前方互換パーサに修正する。

報告されたクラッシュ:

```
例外型: AssetPackNotReadyException
メッセージ: Invalid Asset Pack manifest.json (.../Staging/Unlocalized/manifest.json):
  FormatException: Unknown Asset Pack asset id: KYOSHIN_STATIONS
```

## 原因

`AssetPackManifestItem.fromJson` は未知の asset id を `FormatException` で throw する。これが `AssetPackManifest.fromJson` の `assets.map(...)` の内側で起きるため、**1 件でも未知 id があれば manifest 全体がパース不能**になる。`AssetPackRepository.readManifest()` は全アセット解決の入口なので、単一の未知エントリが Pack 全体を無効化していた。

Managed Background Assets（iOS）/ Play Asset Delivery（Android）は**最新 Pack を既存の全インストールへ配る**。したがってバックエンド側の asset id 追加で古いビルドが manifest を拒否してはならない。これは `KYOSHIN_STATIONS` 固有の問題ではなく、今後どの asset id 追加でも同じ全損が起きる構造だった。

## 変更内容

- `id` のみを open set として扱い、未知 id のエントリを skip する
- 未知 id のエントリは**内部の検証も行わない**（将来 `kind` の追加や制約の追加が起きても古いビルドを壊さないため）
- `id` 以外は従来どおり厳格に検証。`schema_version` が互換性ゲートであるという契約は変えない
- 既知 id が 1 件も残らない場合は、含まれていた id を添えて loud に fail
- `schema_version` / `pack_version` の検証を各エントリのパースより前に移動（schema バージョン変更時に原因が正しく報告されるようにした）
- `AssetPackAssetId` の doc comment を「バックエンドと lockstep で同期する」から「アプリが読む id の部分集合」に修正

## バックエンド側の対応

`KYOSHIN_STATIONS` はこのアプリで参照ゼロ（将来の観測点選択ツリー用データ）なので、配布済み 3.0.0 を即時復旧させるためバックエンド側で Pack から一旦外す: YumNumm/eqmonitor-backend#994

本 PR が最低サポートバージョンになってから、バックエンド側で `KYOSHIN_STATIONS` を再投入する。

## 検証

- `flutter test test/feature/asset_pack/ test/feature/parameter/ test/feature/map/` → 93 tests passed（新規 5 件含む）
- `dart analyze lib/feature/asset_pack test/feature/asset_pack` → No issues found

追加したテスト:
- 未知 id を skip して既知 id を保持する
- 未知 id のエントリが malformed でも skip する
- 全 id が未知なら loud に fail する
- 全 id が未知でも `schema_version` の不一致が正しく報告される
- `AssetPackManifestItem.fromJson` を直接呼んだ場合は従来どおり未知 id を reject する

🤖 Generated with [Claude Code](https://claude.com/claude-code)