### PR TITLE
Fix: 都道府県別 最大震度マップの挙動を全面的に修正

### DIFF
--- a/app/lib/feature/intensity_history/data/repository/prefecture_bounds_resolver.dart
+++ b/app/lib/feature/intensity_history/data/repository/prefecture_bounds_resolver.dart
@@ -1,0 +1,174 @@
+import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:jma_map/jma_map.dart';
+import 'package:maplibre/maplibre.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'prefecture_bounds_resolver.g.dart';
+
+/// 細分区域コードとその外接矩形の組。
+typedef RegionBoundsEntry = ({String code, LngLatBounds bounds});
+
+@Riverpod(keepAlive: true)
+PrefectureBoundsResolver prefectureBoundsResolver(Ref ref) =>
+    const PrefectureBoundsResolver();
+
+/// 都道府県フォーカス時にカメラを合わせる範囲を算出する。
+///
+/// 都道府県配下の細分区域の外接矩形を単純に union すると、遠隔の離島を持つ
+/// 都道府県で範囲が数百km規模に広がり、人口の集中する陸地がほとんど見えない
+/// ズームになる（東京都の小笠原諸島・南鳥島、鹿児島県の十島村、沖縄県の
+/// 大東島など）。
+///
+/// そのため細分区域を近接するものだけで単連結にまとめ、[resolve] の
+/// `seedRegionCode` を含むクラスタ（未指定時は市区町村数が最多のクラスタ）
+/// だけを採用する。
+class PrefectureBoundsResolver {
+  const PrefectureBoundsResolver();
+
+  /// 同一クラスタとみなす外接矩形間の最大ギャップ（度）。
+  ///
+  /// 陸続きの細分区域は境界を共有するため外接矩形が重なる。海で隔たれた
+  /// 離島を別クラスタに分けたいので、矩形量子化の誤差を吸収できる程度の
+  /// 小さな値のみを許容する。
+  static const clusterGapDegrees = 0.2;
+
+  LngLatBounds? resolve({
+    required String prefectureCode,
+    required List<EarthquakeParameterPrefectureItem> prefectures,
+    required Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
+    String? seedRegionCode,
+  }) {
+    final prefecture = prefectures
+        .where((prefecture) => prefecture.code == prefectureCode)
+        .firstOrNull;
+    if (prefecture == null) {
+      return null;
+    }
+
+    final cityCountByRegionCode = {
+      for (final region in prefecture.regions)
+        region.code: region.cities.length,
+    };
+    final regions = jmaMap.areaForecastLocalE.data
+        .where(
+          (item) =>
+              item.hasBounds() &&
+              item.hasProperty() &&
+              cityCountByRegionCode.containsKey(item.property.code),
+        )
+        .map(
+          (item) => (
+            code: item.property.code,
+            bounds: LngLatBounds(
+              longitudeWest: item.bounds.southWest.lng,
+              longitudeEast: item.bounds.northEast.lng,
+              latitudeSouth: item.bounds.southWest.lat,
+              latitudeNorth: item.bounds.northEast.lat,
+            ),
+          ),
+        )
+        .toList();
+    if (regions.isEmpty) {
+      return null;
+    }
+
+    final clusters = clusterByProximity(regions);
+    final seeded = seedRegionCode == null
+        ? null
+        : clusters
+              .where(
+                (cluster) =>
+                    cluster.any((region) => region.code == seedRegionCode),
+              )
+              .firstOrNull;
+    final selected =
+        seeded ??
+        clusters.reduce(
+          (a, b) =>
+              cityCount(
+                    cityCountByRegionCode: cityCountByRegionCode,
+                    cluster: b,
+                  ) >
+                  cityCount(
+                    cityCountByRegionCode: cityCountByRegionCode,
+                    cluster: a,
+                  )
+              ? b
+              : a,
+        );
+
+    return unionBounds(selected.map((region) => region.bounds));
+  }
+
+  /// [clusterGapDegrees] 以内で連結する細分区域どうしを同じクラスタにまとめる。
+  List<List<RegionBoundsEntry>> clusterByProximity(
+    List<RegionBoundsEntry> regions,
+  ) {
+    final labels = List<int>.generate(regions.length, (index) => index);
+    var hasMerged = true;
+    while (hasMerged) {
+      hasMerged = false;
+      for (var i = 0; i < regions.length; i++) {
+        for (var j = i + 1; j < regions.length; j++) {
+          if (labels[i] == labels[j] ||
+              !isNeighbouring(regions[i].bounds, regions[j].bounds)) {
+            continue;
+          }
+          final keep = labels[i] < labels[j] ? labels[i] : labels[j];
+          final drop = labels[i] < labels[j] ? labels[j] : labels[i];
+          for (var k = 0; k < labels.length; k++) {
+            if (labels[k] == drop) {
+              labels[k] = keep;
+            }
+          }
+          hasMerged = true;
+        }
+      }
+    }
+
+    final grouped = <int, List<RegionBoundsEntry>>{};
+    for (var i = 0; i < regions.length; i++) {
+      grouped.putIfAbsent(labels[i], () => []).add(regions[i]);
+    }
+    return grouped.values.toList();
+  }
+
+  /// [clusterGapDegrees] だけ膨らませた矩形同士が交差するかどうか。
+  bool isNeighbouring(LngLatBounds a, LngLatBounds b) =>
+      a.longitudeWest - clusterGapDegrees <= b.longitudeEast &&
+      b.longitudeWest - clusterGapDegrees <= a.longitudeEast &&
+      a.latitudeSouth - clusterGapDegrees <= b.latitudeNorth &&
+      b.latitudeSouth - clusterGapDegrees <= a.latitudeNorth;
+
+  int cityCount({
+    required Map<String, int> cityCountByRegionCode,
+    required List<RegionBoundsEntry> cluster,
+  }) => cluster.fold(
+    0,
+    (sum, region) => sum + (cityCountByRegionCode[region.code] ?? 0),
+  );
+
+  LngLatBounds? unionBounds(Iterable<LngLatBounds> boundsList) {
+    final first = boundsList.firstOrNull;
+    if (first == null) {
+      return null;
+    }
+    var west = first.longitudeWest;
+    var east = first.longitudeEast;
+    var south = first.latitudeSouth;
+    var north = first.latitudeNorth;
+    for (final bounds in boundsList.skip(1)) {
+      west = bounds.longitudeWest < west ? bounds.longitudeWest : west;
+      east = bounds.longitudeEast > east ? bounds.longitudeEast : east;
+      south = bounds.latitudeSouth < south ? bounds.latitudeSouth : south;
+      north = bounds.latitudeNorth > north ? bounds.latitudeNorth : north;
+    }
+    return LngLatBounds(
+      longitudeWest: west,
+      longitudeEast: east,
+      latitudeSouth: south,
+      latitudeNorth: north,
+    );
+  }
+}

--- a/app/lib/feature/intensity_history/data/repository/prefecture_bounds_resolver.g.dart
+++ b/app/lib/feature/intensity_history/data/repository/prefecture_bounds_resolver.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'prefecture_bounds_resolver.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(prefectureBoundsResolver)
+final prefectureBoundsResolverProvider = PrefectureBoundsResolverProvider._();
+
+final class PrefectureBoundsResolverProvider
+    extends
+        $FunctionalProvider<
+          PrefectureBoundsResolver,
+          PrefectureBoundsResolver,
+          PrefectureBoundsResolver
+        >
+    with $Provider<PrefectureBoundsResolver> {
+  PrefectureBoundsResolverProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'prefectureBoundsResolverProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$prefectureBoundsResolverHash();
+
+  @$internal
+  @override
+  $ProviderElement<PrefectureBoundsResolver> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  PrefectureBoundsResolver create(Ref ref) {
+    return prefectureBoundsResolver(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PrefectureBoundsResolver value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PrefectureBoundsResolver>(value),
+    );
+  }
+}
+
+String _$prefectureBoundsResolverHash() =>
+    r'de74e06bfdf0536e3c7ef7d9badcf4dc637fa5ce';

--- a/app/lib/feature/intensity_history/ui/action/intensity_history_map_action.dart
+++ b/app/lib/feature/intensity_history/ui/action/intensity_history_map_action.dart
@@ -1,0 +1,323 @@
+import 'package:eqmonitor/core/extension/async_value.dart';
+import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/city_highest_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
+import 'package:eqmonitor/feature/intensity_history/data/repository/prefecture_bounds_resolver.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/components/city_detail_modal.dart';
+import 'package:eqmonitor/feature/location/data/nearest_jma_feature.dart';
+import 'package:eqmonitor/feature/map/data/model/base_map_tile_spec.dart';
+import 'package:eqmonitor/feature/map/utils/map_zoom_calculator.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lat_lng/lat_lng.dart';
+import 'package:maplibre/maplibre.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'intensity_history_map_action.g.dart';
+
+@Riverpod(keepAlive: true)
+IntensityHistoryMapAction intensityHistoryMapAction(Ref ref) =>
+    const IntensityHistoryMapAction();
+
+/// 地域別最大震度マップのタップ操作・カメラ操作をまとめて担う。
+class IntensityHistoryMapAction {
+  const IntensityHistoryMapAction();
+
+  /// 日本全国の表示範囲。
+  static const japanBounds = LngLatBounds(
+    longitudeWest: JapanBounds.minLng,
+    longitudeEast: JapanBounds.maxLng,
+    latitudeSouth: JapanBounds.minLat,
+    latitudeNorth: JapanBounds.maxLat,
+  );
+
+  /// 都道府県フォーカス時の余白。
+  ///
+  /// 上部のフローティングパネル・下部の凡例に地域が隠れないよう、
+  /// 上下に厚めの余白を確保する。
+  static const focusPadding = EdgeInsets.fromLTRB(24, 96, 24, 88);
+
+  static const japanPadding = EdgeInsets.all(24);
+
+  /// 地図タップを解釈して、都道府県フォーカス / 市区町村選択を行う。
+  ///
+  /// タップ地点を含む地域の判定は Worker Isolate 上のポリゴン判定
+  /// ([jmaMapAreaInformationCityInsideProvider] /
+  /// [jmaMapAreaForecastLocalEInsideProvider]) に委ね、UI スレッドを塞がない。
+  Future<void> handleMapTap({
+    required WidgetRef ref,
+    required BuildContext context,
+    required MapController controller,
+    required Geographic point,
+  }) async {
+    final prefectures = ref
+        .read(parameterSetProvider)
+        .valueOrPrevious
+        ?.earthquake
+        .prefectures;
+    if (prefectures == null || prefectures.isEmpty) {
+      return;
+    }
+
+    final state = ref.read(intensityHistoryControllerProvider);
+    final latLng = LatLng(point.lat, point.lon);
+    final zoom = controller.camera?.zoom ?? 0;
+
+    // 市区町村ポリゴンが描画されないズームでは、市区町村としては解釈しない。
+    if (state is IntensityHistoryStateCity &&
+        zoom >= BaseMapTileSpec.cityMinZoom) {
+      final city = await ref.read(
+        jmaMapAreaInformationCityInsideProvider(latLng).future,
+      );
+      final property = city?.property;
+      if (property != null && context.mounted) {
+        await handleCityTap(
+          ref: ref,
+          context: context,
+          controller: controller,
+          prefectures: prefectures,
+          focusedPrefectureCode: state.prefectureCode,
+          cityCode: property.code,
+          cityName: property.name,
+        );
+        return;
+      }
+    }
+
+    final region = await ref.read(
+      jmaMapAreaForecastLocalEInsideProvider(latLng).future,
+    );
+    final regionCode = region?.property?.code;
+    if (regionCode == null) {
+      // 日本の陸域外。選択中の市区町村があれば解除するだけに留める。
+      if (state is IntensityHistoryStateCity &&
+          state.selectedCityCode != null) {
+        ref.read(intensityHistoryControllerProvider.notifier).deselectCity();
+      }
+      return;
+    }
+
+    if (!context.mounted) {
+      return;
+    }
+    await handleRegionTap(
+      ref: ref,
+      context: context,
+      controller: controller,
+      prefectures: prefectures,
+      regionCode: regionCode,
+    );
+  }
+
+  Future<void> handleCityTap({
+    required WidgetRef ref,
+    required BuildContext context,
+    required MapController controller,
+    required List<EarthquakeParameterPrefectureItem> prefectures,
+    required String focusedPrefectureCode,
+    required String cityCode,
+    required String cityName,
+  }) async {
+    final prefectureCode = prefectureCodeOfCity(cityCode, prefectures);
+    if (prefectureCode == null) {
+      return;
+    }
+
+    final prefecture = prefectures
+        .where((prefecture) => prefecture.code == prefectureCode)
+        .firstOrNull;
+    if (prefecture == null) {
+      return;
+    }
+
+    if (prefectureCode != focusedPrefectureCode) {
+      // 別の都道府県の市区町村 → まずその都道府県へフォーカスを移す。
+      await focusPrefecture(
+        ref: ref,
+        context: context,
+        controller: controller,
+        prefectureCode: prefectureCode,
+        prefectureName: prefecture.name.ja,
+        selectedCityCode: cityCode,
+        selectedCityName: cityName,
+      );
+      return;
+    }
+
+    ref
+        .read(intensityHistoryControllerProvider.notifier)
+        .selectCity(code: cityCode, name: cityName);
+
+    if (!context.mounted) {
+      return;
+    }
+    await showCityDetailModal(
+      context,
+      cityCode: cityCode,
+      cityName: cityName,
+      regionName: prefecture.name.ja,
+      summary: cityHighestEntry(
+        ref: ref,
+        prefectureCode: prefectureCode,
+        cityCode: cityCode,
+      ),
+    );
+  }
+
+  Future<void> handleRegionTap({
+    required WidgetRef ref,
+    required BuildContext context,
+    required MapController controller,
+    required List<EarthquakeParameterPrefectureItem> prefectures,
+    required String regionCode,
+  }) async {
+    final prefecture = prefectureOfRegionCode(regionCode, prefectures);
+    if (prefecture == null) {
+      return;
+    }
+
+    final state = ref.read(intensityHistoryControllerProvider);
+    if (state is IntensityHistoryStateCity &&
+        state.prefectureCode == prefecture.code) {
+      // フォーカス中の都道府県内。市区町村として解釈できなかったので、
+      // 選択中の市区町村の解除だけを行う。
+      ref.read(intensityHistoryControllerProvider.notifier).deselectCity();
+      return;
+    }
+
+    await focusPrefecture(
+      ref: ref,
+      context: context,
+      controller: controller,
+      prefectureCode: prefecture.code,
+      prefectureName: prefecture.name,
+      seedRegionCode: regionCode,
+    );
+  }
+
+  /// ディープリンク（他画面からの直接遷移）で都道府県・市区町村へフォーカスする。
+  Future<void> openFromDeepLink({
+    required WidgetRef ref,
+    required BuildContext context,
+    required MapController controller,
+    required String prefectureCode,
+    required String? cityCode,
+  }) async {
+    final prefectures = ref
+        .read(parameterSetProvider)
+        .valueOrPrevious
+        ?.earthquake
+        .prefectures;
+    if (prefectures == null || prefectures.isEmpty) {
+      return;
+    }
+    final prefecture = prefectures
+        .where((prefecture) => prefecture.code == prefectureCode)
+        .firstOrNull;
+    if (prefecture == null) {
+      return;
+    }
+
+    final city = cityCode == null
+        ? null
+        : prefecture.regions
+              .expand((region) => region.cities)
+              .where((city) => city.code == cityCode)
+              .firstOrNull;
+
+    await focusPrefecture(
+      ref: ref,
+      context: context,
+      controller: controller,
+      prefectureCode: prefecture.code,
+      prefectureName: prefecture.name.ja,
+      selectedCityCode: city?.code,
+      selectedCityName: city?.name.ja,
+    );
+
+    if (city == null || !context.mounted) {
+      return;
+    }
+    await showCityDetailModal(
+      context,
+      cityCode: city.code,
+      cityName: city.name.ja,
+      regionName: prefecture.name.ja,
+      summary: cityHighestEntry(
+        ref: ref,
+        prefectureCode: prefecture.code,
+        cityCode: city.code,
+      ),
+    );
+  }
+
+  Future<void> focusPrefecture({
+    required WidgetRef ref,
+    required BuildContext context,
+    required MapController controller,
+    required String prefectureCode,
+    required String prefectureName,
+    String? selectedCityCode,
+    String? selectedCityName,
+    String? seedRegionCode,
+  }) async {
+    ref
+        .read(intensityHistoryControllerProvider.notifier)
+        .focusPrefecture(
+          code: prefectureCode,
+          name: prefectureName,
+          selectedCityCode: selectedCityCode,
+          selectedCityName: selectedCityName,
+        );
+
+    final prefectures = ref
+        .read(parameterSetProvider)
+        .valueOrPrevious
+        ?.earthquake
+        .prefectures;
+    if (prefectures == null) {
+      return;
+    }
+
+    final jmaMap = await ref.read(jmaMapProvider.future);
+    if (!context.mounted) {
+      return;
+    }
+    final bounds = ref
+        .read(prefectureBoundsResolverProvider)
+        .resolve(
+          prefectureCode: prefectureCode,
+          prefectures: prefectures,
+          jmaMap: jmaMap,
+          seedRegionCode: seedRegionCode,
+        );
+    if (bounds == null) {
+      return;
+    }
+    await controller.fitBounds(bounds: bounds, padding: focusPadding);
+  }
+
+  /// 全国表示（Lv1）に戻す。
+  Future<void> backToJapan({
+    required WidgetRef ref,
+    required MapController controller,
+  }) async {
+    ref.read(intensityHistoryControllerProvider.notifier).backToPrefecture();
+    await controller.fitBounds(bounds: japanBounds, padding: japanPadding);
+  }
+
+  HighestIntensityEntry? cityHighestEntry({
+    required WidgetRef ref,
+    required String prefectureCode,
+    required String cityCode,
+  }) => ref
+      .read(cityHighestProvider(prefectureCode))
+      .valueOrPrevious
+      ?.where((entry) => entry.code == cityCode)
+      .firstOrNull;
+}

--- a/app/lib/feature/intensity_history/ui/action/intensity_history_map_action.dart
+++ b/app/lib/feature/intensity_history/ui/action/intensity_history_map_action.dart
@@ -75,13 +75,17 @@ class IntensityHistoryMapAction {
         jmaMapAreaInformationCityInsideProvider(latLng).future,
       );
       final property = city?.property;
-      if (property != null && context.mounted) {
+      // 所属都道府県を解決できない市区町村は細分区域として解釈し直す。
+      final cityPrefecture = property == null
+          ? null
+          : prefectureOf(cityCode: property.code, prefectures: prefectures);
+      if (property != null && cityPrefecture != null && context.mounted) {
         await handleCityTap(
           ref: ref,
           context: context,
           controller: controller,
-          prefectures: prefectures,
           focusedPrefectureCode: state.prefectureCode,
+          prefecture: cityPrefecture,
           cityCode: property.code,
           cityName: property.name,
         );
@@ -114,34 +118,36 @@ class IntensityHistoryMapAction {
     );
   }
 
+  /// 市区町村コードから所属都道府県を解決する。
+  EarthquakeParameterPrefectureItem? prefectureOf({
+    required String cityCode,
+    required List<EarthquakeParameterPrefectureItem> prefectures,
+  }) {
+    final prefectureCode = prefectureCodeOfCity(cityCode, prefectures);
+    if (prefectureCode == null) {
+      return null;
+    }
+    return prefectures
+        .where((prefecture) => prefecture.code == prefectureCode)
+        .firstOrNull;
+  }
+
   Future<void> handleCityTap({
     required WidgetRef ref,
     required BuildContext context,
     required MapController controller,
-    required List<EarthquakeParameterPrefectureItem> prefectures,
     required String focusedPrefectureCode,
+    required EarthquakeParameterPrefectureItem prefecture,
     required String cityCode,
     required String cityName,
   }) async {
-    final prefectureCode = prefectureCodeOfCity(cityCode, prefectures);
-    if (prefectureCode == null) {
-      return;
-    }
-
-    final prefecture = prefectures
-        .where((prefecture) => prefecture.code == prefectureCode)
-        .firstOrNull;
-    if (prefecture == null) {
-      return;
-    }
-
-    if (prefectureCode != focusedPrefectureCode) {
+    if (prefecture.code != focusedPrefectureCode) {
       // 別の都道府県の市区町村 → まずその都道府県へフォーカスを移す。
       await focusPrefecture(
         ref: ref,
         context: context,
         controller: controller,
-        prefectureCode: prefectureCode,
+        prefectureCode: prefecture.code,
         prefectureName: prefecture.name.ja,
         selectedCityCode: cityCode,
         selectedCityName: cityName,
@@ -163,7 +169,7 @@ class IntensityHistoryMapAction {
       regionName: prefecture.name.ja,
       summary: cityHighestEntry(
         ref: ref,
-        prefectureCode: prefectureCode,
+        prefectureCode: prefecture.code,
         cityCode: cityCode,
       ),
     );

--- a/app/lib/feature/intensity_history/ui/action/intensity_history_map_action.g.dart
+++ b/app/lib/feature/intensity_history/ui/action/intensity_history_map_action.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, type=warning, duplicate_ignore, unused_element_parameter
+
+part of 'intensity_history_map_action.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(intensityHistoryMapAction)
+final intensityHistoryMapActionProvider = IntensityHistoryMapActionProvider._();
+
+final class IntensityHistoryMapActionProvider
+    extends
+        $FunctionalProvider<
+          IntensityHistoryMapAction,
+          IntensityHistoryMapAction,
+          IntensityHistoryMapAction
+        >
+    with $Provider<IntensityHistoryMapAction> {
+  IntensityHistoryMapActionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'intensityHistoryMapActionProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$intensityHistoryMapActionHash();
+
+  @$internal
+  @override
+  $ProviderElement<IntensityHistoryMapAction> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  IntensityHistoryMapAction create(Ref ref) {
+    return intensityHistoryMapAction(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(IntensityHistoryMapAction value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<IntensityHistoryMapAction>(value),
+    );
+  }
+}
+
+String _$intensityHistoryMapActionHash() =>
+    r'ed2b871ddbaad32efa1705f4067ff3ef56bda237';

--- a/app/lib/feature/intensity_history/ui/components/region_floating_panel.dart
+++ b/app/lib/feature/intensity_history/ui/components/region_floating_panel.dart
@@ -157,35 +157,43 @@ class _CityPanel extends ConsumerWidget {
                     ),
                     const SizedBox(width: 10),
                   ],
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (selectedCity != null)
+                  Flexible(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (selectedCity != null)
+                          Text(
+                            prefectureName,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: context
+                                  .designSystem
+                                  .colorTheme
+                                  .onSurfaceVariant,
+                            ),
+                          ),
                         Text(
-                          prefectureName,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: context
-                                .designSystem
-                                .colorTheme
-                                .onSurfaceVariant,
+                          displayName,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
-                      Text(
-                        displayName,
-                        style: theme.textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      if (entry != null)
-                        Text(
-                          '${entry.count}件',
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: context.designSystem.colorTheme.onSurface
-                                .withValues(alpha: 0.7),
+                        if (entry != null)
+                          Text(
+                            '${entry.count}件',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: context.designSystem.colorTheme.onSurface
+                                  .withValues(alpha: 0.7),
+                            ),
                           ),
-                        ),
-                    ],
+                      ],
+                    ),
                   ),
                 ],
               ),

--- a/app/lib/feature/intensity_history/ui/intensity_history_page.dart
+++ b/app/lib/feature/intensity_history/ui/intensity_history_page.dart
@@ -3,37 +3,32 @@ import 'dart:async';
 import 'package:eqmonitor/core/component/cached_data_banner.dart';
 import 'package:eqmonitor/core/component/error/error_card.dart';
 import 'package:eqmonitor/core/extension/async_value.dart';
-import 'package:eqmonitor/core/provider/log/talker.dart';
-import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
-import 'package:eqmonitor/core/provider/map/jma_map_utility.dart';
-import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
 import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
-import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/city_highest_provider.dart';
-import 'package:eqmonitor/feature/intensity_history/data/notifier/prefecture_highest_provider.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
-import 'package:eqmonitor/feature/intensity_history/ui/components/city_detail_modal.dart';
+import 'package:eqmonitor/feature/intensity_history/data/notifier/prefecture_highest_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/action/intensity_history_map_action.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_error_overlay.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_legend.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/intensity_history_navigation_back_button.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/components/region_floating_panel.dart';
 import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer.dart';
+import 'package:eqmonitor/feature/location/data/jma_map_isolate.dart';
+import 'package:eqmonitor/feature/map/data/model/map_configuration.dart';
 import 'package:eqmonitor/feature/map/data/notifier/map_configuration_notifier.dart';
 import 'package:eqmonitor/feature/map/ui/map_operation_queue_scope.dart';
 import 'package:eqmonitor/feature/map/utils/map_zoom_calculator.dart';
-import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:jma_map/jma_map.dart';
 import 'package:maplibre/maplibre.dart';
 
 /// 地域別最大震度マップのページ。
 ///
 /// - [initialPrefectureCode]: 指定時は起動直後に当該都道府県にフォーカスする(Lv2)。
 /// - [initialCityCode]: 指定時はさらに市区町村詳細モーダルを自動表示する。
-class IntensityHistoryPage extends HookConsumerWidget {
+class IntensityHistoryPage extends ConsumerWidget {
   const IntensityHistoryPage({
     this.initialPrefectureCode,
     this.initialCityCode,
@@ -45,23 +40,10 @@ class IntensityHistoryPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final mapConfiguration = ref.watch(mapConfigurationProvider);
-
-    final paramAsync = ref.watch(parameterSetProvider);
-    final code = initialPrefectureCode;
-    final initialPrefName = code == null
-        ? null
-        : paramAsync.valueOrPrevious?.earthquake.prefectures
-              .where((pref) => pref.code == code)
-              .firstOrNull
-              ?.name
-              .ja;
-
-    return switch (mapConfiguration) {
-      AsyncData(:final value) when value.styleString != null => _MapContent(
-        styleString: value.styleString!,
+    return switch (ref.watch(mapConfigurationProvider)) {
+      AsyncData(value: MapConfiguration(:final styleString?)) => _MapContent(
+        styleString: styleString,
         initialPrefectureCode: initialPrefectureCode,
-        initialPrefectureName: initialPrefName ?? initialPrefectureCode ?? '',
         initialCityCode: initialCityCode,
       ),
       AsyncError(:final error) => Scaffold(
@@ -79,440 +61,192 @@ class _MapContent extends HookConsumerWidget {
   const _MapContent({
     required this.styleString,
     required this.initialPrefectureCode,
-    required this.initialPrefectureName,
     required this.initialCityCode,
   });
 
   final String styleString;
   final String? initialPrefectureCode;
-  final String initialPrefectureName;
   final String? initialCityCode;
-
-  static const _regionSourceLayerId = 'areaForecastLocalE';
-  static const _citySourceLayerId = 'areaInformationCityQuake';
-
-  // 日本全国の LngLatBounds
-  static const _japanBounds = LngLatBounds(
-    longitudeWest: JapanBounds.minLng,
-    longitudeEast: JapanBounds.maxLng,
-    latitudeSouth: JapanBounds.minLat,
-    latitudeNorth: JapanBounds.maxLat,
-  );
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(intensityHistoryControllerProvider);
-    final notifier = ref.read(intensityHistoryControllerProvider.notifier);
-    final isCityState = state is IntensityHistoryStateCity;
+    final action = ref.watch(intensityHistoryMapActionProvider);
+    final isFocused = state is IntensityHistoryStateCity;
     final canNavigateBack = Navigator.canPop(context);
     final mapController = useRef<MapController?>(null);
     final isMapCreated = useState(false);
     final didInitializeDeepLink = useRef(false);
-    final parameterAsync = ref.watch(parameterSetProvider);
+    // パラメータ到着を effect の再実行契機にするため watch する。
+    final hasParameter =
+        ref.watch(parameterSetProvider).valueOrPrevious != null;
+    // タップ地点の地域判定に使う Worker Isolate を、初回タップを待たずに温める。
+    ref.watch(jmaMapIsolateProvider);
 
-    // ディープリンク初期化: MapController 作成後に一度だけ実行
     useEffect(
       () {
-        if (didInitializeDeepLink.value || !isMapCreated.value) {
-          return null;
-        }
-        final prefCode = initialPrefectureCode;
-        if (prefCode == null) {
-          return null;
-        }
+        final prefectureCode = initialPrefectureCode;
         final controller = mapController.value;
-        if (controller == null) {
+        if (didInitializeDeepLink.value ||
+            !isMapCreated.value ||
+            !hasParameter ||
+            prefectureCode == null ||
+            controller == null) {
           return null;
-        }
-
-        final prefectures =
-            parameterAsync.valueOrPrevious?.earthquake.prefectures;
-        if (prefectures == null) {
-          return null;
-        }
-        var prefName = prefCode;
-        final pref = prefectures.where((p) => p.code == prefCode).firstOrNull;
-        if (pref != null) {
-          prefName = pref.name.ja;
         }
         didInitializeDeepLink.value = true;
-        notifier.focusPrefecture(code: prefCode, name: prefName);
-
-        unawaited(() async {
-          if (!context.mounted) {
-            return;
-          }
-
-          try {
-            final jmaMap = await ref.read(jmaMapProvider.future);
-            if (!context.mounted) {
-              return;
-            }
-
-            final bounds = _buildPrefectureBounds(
-              prefCode: prefCode,
-              jmaMap: jmaMap,
-              prefectures: prefectures,
-            );
-            if (bounds != null) {
-              await controller.fitBounds(
-                bounds: bounds,
-                padding: const EdgeInsets.all(48),
-              );
-            }
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-
-          // cityCode の自動モーダル表示
-          final cityCode = initialCityCode;
-          if (cityCode != null && context.mounted) {
-            await showCityDetailModal(
-              context,
-              cityCode: cityCode,
-              cityName: cityCode,
-              regionName: initialPrefectureName,
-            );
-          }
-        }());
-
+        unawaited(
+          action.openFromDeepLink(
+            ref: ref,
+            context: context,
+            controller: controller,
+            prefectureCode: prefectureCode,
+            cityCode: initialCityCode,
+          ),
+        );
         return null;
       },
       [
         isMapCreated.value,
+        hasParameter,
         initialPrefectureCode,
-        initialPrefectureName,
         initialCityCode,
-        parameterAsync,
+        action,
       ],
     );
 
-    final mapOptions = calculateJapanViewMapOptions(
-      context: context,
-      styleString: styleString,
-    );
-
-    return Scaffold(
-      body: Stack(
-        children: [
-          MapOperationQueueScope(
-            child: MapLibreMap(
-              onMapCreated: (controller) {
-                mapController.value = controller;
-                isMapCreated.value = true;
-              },
-              options: mapOptions,
-              onEvent: (event) async {
-                if (event is MapEventClick || event is MapEventLongClick) {
-                  final jmaMap = await ref.read(jmaMapProvider.future);
+    return PopScope(
+      // フォーカス中は戻る操作を全国表示への復帰に割り当てる。
+      canPop: !isFocused,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          return;
+        }
+        final controller = mapController.value;
+        if (controller == null) {
+          return;
+        }
+        unawaited(action.backToJapan(ref: ref, controller: controller));
+      },
+      child: Scaffold(
+        body: Stack(
+          children: [
+            MapOperationQueueScope(
+              child: MapLibreMap(
+                onMapCreated: (controller) {
+                  mapController.value = controller;
+                  isMapCreated.value = true;
+                },
+                options: calculateJapanViewMapOptions(
+                  context: context,
+                  styleString: styleString,
+                ),
+                onEvent: (event) async {
+                  final point = switch (event) {
+                    MapEventClick(:final point) => point,
+                    MapEventLongClick(:final point) => point,
+                    _ => null,
+                  };
                   final controller = mapController.value;
-                  if (!context.mounted || controller == null) {
+                  if (point == null || controller == null) {
                     return;
                   }
-                  await _handleTap(
-                    mapController: controller,
-                    context: context,
+                  await action.handleMapTap(
                     ref: ref,
-                    screenPoint: switch (event) {
-                      MapEventClick(:final screenPoint) => screenPoint,
-                      MapEventLongClick(:final screenPoint) => screenPoint,
-                      _ => throw UnimplementedError(),
-                    },
-                    point: switch (event) {
-                      MapEventClick(:final point) => point,
-                      MapEventLongClick(:final point) => point,
-                      _ => throw UnimplementedError(),
-                    },
-                    jmaMap: jmaMap,
-                    state: state,
+                    context: context,
+                    controller: controller,
+                    point: point,
                   );
-                }
-              },
-              children: const [IntensityFillLayer()],
-            ),
-          ),
-
-          // フローティングパネル（上部中央）+ キャッシュ表示バナー
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: SafeArea(
-              child: Column(
-                children: [
-                  const Padding(
-                    padding: EdgeInsets.only(top: 8),
-                    child: RegionFloatingPanel(),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 8),
-                    child: CachedDataBanner(
-                      values: [
-                        ref.watch(prefectureHighestProvider),
-                        if (state is IntensityHistoryStateCity)
-                          ref.watch(cityHighestProvider(state.prefectureCode)),
-                      ],
-                    ),
-                  ),
-                ],
+                },
+                children: const [IntensityFillLayer()],
               ),
             ),
-          ),
 
-          // 凡例（右下）
-          const Positioned(
-            bottom: 8,
-            right: 8,
-            child: SafeArea(child: IntensityHistoryLegend()),
-          ),
-
-          const Positioned(
-            top: 0,
-            left: 0,
-            child: IntensityHistoryNavigationBackButton(),
-          ),
-
-          const IntensityHistoryErrorOverlay(),
-
-          // 全国表示へ戻るボタン（左上、Lv2のときのみ表示）
-          if (isCityState)
+            // フローティングパネル（上部中央）+ キャッシュ表示バナー
             Positioned(
-              top: canNavigateBack ? 56 : 0,
+              top: 0,
               left: 0,
+              right: 0,
               child: SafeArea(
-                child: Padding(
-                  padding: const EdgeInsets.all(8),
-                  child: Card(
-                    elevation: 2,
-                    clipBehavior: Clip.hardEdge,
-                    child: InkWell(
-                      onTap: () {
-                        notifier.backToPrefecture();
-                        final controller = mapController.value;
-                        if (controller != null) {
-                          _zoomToJapan(controller);
-                        }
-                      },
-                      child: const Tooltip(
-                        message: '全国表示に戻る',
-                        child: Padding(
-                          padding: EdgeInsets.all(8),
-                          child: Icon(Icons.public_rounded),
-                        ),
+                child: Column(
+                  children: [
+                    const Padding(
+                      padding: EdgeInsets.only(top: 8),
+                      child: RegionFloatingPanel(),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: CachedDataBanner(
+                        values: [
+                          ref.watch(prefectureHighestProvider),
+                          if (state is IntensityHistoryStateCity)
+                            ref.watch(
+                              cityHighestProvider(state.prefectureCode),
+                            ),
+                        ],
                       ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // 凡例（右下）
+            const Positioned(
+              bottom: 8,
+              right: 8,
+              child: SafeArea(child: IntensityHistoryLegend()),
+            ),
+
+            const Positioned(
+              top: 0,
+              left: 0,
+              child: IntensityHistoryNavigationBackButton(),
+            ),
+
+            const IntensityHistoryErrorOverlay(),
+
+            // 全国表示へ戻るボタン（左上、都道府県フォーカス中のみ表示）
+            if (mapController.value case final controller? when isFocused)
+              Positioned(
+                top: canNavigateBack ? 56 : 0,
+                left: 0,
+                child: SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: _BackToJapanButton(
+                      onTap: () async =>
+                          action.backToJapan(ref: ref, controller: controller),
                     ),
                   ),
                 ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }
+}
 
-  Future<void> _handleTap({
-    required MapController mapController,
-    required BuildContext context,
-    required WidgetRef ref,
-    required Offset screenPoint,
-    required Geographic point,
-    required Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
-    required IntensityHistoryState state,
-  }) async {
-    final hits = mapController.queryLayers(screenPoint);
-    if (hits.isEmpty) {
-      if (state is IntensityHistoryStateCity) {
-        ref
-            .read(intensityHistoryControllerProvider.notifier)
-            .backToPrefecture();
-        _zoomToJapan(mapController);
-      }
-      return;
-    }
+class _BackToJapanButton extends StatelessWidget {
+  const _BackToJapanButton({required this.onTap});
 
-    final hitCity = hits.any((h) => h.sourceLayer == _citySourceLayerId);
-    final hitRegion = hits.any((h) => h.sourceLayer == _regionSourceLayerId);
+  final Future<void> Function() onTap;
 
-    if (!hitCity && !hitRegion) {
-      return;
-    }
-
-    final latLng = JmaMap_LatLng(lat: point.lat, lng: point.lon);
-
-    if (hitCity && state is IntensityHistoryStateCity) {
-      // Lv2: 市区町村タップ
-      final mapData = jmaMap.areaInformationCity;
-      final result = JmaMapUtility().findNearestItem(latLng, mapData);
-      final item = result.item;
-      if (item == null) {
-        return;
-      }
-
-      final cityCode = item.property.code;
-      final cityName = item.property.name;
-
-      final paramAsync = ref.read(parameterSetProvider);
-      final prefectures =
-          paramAsync.valueOrPrevious?.earthquake.prefectures ?? [];
-
-      final cityPrefCode = prefectureCodeOfCity(cityCode, prefectures);
-      if (cityPrefCode != null && cityPrefCode != state.prefectureCode) {
-        // 別の都道府県の市区町村 → その都道府県にフォーカス切り替え
-        final prefInfo = prefectures
-            .where((p) => p.code == cityPrefCode)
-            .firstOrNull;
-        if (prefInfo == null) {
-          return;
-        }
-        ref
-            .read(intensityHistoryControllerProvider.notifier)
-            .focusPrefecture(
-              code: prefInfo.code,
-              name: prefInfo.name.ja,
-              selectedCityCode: cityCode,
-              selectedCityName: cityName,
-            );
-        final bounds = _buildPrefectureBounds(
-          prefCode: prefInfo.code,
-          jmaMap: jmaMap,
-          prefectures: prefectures,
-        );
-        if (bounds != null && context.mounted) {
-          await mapController.fitBounds(
-            bounds: bounds,
-            padding: const EdgeInsets.all(48),
-          );
-        }
-        return;
-      }
-
-      final prefCode = state.prefectureCode;
-      final cityHighest = ref
-          .read(cityHighestProvider(prefCode))
-          .valueOrPrevious;
-      HighestIntensityEntry? summary;
-      if (cityHighest != null) {
-        summary = cityHighest.where((e) => e.code == cityCode).firstOrNull;
-      }
-
-      if (state.selectedCityCode != cityCode) {
-        ref
-            .read(intensityHistoryControllerProvider.notifier)
-            .selectCity(code: cityCode, name: cityName);
-        return;
-      }
-
-      if (!context.mounted) {
-        return;
-      }
-      await showCityDetailModal(
-        context,
-        cityCode: cityCode,
-        cityName: cityName,
-        regionName: state.prefectureName,
-        summary: summary,
-      );
-    } else if (hitRegion && state is IntensityHistoryStatePrefecture) {
-      // Lv1: 細分区域タップ → 都道府県フォーカス
-      final mapData = jmaMap.areaForecastLocalE;
-      final result = JmaMapUtility().findNearestItem(latLng, mapData);
-      final item = result.item;
-      if (item == null) {
-        return;
-      }
-
-      final regionCode = item.property.code;
-
-      final paramAsync = ref.read(parameterSetProvider);
-      final prefectures =
-          paramAsync.valueOrPrevious?.earthquake.prefectures ?? [];
-
-      final prefInfo = prefectureOfRegionCode(regionCode, prefectures);
-      if (prefInfo == null) {
-        return;
-      }
-
-      ref
-          .read(intensityHistoryControllerProvider.notifier)
-          .focusPrefecture(code: prefInfo.code, name: prefInfo.name);
-
-      // 都道府県の bounds へズーム
-      final bounds = _buildPrefectureBounds(
-        prefCode: prefInfo.code,
-        jmaMap: jmaMap,
-        prefectures: prefectures,
-      );
-      if (bounds != null && context.mounted) {
-        await mapController.fitBounds(
-          bounds: bounds,
-          padding: const EdgeInsets.all(48),
-        );
-      }
-    }
-  }
-
-  LngLatBounds? _buildPrefectureBounds({
-    required String prefCode,
-    required Map<JmaMapType, JmaMap_JmaMapData> jmaMap,
-    required List<EarthquakeParameterPrefectureItem> prefectures,
-  }) {
-    final regionCodes = regionCodesOfPrefecture(prefCode, prefectures);
-    if (regionCodes.isEmpty) {
-      return null;
-    }
-
-    final regionSet = Set<String>.from(regionCodes);
-    final items = jmaMap.areaForecastLocalE.data
-        .where(
-          (item) => regionSet.contains(item.property.code) && item.hasBounds(),
-        )
-        .toList();
-
-    if (items.isEmpty) {
-      return null;
-    }
-
-    // 1件目で初期化
-    final firstBounds = items.first.bounds;
-    var minLat = firstBounds.southWest.lat;
-    var minLng = firstBounds.southWest.lng;
-    var maxLat = firstBounds.northEast.lat;
-    var maxLng = firstBounds.northEast.lng;
-
-    for (final item in items.skip(1)) {
-      final b = item.bounds;
-      final swLat = b.southWest.lat;
-      final swLng = b.southWest.lng;
-      final neLat = b.northEast.lat;
-      final neLng = b.northEast.lng;
-
-      if (swLat < minLat) {
-        minLat = swLat;
-      }
-      if (swLng < minLng) {
-        minLng = swLng;
-      }
-      if (neLat > maxLat) {
-        maxLat = neLat;
-      }
-      if (neLng > maxLng) {
-        maxLng = neLng;
-      }
-    }
-
-    return LngLatBounds(
-      longitudeWest: minLng,
-      longitudeEast: maxLng,
-      latitudeSouth: minLat,
-      latitudeNorth: maxLat,
-    );
-  }
-
-  void _zoomToJapan(MapController mapController) {
-    unawaited(
-      mapController.fitBounds(
-        bounds: _japanBounds,
-        padding: const EdgeInsets.all(32),
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      clipBehavior: Clip.hardEdge,
+      child: InkWell(
+        onTap: onTap,
+        child: const Tooltip(
+          message: '全国表示に戻る',
+          child: Padding(
+            padding: EdgeInsets.all(8),
+            child: Icon(Icons.public_rounded),
+          ),
+        ),
       ),
     );
   }

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_expression.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_expression.dart
@@ -8,6 +8,10 @@ import 'package:eqmonitor/core/util/converter/color_converter.dart';
 /// [pairs] に指定した各 code に [IntensityColors] から算出した震度背景色を
 /// 割り当てる。該当なし区域は透明(`rgba(0,0,0,0)`)。
 ///
+/// 同一 code が複数含まれる場合は最大震度側に畳み込む。MapLibre の match 式は
+/// ラベルの重複を許容せず、1 件でも重複すると式全体が不正になりレイヤーが
+/// 一切描画されないため、呼び出し側の入力に依らず必ず一意化する。
+///
 /// [propertyKey] はフィーチャの照合に使うプロパティ名。
 /// - `areaForecastLocalE`(細分区域): `code`(デフォルト)。
 /// - `areaInformationCityQuake`(市区町村): `regioncode`。
@@ -20,16 +24,24 @@ List<Object> buildIntensityMatchExpression(
   IntensityColors colorModel, {
   String propertyKey = 'code',
 }) {
+  final intensityByCode = <String, JmaIntensity>{};
+  for (final pair in pairs) {
+    final current = intensityByCode[pair.code];
+    if (current == null || pair.intensity.orderIndex > current.orderIndex) {
+      intensityByCode[pair.code] = pair.intensity;
+    }
+  }
+
   final args = <Object>[
     'match',
     <Object>['get', propertyKey],
   ];
 
-  for (final pair in pairs) {
+  for (final entry in intensityByCode.entries) {
     args
-      ..add(pair.code)
+      ..add(entry.key)
       ..add(
-        colorModel.fromJmaIntensity(pair.intensity).background.toHexStringRGB(),
+        colorModel.fromJmaIntensity(entry.value).background.toHexStringRGB(),
       );
   }
 

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer.dart
@@ -2,18 +2,15 @@ import 'dart:async';
 
 import 'package:eqmonitor/core/extension/async_value.dart';
 import 'package:eqmonitor/core/hook/use_map_operation_queue.dart';
-import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
 import 'package:eqmonitor/core/provider/log/talker.dart';
 import 'package:eqmonitor/core/theme/provider/app_theme_notifier.dart';
 import 'package:eqmonitor/core/util/map/replace_map_style_layers.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
 import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
-import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/city_highest_provider.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/intensity_history_controller.dart';
 import 'package:eqmonitor/feature/intensity_history/data/notifier/prefecture_highest_provider.dart';
-import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_expression.dart';
-import 'package:eqmonitor/feature/map/data/model/base_map_tile_spec.dart';
-import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer_builder.dart';
 import 'package:eqmonitor/feature/parameter/data/notifier/parameter_set_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -22,23 +19,15 @@ import 'package:maplibre/maplibre.dart';
 
 /// 地域別最大震度マップ用の震度 fill レイヤー Widget。
 ///
-/// - Lv1(都道府県): `areaForecastLocalE` に都道府県最高震度の match 式で塗り分け。
-/// - Lv2(市区町村): `areaInformationCityQuake` に市区町村最高震度で塗り分け +
-///   非選択都道府県を半透明黒でディム。
+/// - Lv1(全国): `areaForecastLocalE` に都道府県最高震度の match 式で塗り分け。
+/// - Lv2(都道府県フォーカス): `areaInformationCityQuake` に市区町村最高震度で
+///   塗り分け + フォーカス外の都道府県を半透明黒でディム。
 ///
-/// `earthquake_history_fill_layer.dart` / `earthquake_history_region_intensity_layer.dart`
-/// の構造に倣い、`useEffect` でレイヤー追加・dispose でレイヤー除去。
+/// 全レイヤーを 1 つの `useEffect` でまとめて置き換える。レイヤーごとに
+/// `useEffect` を分けると、依存の異なる effect が別々に再実行された際に
+/// 追加順が入れ替わり、Lv1 の塗りが Lv2 の塗り・ディムを覆ってしまう。
 class IntensityFillLayer extends HookConsumerWidget {
   const IntensityFillLayer({super.key});
-
-  // --- Layer ID 定数 ---
-  static const _lv1FillLayerId = 'intensity-history-lv1-fill';
-  static const _lv2FillLayerId = 'intensity-history-lv2-city-fill';
-  static const _selectedCityDimLayerId =
-      'intensity-history-lv2-selected-city-dim';
-  static const _dimFillLayerId = 'intensity-history-lv2-dim-fill';
-  static const _selectedCityLineLayerId =
-      'intensity-history-lv2-selected-city-line';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -47,238 +36,49 @@ class IntensityFillLayer extends HookConsumerWidget {
     final state = ref.watch(intensityHistoryControllerProvider);
     final isDarkMode = Theme.brightnessOf(context) == Brightness.dark;
 
-    // --- パラメーター (AsyncValue) ---
-    final parameterAsync = ref.watch(parameterSetProvider);
-    final prefectures = parameterAsync.valueOrPrevious?.earthquake.prefectures;
+    final prefectures = ref
+        .watch(parameterSetProvider)
+        .valueOrPrevious
+        ?.earthquake
+        .prefectures;
+    final prefectureHighest = ref
+        .watch(prefectureHighestProvider)
+        .valueOrPrevious;
 
-    // --- Lv1: 都道府県最高震度 ---
-    final prefectureHighestAsync = ref.watch(prefectureHighestProvider);
-    final prefectureHighest = prefectureHighestAsync.valueOrPrevious;
-
-    // --- Lv2: 市区町村最高震度 (City 状態のときのみ) ---
-    final selectedPrefCode = state is IntensityHistoryStateCity
-        ? state.prefectureCode
-        : null;
-    final selectedCityCode = state is IntensityHistoryStateCity
-        ? state.selectedCityCode
-        : null;
-    final cityHighestAsync = selectedPrefCode != null
-        ? ref.watch(cityHighestProvider(selectedPrefCode))
-        : null;
-    final cityHighest = cityHighestAsync?.valueOrPrevious;
+    final focusedPrefectureCode = switch (state) {
+      IntensityHistoryStateCity(:final prefectureCode) => prefectureCode,
+      IntensityHistoryStatePrefecture() => null,
+    };
+    final cityHighest = focusedPrefectureCode == null
+        ? null
+        : ref.watch(cityHighestProvider(focusedPrefectureCode)).valueOrPrevious;
 
     final enqueue = useMapOperationQueue();
+    const builder = IntensityFillLayerBuilder();
 
-    // --- Lv1 fill effect ---
-    useEffect(() {
-      if (styleController == null || prefectures == null) {
-        return null;
-      }
-      if (prefectureHighest == null || prefectureHighest.isEmpty) {
-        return null;
-      }
-
-      unawaited(
-        enqueue(() async {
-          try {
-            // 都道府県コード → 配下の細分区域コード(areaForecastLocalE)に展開
-            final pairs = <({String code, JmaIntensity intensity})>[];
-            for (final entry in prefectureHighest) {
-              final regionCodes = regionCodesOfPrefecture(
-                entry.code,
-                prefectures,
-              );
-              for (final code in regionCodes) {
-                pairs.add((code: code, intensity: entry.intensity));
-              }
-            }
-
-            final fillColor = buildIntensityMatchExpression(pairs, colorModel);
-
-            await replaceMapStyleLayers(
-              styleController: styleController,
-              layerIds: const [_lv1FillLayerId],
-              layers: [
-                (
-                  layer: FillStyleLayer(
-                    id: _lv1FillLayerId,
-                    sourceId: 'eqmonitor_map',
-                    sourceLayerId: 'areaForecastLocalE',
-                    paint: {'fill-color': fillColor, 'fill-opacity': 0.7},
-                  ),
-                  belowLayerId: BaseLayer.areaForecastLocalELine.name,
-                  aboveLayerId: null,
-                  atIndex: null,
-                ),
-              ],
-            );
-          } on Exception catch (e) {
-            talker.log(e);
-          }
-        }),
-      );
-
-      return () {
-        unawaited(
-          enqueue(() async {
-            try {
-              await styleController.removeLayer(_lv1FillLayerId);
-            } on Exception catch (e) {
-              talker.log(e);
-            }
-          }),
-        );
-      };
-    }, [styleController, prefectures, prefectureHighest, colorModel]);
-
-    // --- Lv2 city fill + dim effect ---
     useEffect(
       () {
         if (styleController == null ||
             prefectures == null ||
-            selectedPrefCode == null) {
+            prefectureHighest == null) {
           return null;
         }
-        if (cityHighest == null || cityHighest.isEmpty) {
-          return null;
-        }
+
+        final layers = builder.build(
+          state: state,
+          prefectureHighest: prefectureHighest,
+          cityHighest: cityHighest ?? const <HighestIntensityEntry>[],
+          prefectures: prefectures,
+          colorModel: colorModel,
+          isDarkMode: isDarkMode,
+        );
 
         unawaited(
           enqueue(() async {
             try {
-              // 市区町村 code → 最高震度 pairs (api.JmaIntensity → app.JmaIntensity 変換)
-              final pairs = cityHighest
-                  .map((e) => (code: e.code, intensity: e.intensity))
-                  .toList();
-              // areaInformationCityQuake のフィーチャ照合プロパティは `regioncode`。
-              // (earthquake_history_fill_layer.dart の cityCodeFilter 参照)
-              final fillColor = buildIntensityMatchExpression(
-                pairs,
-                colorModel,
-                propertyKey: 'regioncode',
-              );
-
-              final layers = <MapStyleLayerEntry>[
-                (
-                  layer: FillStyleLayer(
-                    id: _lv2FillLayerId,
-                    sourceId: 'eqmonitor_map',
-                    sourceLayerId: 'areaInformationCityQuake',
-                    paint: {
-                      'fill-color': fillColor,
-                      // 市区町村ポリゴンは cityMinZoom 未満のタイルに存在しないため、
-                      // その帯では Lv1 (細分区域) の塗りつぶしが可視表現になる。
-                      'fill-opacity': <Object>[
-                        'step',
-                        <Object>['zoom'],
-                        0.0,
-                        BaseMapTileSpec.cityMinZoom,
-                        0.8,
-                      ],
-                    },
-                  ),
-                  belowLayerId: BaseLayer.areaForecastLocalELine.name,
-                  aboveLayerId: null,
-                  atIndex: null,
-                ),
-              ];
-
-              final dimAnchorLayerId = selectedCityCode == null
-                  ? _lv2FillLayerId
-                  : _selectedCityDimLayerId;
-
-              if (selectedCityCode != null) {
-                final selectedCityCodes = cityCodesOfPrefecture(
-                  selectedPrefCode,
-                  prefectures,
-                );
-                layers.add((
-                  layer: FillStyleLayer(
-                    id: _selectedCityDimLayerId,
-                    sourceId: 'eqmonitor_map',
-                    sourceLayerId: 'areaInformationCityQuake',
-                    filter: <Object>[
-                      'all',
-                      <Object>[
-                        'in',
-                        <Object>['get', 'regioncode'],
-                        <Object>['literal', selectedCityCodes],
-                      ],
-                      <Object>[
-                        '!=',
-                        <Object>['get', 'regioncode'],
-                        selectedCityCode,
-                      ],
-                    ],
-                    paint: const {
-                      'fill-color': '#000000',
-                      'fill-opacity': 0.55,
-                    },
-                  ),
-                  belowLayerId: null,
-                  aboveLayerId: _lv2FillLayerId,
-                  atIndex: null,
-                ));
-              }
-
-              // ディムオーバーレイ: 選択都道府県の細分区域コードを除外した全エリアを半透明黒で覆う
-              final selectedRegionCodes = regionCodesOfPrefecture(
-                selectedPrefCode,
-                prefectures,
-              );
-              final dimFilter = <Object>[
-                '!',
-                <Object>[
-                  'in',
-                  <Object>['get', 'code'],
-                  <Object>['literal', selectedRegionCodes],
-                ],
-              ];
-
-              layers.add((
-                layer: FillStyleLayer(
-                  id: _dimFillLayerId,
-                  sourceId: 'eqmonitor_map',
-                  sourceLayerId: 'areaForecastLocalE',
-                  filter: dimFilter,
-                  paint: const {'fill-color': '#000000', 'fill-opacity': 0.45},
-                ),
-                belowLayerId: null,
-                aboveLayerId: dimAnchorLayerId,
-                atIndex: null,
-              ));
-
-              if (selectedCityCode != null) {
-                layers.add((
-                  layer: LineStyleLayer(
-                    id: _selectedCityLineLayerId,
-                    sourceId: 'eqmonitor_map',
-                    sourceLayerId: 'areaInformationCityQuake',
-                    filter: <Object>[
-                      '==',
-                      <Object>['get', 'regioncode'],
-                      selectedCityCode,
-                    ],
-                    paint: {
-                      'line-color': isDarkMode ? '#FFFFFF' : '#000000',
-                      'line-width': 4,
-                      'line-opacity': 0.95,
-                    },
-                  ),
-                  belowLayerId: null,
-                  aboveLayerId: BaseLayer.areaForecastLocalELine.name,
-                  atIndex: null,
-                ));
-              }
-
               await replaceMapStyleLayers(
                 styleController: styleController,
-                layerIds: const [
-                  _lv2FillLayerId,
-                  _selectedCityDimLayerId,
-                  _dimFillLayerId,
-                  _selectedCityLineLayerId,
-                ],
+                layerIds: IntensityFillLayerBuilder.layerIds,
                 layers: layers,
               );
             } on Exception catch (e) {
@@ -290,12 +90,7 @@ class IntensityFillLayer extends HookConsumerWidget {
         return () {
           unawaited(
             enqueue(() async {
-              for (final id in [
-                _lv2FillLayerId,
-                _selectedCityDimLayerId,
-                _dimFillLayerId,
-                _selectedCityLineLayerId,
-              ]) {
+              for (final id in IntensityFillLayerBuilder.layerIds.reversed) {
                 try {
                   await styleController.removeLayer(id);
                 } on Exception catch (e) {
@@ -309,11 +104,12 @@ class IntensityFillLayer extends HookConsumerWidget {
       [
         styleController,
         prefectures,
-        selectedPrefCode,
-        selectedCityCode,
+        prefectureHighest,
         cityHighest,
+        state,
         colorModel,
         isDarkMode,
+        enqueue,
       ],
     );
 

--- a/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer_builder.dart
+++ b/app/lib/feature/intensity_history/ui/layer/intensity_fill_layer_builder.dart
@@ -1,0 +1,230 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/theme/model/intensity_colors.dart';
+import 'package:eqmonitor/core/util/map/replace_map_style_layers.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/region_code_mapping.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_expression.dart';
+import 'package:eqmonitor/feature/map/data/model/base_map_tile_spec.dart';
+import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:maplibre/maplibre.dart';
+
+/// 地域別最大震度マップの fill/line レイヤー一式を組み立てる。
+///
+/// 全レイヤーを 1 回の [build] で、必ず「下 → 上」の順に返す。
+/// レイヤーごとに個別の `useEffect` で追加すると、片方だけが再実行された際に
+/// 追加順が入れ替わり Lv1(細分区域)の塗りが Lv2(市区町村)の塗りを覆ってしまう
+/// ため、順序はこのクラスに集約する。
+class IntensityFillLayerBuilder {
+  const IntensityFillLayerBuilder();
+
+  static const sourceId = 'eqmonitor_map';
+  static const regionSourceLayerId = 'areaForecastLocalE';
+  static const citySourceLayerId = 'areaInformationCityQuake';
+
+  /// 全国の細分区域の塗り。Lv2 ではフォーカス中の都道府県を除外する。
+  static const regionFillLayerId = 'intensity-history-region-fill';
+
+  /// フォーカス中の都道府県の細分区域の塗り。
+  static const focusedRegionFillLayerId =
+      'intensity-history-focused-region-fill';
+
+  /// フォーカス中の都道府県の市区町村の塗り。
+  static const cityFillLayerId = 'intensity-history-city-fill';
+
+  /// フォーカス中の都道府県以外を覆うディム。
+  static const dimFillLayerId = 'intensity-history-dim-fill';
+
+  /// 選択中の市区町村の輪郭線。
+  static const selectedCityLineLayerId = 'intensity-history-selected-city-line';
+
+  /// [build] が生成しうる全レイヤー ID。除去時にも利用する。
+  static const layerIds = [
+    regionFillLayerId,
+    focusedRegionFillLayerId,
+    cityFillLayerId,
+    dimFillLayerId,
+    selectedCityLineLayerId,
+  ];
+
+  static const regionFillOpacity = 0.7;
+  static const cityFillOpacity = 0.8;
+  static const dimFillOpacity = 0.45;
+
+  List<MapStyleLayerEntry> build({
+    required IntensityHistoryState state,
+    required List<HighestIntensityEntry> prefectureHighest,
+    required List<HighestIntensityEntry> cityHighest,
+    required List<EarthquakeParameterPrefectureItem> prefectures,
+    required IntensityColors colorModel,
+    required bool isDarkMode,
+  }) {
+    final focusedPrefectureCode = switch (state) {
+      IntensityHistoryStateCity(:final prefectureCode) => prefectureCode,
+      IntensityHistoryStatePrefecture() => null,
+    };
+    final selectedCityCode = switch (state) {
+      IntensityHistoryStateCity(:final selectedCityCode) => selectedCityCode,
+      IntensityHistoryStatePrefecture() => null,
+    };
+    final focusedRegionCodes = focusedPrefectureCode == null
+        ? const <String>[]
+        : regionCodesOfPrefecture(focusedPrefectureCode, prefectures);
+    final hasCityFill = focusedPrefectureCode != null && cityHighest.isNotEmpty;
+
+    final entries = <MapStyleLayerEntry>[];
+
+    final regionPairs = regionIntensityPairs(
+      prefectureHighest: prefectureHighest,
+      prefectures: prefectures,
+    );
+    if (regionPairs.isNotEmpty) {
+      final fillColor = buildIntensityMatchExpression(regionPairs, colorModel);
+      entries.add(
+        belowRegionLine(
+          FillStyleLayer(
+            id: regionFillLayerId,
+            sourceId: sourceId,
+            sourceLayerId: regionSourceLayerId,
+            filter: focusedRegionCodes.isEmpty
+                ? null
+                : <Object>['!', regionCodeFilter(focusedRegionCodes)],
+            paint: {'fill-color': fillColor, 'fill-opacity': regionFillOpacity},
+          ),
+        ),
+      );
+
+      if (focusedRegionCodes.isNotEmpty) {
+        // 市区町村ポリゴンは cityMinZoom 未満のタイルに存在しないため、その帯では
+        // 細分区域の塗りを可視表現として残す。市区町村の塗りが出るズームでは
+        // 半透明の重なりによる混色を避けるため透明にする。
+        entries.add(
+          belowRegionLine(
+            FillStyleLayer(
+              id: focusedRegionFillLayerId,
+              sourceId: sourceId,
+              sourceLayerId: regionSourceLayerId,
+              filter: regionCodeFilter(focusedRegionCodes),
+              paint: {
+                'fill-color': fillColor,
+                'fill-opacity': hasCityFill
+                    ? <Object>[
+                        'step',
+                        <Object>['zoom'],
+                        regionFillOpacity,
+                        BaseMapTileSpec.cityMinZoom,
+                        0.0,
+                      ]
+                    : regionFillOpacity,
+              },
+            ),
+          ),
+        );
+      }
+    }
+
+    if (hasCityFill) {
+      // areaInformationCityQuake のフィーチャ照合プロパティは `regioncode`。
+      // (earthquake_history_fill_layer.dart の cityCodeFilter 参照)
+      final fillColor = buildIntensityMatchExpression(
+        cityHighest
+            .map((entry) => (code: entry.code, intensity: entry.intensity))
+            .toList(),
+        colorModel,
+        propertyKey: 'regioncode',
+      );
+      entries.add(
+        belowRegionLine(
+          FillStyleLayer(
+            id: cityFillLayerId,
+            sourceId: sourceId,
+            sourceLayerId: citySourceLayerId,
+            paint: {
+              'fill-color': fillColor,
+              'fill-opacity': <Object>[
+                'step',
+                <Object>['zoom'],
+                0.0,
+                BaseMapTileSpec.cityMinZoom,
+                cityFillOpacity,
+              ],
+            },
+          ),
+        ),
+      );
+    }
+
+    if (focusedRegionCodes.isNotEmpty) {
+      entries.add(
+        belowRegionLine(
+          FillStyleLayer(
+            id: dimFillLayerId,
+            sourceId: sourceId,
+            sourceLayerId: regionSourceLayerId,
+            filter: <Object>['!', regionCodeFilter(focusedRegionCodes)],
+            paint: const {
+              'fill-color': '#000000',
+              'fill-opacity': dimFillOpacity,
+            },
+          ),
+        ),
+      );
+    }
+
+    if (selectedCityCode != null) {
+      entries.add((
+        layer: LineStyleLayer(
+          id: selectedCityLineLayerId,
+          sourceId: sourceId,
+          sourceLayerId: citySourceLayerId,
+          filter: <Object>[
+            '==',
+            <Object>['get', 'regioncode'],
+            selectedCityCode,
+          ],
+          paint: {
+            'line-color': isDarkMode ? '#FFFFFF' : '#000000',
+            'line-width': 3,
+            'line-opacity': 0.95,
+          },
+        ),
+        belowLayerId: null,
+        aboveLayerId: BaseLayer.areaForecastLocalELine.name,
+        atIndex: null,
+      ));
+    }
+
+    return entries;
+  }
+
+  /// 都道府県ごとの最高震度を、配下の細分区域コードへ展開する。
+  ///
+  /// `areaForecastLocalE` のフィーチャは細分区域コードを持つため、
+  /// 都道府県コードのままでは 1 区域も一致しない。
+  List<({String code, JmaIntensity intensity})> regionIntensityPairs({
+    required List<HighestIntensityEntry> prefectureHighest,
+    required List<EarthquakeParameterPrefectureItem> prefectures,
+  }) => [
+    for (final entry in prefectureHighest)
+      for (final code in regionCodesOfPrefecture(entry.code, prefectures))
+        (code: code, intensity: entry.intensity),
+  ];
+
+  List<Object> regionCodeFilter(List<String> codes) => <Object>[
+    'in',
+    <Object>['get', 'code'],
+    <Object>['literal', codes],
+  ];
+
+  /// 細分区域の境界線より下に挿入する。
+  ///
+  /// [replaceMapStyleLayers] は与えられた順に「同じアンカーの直下」へ挿入する
+  /// ため、先に渡したものが下、後に渡したものが上になる。
+  MapStyleLayerEntry belowRegionLine(StyleLayer layer) => (
+    layer: layer,
+    belowLayerId: BaseLayer.areaForecastLocalELine.name,
+    aboveLayerId: null,
+    atIndex: null,
+  );
+}

--- a/app/test/feature/intensity_history/intensity_fill_expression_test.dart
+++ b/app/test/feature/intensity_history/intensity_fill_expression_test.dart
@@ -109,6 +109,32 @@ void main() {
       expect(result[1], equals(<Object>['get', 'code']));
     });
 
+    test('同一 code が重複しても match ラベルは一意になり最大震度が採用される', () {
+      const pairs = [
+        (code: '010', intensity: JmaIntensity.three),
+        (code: '010', intensity: JmaIntensity.fiveUpper),
+        (code: '010', intensity: JmaIntensity.four),
+        (code: '020', intensity: JmaIntensity.one),
+      ];
+
+      final result = buildIntensityMatchExpression(pairs, colorModel);
+
+      // ['match', ['get','code'], '010', c(5+), '020', c(1), 'rgba(0,0,0,0)']
+      expect(result, hasLength(7));
+      expect(result[2], equals('010'));
+      expect(
+        result[3],
+        equals(
+          colorModel
+              .fromJmaIntensity(JmaIntensity.fiveUpper)
+              .background
+              .toHexStringRGB(),
+        ),
+      );
+      expect(result[4], equals('020'));
+      expect(result.last, equals('rgba(0,0,0,0)'));
+    });
+
     test('propertyKey に regioncode を指定すると get 式に反映される', () {
       const pairs = [
         (code: '0110100', intensity: JmaIntensity.four),

--- a/app/test/feature/intensity_history/intensity_fill_layer_builder_test.dart
+++ b/app/test/feature/intensity_history/intensity_fill_layer_builder_test.dart
@@ -1,0 +1,328 @@
+import 'package:eqmonitor/core/model/intensity/jma_intensity.dart';
+import 'package:eqmonitor/core/model/telegram/telegram_status.dart';
+import 'package:eqmonitor/core/theme/model/app_theme.dart';
+import 'package:eqmonitor/core/theme/model/intensity_colors.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_data_source.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_depth.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_hypocenter.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_intensity_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_magnitude.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_partial.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_telegram_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/earthquake_type.dart';
+import 'package:eqmonitor/feature/earthquake_history/data/model/origin_time_precision.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/highest_intensity_entry.dart';
+import 'package:eqmonitor/feature/intensity_history/data/model/intensity_history_state.dart';
+import 'package:eqmonitor/feature/intensity_history/ui/layer/intensity_fill_layer_builder.dart';
+import 'package:eqmonitor/feature/map/data/model/base_map_tile_spec.dart';
+import 'package:eqmonitor/feature/map/data/provider/map_style_util.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_common.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+LocalizedName _name(String ja) => LocalizedName(ja: ja, en: ja);
+
+EarthquakeParameterCityItem _city(String code) => EarthquakeParameterCityItem(
+  code: code,
+  name: _name('city-$code'),
+  kana: null,
+  stations: const [],
+);
+
+EarthquakeParameterRegionItem _region(String code, List<String> cityCodes) =>
+    EarthquakeParameterRegionItem(
+      code: code,
+      name: _name('region-$code'),
+      kana: null,
+      cities: cityCodes.map(_city).toList(),
+    );
+
+final _prefectures = [
+  EarthquakeParameterPrefectureItem(
+    code: '01',
+    name: _name('北海道'),
+    regions: [
+      _region('100', ['0110100']),
+      _region('101', ['0110200']),
+    ],
+  ),
+  EarthquakeParameterPrefectureItem(
+    code: '04',
+    name: _name('宮城県'),
+    regions: [
+      _region('220', ['0410000']),
+    ],
+  ),
+];
+
+final _earthquake = EarthquakePartialNormal(
+  eventId: '20240101000000',
+  status: TelegramStatus.normal,
+  originTime: DateTime(2024, 1, 1, 16, 10),
+  originTimePrecision: OriginTimePrecision.minute,
+  arrivalTime: DateTime(2024, 1, 1, 16, 11),
+  dataSources: const [EarthquakeDataSource.jmaIntensityDatabase],
+  hypocenter: const EarthquakeHypocenter(
+    code: '123',
+    name: '能登半島沖',
+    coordinates: null,
+    magnitude: EarthquakeMagnitude.value(value: 7.6),
+    depth: EarthquakeDepth.shallow(),
+    detailedCode: null,
+    detailedName: null,
+  ),
+  intensity: const EarthquakeIntensityPartial(
+    maxIntensity: JmaIntensity.seven,
+    maxLpgmIntensity: null,
+  ),
+  earthquakeType: EarthquakeType.normal,
+  telegramTypes: const [EarthquakeTelegramType.vxse53],
+  estimatedIntensityTileUrl: null,
+);
+
+HighestIntensityEntry _entry(String code, JmaIntensity intensity) =>
+    HighestIntensityEntry(
+      code: code,
+      name: 'name-$code',
+      intensity: intensity,
+      count: 1,
+      earthquake: _earthquake,
+    );
+
+void main() {
+  const builder = IntensityFillLayerBuilder();
+  late IntensityColors colorModel;
+
+  setUp(() {
+    colorModel = AppTheme.eqmonitorDefault().light!.intensity;
+  });
+
+  List<String> idsOf(IntensityHistoryState state, {bool withCity = true}) =>
+      builder
+          .build(
+            state: state,
+            prefectureHighest: [
+              _entry('01', JmaIntensity.fiveLower),
+              _entry('04', JmaIntensity.four),
+            ],
+            cityHighest: withCity
+                ? [_entry('0110100', JmaIntensity.fiveLower)]
+                : const [],
+            prefectures: _prefectures,
+            colorModel: colorModel,
+            isDarkMode: false,
+          )
+          .map((entry) => entry.layer.id)
+          .toList();
+
+  group('build', () {
+    test('全国表示では細分区域の塗りだけを返す', () {
+      expect(idsOf(const IntensityHistoryState.prefecture()), [
+        IntensityFillLayerBuilder.regionFillLayerId,
+      ]);
+    });
+
+    test('都道府県フォーカス中は 下→上 の決定的な順序で返す', () {
+      expect(
+        idsOf(
+          const IntensityHistoryState.city(
+            prefectureCode: '01',
+            prefectureName: '北海道',
+            selectedCityCode: '0110100',
+            selectedCityName: '札幌中央区',
+          ),
+        ),
+        [
+          IntensityFillLayerBuilder.regionFillLayerId,
+          IntensityFillLayerBuilder.focusedRegionFillLayerId,
+          IntensityFillLayerBuilder.cityFillLayerId,
+          IntensityFillLayerBuilder.dimFillLayerId,
+          IntensityFillLayerBuilder.selectedCityLineLayerId,
+        ],
+      );
+    });
+
+    test('市区町村が未選択なら輪郭線レイヤーを追加しない', () {
+      expect(
+        idsOf(
+          const IntensityHistoryState.city(
+            prefectureCode: '01',
+            prefectureName: '北海道',
+          ),
+        ),
+        isNot(contains(IntensityFillLayerBuilder.selectedCityLineLayerId)),
+      );
+    });
+
+    test('市区町村の最高震度が未取得なら市区町村の塗りを追加しない', () {
+      expect(
+        idsOf(
+          const IntensityHistoryState.city(
+            prefectureCode: '01',
+            prefectureName: '北海道',
+          ),
+          withCity: false,
+        ),
+        isNot(contains(IntensityFillLayerBuilder.cityFillLayerId)),
+      );
+    });
+
+    test('全国の塗りはフォーカス中の都道府県を除外する', () {
+      final layers = builder.build(
+        state: const IntensityHistoryState.city(
+          prefectureCode: '01',
+          prefectureName: '北海道',
+        ),
+        prefectureHighest: [_entry('01', JmaIntensity.fiveLower)],
+        cityHighest: [_entry('0110100', JmaIntensity.fiveLower)],
+        prefectures: _prefectures,
+        colorModel: colorModel,
+        isDarkMode: false,
+      );
+
+      final regionFill = layers
+          .where(
+            (entry) =>
+                entry.layer.id == IntensityFillLayerBuilder.regionFillLayerId,
+          )
+          .single;
+      expect(regionFill.layer.filter, [
+        '!',
+        [
+          'in',
+          ['get', 'code'],
+          [
+            'literal',
+            ['100', '101'],
+          ],
+        ],
+      ]);
+    });
+
+    test('市区町村の塗りが出るズームではフォーカス中都道府県の塗りを透明にする', () {
+      final layers = builder.build(
+        state: const IntensityHistoryState.city(
+          prefectureCode: '01',
+          prefectureName: '北海道',
+        ),
+        prefectureHighest: [_entry('01', JmaIntensity.fiveLower)],
+        cityHighest: [_entry('0110100', JmaIntensity.fiveLower)],
+        prefectures: _prefectures,
+        colorModel: colorModel,
+        isDarkMode: false,
+      );
+
+      final focused = layers
+          .where(
+            (entry) =>
+                entry.layer.id ==
+                IntensityFillLayerBuilder.focusedRegionFillLayerId,
+          )
+          .single;
+      expect(focused.layer.paint['fill-opacity'], [
+        'step',
+        ['zoom'],
+        IntensityFillLayerBuilder.regionFillOpacity,
+        BaseMapTileSpec.cityMinZoom,
+        0.0,
+      ]);
+    });
+
+    test('市区町村の最高震度が未取得ならフォーカス中都道府県の塗りを維持する', () {
+      final layers = builder.build(
+        state: const IntensityHistoryState.city(
+          prefectureCode: '01',
+          prefectureName: '北海道',
+        ),
+        prefectureHighest: [_entry('01', JmaIntensity.fiveLower)],
+        cityHighest: const [],
+        prefectures: _prefectures,
+        colorModel: colorModel,
+        isDarkMode: false,
+      );
+
+      final focused = layers
+          .where(
+            (entry) =>
+                entry.layer.id ==
+                IntensityFillLayerBuilder.focusedRegionFillLayerId,
+          )
+          .single;
+      expect(
+        focused.layer.paint['fill-opacity'],
+        IntensityFillLayerBuilder.regionFillOpacity,
+      );
+    });
+
+    test('塗りは細分区域の境界線より下、選択輪郭線はその上に挿入する', () {
+      final layers = builder.build(
+        state: const IntensityHistoryState.city(
+          prefectureCode: '01',
+          prefectureName: '北海道',
+          selectedCityCode: '0110100',
+          selectedCityName: '札幌中央区',
+        ),
+        prefectureHighest: [_entry('01', JmaIntensity.fiveLower)],
+        cityHighest: [_entry('0110100', JmaIntensity.fiveLower)],
+        prefectures: _prefectures,
+        colorModel: colorModel,
+        isDarkMode: false,
+      );
+
+      for (final entry in layers) {
+        if (entry.layer.id ==
+            IntensityFillLayerBuilder.selectedCityLineLayerId) {
+          expect(entry.aboveLayerId, BaseLayer.areaForecastLocalELine.name);
+          expect(entry.belowLayerId, isNull);
+        } else {
+          expect(entry.belowLayerId, BaseLayer.areaForecastLocalELine.name);
+          expect(entry.aboveLayerId, isNull);
+        }
+      }
+    });
+
+    test('都道府県の最高震度が空ならレイヤーを生成しない', () {
+      final layers = builder.build(
+        state: const IntensityHistoryState.prefecture(),
+        prefectureHighest: const [],
+        cityHighest: const [],
+        prefectures: _prefectures,
+        colorModel: colorModel,
+        isDarkMode: false,
+      );
+
+      expect(layers, isEmpty);
+    });
+  });
+
+  group('regionIntensityPairs', () {
+    test('都道府県コードを配下の細分区域コードへ展開する', () {
+      final pairs = builder.regionIntensityPairs(
+        prefectureHighest: [
+          _entry('01', JmaIntensity.fiveLower),
+          _entry('04', JmaIntensity.four),
+        ],
+        prefectures: _prefectures,
+      );
+
+      expect(pairs, [
+        (code: '100', intensity: JmaIntensity.fiveLower),
+        (code: '101', intensity: JmaIntensity.fiveLower),
+        (code: '220', intensity: JmaIntensity.four),
+      ]);
+    });
+
+    test('パラメータに存在しない都道府県コードは無視する', () {
+      final pairs = builder.regionIntensityPairs(
+        prefectureHighest: [_entry('99', JmaIntensity.fiveLower)],
+        prefectures: _prefectures,
+      );
+
+      expect(pairs, isEmpty);
+    });
+  });
+}

--- a/app/test/feature/intensity_history/prefecture_bounds_resolver_test.dart
+++ b/app/test/feature/intensity_history/prefecture_bounds_resolver_test.dart
@@ -1,0 +1,249 @@
+import 'package:eqmonitor/core/provider/map/jma_map_provider.dart';
+import 'package:eqmonitor/feature/intensity_history/data/repository/prefecture_bounds_resolver.dart';
+import 'package:eqmonitor/feature/parameter/data/model/common/parameter_common.dart';
+import 'package:eqmonitor/feature/parameter/data/model/earthquake/earthquake_parameter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jma_map/jma_map.dart';
+import 'package:maplibre/maplibre.dart';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+LocalizedName _name(String ja) => LocalizedName(ja: ja, en: ja);
+
+EarthquakeParameterCityItem _city(String code) => EarthquakeParameterCityItem(
+  code: code,
+  name: _name('city-$code'),
+  kana: null,
+  stations: const [],
+);
+
+EarthquakeParameterRegionItem _region(String code, int cityCount) =>
+    EarthquakeParameterRegionItem(
+      code: code,
+      name: _name('region-$code'),
+      kana: null,
+      cities: List.generate(cityCount, (index) => _city('$code$index')),
+    );
+
+/// 東京都相当のフィクスチャ。
+/// - `100`/`101`: 本土（陸続き・外接矩形が重なる）
+/// - `200`: 伊豆諸島（本土から 1 度以上離れた離島）
+/// - `300`: 小笠原諸島（さらに南方の離島）
+final _prefectures = [
+  EarthquakeParameterPrefectureItem(
+    code: '13',
+    name: _name('東京都'),
+    regions: [
+      _region('100', 23),
+      _region('101', 10),
+      _region('200', 2),
+      _region('300', 1),
+    ],
+  ),
+];
+
+JmaMap_JmaMapData_JmaMapDataItem _item({
+  required String code,
+  required double south,
+  required double north,
+  required double west,
+  required double east,
+}) => JmaMap_JmaMapData_JmaMapDataItem(
+  property: JmaMap_JmaMapData_JmaMapDataItem_Property(code: code, name: code),
+  bounds: JmaMap_LatLngBounds(
+    southWest: JmaMap_LatLng(lat: south, lng: west),
+    northEast: JmaMap_LatLng(lat: north, lng: east),
+  ),
+);
+
+Map<JmaMapType, JmaMap_JmaMapData> _jmaMap() => {
+  JmaMapType.areaForecastLocalE: JmaMap_JmaMapData(
+    mapType: JmaMap_JmaMapData_JmaMapType.AREA_FORECAST_LOCAL_E,
+    data: [
+      _item(code: '100', south: 35.5, north: 35.9, west: 139.5, east: 139.9),
+      _item(code: '101', south: 35.5, north: 35.9, west: 138.9, east: 139.6),
+      _item(code: '200', south: 33.0, north: 34.0, west: 139.1, east: 139.5),
+      _item(code: '300', south: 24.2, north: 27.2, west: 141.0, east: 154.0),
+    ],
+  ),
+};
+
+void main() {
+  const resolver = PrefectureBoundsResolver();
+
+  group('resolve', () {
+    test('遠隔の離島を含めず、市区町村数が最多のクラスタを採用する', () {
+      final bounds = resolver.resolve(
+        prefectureCode: '13',
+        prefectures: _prefectures,
+        jmaMap: _jmaMap(),
+      );
+
+      expect(bounds, isNotNull);
+      expect(bounds!.latitudeSouth, 35.5);
+      expect(bounds.latitudeNorth, 35.9);
+      expect(bounds.longitudeWest, 138.9);
+      expect(bounds.longitudeEast, 139.9);
+    });
+
+    test('seedRegionCode を含むクラスタを優先する', () {
+      final bounds = resolver.resolve(
+        prefectureCode: '13',
+        prefectures: _prefectures,
+        jmaMap: _jmaMap(),
+        seedRegionCode: '300',
+      );
+
+      expect(bounds, isNotNull);
+      expect(bounds!.latitudeSouth, 24.2);
+      expect(bounds.latitudeNorth, 27.2);
+      expect(bounds.longitudeWest, 141.0);
+      expect(bounds.longitudeEast, 154.0);
+    });
+
+    test('存在しない都道府県コードでは null を返す', () {
+      final bounds = resolver.resolve(
+        prefectureCode: '99',
+        prefectures: _prefectures,
+        jmaMap: _jmaMap(),
+      );
+
+      expect(bounds, isNull);
+    });
+
+    test('該当する細分区域ポリゴンが 1 件もない場合は null を返す', () {
+      final bounds = resolver.resolve(
+        prefectureCode: '13',
+        prefectures: _prefectures,
+        jmaMap: {
+          JmaMapType.areaForecastLocalE: JmaMap_JmaMapData(
+            mapType: JmaMap_JmaMapData_JmaMapType.AREA_FORECAST_LOCAL_E,
+            data: [
+              _item(code: '999', south: 35, north: 36, west: 139, east: 140),
+            ],
+          ),
+        },
+      );
+
+      expect(bounds, isNull);
+    });
+  });
+
+  group('clusterByProximity', () {
+    test('外接矩形が重なる区域は同一クラスタになる', () {
+      final clusters = resolver.clusterByProximity([
+        (
+          code: 'a',
+          bounds: const LngLatBounds(
+            longitudeWest: 139.5,
+            longitudeEast: 139.9,
+            latitudeSouth: 35.5,
+            latitudeNorth: 35.9,
+          ),
+        ),
+        (
+          code: 'b',
+          bounds: const LngLatBounds(
+            longitudeWest: 138.9,
+            longitudeEast: 139.6,
+            latitudeSouth: 35.5,
+            latitudeNorth: 35.9,
+          ),
+        ),
+      ]);
+
+      expect(clusters, hasLength(1));
+      expect(clusters.single.map((e) => e.code), containsAll(['a', 'b']));
+    });
+
+    test('ギャップを超えて離れた区域は別クラスタになる', () {
+      final clusters = resolver.clusterByProximity([
+        (
+          code: 'a',
+          bounds: const LngLatBounds(
+            longitudeWest: 139.5,
+            longitudeEast: 139.9,
+            latitudeSouth: 35.5,
+            latitudeNorth: 35.9,
+          ),
+        ),
+        (
+          code: 'b',
+          bounds: const LngLatBounds(
+            longitudeWest: 139.1,
+            longitudeEast: 139.5,
+            latitudeSouth: 33.0,
+            latitudeNorth: 34.0,
+          ),
+        ),
+      ]);
+
+      expect(clusters, hasLength(2));
+    });
+
+    test('連結する区域は推移的に同一クラスタになる', () {
+      final clusters = resolver.clusterByProximity([
+        (
+          code: 'a',
+          bounds: const LngLatBounds(
+            longitudeWest: 139.0,
+            longitudeEast: 139.4,
+            latitudeSouth: 35.0,
+            latitudeNorth: 35.4,
+          ),
+        ),
+        (
+          code: 'c',
+          bounds: const LngLatBounds(
+            longitudeWest: 139.8,
+            longitudeEast: 140.2,
+            latitudeSouth: 35.0,
+            latitudeNorth: 35.4,
+          ),
+        ),
+        (
+          code: 'b',
+          bounds: const LngLatBounds(
+            longitudeWest: 139.3,
+            longitudeEast: 139.9,
+            latitudeSouth: 35.0,
+            latitudeNorth: 35.4,
+          ),
+        ),
+      ]);
+
+      expect(clusters, hasLength(1));
+    });
+  });
+
+  group('unionBounds', () {
+    test('空の場合は null を返す', () {
+      expect(resolver.unionBounds(const []), isNull);
+    });
+
+    test('全体を包含する矩形を返す', () {
+      final bounds = resolver.unionBounds(const [
+        LngLatBounds(
+          longitudeWest: 139.0,
+          longitudeEast: 139.4,
+          latitudeSouth: 35.0,
+          latitudeNorth: 35.4,
+        ),
+        LngLatBounds(
+          longitudeWest: 138.5,
+          longitudeEast: 140.2,
+          latitudeSouth: 34.2,
+          latitudeNorth: 35.1,
+        ),
+      ]);
+
+      expect(bounds, isNotNull);
+      expect(bounds!.longitudeWest, 138.5);
+      expect(bounds.longitudeEast, 140.2);
+      expect(bounds.latitudeSouth, 34.2);
+      expect(bounds.latitudeNorth, 35.4);
+    });
+  });
+}

--- a/docs/knowledge/20260807_map_tap_area_resolution.md
+++ b/docs/knowledge/20260807_map_tap_area_resolution.md
@@ -1,0 +1,45 @@
+# 地図タップ地点の地域判定は Worker Isolate 経由で行う
+
+`JmaMapUtility().findNearestItem` は protobuf の各ポリゴンを
+`Polygon.decode` / `MultiPolygon.decode` しながら内外判定するため、
+main isolate で呼ぶと UI が固まる。`AREA_INFORMATION_CITY` は 1,911 件、
+`AREA_FORECAST_LOCAL_E` は 193 件あり、市区町村判定はタップごとに数百 ms 規模の
+ジャンクになる。
+
+## ルール
+
+判定は `app/lib/feature/location/data/nearest_jma_feature.dart` の provider
+経由で行う。常駐 Worker Isolate（`jmaMapIsolateProvider`）上で実行される。
+
+```dart
+final city = await ref.read(
+  jmaMapAreaInformationCityInsideProvider(LatLng(point.lat, point.lon)).future,
+);
+final code = city?.property?.code;
+```
+
+- `jmaMapAreaForecastLocalEInsideProvider`: 細分区域（3 桁コード）
+- `jmaMapAreaInformationCityInsideProvider`: 市区町村（7 桁コード）
+- `jmaMapAreaForecastLocalEewInsideProvider`: EEW 用区域（4 桁コード）
+- `jmaMapAreaTsunamiNearestProvider`: 津波予報区（海岸線までの距離も返す）
+
+地図を全画面で使うページでは、初回タップを待たせないよう
+`ref.watch(jmaMapIsolateProvider)` で Isolate を事前に温めておく。
+
+## `queryLayers` との使い分け
+
+`MapController.queryLayers(screenPoint)` は「命中したレイヤー」しか返さず、
+フィーチャのプロパティを持たない。ヒット有無のゲートに使うと、
+レイヤーの有無・ズーム帯・タイルの minzoom に暗黙依存して
+「タップしても何も起きない」状態になりやすい。
+
+プロパティが必要なら `MapController.featuresAtPoint(point, layerIds: [...])`
+（`RenderedFeature.properties` を返す）を使う。ただしタイル側のプロパティ名に
+依存するため、コード体系が確定している場合は上記の Isolate 判定のほうが安全。
+
+## ズーム帯による意味づけ
+
+市区町村ポリゴンは `BaseMapTileSpec.cityMinZoom`（6.0）未満のタイルに存在しない。
+ポリゴン判定はズームに関係なく市区町村を返してしまうので、
+「市区町村としてタップを解釈するか」は `MapController.camera?.zoom` で明示的に
+判定すること。

--- a/docs/knowledge/20260807_maplibre_layer_insertion_order.md
+++ b/docs/knowledge/20260807_maplibre_layer_insertion_order.md
@@ -1,0 +1,54 @@
+# MapLibre レイヤーの挿入順は effect の再実行順で壊れる
+
+`StyleController.addLayer(layer, belowLayerId: X)` は「X の直下」へ挿入する
+（iOS: `MLNStyle.insertLayer(_, below:)` / Android: 同等の API）。
+同じアンカー `X` に対して複数のレイヤーを順に追加すると、**後から追加したものが上**
+になる。
+
+```dart
+await style.addLayer(a, belowLayerId: 'line'); // [..., a, line]
+await style.addLayer(b, belowLayerId: 'line'); // [..., a, b, line]  ← b が上
+```
+
+## ハマった問題
+
+`intensity_history` の震度塗り分けは、細分区域(Lv1)用と市区町村(Lv2)用で
+`useEffect` を分けており、どちらも `belowLayerId: areaForecastLocalELine` を
+指定していた。
+
+- 初回は Lv1 → Lv2 の順に追加されるため意図どおり
+- しかし Lv1 側の依存（cache-first SWR による再検証結果、テーマ色）が後から
+  変化して effect が再実行されると、Lv1 が最上位に挿入され Lv2 の塗り・ディムを
+  覆う
+
+例外もログも出ないため「色がときどきおかしい」という再現しにくい不具合になる。
+
+## ルール
+
+- **同一マップ上の複数レイヤーを別々の `useEffect` で追加しない。**
+  1 つの effect でレイヤー一式を組み立て、`replaceMapStyleLayers` に
+  「下 → 上」の順で渡す。
+- レイヤー構築は純粋クラス（例:
+  `app/lib/feature/intensity_history/ui/layer/intensity_fill_layer_builder.dart`）に
+  切り出し、順序・挿入アンカーを unit test で固定する。
+- `belowLayerId` / `aboveLayerId` は存在しないレイヤー ID を渡すと例外になる。
+  ベーススタイルの `BaseLayer` enum（`map_style_util.dart`）以外をアンカーに
+  しないこと。
+- `aboveLayerId` は web では無視される。
+
+## 半透明レイヤーの重ね合わせ
+
+不透明度 < 1 のレイヤーを重ねると下のレイヤーの色が混ざる。震度色のように
+「色そのものが情報」である塗りは重ねないこと。ズームで表示を切り替える場合は、
+下側のレイヤーの `fill-opacity` を `['step', ['zoom'], ...]` で 0 にして
+明示的に消す。
+
+```dart
+'fill-opacity': <Object>[
+  'step',
+  <Object>['zoom'],
+  0.7,                          // cityMinZoom 未満: 細分区域を見せる
+  BaseMapTileSpec.cityMinZoom,
+  0.0,                          // cityMinZoom 以上: 市区町村の塗りに譲る
+],
+```

--- a/docs/todo/300_intensity_history_state_naming.md
+++ b/docs/todo/300_intensity_history_state_naming.md
@@ -1,0 +1,42 @@
+# `IntensityHistoryState` の命名が実態と逆で誤読を招く
+
+## 現状
+
+`app/lib/feature/intensity_history/data/model/intensity_history_state.dart`
+
+| コンストラクタ | 実際の意味 |
+|---|---|
+| `IntensityHistoryState.prefecture()` | 全国表示（都道府県ごとに色分け） |
+| `IntensityHistoryState.city(prefectureCode: ...)` | 特定の**都道府県**にフォーカス（市区町村ごとに色分け） |
+| `IntensityHistoryController.backToPrefecture()` | 全国表示に戻す |
+
+「塗り分けの粒度」を名前にしているが、状態としては「何にフォーカスしているか」を
+表しているため、読み手はほぼ確実に逆の意味に取る。
+
+## 実害
+
+この命名により、タップ処理に
+
+```dart
+} else if (hitRegion && state is IntensityHistoryStatePrefecture) {
+```
+
+という条件が書かれ、「都道府県フォーカス中に別の都道府県をタップしても無反応」という
+不具合が生まれていた（#1614 で修正）。
+
+## 対応方針
+
+- `IntensityHistoryState.prefecture()` → `.nationwide()`
+- `IntensityHistoryState.city(...)` → `.prefectureFocused(...)`
+- `backToPrefecture()` → `backToNationwide()`
+
+参照箇所は以下。Freezed の再生成とテスト更新が必要。
+
+- `data/notifier/intensity_history_controller.dart`
+- `ui/action/intensity_history_map_action.dart`
+- `ui/intensity_history_page.dart`
+- `ui/layer/intensity_fill_layer.dart` / `intensity_fill_layer_builder.dart`
+- `ui/components/region_floating_panel.dart`
+- `test/feature/intensity_history/` 配下
+
+#1614 の変更と競合しやすいため、マージ後に単独の PR で行う。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`app/lib/feature/intensity_history/`（都道府県別 最大震度マップ）の挙動を調査し、塗り分け・タップ判定・カメラ・戻る操作にまたがる不具合をまとめて修正しました。

## 調査で判明した不具合

### 1. Lv1(細分区域)の塗りが Lv2(市区町村)の塗りを覆う

`IntensityFillLayer` が Lv1 用・Lv2 用でレイヤー追加の `useEffect` を分けており、どちらも `belowLayerId: areaForecastLocalELine` を指定していた。`addLayer(belowLayerId:)` は「指定レイヤーの直下」に挿入するため、Lv1 側の effect が後から再実行されると Lv1 の塗りが Lv2 の塗り・ディムより上に来る。`prefectureHighest` は cache-first SWR で再検証結果が後から届くため、都道府県フォーカス中に高確率で発生していた。例外もログも出ないため再現しにくい。

### 2. フォーカス中の都道府県で色が混ざる

Lv2 でも下に Lv1 の塗り(不透明度 0.7)が残っており、その上に市区町村の塗り(0.8)が重なるため、市区町村の震度色が都道府県色と混色していた。

### 3. 都道府県フォーカス中はタップでフォーカスを切り替えられない

細分区域のヒット処理が `state is IntensityHistoryStatePrefecture`(＝全国表示)に限定されていたため、フォーカス中に別の都道府県をタップしても無反応。市区町村ポリゴンが存在しないズーム(< 6)では、フォーカス中のタップが完全に何も起きない状態だった。

### 4. 市区町村モーダルを開くのに 2 回タップが必要

1 回目で選択、2 回目で初めてモーダルが開く実装で、設計書の「市区町村をタップするとモーダルを表示」と乖離していた。`deselectCity()` はどこからも呼ばれていなかった。

### 5. 離島を持つ都道府県でカメラが極端にズームアウトする

配下の全細分区域の外接矩形を単純に union していたため、東京都(小笠原諸島・南鳥島)・鹿児島県(十島村)・沖縄県(大東島)などで表示範囲が数百 km 規模に広がり、本土がほとんど見えないズームになっていた。

### 6. タップ判定が UI スレッドで全ポリゴンをデコードしていた

`JmaMapUtility().findNearestItem` を main isolate で実行しており、市区町村(1,911 件)のポリゴンデコードでタップごとに UI が固まっていた。

### 7. その他

- 端末の戻る操作で Lv2 → Lv1 に戻れず、いきなりページが閉じていた(設計書の `PopScope` 未実装)
- ディープリンク経由のモーダルで市区町村名の代わりに市区町村コードが表示されていた
- 市区町村を選択すると同一都道府県内の他市区町村が黒 0.55 で潰され、震度色が読めなくなっていた
- 海上タップで意図せず全国表示までズームアウトしていた
- `match` 式に同一 code が重複すると式全体が不正になりレイヤーが一切描画されないが、防御がなかった
- 地域パネルの `Row` 内 `Text` に `Flexible` がなく、長い地名・大きな textScale で overflow しうる

## 変更内容

| ファイル | 内容 |
|---|---|
| `ui/layer/intensity_fill_layer_builder.dart` (新規) | 全レイヤーを 1 回で「下 → 上」の決定的な順序で組み立てる純粋クラス |
| `ui/layer/intensity_fill_layer.dart` | 単一の `useEffect` で全レイヤーを `replaceMapStyleLayers` に置き換え |
| `ui/layer/intensity_fill_expression.dart` | 同一 code を最大震度側に畳み込んで match ラベルを一意化 |
| `data/repository/prefecture_bounds_resolver.dart` (新規) | 細分区域を近接クラスタに分割し、タップした区域(未指定時は市区町村数最多)のクラスタのみを採用 |
| `ui/action/intensity_history_map_action.dart` (新規) | タップ判定・フォーカス・カメラ操作・ディープリンクを集約した Action |
| `ui/intensity_history_page.dart` | Widget から private メソッドを排除し Action へ委譲、`PopScope` を追加、判定用 Isolate を事前起動 |
| `ui/components/region_floating_panel.dart` | 長い地名の overflow 対策(`Flexible` + `maxLines`) |

タップ判定は `queryLayers` のヒット有無ゲートをやめ、常駐 Worker Isolate 上のポリゴン内外判定(`jmaMapAreaInformationCityInsideProvider` / `jmaMapAreaForecastLocalEInsideProvider`)に統一しました。「市区町村として解釈するか」は `MapController.camera?.zoom` と `BaseMapTileSpec.cityMinZoom` で明示的に判定します。

フォーカス中の都道府県は、市区町村の塗りが出るズーム以上では細分区域の塗りを透明にし、それ未満では従来どおり細分区域の塗りへフォールバックします。市区町村の最高震度が未取得のあいだは細分区域の塗りを維持するため、空白にはなりません。

## テスト

```
dart analyze lib                                            # No issues found!
flutter test test/feature/intensity_history                 # All tests passed! (67)
flutter test                                                # All tests passed! (1597)
```

追加したテスト:

- `prefecture_bounds_resolver_test.dart`: 近接クラスタリング、seed 優先、union 範囲、離島除外
- `intensity_fill_layer_builder_test.dart`: レイヤー順序・挿入アンカー・filter・不透明度・都道府県コードの細分区域展開
- `intensity_fill_expression_test.dart`: code 重複時の一意化

## ドキュメント

- `docs/knowledge/20260807_maplibre_layer_insertion_order.md`: `belowLayerId` の挿入順と、effect を分けると壊れる話
- `docs/knowledge/20260807_map_tap_area_resolution.md`: タップ地点の地域判定を Isolate 経由で行う理由と `queryLayers` / `featuresAtPoint` の使い分け
- `docs/todo/300_intensity_history_state_naming.md`: `IntensityHistoryState` の命名が実態と逆で、今回の不具合#3 の原因になっている件（本 PR と競合するためマージ後に別 PR で対応）

## 動作確認できていない点

実機・シミュレータでの目視確認は行えていません。特に以下は実機確認が望ましいです。

- 都道府県フォーカス時のカメラ範囲(東京都・鹿児島県・沖縄県・北海道)
- 市区町村タップ 1 回でのモーダル表示と輪郭線ハイライト
- Lv1/Lv2 のレイヤー重なり順

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdd0d-d8f5-725b-8755-c3425078eac5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdd0d-d8f5-725b-8755-c3425078eac5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

